### PR TITLE
feat(cli): pre-flight checks for empty coverage and missing source files (#22)

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -247,9 +247,20 @@ fn check_coverage_has_data(path: &std::path::Path) -> Result<()> {
 
     let file = std::fs::File::open(path)?;
     let reader = BufReader::new(file);
+    let mut in_sf_block = false;
+
     for line in reader.lines() {
         let line = line?;
-        if line.starts_with("DA:") {
+        if line.starts_with("SF:") {
+            in_sf_block = true;
+            continue;
+        }
+        if in_sf_block
+            && let Some(rest) = line.strip_prefix("DA:")
+            && let Some((line_no, hits)) = rest.split_once(',')
+            && line_no.parse::<usize>().is_ok()
+            && hits.split(',').next().unwrap_or("").parse::<u64>().is_ok()
+        {
             return Ok(());
         }
     }
@@ -552,6 +563,28 @@ mod tests {
         std::fs::write(&cov, "SF:src/main.rs\nDA:1,5\nend_of_record\n").unwrap();
 
         assert!(check_coverage_has_data(&cov).is_ok());
+    }
+
+    #[test]
+    fn preflight_coverage_da_outside_sf_block_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let cov = dir.path().join("orphan_da.info");
+        std::fs::write(&cov, "DA:1,5\nend_of_record\n").unwrap();
+
+        let err = check_coverage_has_data(&cov).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("no coverage data found"));
+    }
+
+    #[test]
+    fn preflight_coverage_malformed_da_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let cov = dir.path().join("bad_da.info");
+        std::fs::write(&cov, "SF:src/main.rs\nDA:not_a_number\nend_of_record\n").unwrap();
+
+        let err = check_coverage_has_data(&cov).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("no coverage data found"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add `check_coverage_has_data()` — reads coverage file, ensures at least one `DA:` line exists
- Add `check_src_has_rust_files()` — recursively walks src dir for `.rs` files
- Both checks run after input validation, before analysis engine, with actionable error messages

## Acceptance Criteria (from #22)

- [x] Missing coverage file → actionable error with `cargo llvm-cov` hint
- [x] Missing src directory → actionable error
- [x] Empty LCOV file → "No coverage data found in {path}. Ensure tests ran with coverage enabled."
- [x] No functions found → "No Rust source files found in {path}. Check --src points to Rust source files."
- [x] Invalid metric value → handled by clap ValueEnum
- [x] No panics in error paths (7 new tests covering all pre-flight paths)

## Test plan

- `cargo nextest run -E 'test(cli::tests)'` — 30 tests pass (7 new)

**Note:** `domain::summary::tests` has a pre-existing index-out-of-bounds bug unrelated to this PR.

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pre-flight validation checks that verify the coverage file contains data and the source directory contains Rust files, enabling earlier detection of configuration issues with clearer error messages.

* **Tests**
  * Added comprehensive unit tests covering both success and failure cases for the new validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->