### PR TITLE
chore: pipeline closeout hardening — minimal-view + CI gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,3 +89,53 @@ jobs:
       - run: cargo build --release
       - name: Run crap4rs against itself
         run: ./target/release/crap4rs --coverage lcov.info --src src --strict --exclude "cli/**" --color always
+
+  self-crap-view:
+    name: domain/view.rs per-function CC <= 15
+    runs-on: ubuntu-latest
+    needs: [coverage]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions/download-artifact@v4
+        with:
+          name: lcov
+      - run: cargo build --release
+      - name: Assert max CC in src/domain/view.rs is <= 15
+        run: |
+          set -euo pipefail
+          ./target/release/crap4rs --coverage lcov.info --src src --threshold 1000 --format json > view-report.json
+          python3 - <<'PY'
+          import json, sys
+          MAX_CC = 15
+          with open("view-report.json") as fh:
+              data = json.load(fh)
+          view_fns = [
+              f for f in data["result"]["functions"]
+              if "domain/view.rs" in f["scored"]["identity"]["file_path"]
+          ]
+          offenders = [f for f in view_fns if f["scored"]["complexity"] > MAX_CC]
+          if offenders:
+              print(f"FAIL: {len(offenders)} function(s) in src/domain/view.rs exceed CC {MAX_CC}:")
+              for f in sorted(offenders, key=lambda x: x["scored"]["complexity"], reverse=True):
+                  ident = f["scored"]["identity"]
+                  print(f"  CC={f['scored']['complexity']} {ident['qualified_name']} ({ident['file_path']})")
+              sys.exit(1)
+          worst = max((f["scored"]["complexity"] for f in view_fns), default=0)
+          print(f"PASS: {len(view_fns)} fn(s) in src/domain/view.rs, worst CC={worst} (limit {MAX_CC})")
+          PY
+
+  mutants:
+    name: Mutation testing on domain/view.rs
+    runs-on: ubuntu-latest
+    needs: [test]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-mutants
+      - name: Run cargo mutants on src/domain/view.rs
+        run: cargo mutants --package crap4rs --file src/domain/view.rs --no-shuffle --in-place

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`--minimal-view` opt-in JSON shape** — omit the denormalized `view.shown` row array from JSON output for very large codebases where the per-row payload dominates. Every other view metadata key (`spec`, `eligible_count`, `truncated`, `shown_summary`) is preserved so consumers retain scope context. Default behaviour is unchanged. (#79)
 - **`--no-fail` exit-code override** — force the process to exit `0` regardless of threshold violations. The underlying analysis is untouched: `result.passed` in JSON output still reflects the truthful pass/fail state, so consumers can detect "would have failed" even when the process exits 0. Composes with `--quiet` for silent success in CI; `--quiet` alone still preserves the standard exit-1 semantics on violations. (#65)
 - **`--sort-by` choose sort dimension** — reorder the displayed view by `crap` (default, descending), `coverage` (ascending — lowest first surfaces investigation targets), `complexity` (descending), or `path` (alphabetical by file, then CRAP descending within file). Sorting reorders without reducing rows, so the gate (exit code) is unaffected and `--sort-by` alone does not render a "View:" banner in table output. Unknown values exit `2` with a clap value error attributed to `--sort-by`. JSON envelope echoes the resolved key under `view.spec.sort` as a lowercase string. (#68)
 - **`--top N` row limit** — truncate the displayed view to the top `N` highest-CRAP rows. `--top 0` means "no limit" (canonicalised to `null` in the JSON envelope, so consumers see effective behaviour, not the literal input). Truncating violations out of the view does not change the gate (exit code) — `result.passed` always reflects the full unfiltered analysis. JSON envelope echoes the resolved limit under `view.spec.limit` and surfaces `view.truncated` / `view.eligible_count`. (#62)
@@ -18,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 - `--only-failing` migrated from `OutputArgs.only_failing` (top-level `result.functions.retain`) to `FilterArgs.only_failing` flowing through `domain::view::Filters`. CLI behavior of the flag itself is unchanged.
+- **CI gates: `cargo mutants` + per-function CC ≤ 15 on `src/domain/view.rs`** — two new jobs (`mutants`, `self-crap-view`) defend the View module's mutation kill rate and complexity ceiling. Drift in either trips CI. (#83)
 
 ## [0.1.1] - 2026-04-05
 

--- a/src/adapters/reporters/json.rs
+++ b/src/adapters/reporters/json.rs
@@ -6,8 +6,10 @@
 //! reported rows were filtered, sorted, and truncated. `view.full` is
 //! `#[serde(skip)]` so the analysis is emitted exactly once.
 
-use crate::domain::types::{AnalysisDiagnostics, AnalysisResult, ComplexityMetric};
-use crate::domain::view::AnalysisView;
+use crate::domain::types::{
+    AnalysisDiagnostics, AnalysisResult, AnalysisSummary, ComplexityMetric, FunctionVerdict,
+};
+use crate::domain::view::{AnalysisView, ViewSpec};
 use serde::Serialize;
 
 /// Configuration for the JSON envelope metadata.
@@ -21,6 +23,10 @@ pub struct JsonConfig<'a> {
     pub diagnostics: Option<&'a AnalysisDiagnostics>,
     /// Git ref used for diff filtering (`--diff <ref>`). `None` when not in diff mode.
     pub diff_ref: Option<&'a str>,
+    /// When true, the per-row `view.shown` array is omitted (`--minimal-view`).
+    /// All other view metadata (`spec`, `eligible_count`, `truncated`,
+    /// `shown_summary`) is preserved so consumers retain scope context.
+    pub minimal_view: bool,
 }
 
 /// JSON envelope. Field order is **load-bearing** —
@@ -40,9 +46,40 @@ struct JsonEnvelope<'a> {
     threshold: f64,
     diff_ref: Option<&'a str>,
     result: &'a AnalysisResult,
-    view: &'a AnalysisView<'a>,
+    view: ViewWire<'a>,
     #[serde(skip_serializing_if = "Option::is_none")]
     diagnostics: Option<&'a AnalysisDiagnostics>,
+}
+
+/// On-the-wire view representation. Mirrors `AnalysisView`'s serialized
+/// shape exactly when `shown` is `Some`, so the default JSON output is
+/// byte-identical to the prior `view: &AnalysisView` serialization.
+/// `--minimal-view` sets `shown = None`, which `skip_serializing_if`
+/// elides — every other key remains for scope context.
+#[derive(Serialize)]
+struct ViewWire<'a> {
+    spec: &'a ViewSpec,
+    eligible_count: usize,
+    truncated: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    shown: Option<&'a [&'a FunctionVerdict]>,
+    shown_summary: &'a AnalysisSummary,
+}
+
+impl<'a> ViewWire<'a> {
+    fn from_view(view: &'a AnalysisView<'a>, minimal: bool) -> Self {
+        ViewWire {
+            spec: &view.spec,
+            eligible_count: view.eligible_count,
+            truncated: view.truncated,
+            shown: if minimal {
+                None
+            } else {
+                Some(view.shown.as_slice())
+            },
+            shown_summary: &view.shown_summary,
+        }
+    }
 }
 
 // Note: per-function thresholds are already visible in each FunctionVerdict's
@@ -67,7 +104,7 @@ pub fn format_json(
         threshold: config.threshold,
         diff_ref: config.diff_ref,
         result: view.full,
-        view,
+        view: ViewWire::from_view(view, config.minimal_view),
         diagnostics: config.diagnostics,
     };
     serde_json::to_string_pretty(&envelope)
@@ -87,6 +124,7 @@ mod tests {
             timestamp: "2026-03-28T12:00:00Z".to_string(),
             diagnostics: None,
             diff_ref: None,
+            minimal_view: false,
         }
     }
 
@@ -427,6 +465,7 @@ mod proptests {
             timestamp: "2026-01-01T00:00:00Z".to_string(),
             diagnostics: None,
             diff_ref: None,
+            minimal_view: false,
         })
     }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -142,6 +142,16 @@ pub struct OutputArgs {
     /// `--quiet` for silent success in CI.
     #[arg(long)]
     pub no_fail: bool,
+
+    /// Omit the denormalized `view.shown` row array from JSON output.
+    ///
+    /// Payload-size escape hatch for very large codebases. The
+    /// envelope's `result` block (the gate) is unaffected; `view.spec`,
+    /// `view.eligible_count`, `view.truncated`, and `view.shown_summary`
+    /// remain so consumers retain full scope context. Only meaningful
+    /// with `--format json`.
+    #[arg(long)]
+    pub minimal_view: bool,
 }
 
 #[derive(Debug, Args)]
@@ -383,6 +393,7 @@ fn run_inner() -> Result<bool> {
                     timestamp: now_unix_epoch(),
                     diagnostics: cli.display.verbose.then_some(&analysis.diagnostics),
                     diff_ref: cli.filter.diff.as_deref(),
+                    minimal_view: cli.output.minimal_view,
                 };
                 reporters::format_json(&view, &config)?
             }

--- a/tests/cli_minimal_view_integration.rs
+++ b/tests/cli_minimal_view_integration.rs
@@ -1,0 +1,152 @@
+//! Integration tests for `--minimal-view` (issue #79).
+//!
+//! `--minimal-view` is a payload-size escape hatch for very large
+//! codebases. When set, the JSON envelope omits `view.shown` (the
+//! denormalized per-row array) but keeps every other view metadata
+//! key — `spec`, `eligible_count`, `truncated`, `shown_summary` —
+//! so consumers retain full scope context. The flag is opt-in;
+//! default behavior is unchanged.
+
+use std::path::Path;
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_crap4rs");
+
+fn setup_dir(dir: &Path, src_content: &str, lcov_content: &str) {
+    let src = dir.join("src");
+    std::fs::create_dir_all(&src).expect("create src dir");
+    std::fs::write(src.join("lib.rs"), src_content).expect("write lib.rs fixture");
+    std::fs::write(dir.join("lcov.info"), lcov_content).expect("write lcov.info fixture");
+}
+
+fn run(dir: &Path, extra_args: &[&str]) -> std::process::Output {
+    Command::new(BINARY)
+        .current_dir(dir)
+        .args(["--coverage", "lcov.info", "--src", "src"])
+        .args(extra_args)
+        .output()
+        .expect("failed to run crap4rs binary")
+}
+
+fn parse_json(output: &std::process::Output) -> serde_json::Value {
+    let out = String::from_utf8_lossy(&output.stdout).into_owned();
+    serde_json::from_str(&out)
+        .unwrap_or_else(|e| panic!("stdout was not valid JSON: {e}\nraw stdout:\n{out}"))
+}
+
+/// 6-function fixture: 3 simple/covered, 3 branchy/uncovered.
+const FIXTURE_SRC: &str = "\
+pub fn passing_a() -> i32 { 1 }
+pub fn passing_b() -> i32 { 2 }
+pub fn passing_c() -> i32 { 3 }
+pub fn failing_a(x: i32) -> i32 { if x > 0 { if x > 5 { 1 } else { 2 } } else { 3 } }
+pub fn failing_b(x: i32) -> i32 { if x > 0 { if x > 5 { 1 } else { 2 } } else { 3 } }
+pub fn failing_c(x: i32) -> i32 { if x > 0 { if x > 5 { 1 } else { 2 } } else { 3 } }
+";
+
+const FIXTURE_LCOV: &str = "\
+SF:lib.rs
+DA:1,1
+DA:2,1
+DA:3,1
+DA:4,0
+DA:5,0
+DA:6,0
+end_of_record
+";
+
+#[test]
+fn minimal_view_omits_shown_array() {
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    setup_dir(tmp.path(), FIXTURE_SRC, FIXTURE_LCOV);
+
+    let output = run(
+        tmp.path(),
+        &[
+            "--threshold",
+            "5",
+            "--no-gitignore",
+            "--no-fail",
+            "--minimal-view",
+            "--format",
+            "json",
+        ],
+    );
+    assert_eq!(output.status.code(), Some(0), "--no-fail forces exit 0");
+
+    let json = parse_json(&output);
+    let view = json["view"]
+        .as_object()
+        .expect("view must be a JSON object even under --minimal-view");
+    assert!(
+        !view.contains_key("shown"),
+        "--minimal-view must omit the `shown` array; keys: {:?}",
+        view.keys().collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn minimal_view_preserves_scope_context() {
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    setup_dir(tmp.path(), FIXTURE_SRC, FIXTURE_LCOV);
+
+    let output = run(
+        tmp.path(),
+        &[
+            "--threshold",
+            "5",
+            "--no-gitignore",
+            "--no-fail",
+            "--minimal-view",
+            "--format",
+            "json",
+        ],
+    );
+    let json = parse_json(&output);
+    let view = json["view"].as_object().expect("view object");
+
+    for key in ["spec", "eligible_count", "truncated", "shown_summary"] {
+        assert!(
+            view.contains_key(key),
+            "--minimal-view must preserve `{key}` so consumers keep scope context; \
+             actual keys: {:?}",
+            view.keys().collect::<Vec<_>>()
+        );
+    }
+
+    // result.passed must remain truthful — gate is unshapeable.
+    assert_eq!(
+        json["result"]["passed"].as_bool(),
+        Some(false),
+        "result.passed must remain false (gate is unshapeable)"
+    );
+}
+
+#[test]
+fn default_invocation_includes_shown() {
+    // Regression: without --minimal-view, the envelope still carries
+    // `view.shown` exactly as before. This guards against accidental
+    // tightening of the default JSON shape.
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    setup_dir(tmp.path(), FIXTURE_SRC, FIXTURE_LCOV);
+
+    let output = run(
+        tmp.path(),
+        &[
+            "--threshold",
+            "5",
+            "--no-gitignore",
+            "--no-fail",
+            "--format",
+            "json",
+        ],
+    );
+    let json = parse_json(&output);
+    let shown = json["view"]["shown"]
+        .as_array()
+        .expect("default invocation must include `view.shown` as an array");
+    assert!(
+        !shown.is_empty(),
+        "fixture has 6 functions; default `view.shown` should not be empty"
+    );
+}

--- a/tests/diff_integration.rs
+++ b/tests/diff_integration.rs
@@ -572,6 +572,7 @@ fn json_envelope_contains_diff_ref() {
         timestamp: "2026-03-29T00:00:00Z".to_string(),
         diagnostics: None,
         diff_ref: Some("HEAD"),
+        minimal_view: false,
     };
     let view = crap4rs::domain::view::apply(&result, crap4rs::domain::view::ViewSpec::default());
     let json_str = reporters::format_json(&view, &config).unwrap();
@@ -605,6 +606,7 @@ fn json_envelope_diff_ref_null_without_flag() {
         timestamp: "2026-03-29T00:00:00Z".to_string(),
         diagnostics: None,
         diff_ref: None,
+        minimal_view: false,
     };
     let view = crap4rs::domain::view::apply(&result, crap4rs::domain::view::ViewSpec::default());
     let json_str = reporters::format_json(&view, &config).unwrap();


### PR DESCRIPTION
## Summary

Bundle A from the [`20260425-cli-presentation-view`](https://github.com/breezy-bays-labs/crap4rs/issues/78) closeout: the two follow-ups that **harden what the V1a–V6 pipeline shipped**. Single PR, two issues.

- **#79 `--minimal-view`** — opt-in JSON shape that omits the denormalized `view.shown` array for very large codebases. Every other view metadata key (`spec`, `eligible_count`, `truncated`, `shown_summary`) is preserved so consumers retain scope context. Default JSON output is byte-identical to before.
- **#83 CI gates** — two new jobs defend the View module from drift:
  - `mutants` — `cargo mutants --package crap4rs --file src/domain/view.rs --no-shuffle --in-place` (preserves V1a's 100% kill rate).
  - `self-crap-view` — asserts no function in `src/domain/view.rs` exceeds CC 15 by parsing the binary's JSON output.

## Why now

These closed out the V1a/V6 wave: `--minimal-view` was reserved by ADR D7 as the payload-size escape hatch, and the mutation + CC≤15 gates were asserted in V1a's PR acceptance but only enforced manually. Bundling tightens the cohesion ("harden what's built") and keeps reviewer scope small.

## Implementation

- `OutputArgs.minimal_view: bool` flag (`--minimal-view`).
- `JsonConfig.minimal_view: bool` threaded through `format_json`.
- `ViewWire<'a>` newtype in `src/adapters/reporters/json.rs` mirrors `AnalysisView`'s serialized shape exactly when `shown = Some(...)`, then `skip_serializing_if` elides it when `None`. Domain (`src/domain/view.rs`) is **not touched** — minimal-view is purely a wire-format concern.
- 3 new integration tests in `tests/cli_minimal_view_integration.rs`:
  - `minimal_view_omits_shown_array`
  - `minimal_view_preserves_scope_context`
  - `default_invocation_includes_shown` (regression)
- ADR D7 closeout note appended (F8 from manual follow-ups): `view::apply` is the public domain entry point; `--minimal-view` is the documented payload-size escape hatch.

## Quality gates

- `cargo fmt --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo nextest run` ✅ — **518 passing** (up from 515 by the 3 new tests).
- Self-CRAP gate at `--threshold 25` ✅ — 602 functions, 0 above threshold, max CC in `src/domain/view.rs` = 5 (limit 15).
- Mutation gate **skipped** locally — no `domain::view` change. CI's new `mutants` job will run it on this PR.
- `full_json_snapshot.snap` **not regenerated** — the `ViewWire` ordering matches `AnalysisView`'s field order, so default JSON is byte-identical.

## Test plan

- [x] `cargo nextest run --test cli_minimal_view_integration` — 3/3 pass
- [x] `cargo nextest run` — 518/518 pass
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] Self-CRAP gate at threshold 25 — pass (worst CRAP 16.0, 0 above threshold)

Closes #79
Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)