### PR TITLE
chore: add cargo-binstall metadata for pre-built binary installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Breakdown explanation** (`--explain`) — optional legend for `--breakdown` table output that explains base increments, nested increments, and nesting-triggering constructs without changing default or JSON output
+- **`cargo-binstall` support** — added `[package.metadata.binstall]` to `Cargo.toml` so `cargo binstall crap4rs` installs from pre-built GitHub release binaries
 
 ## [0.1.0] - 2026-03-30
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,11 @@ repository = "https://github.com/breezy-bays-labs/crap4rs"
 keywords = ["crap", "complexity", "coverage", "testing", "quality"]
 categories = ["development-tools::testing", "command-line-utilities"]
 
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }.tar.gz"
+pkg-fmt = "tgz"
+bin-dir = "{ bin }{ binary-ext }"
+
 [lib]
 name = "crap4rs"
 path = "src/lib.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["development-tools::testing", "command-line-utilities"]
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }.tar.gz"
 pkg-fmt = "tgz"
-bin-dir = "{ bin }{ binary-ext }"
+bin-dir = "."
 
 [lib]
 name = "crap4rs"


### PR DESCRIPTION
## Summary

- Adds `[package.metadata.binstall]` to `Cargo.toml` so `cargo binstall crap4rs` works out of the box
- Release assets already follow the standard naming convention (`crap4rs-{target}.tar.gz` with binary at archive root) — this just registers that fact with binstall

## Why

Without this metadata, `cargo-binstall` cannot locate the pre-built binaries even though they exist in GitHub Releases. It was discovered when `moonrepo/setup-rust bins: crap4rs` failed in a downstream project's CI with:

```
× For crate crap4rs: crap4rs is not found
```

## Test plan

- [ ] Verify `cargo binstall crap4rs` installs successfully after this merges and a new release is cut
- [ ] Confirm `moonrepo/setup-rust bins: cargo-nextest,cargo-llvm-cov,crap4rs` works in downstream CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added metadata to support installation from pre-built release binaries, improving distribution and deployment.
* **Documentation**
  * Updated release notes to document the new pre-built binary installation support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->