### PR TITLE
fix(cli): relocate --only-failing through ViewSpec for self-consistent summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **`--only-failing` summary semantics** — the summary line now reflects the full unfiltered analysis (correctness fix). Previously, `--only-failing` mutated `result.functions` in-place via `retain`, so `total_functions` and `exceeding_threshold` reflected the post-mutation count while `average_crap`, `median_crap`, `max_crap`, and `distribution` retained pre-mutation values — an internally inconsistent state. The flag's row-level filter behavior is unchanged; only the printed summary is now coherent. (#78 follow-up)
+
+### Internal
+- `--only-failing` migrated from `OutputArgs.only_failing` (top-level `result.functions.retain`) to `FilterArgs.only_failing` flowing through `domain::view::Filters`. CLI behavior of the flag itself is unchanged.
+
 ## [0.1.1] - 2026-04-05
 
 ### Added

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -104,10 +104,6 @@ pub struct OutputArgs {
     /// Use lenient threshold (40) — for legacy or transitional code
     #[arg(long, group = "threshold_select")]
     pub lenient: bool,
-
-    /// Only show functions that exceed the threshold
-    #[arg(long)]
-    pub only_failing: bool,
 }
 
 #[derive(Debug, Args)]
@@ -134,6 +130,16 @@ pub struct FilterArgs {
     /// Useful for CI PR gating: `crap4rs --coverage lcov.info --diff main`
     #[arg(long, value_name = "REF")]
     pub diff: Option<String>,
+
+    /// Only show functions that exceed the threshold
+    ///
+    /// Display-only filter: the underlying analysis (the gate) and its
+    /// summary remain over the full unfiltered set, so the exit code and
+    /// every aggregate (`average_crap`, `median_crap`, `distribution`,
+    /// etc.) reflect the whole codebase. Only the row list and
+    /// `view.shown_summary` are reduced.
+    #[arg(long)]
+    pub only_failing: bool,
 }
 
 #[derive(Debug, Args)]
@@ -261,7 +267,7 @@ fn run_inner() -> Result<bool> {
     };
 
     let analysis = crap4rs::core::analyze(&options)?;
-    let mut result = analysis.result;
+    let result = analysis.result;
     let passed = result.passed;
 
     // Always warn about non-fatal issues (details require --verbose)
@@ -272,21 +278,10 @@ fn run_inner() -> Result<bool> {
         print_diagnostics(&analysis.diagnostics);
     }
 
-    // Filter to only failing functions if requested (summary stays unfiltered).
-    //
-    // NOTE (V1a): this `retain` is the legacy, behavior-preserving path
-    // for `--only-failing`. V1b relocates the flag to `FilterArgs` and
-    // routes it through `view::Filters::only_failing` so the row reduction
-    // is consistent with the View pipeline. Until then the V1a wiring
-    // continues to mutate `result.functions` here to keep this PR strictly
-    // behavior-preserving.
-    if cli.output.only_failing {
-        result.functions.retain(|v| v.exceeds);
-    }
-
     // Build the spec, then shape the result through the View pipeline.
-    // V1a: spec is always `ViewSpec::default()`. W1/W2 surface `--top`,
-    // `--min/max-coverage`, `--sort-by` via `view_args::build_view_spec`.
+    // V1b: `--only-failing` flows through `Filters::only_failing` here.
+    // W2 fills in `--top`, `--min/max-coverage`, `--sort-by`. The
+    // underlying `result` is never mutated — the gate is unshapeable.
     let spec = view_args::build_view_spec(&cli);
     let view = view::apply(&result, spec);
 
@@ -720,7 +715,7 @@ mod tests {
     #[test]
     fn only_failing_flag() {
         let cli = parse(&["--coverage", "lcov.info", "--only-failing"]).unwrap();
-        assert!(cli.output.only_failing);
+        assert!(cli.filter.only_failing);
     }
 
     #[test]

--- a/src/cli/view_args.rs
+++ b/src/cli/view_args.rs
@@ -1,19 +1,21 @@
 //! CLI → ViewSpec adapter.
 //!
-//! V1a stub: every CLI invocation maps to `ViewSpec::default()`. Wave 1
-//! (V1b: `--only-failing` relocation) and Wave 2 (`--top`,
-//! `--min/max-coverage`, `--sort-by`) flesh this out without further
-//! changes to `cli/mod.rs::run_inner`.
+//! V1b wires `--only-failing` through `Filters::only_failing`. Wave 2
+//! (`--top`, `--min/max-coverage`, `--sort-by`) extends this without
+//! further changes to `cli/mod.rs::run_inner`.
 
 use super::Cli;
 use crap4rs::domain::view::ViewSpec;
 
-/// Build a `ViewSpec` from the parsed CLI. V1a returns the default
-/// spec unconditionally — `apply()` is a no-op shape-preserving pass
-/// over the analysis. Subsequent waves pull `top`, `coverage_range`,
-/// `sort_by`, and `only_failing` off the CLI struct here.
-pub(super) fn build_view_spec(_cli: &Cli) -> ViewSpec {
-    ViewSpec::default()
+/// Build a `ViewSpec` from the parsed CLI.
+///
+/// `Filters` and `ViewSpec` are `#[non_exhaustive]` (per ADR D3 — they
+/// reserve namespace for future filters/sort keys), so we mutate fields
+/// on a default rather than using a struct literal.
+pub(super) fn build_view_spec(cli: &Cli) -> ViewSpec {
+    let mut spec = ViewSpec::default();
+    spec.filters.only_failing = cli.filter.only_failing;
+    spec
 }
 
 /// Validation hook for view-specific args. V1a: vacuously OK. W2's

--- a/tests/view_integration.rs
+++ b/tests/view_integration.rs
@@ -230,3 +230,127 @@ fn schema_version_remains_one_with_additive_view() {
         "View block was added per ADR D2 additive rule; schema_version stays at 1"
     );
 }
+
+// ── V1b: --only-failing routes through the View, summary stays unfiltered ──
+
+/// 6-function fixture: 3 simple (CC=1, fully covered) and 3 branching
+/// (uncovered). Threshold 5 puts 3 functions over the edge.
+const ONLY_FAILING_SRC: &str = "\
+pub fn passing_a() -> i32 { 1 }
+pub fn passing_b() -> i32 { 2 }
+pub fn passing_c() -> i32 { 3 }
+pub fn failing_a(x: i32) -> i32 { if x > 0 { if x > 5 { 1 } else { 2 } } else { 3 } }
+pub fn failing_b(x: i32) -> i32 { if x > 0 { if x > 5 { 1 } else { 2 } } else { 3 } }
+pub fn failing_c(x: i32) -> i32 { if x > 0 { if x > 5 { 1 } else { 2 } } else { 3 } }
+";
+
+const ONLY_FAILING_LCOV: &str = "\
+SF:lib.rs
+DA:1,1
+DA:2,1
+DA:3,1
+DA:4,0
+DA:5,0
+DA:6,0
+end_of_record
+";
+
+#[test]
+fn only_failing_summary_is_self_consistent() {
+    // V1b regression: `--only-failing` must NOT mutate `result.functions`
+    // or any field of `result.summary`. The full unfiltered analysis is
+    // the unshapeable gate; only `view.shown` reflects the filter.
+    //
+    // CQO-C3: enumerate every summary field (total_functions,
+    // exceeding_threshold, average_crap, median_crap, max_crap.value,
+    // and all four distribution buckets) and assert each one matches
+    // the baseline (no-filter) run.
+    let dir = tempfile::tempdir().unwrap();
+    setup_dir(dir.path(), ONLY_FAILING_SRC, ONLY_FAILING_LCOV);
+
+    // Threshold violations are expected → exit code 1, but stdout still
+    // carries the JSON envelope. Only exit 2 (validation error) would be
+    // a fatal failure here.
+    let baseline = run(
+        dir.path(),
+        &["--threshold", "5", "--format", "json", "--no-gitignore"],
+    );
+    assert_ne!(
+        baseline.status.code(),
+        Some(2),
+        "baseline run must not error: stderr:\n{}",
+        stderr_str(&baseline)
+    );
+    let base = parse_json(&baseline);
+
+    // Sanity: 6 total functions, 3 exceed at threshold 5.
+    assert_eq!(
+        base["result"]["summary"]["total_functions"], 6,
+        "fixture sanity: expected 6 functions"
+    );
+    assert_eq!(
+        base["result"]["summary"]["exceeding_threshold"], 3,
+        "fixture sanity: expected 3 to exceed threshold 5"
+    );
+
+    let filtered = run(
+        dir.path(),
+        &[
+            "--threshold",
+            "5",
+            "--format",
+            "json",
+            "--no-gitignore",
+            "--only-failing",
+        ],
+    );
+    assert_ne!(
+        filtered.status.code(),
+        Some(2),
+        "--only-failing run must not error: stderr:\n{}",
+        stderr_str(&filtered)
+    );
+    let v = parse_json(&filtered);
+
+    // Key: V1b leaves result.functions untouched. Under V1a this would
+    // be 3 (the legacy retain). Under V1b it stays at 6.
+    let funcs = v["result"]["functions"].as_array().expect("array");
+    assert_eq!(
+        funcs.len(),
+        6,
+        "result.functions must NOT be mutated by --only-failing under V1b"
+    );
+
+    // CQO-C3: every summary field equals the baseline.
+    let s = &v["result"]["summary"];
+    let bs = &base["result"]["summary"];
+    assert_eq!(s["total_functions"], bs["total_functions"]);
+    assert_eq!(s["total_files"], bs["total_files"]);
+    assert_eq!(s["exceeding_threshold"], bs["exceeding_threshold"]);
+    assert_eq!(s["average_crap"], bs["average_crap"]);
+    assert_eq!(s["median_crap"], bs["median_crap"]);
+    assert_eq!(s["max_crap"], bs["max_crap"]);
+    assert_eq!(s["worst_function"], bs["worst_function"]);
+    assert_eq!(s["distribution"]["low"], bs["distribution"]["low"]);
+    assert_eq!(
+        s["distribution"]["acceptable"],
+        bs["distribution"]["acceptable"]
+    );
+    assert_eq!(
+        s["distribution"]["moderate"],
+        bs["distribution"]["moderate"]
+    );
+    assert_eq!(s["distribution"]["high"], bs["distribution"]["high"]);
+
+    // The View carries the filtered subset.
+    let shown = v["view"]["shown"].as_array().expect("view.shown array");
+    assert_eq!(shown.len(), 3, "view.shown must reflect the filter");
+    assert_eq!(
+        v["view"]["shown_summary"]["total_functions"], 3,
+        "view.shown_summary derives from the filtered subset"
+    );
+    assert_eq!(
+        v["view"]["spec"]["filters"]["only_failing"], true,
+        "ViewSpec must record the filter that was applied"
+    );
+}


### PR DESCRIPTION
## Summary

W1 / V1b of pipeline `crap4rs/20260425-cli-presentation-view`. Follow-up to V1a walking skeleton (PR #84, issue #78).

`--only-failing` now flows through `domain::view::Filters::only_failing` instead of mutating `result.functions` via `retain`. The gate is unshapeable: `result` and `result.summary` always reflect the full unfiltered analysis; only `view.shown` and `view.shown_summary` reflect the filter.

## Why this matters

Under V1a (and prior), passing `--only-failing` mutated `result.functions` in place — but `result.summary` was already computed over the unfiltered set. The result was an internally inconsistent JSON envelope: `result.functions.length == 3` while `result.summary.total_functions == 6`. JSON consumers walking both fields could see contradictory totals.

V1a was deliberately behavior-preserving (per the impl plan / triage in PR #84). V1b is the bisectable user-visible fix.

## Changes

- **`src/cli/mod.rs`** — moved `pub only_failing: bool` from `OutputArgs` to `FilterArgs` (so `--help` lists it under "Filtering"). Removed the legacy `result.functions.retain(...)` block in `run_inner`. Updated `only_failing_flag` test to read `cli.filter.only_failing`.
- **`src/cli/view_args.rs`** — replaced the V1a stub: `build_view_spec` now sets `spec.filters.only_failing = cli.filter.only_failing`.
- **`tests/view_integration.rs`** — new regression test `only_failing_summary_is_self_consistent` (six-function fixture, three exceeding @ threshold 5). Asserts every `result.summary` field is identical to the unfiltered baseline (CQO-C3 enumeration), and that `result.functions.length == 6` post-filter (the bit that fails under V1a).
- **`CHANGELOG.md`** — `[Unreleased]` Changed entry explaining the user-visible semantics, plus an Internal note on the structural move.

## What did NOT change

- The flag name, short form, semantics for the row list (still shows only failing functions), and exit code (still 1 when violations exist).
- `domain::view::apply` and friends — V1a's mutation gate (100% kill) still covers the View pipeline.
- Snapshots — no `--only-failing` snapshot existed under V1a; CAO-F is preserved.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo nextest run` — 481 / 481 pass (was 480, +1 regression test)
- [x] Self-CRAP gate at threshold 25 still PASS — `cargo run --release -- --coverage lcov.info --threshold 25` reports `0 above threshold (25) | worst: 15.0 | PASS`
- [x] `--help` shows `--only-failing` under **Filtering**
- [x] Regression test fails under V1a behavior (verified RED → GREEN locally before / after the relocation commit)

Closes nothing standalone — referenced as the V1b follow-up to #78 / PR #84. Unblocks W2 (#62, #63, #65, #68).

🤖 Generated with [Claude Code](https://claude.com/claude-code)