### PR TITLE
feat(action): CRAP scorecard composite action (#75)

### DIFF
--- a/.github/actions/scorecard/README.md
+++ b/.github/actions/scorecard/README.md
@@ -1,0 +1,156 @@
+# `crap-scorecard` action
+
+Runs `crap4rs` on a coverage file and emits a markdown scorecard. Composable
+into aggregator PR-comment bots; can also post its own sticky comment.
+
+## Why composite, not standalone
+
+The scorecard is one row in a richer "PR metrics" comment (mokumo's
+[#650](https://github.com/breezy-bays-labs/mokumo/issues/650) for example
+combines coverage, CRAP, mutation, module size, architecture violations).
+This action exposes the rendered markdown as an **output** so an aggregator
+job can drop it into a larger sticky comment without two bots fighting over
+the same comment.
+
+For repos that only care about CRAP, set `comment-mode: sticky` and the
+action manages its own sticky comment.
+
+## Languages
+
+Polyglot interface, Rust wired today. TypeScript (via `crap4ts`) is reserved
+for a future release of this action — see ops
+[#231](https://github.com/breezy-bays-labs/ops/issues/231).
+
+```yaml
+- uses: breezy-bays-labs/crap4rs/.github/actions/scorecard@v0.3.0
+  with:
+    language: auto                 # rust | typescript | auto (infers from extension)
+    coverage: lcov.info
+```
+
+## Minimal usage — analysis only, no delta
+
+```yaml
+- uses: actions/checkout@v4
+- run: cargo llvm-cov --workspace --lcov --output-path lcov.info
+- uses: breezy-bays-labs/crap4rs/.github/actions/scorecard@v0.3.0
+  id: crap
+  with:
+    coverage: lcov.info
+    threshold: '15'
+- run: echo "${{ steps.crap.outputs.markdown }}"
+```
+
+## Standalone PR-comment bot — analysis + baseline + sticky
+
+The caller is responsible for producing the baseline JSON envelope (typically
+a coverage run on the PR base). This action does **not** auto-checkout the
+base ref — that's a deliberate boundary. CI orchestrates two passes; the
+analyzer doesn't reach into git.
+
+```yaml
+permissions:
+  pull-requests: write   # required for sticky comments
+
+jobs:
+  scorecard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # need both refs for the base coverage run
+
+      # 1. Run coverage on the PR base, capture the JSON envelope.
+      - name: Capture baseline
+        run: |
+          git switch --detach origin/${{ github.base_ref }}
+          cargo llvm-cov --workspace --lcov --output-path /tmp/base.lcov
+          cargo install --locked crap4rs
+          crap4rs --coverage /tmp/base.lcov --src . --format json --no-fail > /tmp/baseline.json
+          git switch -
+
+      # 2. Run coverage on HEAD.
+      - name: Capture HEAD coverage
+        run: cargo llvm-cov --workspace --lcov --output-path /tmp/head.lcov
+
+      # 3. Render the scorecard, post sticky comment.
+      - uses: breezy-bays-labs/crap4rs/.github/actions/scorecard@v0.3.0
+        with:
+          coverage: /tmp/head.lcov
+          baseline: /tmp/baseline.json
+          threshold: '15'
+          delta-gate: 'false'        # measurement, not gating
+          comment-mode: 'sticky'
+          comment-header: 'crap-scorecard'
+```
+
+## Aggregator pattern — one row of a richer metrics comment
+
+Mokumo's metrics-delta bot wants coverage + CRAP + mutation + module size in
+one sticky comment. This action contributes the CRAP rows; the aggregator
+owns the comment.
+
+```yaml
+- uses: breezy-bays-labs/crap4rs/.github/actions/scorecard@v0.3.0
+  id: crap
+  with:
+    coverage: /tmp/head.lcov
+    baseline: /tmp/baseline.json
+    comment-mode: 'none'           # outputs only — no comment of our own
+
+- uses: ./.github/actions/coverage-delta
+  id: coverage
+  # ... whatever your coverage-delta step is
+
+- name: Post combined metrics comment
+  uses: marocchino/sticky-pull-request-comment@v2
+  with:
+    header: 'pr-metrics'
+    message: |
+      ## PR metrics
+
+      ### Coverage
+      ${{ steps.coverage.outputs.markdown }}
+
+      ${{ steps.crap.outputs.markdown }}
+```
+
+## Inputs
+
+| Name | Default | Notes |
+|---|---|---|
+| `language` | `auto` | `rust`, `typescript`, or `auto` (infer from coverage extension) |
+| `coverage` | (required) | Path to LCOV (`.info`) for Rust, Istanbul JSON for TS |
+| `src` | `.` | Source root passed to the analyzer |
+| `baseline` | `''` | Path to a previously-captured CRAP JSON envelope. Empty = no delta |
+| `threshold` | `15` | Threshold for violations |
+| `config` | `''` | Path to `crap4rs.toml` |
+| `delta-gate` | `false` | Exit non-zero on new violations (only when baseline supplied) |
+| `analysis-gate` | `false` | Exit non-zero if the analysis itself fails |
+| `comment-mode` | `none` | `none` (outputs only) or `sticky` (post/update sticky comment) |
+| `comment-header` | `crap-scorecard` | Sticky-comment identifier |
+| `version` | `latest` | crap4rs version to install (`latest` or pinned tag) |
+
+## Outputs
+
+| Name | Notes |
+|---|---|
+| `markdown` | The rendered scorecard — drop into aggregator comments |
+| `json-envelope-path` | Path to the full JSON envelope on the runner |
+| `analysis-passed` | `true` / `false` |
+| `delta-passed` | `true` / `false`, or empty string when no baseline |
+| `new-violations` | Count of functions exceeding threshold but not in baseline |
+| `regressions` | Count of modified functions whose CRAP increased above rendering precision |
+
+## Design notes
+
+- **Baseline source is the caller's choice.** Auto-checkout-and-cache is a
+  natural future enhancement (artifact cache keyed on base SHA), but the
+  v1 contract keeps orchestration explicit because that's what made the
+  v0.2.0 baseline design clean: the analyzer never reaches into git.
+- **Measurement-first.** Both gates default off. The action's primary value
+  is the scorecard string; gates are opt-in for repos that want hard CI
+  failures.
+- **`comment-mode` separates plumbing from content.** The same scorecard
+  string serves standalone bots and aggregators — only the post step
+  changes.

--- a/.github/actions/scorecard/README.md
+++ b/.github/actions/scorecard/README.md
@@ -22,7 +22,7 @@ for a future release of this action — see ops
 [#231](https://github.com/breezy-bays-labs/ops/issues/231).
 
 ```yaml
-- uses: breezy-bays-labs/crap4rs/.github/actions/scorecard@v0.3.0
+- uses: breezy-bays-labs/crap4rs/.github/actions/scorecard@main
   with:
     language: auto                 # rust | typescript | auto (infers from extension)
     coverage: lcov.info
@@ -33,7 +33,7 @@ for a future release of this action — see ops
 ```yaml
 - uses: actions/checkout@v4
 - run: cargo llvm-cov --workspace --lcov --output-path lcov.info
-- uses: breezy-bays-labs/crap4rs/.github/actions/scorecard@v0.3.0
+- uses: breezy-bays-labs/crap4rs/.github/actions/scorecard@main
   id: crap
   with:
     coverage: lcov.info
@@ -74,7 +74,7 @@ jobs:
         run: cargo llvm-cov --workspace --lcov --output-path /tmp/head.lcov
 
       # 3. Render the scorecard, post sticky comment.
-      - uses: breezy-bays-labs/crap4rs/.github/actions/scorecard@v0.3.0
+      - uses: breezy-bays-labs/crap4rs/.github/actions/scorecard@main
         with:
           coverage: /tmp/head.lcov
           baseline: /tmp/baseline.json
@@ -91,7 +91,7 @@ one sticky comment. This action contributes the CRAP rows; the aggregator
 owns the comment.
 
 ```yaml
-- uses: breezy-bays-labs/crap4rs/.github/actions/scorecard@v0.3.0
+- uses: breezy-bays-labs/crap4rs/.github/actions/scorecard@main
   id: crap
   with:
     coverage: /tmp/head.lcov
@@ -141,6 +141,21 @@ owns the comment.
 | `delta-passed` | `true` / `false`, or empty string when no baseline |
 | `new-violations` | Count of functions exceeding threshold but not in baseline |
 | `regressions` | Count of modified functions whose CRAP increased above rendering precision |
+
+## Pinning
+
+Examples above use `@main` for clarity. **Pin to a commit SHA in production
+workflows** so a regression in the action can't break your CI without you
+noticing:
+
+```yaml
+uses: breezy-bays-labs/crap4rs/.github/actions/scorecard@<sha>
+```
+
+When the action is folded into the future
+[crap monorepo](https://github.com/breezy-bays-labs/ops/issues/231) it'll get
+a Marketplace listing with proper version tags; for now `@main` is the only
+moving ref and SHA-pinning is the safe default.
 
 ## Design notes
 

--- a/.github/actions/scorecard/action.yml
+++ b/.github/actions/scorecard/action.yml
@@ -1,0 +1,226 @@
+name: 'CRAP Scorecard'
+description: 'Run CRAP analysis with optional baseline delta and emit a markdown scorecard composable into PR-comment bots.'
+author: 'Breezy Bays Labs'
+branding:
+  icon: 'activity'
+  color: 'orange'
+
+inputs:
+  language:
+    description: |
+      Language to analyze. `rust` runs crap4rs over an LCOV file. `typescript`
+      is reserved for crap4ts integration (coming in a future release of this
+      action). `auto` (default) infers from the `coverage` file extension:
+      `.info` -> rust, `.json` (Istanbul) -> typescript.
+    required: false
+    default: 'auto'
+  coverage:
+    description: 'Path to the coverage file. LCOV (.info) for Rust, Istanbul JSON for TypeScript.'
+    required: true
+  src:
+    description: 'Source root directory passed to the analyzer.'
+    required: false
+    default: '.'
+  baseline:
+    description: |
+      Path to a previously-captured CRAP JSON envelope to compare against.
+      Leave empty to skip delta and emit an analysis-only scorecard. Producing
+      the baseline (typically a coverage run on the PR base) is the caller's
+      responsibility — this action does not auto-checkout, by design.
+    required: false
+    default: ''
+  threshold:
+    description: 'CRAP threshold — functions above this are violations.'
+    required: false
+    default: '15'
+  config:
+    description: 'Optional path to a crap4rs.toml config file.'
+    required: false
+    default: ''
+  delta-gate:
+    description: |
+      When `true` and a baseline is provided, the action exits non-zero if any
+      new threshold violations land. The markdown scorecard is still emitted as
+      an output. Independent of `analysis-gate`.
+    required: false
+    default: 'false'
+  analysis-gate:
+    description: |
+      When `true`, the action exits non-zero if the analysis itself fails the
+      threshold. Default `false` keeps the action measurement-only — callers
+      who want hard gates run a separate `crap4rs` step or set this true.
+    required: false
+    default: 'false'
+  comment-mode:
+    description: |
+      `none` (default): outputs only — composable into aggregator bots like
+      mokumo's metrics-delta comment.
+      `sticky`: post/update a sticky PR comment using
+      marocchino/sticky-pull-request-comment. Requires `pull-requests: write`
+      on the calling job.
+    required: false
+    default: 'none'
+  comment-header:
+    description: |
+      Sticky-comment identifier when `comment-mode: sticky`. Multiple actions
+      can post distinct sticky comments by varying this header.
+    required: false
+    default: 'crap-scorecard'
+  version:
+    description: |
+      `crap4rs` version to install. `latest` (default) resolves to the most
+      recent release. Pin to a tag (e.g. `0.2.1`) for reproducible CI.
+    required: false
+    default: 'latest'
+
+outputs:
+  markdown:
+    description: 'The rendered markdown scorecard. Consume directly in aggregator bots.'
+    value: ${{ steps.run.outputs.markdown }}
+  json-envelope-path:
+    description: 'Path to the full JSON envelope on the runner — pass to downstream tooling.'
+    value: ${{ steps.run.outputs.envelope_path }}
+  analysis-passed:
+    description: '`true` if the analysis itself passed the threshold.'
+    value: ${{ steps.run.outputs.analysis_passed }}
+  delta-passed:
+    description: '`true` if a baseline was supplied and no new violations landed. Empty string when no baseline was supplied.'
+    value: ${{ steps.run.outputs.delta_passed }}
+  new-violations:
+    description: 'Count of functions that exceed the threshold but did not in the baseline. `0` when no baseline.'
+    value: ${{ steps.run.outputs.new_violations }}
+  regressions:
+    description: 'Count of modified functions whose CRAP score increased above the rendering precision threshold. `0` when no baseline.'
+    value: ${{ steps.run.outputs.regressions }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Resolve language
+      id: lang
+      shell: bash
+      env:
+        LANGUAGE: ${{ inputs.language }}
+        COVERAGE: ${{ inputs.coverage }}
+      run: |
+        set -euo pipefail
+        resolved="$LANGUAGE"
+        if [ "$resolved" = "auto" ]; then
+          case "$COVERAGE" in
+            *.info|*.lcov) resolved="rust" ;;
+            *.json)        resolved="typescript" ;;
+            *) echo "::error::cannot infer language from coverage path '$COVERAGE'; set inputs.language explicitly"; exit 1 ;;
+          esac
+        fi
+        echo "language=$resolved" >> "$GITHUB_OUTPUT"
+        echo "Resolved language: $resolved"
+
+    - name: Reject TypeScript (not yet wired)
+      if: steps.lang.outputs.language == 'typescript'
+      shell: bash
+      run: |
+        echo "::error::TypeScript scoring is not yet wired in this action."
+        echo "::error::Track progress at https://github.com/breezy-bays-labs/ops/issues/231"
+        echo "::error::For now, run crap4ts directly and post the markdown yourself."
+        exit 1
+
+    - name: Install cargo-binstall
+      if: steps.lang.outputs.language == 'rust'
+      uses: cargo-bins/cargo-binstall@main
+
+    - name: Install crap4rs
+      if: steps.lang.outputs.language == 'rust'
+      shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+        if [ "$VERSION" = "latest" ]; then
+          cargo binstall --no-confirm --force crap4rs
+        else
+          cargo binstall --no-confirm --force "crap4rs@$VERSION"
+        fi
+        crap4rs --version
+
+    - name: Run analysis + render scorecard
+      id: run
+      if: steps.lang.outputs.language == 'rust'
+      shell: bash
+      env:
+        COVERAGE: ${{ inputs.coverage }}
+        SRC: ${{ inputs.src }}
+        BASELINE: ${{ inputs.baseline }}
+        THRESHOLD: ${{ inputs.threshold }}
+        CONFIG: ${{ inputs.config }}
+        DELTA_GATE: ${{ inputs.delta-gate }}
+        ANALYSIS_GATE: ${{ inputs.analysis-gate }}
+      run: |
+        set -euo pipefail
+        envelope="$RUNNER_TEMP/crap4rs-envelope.json"
+        markdown_file="$RUNNER_TEMP/crap4rs-scorecard.md"
+        common=(--coverage "$COVERAGE" --src "$SRC" --threshold "$THRESHOLD")
+        [ -n "$CONFIG" ] && common+=(--config "$CONFIG")
+        if [ -n "$BASELINE" ]; then
+          common+=(--baseline "$BASELINE")
+        fi
+
+        # Always capture truth into the envelope; --no-fail keeps the step
+        # green so we can surface counts/passed status via outputs even when
+        # gates would have tripped. The hard gating happens in the dedicated
+        # gate step below, gated by the analysis-gate / delta-gate inputs.
+        crap4rs "${common[@]}" --format json --no-fail > "$envelope"
+        crap4rs "${common[@]}" --format markdown --no-fail > "$markdown_file"
+
+        # Parse the envelope. jq is preinstalled on GitHub-hosted runners.
+        analysis_passed=$(jq -r '.result.passed' "$envelope")
+        delta_passed=$(jq -r '.delta.summary.passed // ""' "$envelope")
+        new_violations=$(jq -r '.delta.summary.new_violations // 0' "$envelope")
+        regressions=$(jq -r '.delta.summary.regressions // 0' "$envelope")
+
+        echo "analysis_passed=$analysis_passed" >> "$GITHUB_OUTPUT"
+        echo "delta_passed=$delta_passed"       >> "$GITHUB_OUTPUT"
+        echo "new_violations=$new_violations"   >> "$GITHUB_OUTPUT"
+        echo "regressions=$regressions"         >> "$GITHUB_OUTPUT"
+        echo "envelope_path=$envelope"          >> "$GITHUB_OUTPUT"
+
+        # Multi-line output: file the markdown via the heredoc-delimited form.
+        {
+          echo "markdown<<__CRAP_SCORECARD_EOF__"
+          cat "$markdown_file"
+          echo "__CRAP_SCORECARD_EOF__"
+        } >> "$GITHUB_OUTPUT"
+
+        # Surface a compact summary in the job log so failures are obvious
+        # without scrolling.
+        echo "::group::CRAP scorecard"
+        cat "$markdown_file"
+        echo "::endgroup::"
+
+    - name: Post sticky PR comment
+      if: steps.lang.outputs.language == 'rust' && inputs.comment-mode == 'sticky' && github.event_name == 'pull_request'
+      uses: marocchino/sticky-pull-request-comment@v2
+      with:
+        header: ${{ inputs.comment-header }}
+        message: ${{ steps.run.outputs.markdown }}
+
+    - name: Enforce gates
+      if: steps.lang.outputs.language == 'rust'
+      shell: bash
+      env:
+        ANALYSIS_GATE: ${{ inputs.analysis-gate }}
+        DELTA_GATE: ${{ inputs.delta-gate }}
+        ANALYSIS_PASSED: ${{ steps.run.outputs.analysis_passed }}
+        DELTA_PASSED: ${{ steps.run.outputs.delta_passed }}
+      run: |
+        set -euo pipefail
+        if [ "$ANALYSIS_GATE" = "true" ] && [ "$ANALYSIS_PASSED" != "true" ]; then
+          echo "::error::analysis-gate failed: result.passed=$ANALYSIS_PASSED"
+          exit 1
+        fi
+        # delta_passed is "" when no baseline supplied; only enforce when a
+        # boolean came back.
+        if [ "$DELTA_GATE" = "true" ] && [ "$DELTA_PASSED" = "false" ]; then
+          echo "::error::delta-gate failed: new threshold violations landed"
+          exit 1
+        fi
+        echo "Gates passed (analysis-gate=$ANALYSIS_GATE delta-gate=$DELTA_GATE)"

--- a/.github/actions/scorecard/action.yml
+++ b/.github/actions/scorecard/action.yml
@@ -126,7 +126,7 @@ runs:
 
     - name: Install cargo-binstall
       if: steps.lang.outputs.language == 'rust'
-      uses: cargo-bins/cargo-binstall@main
+      uses: cargo-bins/cargo-binstall@v1.18.1
 
     - name: Install crap4rs
       if: steps.lang.outputs.language == 'rust'
@@ -135,10 +135,14 @@ runs:
         VERSION: ${{ inputs.version }}
       run: |
         set -euo pipefail
+        # No `--force`: skip reinstall if a matching version is already on
+        # PATH (e.g., from `moonrepo/setup-rust` bins or a user-supplied
+        # pre-step that prepends a workspace-local build of crap4rs onto
+        # PATH for end-to-end dogfooding).
         if [ "$VERSION" = "latest" ]; then
-          cargo binstall --no-confirm --force crap4rs
+          cargo binstall --no-confirm crap4rs
         else
-          cargo binstall --no-confirm --force "crap4rs@$VERSION"
+          cargo binstall --no-confirm "crap4rs@$VERSION"
         fi
         crap4rs --version
 
@@ -168,6 +172,13 @@ runs:
         # green so we can surface counts/passed status via outputs even when
         # gates would have tripped. The hard gating happens in the dedicated
         # gate step below, gated by the analysis-gate / delta-gate inputs.
+        #
+        # Two-pass note: we run crap4rs twice — once for JSON, once for
+        # markdown — because the analyzer doesn't yet support multi-format
+        # output in a single invocation. The cost is one extra LCOV parse +
+        # CRAP recompute (cheap relative to runner setup); the user-visible
+        # latency is dominated by `cargo binstall crap4rs` upstream. Tracked
+        # in https://github.com/breezy-bays-labs/crap4rs/issues/100.
         crap4rs "${common[@]}" --format json --no-fail > "$envelope"
         crap4rs "${common[@]}" --format markdown --no-fail > "$markdown_file"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,14 +141,60 @@ jobs:
         run: cargo mutants --package crap4rs --file src/domain/view.rs --no-shuffle --in-place
 
   scorecard-smoke:
+    # Two-layer smoke for the composite action:
+    #   (1) Run the PR's locally-built crap4rs directly against lcov.info
+    #       in JSON + markdown modes. Catches any regression in the
+    #       analyzer/renderer/envelope shape introduced by THIS PR before
+    #       it can mask itself by being installed-from-crates.io later.
+    #   (2) Exercise the composite action's wiring (input plumbing,
+    #       output emission). The action installs crap4rs via `cargo
+    #       binstall` — that path resolves to the latest published
+    #       version, so layer (1) is what guards against PR regressions
+    #       in the binary itself.
     name: Scorecard action smoke (analysis-only)
     runs-on: ubuntu-latest
     needs: [coverage]
     steps:
       - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
       - uses: actions/download-artifact@v4
         with:
           name: lcov
+
+      # Layer (1): exercise the PR's binary directly.
+      - name: Build PR binary
+        run: cargo build --release
+      - name: Direct smoke — JSON envelope shape
+        env:
+          BIN: ./target/release/crap4rs
+        run: |
+          set -euo pipefail
+          envelope=$("$BIN" --coverage lcov.info --src src --threshold 25 --format json --no-fail)
+          # Required fields the action's jq queries depend on.
+          for field in '.schema_version' '.tool_version' '.result.passed' '.result.functions'; do
+            value=$(printf '%s' "$envelope" | jq -e "$field" >/dev/null && echo ok || echo missing)
+            if [ "$value" = "missing" ]; then
+              echo "::error::JSON envelope missing $field — action's output parsing would break"
+              exit 1
+            fi
+          done
+      - name: Direct smoke — markdown render
+        env:
+          BIN: ./target/release/crap4rs
+        run: |
+          set -euo pipefail
+          md=$("$BIN" --coverage lcov.info --src src --threshold 25 --format markdown --no-fail)
+          if [ -z "$md" ]; then
+            echo "::error::markdown reporter produced empty output"
+            exit 1
+          fi
+          # Sanity: the rendered scorecard always opens with an h1 carrying
+          # the tool version. The action consumes the whole string verbatim,
+          # so a regression here means consumers get garbage.
+          printf '%s\n' "$md" | head -1 | grep -q "^# crap4rs"
+
+      # Layer (2): exercise the composite action's plumbing.
       - name: Dogfood the scorecard action
         id: crap
         uses: ./.github/actions/scorecard
@@ -156,7 +202,7 @@ jobs:
           coverage: lcov.info
           src: src
           threshold: '25'
-      - name: Assert outputs are populated
+      - name: Assert action outputs are populated
         env:
           MARKDOWN: ${{ steps.crap.outputs.markdown }}
           ENVELOPE_PATH: ${{ steps.crap.outputs.json-envelope-path }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,3 +139,37 @@ jobs:
           tool: cargo-mutants
       - name: Run cargo mutants on src/domain/view.rs
         run: cargo mutants --package crap4rs --file src/domain/view.rs --no-shuffle --in-place
+
+  scorecard-smoke:
+    name: Scorecard action smoke (analysis-only)
+    runs-on: ubuntu-latest
+    needs: [coverage]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: lcov
+      - name: Dogfood the scorecard action
+        id: crap
+        uses: ./.github/actions/scorecard
+        with:
+          coverage: lcov.info
+          src: src
+          threshold: '25'
+      - name: Assert outputs are populated
+        env:
+          MARKDOWN: ${{ steps.crap.outputs.markdown }}
+          ENVELOPE_PATH: ${{ steps.crap.outputs.json-envelope-path }}
+          ANALYSIS_PASSED: ${{ steps.crap.outputs.analysis-passed }}
+          REGRESSIONS: ${{ steps.crap.outputs.regressions }}
+          NEW_VIOLATIONS: ${{ steps.crap.outputs.new-violations }}
+        run: |
+          set -euo pipefail
+          if [ -z "$MARKDOWN" ]; then
+            echo "::error::scorecard action emitted empty markdown output"
+            exit 1
+          fi
+          test -f "$ENVELOPE_PATH"
+          echo "analysis_passed=$ANALYSIS_PASSED"
+          echo "regressions=$REGRESSIONS"
+          echo "new_violations=$NEW_VIOLATIONS"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,7 +192,16 @@ jobs:
           # Sanity: the rendered scorecard always opens with an h1 carrying
           # the tool version. The action consumes the whole string verbatim,
           # so a regression here means consumers get garbage.
-          printf '%s\n' "$md" | head -1 | grep -q "^# crap4rs"
+          # Pure-bash prefix match (no `head -1` pipe, which would race
+          # SIGPIPE under `pipefail`).
+          case "$md" in
+            '# crap4rs'*) ;;
+            *)
+              echo "::error::markdown reporter output did not begin with '# crap4rs' header"
+              echo "First 80 chars: ${md:0:80}"
+              exit 1
+              ;;
+          esac
 
       # Layer (2): exercise the composite action's plumbing.
       - name: Dogfood the scorecard action


### PR DESCRIPTION
## Summary

Composable GitHub Action that runs crap4rs against a coverage file and emits a markdown scorecard, designed as a building block for richer aggregator PR-comment bots — primarily mokumo [#650 (metrics-delta PR comment bot)](https://github.com/breezy-bays-labs/mokumo/issues/650).

## Architectural choices (worth a careful look)

**Composite action in a subfolder, not a separate repo.** Per the design discussion, separate-repo-per-action was overstating the marketplace polish requirement. Subfolder action is the boring correct answer for solo-founder internal use; we can extract on the day we want a Marketplace listing. Migration cost is low.

**Polyglot interface, Rust wired today.** `language: rust|typescript|auto` reserves namespace for crap4ts integration (ops [#231](https://github.com/breezy-bays-labs/ops/issues/231)) without committing to it now. TypeScript path errors loudly with a pointer to the tracking issue.

**Composable by default; sticky comment opt-in.** `comment-mode: none` (default) emits the markdown as a step output. Aggregator bots like mokumo's metrics-delta bot drop it into a larger sticky comment. `comment-mode: sticky` manages a standalone sticky for repos that only care about CRAP. Two consumers, one renderer.

**Measurement-first gates.** Both `analysis-gate` and `delta-gate` default off. The action's primary product is the scorecard string. Consumers who want hard CI failures opt in.

**No auto-checkout of base ref.** The caller produces the baseline JSON envelope (typically by running coverage on the PR base). This was the v0.2.0 design rationale — CI orchestrates two passes; the analyzer never reaches into git. The action preserves that boundary. Auto-checkout-and-cache is a natural future enhancement once we see real friction.

## Lead user

Mokumo's `scripts/check-crap-delta.sh` (114 lines of git-worktree + jq) is the natural first replacement target — it does manually what `--baseline` now does natively. A follow-up draft PR on mokumo will wire this action into the metrics-delta bot.

## Test plan

- [x] YAML syntax valid (`ruby -ryaml`)
- [x] CI dogfoods the action via new `scorecard-smoke` job (analysis-only, threshold 25, validates outputs are populated)
- [x] Hook-flagged code-injection vector neutralized (markdown output passed via `env:` to bash, not interpolated into `run:`)
- [ ] Live action run (this PR's CI is the test)
- [ ] Future: mokumo draft PR exercising the aggregator pattern

## Closes

- closes #75 (port crap4ts GitHub Action — done as a polyglot composite action, not a port)

## Cross-links

- mokumo [#650](https://github.com/breezy-bays-labs/mokumo/issues/650) — primary consumer
- ops [#231](https://github.com/breezy-bays-labs/ops/issues/231) — future crap monorepo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a GitHub Action for CRAP scorecard analysis that generates markdown reports and optionally posts/updates sticky PR comments with code quality metrics.

* **Documentation**
  * Added README documenting the scorecard action's usage modes, configuration inputs, and outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->