### PR TITLE
docs(cli): add investigation patterns to --help and README (V6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ crap4rs --src src/ --coverage lcov.info
 | `--verbose` | — | Print analysis diagnostics to stderr |
 | `--breakdown` | — | Show per-contributor complexity breakdown for failing functions in table output |
 | `--explain` | — | With `--breakdown`, explain nested cognitive increments in table output |
+| `--only-failing` | — | Display only functions exceeding the threshold (full analysis still drives the gate) |
+| `--top <n>` | — | Truncate the report to the top `n` highest-CRAP rows (`--top 0` means no limit) |
+| `--min-coverage <pct>` | — | Drop functions whose `coverage_percent` falls below the bound |
+| `--max-coverage <pct>` | — | Drop functions whose `coverage_percent` exceeds the bound |
+| `--sort-by <key>` | `crap` | Reorder rows by `crap`, `coverage`, `complexity`, or `path` |
+| `--no-fail` | — | Always exit `0`; `result.passed` in JSON still reflects the truthful state |
 
 Threshold presets are Rust-specific:
 
@@ -58,6 +64,24 @@ These do not match `crap4ts` exactly. The long-term goal is shared CRAP math and
 ### Why cognitive by default?
 
 Rust's `match` expressions with many arms inflate cyclomatic complexity without adding real risk. A flat 20-arm match is cyclomatic 20 but cognitive 1. Cognitive complexity better reflects actual Rust code risk.
+
+## Investigation patterns
+
+The shaping flags (`--only-failing`, `--top`, `--min-coverage`, `--max-coverage`, `--sort-by`) reorder, filter, and truncate the **displayed report** without ever touching the **underlying analysis**. The gate is unshapeable: `result.passed` and the exit code always reflect the full unfiltered codebase, so a filter that hides every violation does not change the outcome. `--no-fail` overrides only the gate-to-exit-code translation; `result.passed` in JSON still tells the truth, so consumers can detect "would have failed" even when the process exits `0`.
+
+```bash
+# First-run scan: keep the report short
+crap4rs --coverage lcov.info --top 20
+
+# Worst partially-covered functions, sorted by coverage ascending,
+# never fail the build — useful when investigating an untested codebase
+crap4rs --coverage lcov.info \
+  --min-coverage 1 --max-coverage 90 \
+  --sort-by coverage --top 10 \
+  --no-fail
+```
+
+The JSON envelope reflects the same separation: `result.*` always describes the full analysis (gate); `view.*` describes what the operator chose to see (display). An agent or dashboard can act on `result.passed`, `result.summary`, and `result.functions` while rendering only `view.shown`.
 
 ## Coverage notes
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -263,7 +263,15 @@ EXAMPLES:
   crap4rs --coverage lcov.info --threshold 15 --metric cyclomatic
   crap4rs --coverage lcov.info --format json | jq '.functions[] | select(.exceeds)'
   crap4rs --coverage lcov.info --only-failing
-  crap4rs --coverage lcov.info --exclude \"tests/**\" --exclude \"benches/**\""
+  crap4rs --coverage lcov.info --exclude \"tests/**\" --exclude \"benches/**\"
+
+INVESTIGATION PATTERNS:
+  # First-run scan: keep the report short
+  crap4rs --coverage lcov.info --top 20
+
+  # Worst partially-covered functions, sorted by coverage ascending,
+  # never fail the build — useful when investigating an untested codebase
+  crap4rs --coverage lcov.info --min-coverage 1 --max-coverage 90 --sort-by coverage --top 10 --no-fail"
 )]
 pub struct Cli {
     #[command(flatten)]


### PR DESCRIPTION
## Summary
Final task in the CLI presentation View pipeline (`crap4rs/20260425-cli-presentation-view`, Wave 3 / Task 3.1). Pure docs — no behavior change.

- `--help` after_help gains an **INVESTIGATION PATTERNS** section with two breadboard-derived examples (basic top-20 scan; full investigator flag-set with `--no-fail`).
- README **Options** table now documents every View flag added across W2 (`--only-failing`, `--top`, `--min-coverage`, `--max-coverage`, `--sort-by`, `--no-fail`).
- README **Investigation patterns** subsection frames the keystone: shaping flags reorder/filter/truncate the displayed report; the gate is unshapeable; `--no-fail` overrides only the gate-to-exit-code translation. JSON consumers act on \`result.*\`, render \`view.*\`.

## Pipeline closeout
After this PR merges, the W2 quartet is fully discoverable:
- ✅ #62 \`--top N\` (PR #87)
- ✅ #63 \`--min-coverage\` / \`--max-coverage\` (PR #86)
- ✅ #65 \`--no-fail\` (PR #89)
- ✅ #68 \`--sort-by\` (PR #88)

All issues already closed by their per-PR \`Closes #N\` lines, so this PR has no \`Closes\` directive of its own — it's the documentation closeout.

## Test plan
- [x] \`cargo fmt --check\` — clean
- [x] \`cargo clippy --all-targets -- -D warnings\` — clean
- [x] \`cargo nextest run\` — 515/515 pass (no behavior change)
- [x] Manual: \`cargo run -- --help\` renders the new EXAMPLES + INVESTIGATION PATTERNS sections cleanly
- [x] No snapshot tests on \`--help\` output exist (verified via grep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)