### PR TITLE
test(cli): --verbose integration tests (#44)

### DIFF
--- a/tests/verbose_integration.rs
+++ b/tests/verbose_integration.rs
@@ -62,6 +62,7 @@ fn verbose_stderr_lines_present() {
     setup_dir(dir.path(), SIMPLE_SRC, SIMPLE_LCOV);
 
     let output = run(dir.path(), &["--verbose"]);
+    assert_success(&output);
     let err = stderr_str(&output);
 
     assert!(
@@ -86,6 +87,7 @@ fn no_verbose_no_verbose_lines() {
     setup_dir(dir.path(), SIMPLE_SRC, SIMPLE_LCOV);
 
     let output = run(dir.path(), &[]);
+    assert_success(&output);
     let err = stderr_str(&output);
 
     assert!(
@@ -103,6 +105,7 @@ fn warn_without_verbose_on_lcov_parse_issues() {
     setup_dir(dir.path(), SIMPLE_SRC, malformed_lcov);
 
     let output = run(dir.path(), &[]);
+    assert_success(&output);
     let err = stderr_str(&output);
 
     assert!(
@@ -122,6 +125,7 @@ fn verbose_adds_lcov_parse_detail() {
     setup_dir(dir.path(), SIMPLE_SRC, malformed_lcov);
 
     let output = run(dir.path(), &["--verbose"]);
+    assert_success(&output);
     let err = stderr_str(&output);
 
     assert!(
@@ -146,6 +150,7 @@ fn warn_on_unparseable_source_files() {
         .expect("write broken.rs");
 
     let output = run(dir.path(), &[]);
+    assert_success(&output);
     let err = stderr_str(&output);
 
     assert!(
@@ -227,6 +232,7 @@ fn verbose_counts_match_source() {
     setup_dir(dir.path(), two_fn_src, two_fn_lcov);
 
     let output = run(dir.path(), &["--verbose"]);
+    assert_success(&output);
     let err = stderr_str(&output);
 
     assert!(
@@ -247,6 +253,7 @@ fn verbose_quiet_suppresses_stdout_not_stderr() {
     setup_dir(dir.path(), SIMPLE_SRC, SIMPLE_LCOV);
 
     let output = run(dir.path(), &["--verbose", "--quiet"]);
+    assert_success(&output);
     let err = stderr_str(&output);
     let out = stdout_str(&output);
 
@@ -272,6 +279,7 @@ fn verbose_no_coverage_count() {
     setup_dir(dir.path(), two_fn_src, unmatched_lcov);
 
     let output = run(dir.path(), &["--verbose"]);
+    assert_success(&output);
     let err = stderr_str(&output);
 
     assert!(


### PR DESCRIPTION
## Summary

- Adds `tests/verbose_integration.rs` — 11 binary integration tests for the `--verbose` CLI flag
- Covers the wiring path through `warn_if_issues()` and `print_diagnostics()` that was untested after PR #42 merged the feature

## What's tested

| Scenario | Test |
|---|---|
| `--verbose` emits `verbose: file discovery/complexity/matching` to stderr | `verbose_stderr_lines_present` |
| Without `--verbose`, no `verbose:` lines | `no_verbose_no_verbose_lines` |
| LCOV parse issues always warn (without `--verbose`) | `warn_without_verbose_on_lcov_parse_issues` |
| `--verbose` adds LCOV parse detail section | `verbose_adds_lcov_parse_detail` |
| Unparseable `.rs` files always warn | `warn_on_unparseable_source_files` |
| `--verbose --format json` includes `diagnostics` field | `verbose_json_includes_diagnostics` |
| `--format json` without `--verbose` omits `diagnostics` | `no_verbose_json_omits_diagnostics` |
| `--verbose --format json` populates `parse_diagnostics` array when issues exist | `verbose_json_parse_issues_in_diagnostics` |
| Verbose counts match source (complexity + file discovery) | `verbose_counts_match_source` |
| `--verbose --quiet` suppresses stdout, not stderr | `verbose_quiet_suppresses_stdout_not_stderr` |
| `without coverage data` count reflects unmatched functions | `verbose_no_coverage_count` |

## Test plan

- [x] `cargo nextest run --test verbose_integration` — 11/11 pass
- [x] `cargo nextest run` — 356/356 pass
- [x] `cargo fmt --check && cargo clippy -- -D warnings` — clean

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive integration tests for the CLI validating: verbose output behavior, warnings for malformed coverage data and unparseable sources, JSON output containing diagnostics only when verbose, interaction of verbose with quiet mode, accurate verbose counts for files/functions, and reporting of functions without coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->