### PR TITLE
feat(cli): --min-coverage / --max-coverage range filter (#63)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`--min-coverage` / `--max-coverage` range filter** — drop functions whose `coverage_percent` falls outside `[min, max]` (inclusive). Either bound is optional; the unspecified side defaults to `0.0` or `100.0`. Invalid bounds (out-of-range or `min > max`) exit `2` with flag-attributed stderr. The full unfiltered analysis still drives the gate (exit code), so a filter that hides every violation does not change the outcome. JSON envelope echoes the resolved range under `view.filters.coverage_range`. (#63)
+
 ### Changed
 - **`--only-failing` summary semantics** — the summary line now reflects the full unfiltered analysis (correctness fix). Previously, `--only-failing` mutated `result.functions` in-place via `retain`, so `total_functions` and `exceeding_threshold` reflected the post-mutation count while `average_crap`, `median_crap`, `max_crap`, and `distribution` retained pre-mutation values — an internally inconsistent state. The flag's row-level filter behavior is unchanged; only the printed summary is now coherent. (#78 follow-up)
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -140,6 +140,18 @@ pub struct FilterArgs {
     /// `view.shown_summary` are reduced.
     #[arg(long)]
     pub only_failing: bool,
+
+    /// Lower bound (inclusive) on coverage_percent for the displayed view.
+    ///
+    /// `allow_hyphen_values`: lets clap parse `--min-coverage -5` as a
+    /// value (not an unknown flag) so `validate_view_args` can report
+    /// the right error.
+    #[arg(long, allow_hyphen_values = true, value_name = "PCT")]
+    pub min_coverage: Option<f64>,
+
+    /// Upper bound (inclusive) on coverage_percent for the displayed view.
+    #[arg(long, allow_hyphen_values = true, value_name = "PCT")]
+    pub max_coverage: Option<f64>,
 }
 
 #[derive(Debug, Args)]
@@ -223,6 +235,7 @@ fn run_inner() -> Result<bool> {
     let cli = Cli::parse();
 
     validate_display_flags(&cli)?;
+    view_args::validate_view_args(&cli)?;
 
     apply_color(cli.display.color);
 

--- a/src/cli/view_args.rs
+++ b/src/cli/view_args.rs
@@ -1,27 +1,77 @@
 //! CLI → ViewSpec adapter.
 //!
-//! V1b wires `--only-failing` through `Filters::only_failing`. Wave 2
-//! (`--top`, `--min/max-coverage`, `--sort-by`) extends this without
-//! further changes to `cli/mod.rs::run_inner`.
+//! V1b wires `--only-failing` through `Filters::only_failing`. W2 layers
+//! `--min/--max-coverage` through `Filters::coverage_range` (this module);
+//! `--top` and `--sort-by` follow without further changes to
+//! `cli/mod.rs::run_inner`.
+
+use anyhow::{Result, bail};
 
 use super::Cli;
-use crap4rs::domain::view::ViewSpec;
+use crap4rs::domain::view::{CoverageRange, CoverageRangeError, ViewSpec};
 
 /// Build a `ViewSpec` from the parsed CLI.
 ///
 /// `Filters` and `ViewSpec` are `#[non_exhaustive]` (per ADR D3 — they
 /// reserve namespace for future filters/sort keys), so we mutate fields
 /// on a default rather than using a struct literal.
+///
+/// Assumes `validate_view_args` already ran and accepted the input —
+/// the `CoverageRange::new` call below cannot fail in `run_inner`.
 pub(super) fn build_view_spec(cli: &Cli) -> ViewSpec {
     let mut spec = ViewSpec::default();
     spec.filters.only_failing = cli.filter.only_failing;
+    if let Some((lo, hi)) = resolve_coverage_bounds(cli) {
+        spec.filters.coverage_range = CoverageRange::new(lo, hi).ok();
+    }
     spec
 }
 
-/// Validation hook for view-specific args. V1a: vacuously OK. W2's
-/// `--min-coverage` / `--max-coverage` will translate
-/// `CoverageRangeError` to user-facing prose here.
-#[allow(dead_code)] // V1b/V2 wires this in; reserved scaffold for now.
-pub(super) fn validate_view_args(_cli: &Cli) -> anyhow::Result<()> {
-    Ok(())
+/// Validate view-specific args and translate domain errors to flag-attributed
+/// CLI prose.
+///
+/// `CoverageRange::new` (in `domain::view`) is the single source of truth for
+/// validity rules. We pre-check each bound for OutOfRange so the message can
+/// name the offending flag, then rely on `CoverageRange::new` for the
+/// relational `MinExceedsMax` check.
+pub(super) fn validate_view_args(cli: &Cli) -> Result<()> {
+    let Some((lo, hi)) = resolve_coverage_bounds(cli) else {
+        return Ok(());
+    };
+
+    if cli
+        .filter
+        .min_coverage
+        .is_some_and(|v| !(0.0..=100.0).contains(&v))
+    {
+        bail!("--min-coverage must be in [0, 100]");
+    }
+    if cli
+        .filter
+        .max_coverage
+        .is_some_and(|v| !(0.0..=100.0).contains(&v))
+    {
+        bail!("--max-coverage must be in [0, 100]");
+    }
+
+    match CoverageRange::new(lo, hi) {
+        Ok(_) => Ok(()),
+        Err(CoverageRangeError::MinExceedsMax { .. }) => {
+            bail!("--min-coverage must not exceed --max-coverage")
+        }
+        // OutOfRange is unreachable: per-bound checks above handle it. The
+        // wildcard catches future `#[non_exhaustive]` variants too — domain
+        // errors must be translated to flag-attributed prose at the CLI edge.
+        Err(e) => bail!("invalid --min-coverage / --max-coverage: {e}"),
+    }
+}
+
+/// Returns the resolved `(min, max)` pair iff at least one bound was passed.
+/// Unspecified sides default to 0.0 / 100.0 — the natural domain of the
+/// percentage scale (cli_ergonomics.feature:79-86).
+fn resolve_coverage_bounds(cli: &Cli) -> Option<(f64, f64)> {
+    match (cli.filter.min_coverage, cli.filter.max_coverage) {
+        (None, None) => None,
+        (lo, hi) => Some((lo.unwrap_or(0.0), hi.unwrap_or(100.0))),
+    }
 }

--- a/tests/cli_coverage_range_integration.rs
+++ b/tests/cli_coverage_range_integration.rs
@@ -1,0 +1,335 @@
+//! Integration tests for `--min-coverage` / `--max-coverage` (issue #63).
+//!
+//! Wires CLI flags through `cli::view_args::validate_view_args` and
+//! `cli::view_args::build_view_spec` into `domain::view::Filters::coverage_range`.
+//! `CoverageRange::new` (V1a) is the single source of truth for validity;
+//! the CLI translates each domain error variant to flag-attributed prose.
+
+use std::path::Path;
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_crap4rs");
+
+fn setup_dir(dir: &Path, src_content: &str, lcov_content: &str) {
+    let src = dir.join("src");
+    std::fs::create_dir_all(&src).expect("create src dir");
+    std::fs::write(src.join("lib.rs"), src_content).expect("write lib.rs fixture");
+    std::fs::write(dir.join("lcov.info"), lcov_content).expect("write lcov.info fixture");
+}
+
+fn run(dir: &Path, extra_args: &[&str]) -> std::process::Output {
+    Command::new(BINARY)
+        .current_dir(dir)
+        .args(["--coverage", "lcov.info", "--src", "src"])
+        .args(extra_args)
+        .output()
+        .expect("failed to run crap4rs binary")
+}
+
+fn stdout_str(output: &std::process::Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn stderr_str(output: &std::process::Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+fn parse_json(output: &std::process::Output) -> serde_json::Value {
+    let out = stdout_str(output);
+    serde_json::from_str(&out)
+        .unwrap_or_else(|e| panic!("stdout was not valid JSON: {e}\nraw stdout:\n{out}"))
+}
+
+/// 6-function fixture mirroring `view_integration::ONLY_FAILING_*`.
+/// Lines 1–3 fully covered; lines 4–6 uncovered.
+const FIXTURE_SRC: &str = "\
+pub fn passing_a() -> i32 { 1 }
+pub fn passing_b() -> i32 { 2 }
+pub fn passing_c() -> i32 { 3 }
+pub fn failing_a(x: i32) -> i32 { if x > 0 { if x > 5 { 1 } else { 2 } } else { 3 } }
+pub fn failing_b(x: i32) -> i32 { if x > 0 { if x > 5 { 1 } else { 2 } } else { 3 } }
+pub fn failing_c(x: i32) -> i32 { if x > 0 { if x > 5 { 1 } else { 2 } } else { 3 } }
+";
+
+const FIXTURE_LCOV: &str = "\
+SF:lib.rs
+DA:1,1
+DA:2,1
+DA:3,1
+DA:4,0
+DA:5,0
+DA:6,0
+end_of_record
+";
+
+// ── Happy path: --min-coverage filters and the JSON shape carries the range ──
+
+#[test]
+fn min_coverage_filters_uncovered_functions() {
+    // cli_ergonomics.feature:78-81. With --min-coverage 1, the 3 fully-uncovered
+    // (cov=0.0) functions must drop out of `view.shown`. The JSON envelope
+    // declares the resolved range as `{ "min": 1.0, "max": 100.0 }`.
+    let dir = tempfile::tempdir().unwrap();
+    setup_dir(dir.path(), FIXTURE_SRC, FIXTURE_LCOV);
+
+    let output = run(
+        dir.path(),
+        &[
+            "--threshold",
+            "5",
+            "--format",
+            "json",
+            "--no-gitignore",
+            "--min-coverage",
+            "1",
+        ],
+    );
+    assert_ne!(
+        output.status.code(),
+        Some(2),
+        "validation should pass: stderr:\n{}",
+        stderr_str(&output)
+    );
+    let v = parse_json(&output);
+
+    let shown = v["view"]["shown"].as_array().expect("view.shown array");
+    for entry in shown {
+        let cov = entry["scored"]["coverage_percent"].as_f64().unwrap();
+        assert!(
+            cov >= 1.0,
+            "every shown function must have coverage >= 1.0; got {cov}"
+        );
+    }
+
+    let range = &v["view"]["spec"]["filters"]["coverage_range"];
+    assert!(!range.is_null(), "coverage_range must be present");
+    assert_eq!(range["min"].as_f64(), Some(1.0));
+    assert_eq!(range["max"].as_f64(), Some(100.0));
+}
+
+#[test]
+fn max_coverage_zero_surfaces_only_untested_functions() {
+    // cli_ergonomics.feature:83-86. With --max-coverage 0, only fully-uncovered
+    // (cov=0.0) functions remain. JSON resolved range is `{ "min": 0, "max": 0 }`.
+    let dir = tempfile::tempdir().unwrap();
+    setup_dir(dir.path(), FIXTURE_SRC, FIXTURE_LCOV);
+
+    let output = run(
+        dir.path(),
+        &[
+            "--threshold",
+            "5",
+            "--format",
+            "json",
+            "--no-gitignore",
+            "--max-coverage",
+            "0",
+        ],
+    );
+    assert_ne!(
+        output.status.code(),
+        Some(2),
+        "validation should pass: stderr:\n{}",
+        stderr_str(&output)
+    );
+    let v = parse_json(&output);
+
+    let shown = v["view"]["shown"].as_array().expect("view.shown array");
+    for entry in shown {
+        let cov = entry["scored"]["coverage_percent"].as_f64().unwrap();
+        assert_eq!(cov, 0.0, "--max-coverage 0 must keep only cov=0 rows");
+    }
+
+    let range = &v["view"]["spec"]["filters"]["coverage_range"];
+    assert_eq!(range["min"].as_f64(), Some(0.0));
+    assert_eq!(range["max"].as_f64(), Some(0.0));
+}
+
+#[test]
+fn combining_min_and_max_targets_partial_coverage() {
+    // cli_ergonomics.feature:92-95. Both bounds explicit.
+    let dir = tempfile::tempdir().unwrap();
+    setup_dir(dir.path(), FIXTURE_SRC, FIXTURE_LCOV);
+
+    let output = run(
+        dir.path(),
+        &[
+            "--threshold",
+            "5",
+            "--format",
+            "json",
+            "--no-gitignore",
+            "--min-coverage",
+            "1",
+            "--max-coverage",
+            "90",
+        ],
+    );
+    assert_ne!(
+        output.status.code(),
+        Some(2),
+        "validation should pass: stderr:\n{}",
+        stderr_str(&output)
+    );
+    let v = parse_json(&output);
+
+    let range = &v["view"]["spec"]["filters"]["coverage_range"];
+    assert_eq!(range["min"].as_f64(), Some(1.0));
+    assert_eq!(range["max"].as_f64(), Some(90.0));
+}
+
+#[test]
+fn no_coverage_flags_leaves_range_null() {
+    // cli_ergonomics.feature:204-205 — view.filters.coverage_range is null
+    // on default invocation (no bound passed).
+    let dir = tempfile::tempdir().unwrap();
+    setup_dir(dir.path(), FIXTURE_SRC, FIXTURE_LCOV);
+
+    let output = run(
+        dir.path(),
+        &["--threshold", "5", "--format", "json", "--no-gitignore"],
+    );
+    assert_ne!(
+        output.status.code(),
+        Some(2),
+        "default invocation should not error: stderr:\n{}",
+        stderr_str(&output)
+    );
+    let v = parse_json(&output);
+
+    assert!(
+        v["view"]["spec"]["filters"]["coverage_range"].is_null(),
+        "default invocation must leave coverage_range null"
+    );
+}
+
+// ── Validation errors → exit 2 with flag-attributed prose ──
+
+#[test]
+fn min_out_of_range_negative_exits_2() {
+    // cli_ergonomics.feature:104.
+    let dir = tempfile::tempdir().unwrap();
+    setup_dir(dir.path(), FIXTURE_SRC, FIXTURE_LCOV);
+
+    let output = run(dir.path(), &["--no-gitignore", "--min-coverage", "-5"]);
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = stderr_str(&output);
+    assert!(
+        stderr.contains("--min-coverage must be in [0, 100]"),
+        "expected `--min-coverage must be in [0, 100]` in stderr; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn max_out_of_range_above_100_exits_2() {
+    // cli_ergonomics.feature:105.
+    let dir = tempfile::tempdir().unwrap();
+    setup_dir(dir.path(), FIXTURE_SRC, FIXTURE_LCOV);
+
+    let output = run(dir.path(), &["--no-gitignore", "--max-coverage", "105"]);
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = stderr_str(&output);
+    assert!(
+        stderr.contains("--max-coverage must be in [0, 100]"),
+        "expected `--max-coverage must be in [0, 100]` in stderr; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn min_exceeds_max_exits_2() {
+    // cli_ergonomics.feature:106.
+    let dir = tempfile::tempdir().unwrap();
+    setup_dir(dir.path(), FIXTURE_SRC, FIXTURE_LCOV);
+
+    let output = run(
+        dir.path(),
+        &[
+            "--no-gitignore",
+            "--min-coverage",
+            "90",
+            "--max-coverage",
+            "30",
+        ],
+    );
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = stderr_str(&output);
+    assert!(
+        stderr.contains("--min-coverage must not exceed --max-coverage"),
+        "expected `--min-coverage must not exceed --max-coverage` in stderr; got:\n{stderr}"
+    );
+}
+
+// ── Filter hiding violations does NOT change the gate (exit code) ──
+
+#[test]
+fn filter_hiding_violations_still_exits_1() {
+    // cli_ergonomics.feature:108-111 — keystone: gate is unshapeable.
+    // --min-coverage 99 hides every failing row from the view, yet
+    // result.passed (the gate) reflects the unfiltered analysis.
+    let dir = tempfile::tempdir().unwrap();
+    setup_dir(dir.path(), FIXTURE_SRC, FIXTURE_LCOV);
+
+    let output = run(
+        dir.path(),
+        &["--threshold", "5", "--no-gitignore", "--min-coverage", "99"],
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "filter hiding violations must NOT flip the gate to exit 0; stderr:\n{}",
+        stderr_str(&output)
+    );
+}
+
+// ── --only-failing composes with --min-coverage as AND (W2 composition test) ──
+
+#[test]
+fn only_failing_composes_with_min_coverage_as_and() {
+    // cli_ergonomics.feature:195-197. Composes V1b's --only-failing with
+    // V2.2's --min-coverage. Every shown row must satisfy BOTH predicates.
+    // Fixture: 3 passing (CRAP < 5, fully covered) and 3 failing (uncovered).
+    // --only-failing --min-coverage 50 should produce zero shown rows
+    // (failing rows have cov=0; passing rows are excluded by only_failing).
+    let dir = tempfile::tempdir().unwrap();
+    setup_dir(dir.path(), FIXTURE_SRC, FIXTURE_LCOV);
+
+    let output = run(
+        dir.path(),
+        &[
+            "--threshold",
+            "5",
+            "--format",
+            "json",
+            "--no-gitignore",
+            "--only-failing",
+            "--min-coverage",
+            "50",
+        ],
+    );
+    assert_ne!(
+        output.status.code(),
+        Some(2),
+        "validation should pass: stderr:\n{}",
+        stderr_str(&output)
+    );
+    let v = parse_json(&output);
+
+    let shown = v["view"]["shown"].as_array().expect("view.shown array");
+    for entry in shown {
+        let exceeds = entry["exceeds"].as_bool().unwrap();
+        let cov = entry["scored"]["coverage_percent"].as_f64().unwrap();
+        assert!(exceeds, "every shown row must exceed (only_failing)");
+        assert!(
+            cov >= 50.0,
+            "every shown row must have cov >= 50; got {cov}"
+        );
+    }
+    // Both filter spec fields are reflected.
+    assert_eq!(v["view"]["spec"]["filters"]["only_failing"], true);
+    let range = &v["view"]["spec"]["filters"]["coverage_range"];
+    assert_eq!(range["min"].as_f64(), Some(50.0));
+    assert_eq!(range["max"].as_f64(), Some(100.0));
+
+    // Underlying gate still reflects threshold violations on the full set.
+    assert_eq!(v["result"]["summary"]["exceeding_threshold"], 3);
+}


### PR DESCRIPTION
## Summary

- Adds `--min-coverage` and `--max-coverage` to `FilterArgs`, wired through `cli::view_args::validate_view_args` and `build_view_spec` into `domain::view::Filters::coverage_range`.
- `CoverageRange::new` (V1a) stays the single source of truth for validity; the CLI translates each domain error variant to flag-attributed stderr prose.
- Both flags use `#[arg(allow_hyphen_values = true)]` so clap parses `--min-coverage -5` as a value (precedent: `--threshold` at `cli/mod.rs:97`). Without it, clap rejects with `UnknownArgument` and the BDD scenario at `cli_ergonomics.feature:104` would fail on the wrong error type.
- Defaulting: when only one bound is passed, the unspecified side defaults (`--min-coverage 50` ⇒ range 50–100; `--max-coverage 90` ⇒ range 0–90). Neither bound passed ⇒ `view.filters.coverage_range` stays `null`.
- The gate is unshapeable: a filter that hides every violation still exits 1, because `result.passed` derives from the unfiltered analysis (`tests/cli_coverage_range_integration.rs::filter_hiding_violations_still_exits_1`).
- W2 composition coverage: `--only-failing --min-coverage` AND-composes (every shown row exceeds AND has cov ≥ min).

Wave 2 / Task 2.2 — first of four sequential W2 tasks per the impl plan (`crap4rs/20260425-cli-presentation-view`). This task creates the `validate_view_args` plumbing that #62, #68, and #65 inherit.

## Test plan

- [x] `tests/cli_coverage_range_integration.rs` — 9 new scenarios from `cli_ergonomics.feature` lines 78–111 + 195–197:
  - `min_coverage_filters_uncovered_functions`
  - `max_coverage_zero_surfaces_only_untested_functions`
  - `combining_min_and_max_targets_partial_coverage`
  - `no_coverage_flags_leaves_range_null`
  - `min_out_of_range_negative_exits_2`
  - `max_out_of_range_above_100_exits_2`
  - `min_exceeds_max_exits_2`
  - `filter_hiding_violations_still_exits_1`
  - `only_failing_composes_with_min_coverage_as_and` *(W2 composition test)*
- [x] Existing 481 tests — all still pass (490/490 total).
- [x] `cargo fmt --check` clean.
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] Self-CRAP gate: `cargo run --release -- --coverage lcov.info --threshold 25` PASS (600 functions, 0 above threshold, worst 15.0).
- [x] `validate_view_args` CC = 5; `build_view_spec` CC = 2; `resolve_coverage_bounds` CC = 2 — all comfortably under the 15-cap (CAO-D).
- [x] `domain::view` was not touched, so the V1a mutation-testing baseline carries forward (per impl plan).

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)