### PR TITLE
feat(cli): add --top N row limit (#62)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`--top N` row limit** — truncate the displayed view to the top `N` highest-CRAP rows. `--top 0` means "no limit" (canonicalised to `null` in the JSON envelope, so consumers see effective behaviour, not the literal input). Truncating violations out of the view does not change the gate (exit code) — `result.passed` always reflects the full unfiltered analysis. JSON envelope echoes the resolved limit under `view.spec.limit` and surfaces `view.truncated` / `view.eligible_count`. (#62)
 - **`--min-coverage` / `--max-coverage` range filter** — drop functions whose `coverage_percent` falls outside `[min, max]` (inclusive). Either bound is optional; the unspecified side defaults to `0.0` or `100.0`. Invalid bounds (out-of-range or `min > max`) exit `2` with flag-attributed stderr. The full unfiltered analysis still drives the gate (exit code), so a filter that hides every violation does not change the outcome. JSON envelope echoes the resolved range under `view.filters.coverage_range`. (#63)
 
 ### Changed

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -152,6 +152,17 @@ pub struct FilterArgs {
     /// Upper bound (inclusive) on coverage_percent for the displayed view.
     #[arg(long, allow_hyphen_values = true, value_name = "PCT")]
     pub max_coverage: Option<f64>,
+
+    /// Truncate the displayed view to the top N highest-CRAP rows.
+    ///
+    /// `--top 0` means "no limit" — equivalent to omitting the flag.
+    /// The full unfiltered analysis still drives the gate (exit code),
+    /// so truncating violations out of the view does not change the outcome.
+    ///
+    /// `allow_hyphen_values`: lets clap parse `--top -3` as a value (not an
+    /// unknown flag) so the resulting error message is attributed to `--top`.
+    #[arg(long, allow_hyphen_values = true, value_name = "N")]
+    pub top: Option<u32>,
 }
 
 #[derive(Debug, Args)]

--- a/src/cli/view_args.rs
+++ b/src/cli/view_args.rs
@@ -24,6 +24,10 @@ pub(super) fn build_view_spec(cli: &Cli) -> ViewSpec {
     if let Some((lo, hi)) = resolve_coverage_bounds(cli) {
         spec.filters.coverage_range = CoverageRange::new(lo, hi).ok();
     }
+    // `Some(0)` and `None` are both "no limit" (per `domain::view::truncate_to`);
+    // canonicalise at the boundary so JSON consumers see effective behaviour
+    // rather than the user's literal input.
+    spec.limit = cli.filter.top.and_then(|n| (n > 0).then_some(n as usize));
     spec
 }
 

--- a/tests/cli_top_integration.rs
+++ b/tests/cli_top_integration.rs
@@ -1,0 +1,324 @@
+//! Integration tests for `--top N` (issue #62).
+//!
+//! Wires CLI flag through `cli::view_args::build_view_spec` into
+//! `domain::view::ViewSpec::limit`. `Some(0)` and `None` are treated
+//! identically as "no limit" by `domain::view::truncate_to`; the CLI
+//! canonicalises `--top 0` to `None` at the boundary so JSON readers
+//! see the effective behaviour rather than the user's literal input.
+
+use std::path::Path;
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_crap4rs");
+
+fn setup_dir(dir: &Path, src_content: &str, lcov_content: &str) {
+    let src = dir.join("src");
+    std::fs::create_dir_all(&src).expect("create src dir");
+    std::fs::write(src.join("lib.rs"), src_content).expect("write lib.rs fixture");
+    std::fs::write(dir.join("lcov.info"), lcov_content).expect("write lcov.info fixture");
+}
+
+fn run(dir: &Path, extra_args: &[&str]) -> std::process::Output {
+    Command::new(BINARY)
+        .current_dir(dir)
+        .args(["--coverage", "lcov.info", "--src", "src"])
+        .args(extra_args)
+        .output()
+        .expect("failed to run crap4rs binary")
+}
+
+fn stdout_str(output: &std::process::Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn stderr_str(output: &std::process::Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+fn parse_json(output: &std::process::Output) -> serde_json::Value {
+    let out = stdout_str(output);
+    serde_json::from_str(&out)
+        .unwrap_or_else(|e| panic!("stdout was not valid JSON: {e}\nraw stdout:\n{out}"))
+}
+
+/// 6-function fixture: 3 simple/covered, 3 branchy/uncovered.
+/// Mirrors `cli_coverage_range_integration::FIXTURE_*` so composition
+/// scenarios produce comparable shapes.
+const FIXTURE_SRC: &str = "\
+pub fn passing_a() -> i32 { 1 }
+pub fn passing_b() -> i32 { 2 }
+pub fn passing_c() -> i32 { 3 }
+pub fn failing_a(x: i32) -> i32 { if x > 0 { if x > 5 { 1 } else { 2 } } else { 3 } }
+pub fn failing_b(x: i32) -> i32 { if x > 0 { if x > 5 { 1 } else { 2 } } else { 3 } }
+pub fn failing_c(x: i32) -> i32 { if x > 0 { if x > 5 { 1 } else { 2 } } else { 3 } }
+";
+
+const FIXTURE_LCOV: &str = "\
+SF:lib.rs
+DA:1,1
+DA:2,1
+DA:3,1
+DA:4,0
+DA:5,0
+DA:6,0
+end_of_record
+";
+
+// ── Happy path: --top truncates and JSON shape carries the limit ──
+
+#[test]
+fn top_n_truncates_to_n_rows() {
+    // cli_ergonomics.feature:35-40. With 6 eligible functions and --top 3,
+    // view.shown collapses to 3 rows, view.truncated is true, and
+    // view.eligible_count reports the pre-truncation count.
+    let dir = tempfile::tempdir().unwrap();
+    setup_dir(dir.path(), FIXTURE_SRC, FIXTURE_LCOV);
+
+    let output = run(
+        dir.path(),
+        &[
+            "--threshold",
+            "5",
+            "--format",
+            "json",
+            "--no-gitignore",
+            "--top",
+            "3",
+        ],
+    );
+    assert_ne!(
+        output.status.code(),
+        Some(2),
+        "validation should pass: stderr:\n{}",
+        stderr_str(&output)
+    );
+    let v = parse_json(&output);
+
+    let shown = v["view"]["shown"].as_array().expect("view.shown array");
+    assert_eq!(shown.len(), 3, "shown must collapse to top 3");
+    assert_eq!(v["view"]["truncated"], true);
+    assert_eq!(v["view"]["eligible_count"], 6);
+    assert_eq!(v["view"]["spec"]["limit"].as_u64(), Some(3));
+}
+
+#[test]
+fn top_zero_is_no_limit() {
+    // view.feature:213. --top 0 means "no limit" — view.shown equals
+    // eligible_count and view.truncated is false. JSON view.spec.limit
+    // serialises as null because the CLI canonicalises 0 → None.
+    let dir = tempfile::tempdir().unwrap();
+    setup_dir(dir.path(), FIXTURE_SRC, FIXTURE_LCOV);
+
+    let output = run(
+        dir.path(),
+        &[
+            "--threshold",
+            "5",
+            "--format",
+            "json",
+            "--no-gitignore",
+            "--top",
+            "0",
+        ],
+    );
+    assert_ne!(
+        output.status.code(),
+        Some(2),
+        "--top 0 must not error: stderr:\n{}",
+        stderr_str(&output)
+    );
+    let v = parse_json(&output);
+
+    let shown = v["view"]["shown"].as_array().expect("view.shown array");
+    let eligible = v["view"]["eligible_count"].as_u64().unwrap() as usize;
+    assert_eq!(shown.len(), eligible, "--top 0 must not truncate");
+    assert_eq!(v["view"]["truncated"], false);
+    assert!(
+        v["view"]["spec"]["limit"].is_null(),
+        "--top 0 canonicalises to spec.limit = null; got {:?}",
+        v["view"]["spec"]["limit"]
+    );
+}
+
+#[test]
+fn top_greater_than_eligible_does_not_truncate() {
+    // cli_ergonomics.feature:42-45. Limit far above the eligible count
+    // is effectively no-op and must NOT mark view.truncated.
+    let dir = tempfile::tempdir().unwrap();
+    setup_dir(dir.path(), FIXTURE_SRC, FIXTURE_LCOV);
+
+    let output = run(
+        dir.path(),
+        &[
+            "--threshold",
+            "5",
+            "--format",
+            "json",
+            "--no-gitignore",
+            "--top",
+            "1000000",
+        ],
+    );
+    assert_ne!(
+        output.status.code(),
+        Some(2),
+        "stderr:\n{}",
+        stderr_str(&output)
+    );
+    let v = parse_json(&output);
+
+    let shown = v["view"]["shown"].as_array().expect("view.shown array");
+    let eligible = v["view"]["eligible_count"].as_u64().unwrap() as usize;
+    assert_eq!(shown.len(), eligible);
+    assert_eq!(v["view"]["truncated"], false);
+}
+
+#[test]
+fn no_top_flag_leaves_limit_null() {
+    // Default invocation echoes spec.limit as null (no truncation).
+    let dir = tempfile::tempdir().unwrap();
+    setup_dir(dir.path(), FIXTURE_SRC, FIXTURE_LCOV);
+
+    let output = run(
+        dir.path(),
+        &["--threshold", "5", "--format", "json", "--no-gitignore"],
+    );
+    assert_ne!(output.status.code(), Some(2));
+    let v = parse_json(&output);
+
+    assert!(
+        v["view"]["spec"]["limit"].is_null(),
+        "default invocation must leave spec.limit null; got {:?}",
+        v["view"]["spec"]["limit"]
+    );
+    assert_eq!(v["view"]["truncated"], false);
+}
+
+// ── Validation errors → exit 2 with clap's flag-attributed prose ──
+
+#[test]
+fn top_negative_exits_2() {
+    // cli_ergonomics.feature:72. --top -3 must exit 2 with a clap-attributed
+    // value error, not "unexpected argument" — that's what
+    // allow_hyphen_values = true protects.
+    let dir = tempfile::tempdir().unwrap();
+    setup_dir(dir.path(), FIXTURE_SRC, FIXTURE_LCOV);
+
+    let output = run(dir.path(), &["--no-gitignore", "--top", "-3"]);
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = stderr_str(&output);
+    assert!(
+        stderr.contains("invalid value '-3' for '--top"),
+        "expected clap value error attributed to --top; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn top_non_integer_exits_2() {
+    let dir = tempfile::tempdir().unwrap();
+    setup_dir(dir.path(), FIXTURE_SRC, FIXTURE_LCOV);
+
+    let output = run(dir.path(), &["--no-gitignore", "--top", "3.5"]);
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = stderr_str(&output);
+    assert!(
+        stderr.contains("invalid value '3.5' for '--top"),
+        "expected clap value error attributed to --top; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn top_alpha_exits_2() {
+    let dir = tempfile::tempdir().unwrap();
+    setup_dir(dir.path(), FIXTURE_SRC, FIXTURE_LCOV);
+
+    let output = run(dir.path(), &["--no-gitignore", "--top", "abc"]);
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = stderr_str(&output);
+    assert!(
+        stderr.contains("invalid value 'abc' for '--top"),
+        "expected clap value error attributed to --top; got:\n{stderr}"
+    );
+}
+
+// ── Keystone: truncating violations does NOT change the gate ──
+
+#[test]
+fn top_truncating_violations_still_exits_1() {
+    // cli_ergonomics.feature:328 — gate is unshapeable. The fixture has 3
+    // failing functions exceeding threshold 5; --top 1 hides 2 of them
+    // from the displayed view, but result.passed (the gate) reflects the
+    // full unfiltered analysis.
+    let dir = tempfile::tempdir().unwrap();
+    setup_dir(dir.path(), FIXTURE_SRC, FIXTURE_LCOV);
+
+    let output = run(
+        dir.path(),
+        &[
+            "--threshold",
+            "5",
+            "--format",
+            "json",
+            "--no-gitignore",
+            "--top",
+            "1",
+        ],
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "truncating violations must NOT flip the gate to exit 0; stderr:\n{}",
+        stderr_str(&output)
+    );
+    let v = parse_json(&output);
+    // Sanity: only one row shown, but the underlying gate counts all 3.
+    assert_eq!(v["view"]["shown"].as_array().unwrap().len(), 1);
+    assert_eq!(v["view"]["truncated"], true);
+    assert_eq!(v["result"]["summary"]["exceeding_threshold"], 3);
+}
+
+// ── Composition with --min/--max-coverage (W2 cross-flag check) ──
+
+#[test]
+fn top_composes_with_coverage_range() {
+    // cli_ergonomics.feature:224-227. Filter first (coverage range), then
+    // truncate. The fixture has 3 covered (cov=100) and 3 uncovered (cov=0)
+    // functions. `--max-coverage 90` excludes the 3 fully-covered rows;
+    // 3 remain eligible, so `--top 1` truncates from 3 to 1.
+    let dir = tempfile::tempdir().unwrap();
+    setup_dir(dir.path(), FIXTURE_SRC, FIXTURE_LCOV);
+
+    let output = run(
+        dir.path(),
+        &[
+            "--threshold",
+            "5",
+            "--format",
+            "json",
+            "--no-gitignore",
+            "--max-coverage",
+            "90",
+            "--top",
+            "1",
+        ],
+    );
+    assert_ne!(
+        output.status.code(),
+        Some(2),
+        "validation should pass: stderr:\n{}",
+        stderr_str(&output)
+    );
+    let v = parse_json(&output);
+
+    assert_eq!(
+        v["view"]["eligible_count"], 3,
+        "filter must keep 3 uncovered rows before truncate"
+    );
+    assert_eq!(
+        v["view"]["shown"].as_array().unwrap().len(),
+        1,
+        "--top 1 must truncate the 3 eligible to 1"
+    );
+    assert_eq!(v["view"]["truncated"], true);
+    assert_eq!(v["view"]["spec"]["limit"].as_u64(), Some(1));
+}


### PR DESCRIPTION
## Summary
- Add `--top N` flag that truncates the displayed view to the top N highest-CRAP rows
- `--top 0` means "no limit" (canonicalised to `null` in JSON envelope)
- Truncating violations does **not** change the gate — `result.passed` reflects the full unfiltered analysis (keystone invariant)
- `allow_hyphen_values = true` so `--top -3` produces `invalid value '-3' for '--top'` (matches BDD scenario), not `UnknownArgument`

## Implementation
- `FilterArgs.top: Option<u32>` with `allow_hyphen_values = true` (precedent: `--threshold` at `cli/mod.rs:97`, `--min/--max-coverage` from #63)
- `build_view_spec` canonicalises `Some(0)` → `None` at the boundary
- No domain-layer changes — flows entirely through V1a's existing `domain::view::ViewSpec::limit`
- No new `validate_view_args` arm needed — clap rejects malformed `--top` values at parse time

## Test plan
- [x] 9 integration tests in `tests/cli_top_integration.rs` (mirrors `cli_coverage_range_integration.rs` pattern)
  - Happy path: `top_n_truncates_to_n_rows`, `top_zero_is_no_limit`, `top_greater_than_eligible_does_not_truncate`, `no_top_flag_leaves_limit_null`
  - Validation: `top_negative_exits_2`, `top_non_integer_exits_2`, `top_alpha_exits_2`
  - Keystone: `top_truncating_violations_still_exits_1` (gate is unshapeable, owns matrix row from cli_ergonomics.feature:328)
  - Composition: `top_composes_with_coverage_range`
- [x] `cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo nextest run` — 499/499 pass
- [x] Self-CRAP gate at threshold 25: PASS, 0 functions above threshold, worst 15.0; `build_view_spec` CC=2

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* **`--top N` Flag**: Limit displayed violations to the top N highest-CRAP entries; `--top 0` treats as unlimited.
* **Coverage Range Filtering**: New `--min-coverage` and `--max-coverage` flags enable inclusive filtering of displayed violations by coverage percentage.
* **Enhanced Output**: View now includes resolved limit and truncation metadata. Exit code and pass/fail gate remain based on full unfiltered analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->