### PR TITLE
chore: prepare repo for public visibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# crap4rs Agent Notes
+
+- This repo uses a shared Cargo target directory via `.cargo/config.toml`; let worktrees inherit it normally.
+- Preserve any worktree the user identifies as active.
+
+## Repo Context
+
+- Architecture: hexagonal (ports & adapters) — `domain/` → `ports/` → `adapters/` → `core/` → `cli/`. Never import "inward."
+- Testing: `cargo nextest run` for tests, `cargo clippy -- -D warnings` for lints, `cargo fmt --check` for formatting. Quick verify: all three chained.
+- Property tests use `proptest` — regression files in `proptest-regressions/` are committed to git, never gitignored.
+- Safety: do not push directly to `main`, always branch + PR. Do not modify `.github/workflows/*` unless the task clearly requires CI changes.
+- The `domain/` and `ports/` layers must stay language-agnostic (no `syn`, no LCOV types) — they are designed for future extraction into a shared `crap-core` library.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,5 @@
+@AGENTS.md
+
 # CLAUDE.md — crap4rs
 
 CRAP (Change Risk Anti-Patterns) analyzer for Rust codebases. Library crate + thin CLI binary.
@@ -27,8 +29,6 @@ Never import "inward." Library crate layout preserves future `crap-core` extract
 **Complexity metrics**: cognitive (default, better for match-heavy Rust) and cyclomatic via `--metric` flag. `ComplexityPort` is metric-agnostic.
 
 **LCOV only**: parse `SF:` and `DA:` records from `cargo-llvm-cov --lcov`. Ignore `FN:`/`FNDA:` (mangled symbols, redundant).
-
-**Spike reference**: `~/Github/ops/pipelines/crap4rs/crap4rs-20260324-council-spike.md`
 
 ## Commands
 
@@ -118,15 +118,10 @@ crap/ (future monorepo)
 - `adapters/` is where all Rust-specific code lives (syn walker, LCOV parser). These become `crap-rust`.
 - When adding new features, ask: "Is this language-specific or universal?" Universal → domain/core. Language-specific → adapters.
 
-Tracking: `breezy-bays-labs/ops#231`
-
 ## Cross-References
 
-- **crap4ts** (TS equivalent): `~/Github/crap4ts/`
-- **Ecosystem plan**: `~/.claude/projects/-Users-cmbays-github-ops/memory/project_crap-ecosystem-plan.md`
-- **Testing standard**: `~/Github/ops/standards/testing.md`
-- **Quality loop**: `~/Github/ops/playbooks/quality-loop.md`
-- **Kanban board**: `~/Github/ops/boards/crap4rs/v0.1.0-mvp.md`
+- **crap4ts** (TS equivalent): [breezy-bays-labs/crap4ts](https://github.com/breezy-bays-labs/crap4ts)
+- **Unified monorepo tracking**: breezy-bays-labs/ops#231
 
 ## Compact Instructions
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,84 @@
+# crap4rs
+
+CRAP (Change Risk Anti-Patterns) score analyzer for Rust codebases. Finds complex, under-tested functions.
+
+> **Status:** Pre-release. MVP in progress.
+
+## What is CRAP?
+
+The CRAP metric combines **complexity** and **code coverage** into a single risk score:
+
+```
+CRAP(complexity, coverage) = complexity^2 * (1 - coverage)^3 + complexity
+```
+
+High complexity + low coverage = high CRAP score = high risk of bugs when changed.
+
+| CRAP Score | Risk Level |
+|------------|------------|
+| ≤ 5 | Low |
+| ≤ 8 | Acceptable |
+| ≤ 30 | Moderate |
+| > 30 | High |
+
+## Usage
+
+```bash
+# Generate coverage data
+cargo llvm-cov --lcov --output-path lcov.info
+
+# Run CRAP analysis
+crap4rs --src src/ --coverage lcov.info --threshold 8
+```
+
+### Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--src <path>` | required | Path to Rust source files |
+| `--coverage <path>` | required | Path to LCOV coverage file |
+| `--threshold <n>` | 30 | CRAP score threshold (exit 1 if exceeded) |
+| `--metric <type>` | cognitive | Complexity metric: `cognitive` or `cyclomatic` |
+| `--format <type>` | table | Output format: `table` or `json` |
+
+### Why cognitive by default?
+
+Rust's `match` expressions with many arms inflate cyclomatic complexity without adding real risk. A flat 20-arm match is cyclomatic 20 but cognitive 1. Cognitive complexity better reflects actual Rust code risk.
+
+## Installation
+
+```bash
+# From source (requires Rust toolchain)
+cargo install crap4rs
+
+# Or clone and build
+git clone https://github.com/breezy-bays-labs/crap4rs.git
+cd crap4rs
+cargo build --release
+```
+
+> `cargo install` will work once published to crates.io. For now, build from source.
+
+## Prerequisites
+
+- [cargo-llvm-cov](https://github.com/taiki-e/cargo-llvm-cov) for generating LCOV coverage data
+
+## Architecture
+
+Hexagonal (ports & adapters) design for future extraction into a polyglot `crap-core` library:
+
+```
+domain/    Pure logic: CRAP formula, thresholds, types
+ports/     Trait definitions (ComplexityPort, CoveragePort)
+adapters/  syn walker, LCOV parser, reporters
+core/      Wires adapters through ports
+cli/       clap argument parsing
+```
+
+## Related
+
+- [crap4ts](https://github.com/breezy-bays-labs/crap4ts) — CRAP analyzer for TypeScript
+
+## License
+
+GPL-3.0-or-later. See [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary
- Remove private ops repo references from CLAUDE.md (local paths to pipelines, standards, memory files)
- Add @AGENTS.md import for cross-agent contract
- Create AGENTS.md with repo context for Codex
- Create README.md with usage, architecture, and installation docs

Prepares for flipping repo visibility to public + enabling CodeRabbit.

## Test plan
- [ ] No private paths remain in committed files
- [ ] README renders correctly on GitHub
- [ ] After merge, flip visibility to public

🤖 Generated with [Claude Code](https://claude.com/claude-code)