### PR TITLE
feat: markdown summary-first redesign + binstall fix (v0.2.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-04-26
+
+### Changed
+- **Markdown reporter is now summary-first.** `--format markdown` renders a compact title + multi-metric summary block (CRAP / Complexity / Coverage stats with worst, average, median + risk distribution) followed by a top-N spotlight: failures sorted CRAP-desc when violations exist, otherwise the worst-by-CRAP slice on a clean run. Designed to fit in a PR comment regardless of codebase size — a 1099-function self-analysis renders in ~1.4 KB (down from ~92 KB). The legacy row-per-function table is preserved behind `--md-full-table`.
+
+### Added
+- `--md-full-table` flag in the Display group: append the legacy row-per-function table after the summary. Useful when piping `--format markdown` into a longer document instead of a PR comment.
+- `--md-top N` flag: bound the markdown spotlight table size (default 10). The summary block is unaffected — its stats always reflect the full unshapeable analysis.
+- `AnalysisSummary` now carries Complexity stats (`max_complexity`, `average_complexity`, `median_complexity`) and Coverage stats (`min_coverage`, `average_coverage`, `median_coverage`) alongside the existing CRAP stats. JSON envelope additions are non-breaking; `schema_version` stays at `1`. Older baseline JSON deserializes cleanly via `#[serde(default)]`.
+
+### Fixed
+- **`cargo binstall crap4rs`** now extracts the pre-built binary instead of falling back to source build. The `[package.metadata.binstall]` `bin-dir` template was `"."`, which resolves to an empty source path under cargo-binstall ≥ 1.x; corrected to `"{ bin }{ binary-ext }"`. Closes #101.
+
 ## [0.2.1] - 2026-04-26
 
 Patch release addressing CodeRabbit review feedback on the v0.2.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,7 +248,7 @@ dependencies = [
 
 [[package]]
 name = "crap4rs"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crap4rs"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 authors = ["Christopher Bays <cmbays@breezybayslabs.com>"]
 description = "CRAP score analyzer for Rust — find complex, under-tested functions"
@@ -12,7 +12,11 @@ categories = ["development-tools::testing", "command-line-utilities"]
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }.tar.gz"
 pkg-fmt = "tgz"
-bin-dir = "."
+# Binary lives at the archive root (release.yml's `tar -C target/{target}/release crap4rs`).
+# `"."` resolves to an empty source path under cargo-binstall ≥ 1.x and forces fallback to
+# `cargo install`. `{ bin }{ binary-ext }` resolves to `crap4rs` on Linux/macOS, `crap4rs.exe`
+# on Windows. Closes #101.
+bin-dir = "{ bin }{ binary-ext }"
 
 [lib]
 name = "crap4rs"

--- a/src/adapters/reporters/csv.rs
+++ b/src/adapters/reporters/csv.rs
@@ -368,6 +368,7 @@ mod tests {
                     moderate: 0,
                     high: 0,
                 },
+                ..Default::default()
             },
             passed: true,
         };

--- a/src/adapters/reporters/markdown.rs
+++ b/src/adapters/reporters/markdown.rs
@@ -81,7 +81,7 @@ fn format_markdown_body(
     if full_table {
         out.push_str(&full_table_block(view, breakdown, explain));
     } else {
-        out.push_str(&spotlight_block(view, threshold, top_n));
+        out.push_str(&spotlight_block(view, threshold, top_n, breakdown, explain));
     }
 
     out
@@ -89,7 +89,15 @@ fn format_markdown_body(
 
 /// Default body section: top-N failures when violations exist,
 /// otherwise the worst-by-CRAP slice. Bounded to `top_n` rows.
-fn spotlight_block(view: &AnalysisView<'_>, threshold: f64, top_n: usize) -> String {
+/// Honors `--breakdown` and `--explain` so the spotlight matches the
+/// legacy full-table format's level of detail.
+fn spotlight_block(
+    view: &AnalysisView<'_>,
+    threshold: f64,
+    top_n: usize,
+    breakdown: bool,
+    explain: bool,
+) -> String {
     let mut out = String::new();
     let summary = &view.full.summary;
 
@@ -101,14 +109,16 @@ fn spotlight_block(view: &AnalysisView<'_>, threshold: f64, top_n: usize) -> Str
             return out;
         }
         out.push_str(&format!("## Top {} worst by CRAP\n\n", worst.len()));
-        out.push_str(&function_table(&worst));
+        out.push_str(&function_table(&worst, breakdown));
+        if breakdown && explain && needs_legend(view) {
+            out.push_str(LEGEND);
+        }
         out.push_str("\n_All functions are within threshold._\n");
         return out;
     }
 
     // Failure path. Render up to `top_n` failures sorted CRAP-desc.
-    let failing: Vec<&FunctionVerdict> = view.shown.iter().copied().filter(|v| v.exceeds).collect();
-    let shown_failures = top_n_by_crap(failing.iter().copied(), top_n);
+    let shown_failures = top_n_by_crap(view.shown.iter().copied().filter(|v| v.exceeds), top_n);
 
     let header = if summary.exceeding_threshold > shown_failures.len() {
         format!(
@@ -125,7 +135,10 @@ fn spotlight_block(view: &AnalysisView<'_>, threshold: f64, top_n: usize) -> Str
         )
     };
     out.push_str(&header);
-    out.push_str(&function_table(&shown_failures));
+    out.push_str(&function_table(&shown_failures, breakdown));
+    if breakdown && explain && needs_legend(view) {
+        out.push_str(LEGEND);
+    }
     out
 }
 
@@ -145,32 +158,27 @@ where
     v
 }
 
-fn function_table(verdicts: &[&FunctionVerdict]) -> String {
+fn function_table(verdicts: &[&FunctionVerdict], breakdown: bool) -> String {
     let mut out = String::new();
     out.push_str("| File | Function | CC | Cov% | CRAP | Risk |\n");
     out.push_str("|------|----------|----|------|------|------|\n");
     for v in verdicts {
         out.push_str(&row_for(v));
         out.push('\n');
+        append_breakdown_bullets(&mut out, v, breakdown);
     }
     out
 }
+
+const LEGEND: &str = "\n_Legend: +1 = base structural increment. +N (nested) = +1 base plus +(N-1) from active nesting depth (if/else, match arms, while/for/loop, let-else diverging branches, closures)._\n";
 
 /// Legacy row-per-function table (preserved behind `--md-full-table`).
 fn full_table_block(view: &AnalysisView<'_>, breakdown: bool, explain: bool) -> String {
     let mut out = String::new();
     out.push_str("## All functions\n\n");
-    out.push_str("| File | Function | CC | Cov% | CRAP | Risk |\n");
-    out.push_str("|------|----------|----|------|------|------|\n");
-    for verdict in view.shown.iter() {
-        out.push_str(&row_for(verdict));
-        out.push('\n');
-        append_breakdown_bullets(&mut out, verdict, breakdown);
-    }
+    out.push_str(&function_table(view.shown.as_slice(), breakdown));
     if breakdown && explain && needs_legend(view) {
-        out.push_str(
-            "\n_Legend: +1 = base structural increment. +N (nested) = +1 base plus +(N-1) from active nesting depth (if/else, match arms, while/for/loop, let-else diverging branches, closures)._\n",
-        );
+        out.push_str(LEGEND);
     }
     out
 }
@@ -482,6 +490,81 @@ mod tests {
             10,
         );
         insta::assert_snapshot!(out);
+    }
+
+    #[test]
+    fn md_full_table_renders_all_functions_section() {
+        let result = make_multi_function_result();
+        let out = format_markdown(
+            &make_view_default(&result),
+            None,
+            8.0,
+            false,
+            false,
+            true, // --md-full-table
+            10,
+        );
+        // Summary block still leads.
+        assert!(out.contains("## Summary"));
+        // Full-table escape hatch renders the legacy section.
+        assert!(out.contains("## All functions"));
+        // Every function row is present (3 in the fixture).
+        assert!(out.contains("complex_fn"));
+        assert!(out.contains("parse_record"));
+        assert!(out.contains("simple_fn"));
+        // No spotlight section when full-table is requested.
+        assert!(!out.contains("## Failures"));
+        assert!(!out.contains("## Top "));
+    }
+
+    #[test]
+    fn md_full_table_with_breakdown_includes_contributors_and_legend() {
+        use crate::domain::types::{AnalysisResult, ComplexityContributor, ContributorKind};
+        let verdict = make_verdict_with_contributors(
+            make_verdict(
+                "risky_fn",
+                "src/lib.rs",
+                5,
+                30.0,
+                45.0,
+                RiskLevel::High,
+                8.0,
+            ),
+            vec![
+                ComplexityContributor {
+                    kind: ContributorKind::IfBranch,
+                    line: 12,
+                    column: None,
+                    increment: 1,
+                },
+                ComplexityContributor {
+                    kind: ContributorKind::Match,
+                    line: 18,
+                    column: None,
+                    increment: 2, // nested → triggers legend
+                },
+            ],
+        );
+        let result = AnalysisResult {
+            functions: vec![verdict.clone()],
+            summary: crate::domain::summary::compute_summary(std::slice::from_ref(&verdict)),
+            passed: false,
+        };
+        let out = format_markdown(
+            &make_view_default(&result),
+            None,
+            8.0,
+            true, // --breakdown
+            true, // --explain
+            true, // --md-full-table
+            10,
+        );
+        assert!(out.contains("## All functions"));
+        // Breakdown bullets rendered for the exceeding row.
+        assert!(out.contains("L12 if-branch +1"));
+        assert!(out.contains("L18 match +2"));
+        // Explain legend present (any nested increment > 1).
+        assert!(out.contains("Legend:"));
     }
 
     #[test]

--- a/src/adapters/reporters/markdown.rs
+++ b/src/adapters/reporters/markdown.rs
@@ -10,22 +10,36 @@ use crate::domain::view::AnalysisView;
 
 /// Format an `AnalysisView` as GitHub-flavored Markdown.
 ///
+/// Default body shape: title + summary block (multi-metric stats +
+/// risk distribution) + a top-N spotlight (failures if any exceed
+/// threshold, otherwise the worst by CRAP). Designed to fit comfortably
+/// in a PR comment — bounded output regardless of codebase size.
+///
 /// `breakdown` injects an indented bullet list of complexity
-/// contributors under each exceeding function. `explain` adds a
-/// trailing legend describing increment semantics (only meaningful
-/// when `breakdown` is set).
+/// contributors under each exceeding function in the spotlight (or
+/// the full table when `full_table` is set). `explain` adds a trailing
+/// legend describing increment semantics (only meaningful when
+/// `breakdown` is set).
+///
+/// `full_table` switches the body to the legacy row-per-function table
+/// rendered after the summary — useful when piping into a longer
+/// document instead of a PR comment. Off by default.
+///
+/// `top_n` bounds the spotlight table size. The summary block is
+/// always full-fidelity (computed from `view.full.summary`).
 ///
 /// When `delta` is `Some`, a `## CRAP Scorecard` section is appended
-/// after the analysis summary — designed for PR-comment rendering.
-/// When `delta` is `None`, output is byte-identical to today.
+/// after the analysis body — designed for PR-comment rendering.
 pub fn format_markdown(
     view: &AnalysisView<'_>,
     delta: Option<&DeltaView<'_>>,
     threshold: f64,
     breakdown: bool,
     explain: bool,
+    full_table: bool,
+    top_n: usize,
 ) -> String {
-    let mut out = format_markdown_body(view, threshold, breakdown, explain);
+    let mut out = format_markdown_body(view, threshold, breakdown, explain, full_table, top_n);
     if let Some(delta_view) = delta {
         out.push('\n');
         out.push_str(&format_markdown_delta(delta_view));
@@ -34,13 +48,15 @@ pub fn format_markdown(
 }
 
 /// Render the analysis-only body (no delta block). Branches on
-/// empty / grouped / per-function paths; the delta block is appended
-/// once by the caller.
+/// empty / grouped / spotlight / full-table paths; the delta block is
+/// appended once by the caller.
 fn format_markdown_body(
     view: &AnalysisView<'_>,
     threshold: f64,
     breakdown: bool,
     explain: bool,
+    full_table: bool,
+    top_n: usize,
 ) -> String {
     let mut out = String::new();
     out.push_str(&format!(
@@ -53,13 +69,97 @@ fn format_markdown_body(
         return out;
     }
 
+    out.push_str(&summary_block(view, threshold));
+
     if view.grouped.is_some() {
+        out.push_str("\n## Per-file aggregates\n\n");
         out.push_str(&format_grouped_table_md(view));
-        out.push('\n');
-        out.push_str(&summary_block(view, threshold));
         return out;
     }
 
+    out.push('\n');
+    if full_table {
+        out.push_str(&full_table_block(view, breakdown, explain));
+    } else {
+        out.push_str(&spotlight_block(view, threshold, top_n));
+    }
+
+    out
+}
+
+/// Default body section: top-N failures when violations exist,
+/// otherwise the worst-by-CRAP slice. Bounded to `top_n` rows.
+fn spotlight_block(view: &AnalysisView<'_>, threshold: f64, top_n: usize) -> String {
+    let mut out = String::new();
+    let summary = &view.full.summary;
+
+    if summary.exceeding_threshold == 0 {
+        // Clean run — show the hot spots so reviewers see what's
+        // approaching threshold.
+        let worst = top_n_by_crap(view.shown.iter().copied(), top_n);
+        if worst.is_empty() {
+            return out;
+        }
+        out.push_str(&format!("## Top {} worst by CRAP\n\n", worst.len()));
+        out.push_str(&function_table(&worst));
+        out.push_str("\n_All functions are within threshold._\n");
+        return out;
+    }
+
+    // Failure path. Render up to `top_n` failures sorted CRAP-desc.
+    let failing: Vec<&FunctionVerdict> = view.shown.iter().copied().filter(|v| v.exceeds).collect();
+    let shown_failures = top_n_by_crap(failing.iter().copied(), top_n);
+
+    let header = if summary.exceeding_threshold > shown_failures.len() {
+        format!(
+            "## Failures (top {} of {} above threshold {})\n\n",
+            shown_failures.len(),
+            summary.exceeding_threshold,
+            format_threshold(view, threshold),
+        )
+    } else {
+        format!(
+            "## Failures ({} above threshold {})\n\n",
+            summary.exceeding_threshold,
+            format_threshold(view, threshold),
+        )
+    };
+    out.push_str(&header);
+    out.push_str(&function_table(&shown_failures));
+    out
+}
+
+fn top_n_by_crap<'a, I>(iter: I, n: usize) -> Vec<&'a FunctionVerdict>
+where
+    I: IntoIterator<Item = &'a FunctionVerdict>,
+{
+    let mut v: Vec<&FunctionVerdict> = iter.into_iter().collect();
+    v.sort_by(|a, b| {
+        b.scored
+            .crap
+            .value
+            .partial_cmp(&a.scored.crap.value)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    v.truncate(n);
+    v
+}
+
+fn function_table(verdicts: &[&FunctionVerdict]) -> String {
+    let mut out = String::new();
+    out.push_str("| File | Function | CC | Cov% | CRAP | Risk |\n");
+    out.push_str("|------|----------|----|------|------|------|\n");
+    for v in verdicts {
+        out.push_str(&row_for(v));
+        out.push('\n');
+    }
+    out
+}
+
+/// Legacy row-per-function table (preserved behind `--md-full-table`).
+fn full_table_block(view: &AnalysisView<'_>, breakdown: bool, explain: bool) -> String {
+    let mut out = String::new();
+    out.push_str("## All functions\n\n");
     out.push_str("| File | Function | CC | Cov% | CRAP | Risk |\n");
     out.push_str("|------|----------|----|------|------|------|\n");
     for verdict in view.shown.iter() {
@@ -67,16 +167,20 @@ fn format_markdown_body(
         out.push('\n');
         append_breakdown_bullets(&mut out, verdict, breakdown);
     }
-
     if breakdown && explain && needs_legend(view) {
         out.push_str(
             "\n_Legend: +1 = base structural increment. +N (nested) = +1 base plus +(N-1) from active nesting depth (if/else, match arms, while/for/loop, let-else diverging branches, closures)._\n",
         );
     }
-
-    out.push('\n');
-    out.push_str(&summary_block(view, threshold));
     out
+}
+
+fn format_threshold(view: &AnalysisView<'_>, threshold: f64) -> String {
+    if has_varied_thresholds(&view.full.functions) {
+        format!("varied (default: {})", threshold)
+    } else {
+        format!("{}", threshold)
+    }
 }
 
 fn append_breakdown_bullets(out: &mut String, verdict: &FunctionVerdict, breakdown: bool) {
@@ -216,36 +320,41 @@ fn escape_cell(s: &str) -> String {
 fn summary_block(view: &AnalysisView<'_>, threshold: f64) -> String {
     let summary = &view.full.summary;
     let pass_fail = if view.full.passed { "PASS" } else { "FAIL" };
-    let worst = summary
+    let crap_max = summary
         .max_crap
-        .map(|c| format!("{:.1}", c.value))
-        .unwrap_or_else(|| "N/A".to_string());
-
-    let threshold_display = if has_varied_thresholds(&view.full.functions) {
-        format!("varied (default: {})", threshold)
-    } else {
-        format!("{}", threshold)
-    };
-
+        .as_ref()
+        .map(|c| format!("{:.2}", c.value))
+        .unwrap_or_else(|| "—".to_string());
+    let threshold_display = format_threshold(view, threshold);
     let d = &summary.distribution;
-    format!(
-        "## Summary\n\n\
-         - **Result:** {pass_fail}\n\
-         - **Functions:** {} ({} above threshold {})\n\
-         - **Worst CRAP:** {worst}\n\
-         - **Average CRAP:** {:.1}\n\
-         - **Median CRAP:** {:.1}\n\
-         - **Distribution:** low {} · acceptable {} · moderate {} · high {}\n",
-        summary.total_functions,
-        summary.exceeding_threshold,
-        threshold_display,
-        summary.average_crap,
-        summary.median_crap,
-        d.low,
-        d.acceptable,
-        d.moderate,
-        d.high,
-    )
+
+    let mut out = String::new();
+    out.push_str("## Summary\n\n");
+    out.push_str(&format!(
+        "**Result:** {pass_fail} · **Functions:** {} · **Above threshold ({threshold_display}):** {}\n\n",
+        summary.total_functions, summary.exceeding_threshold,
+    ));
+    out.push_str("| Metric     | Worst | Average | Median |\n");
+    out.push_str("|------------|------:|--------:|-------:|\n");
+    out.push_str(&format!(
+        "| CRAP       | {crap_max} | {:>7.2} | {:>6.2} |\n",
+        summary.average_crap, summary.median_crap,
+    ));
+    out.push_str(&format!(
+        "| Complexity | {:>5} | {:>7.1} | {:>6.1} |\n",
+        summary.max_complexity, summary.average_complexity, summary.median_complexity,
+    ));
+    out.push_str(&format!(
+        "| Coverage   | {min:>4.1}% | {avg:>6.1}% | {median:>5.1}% |\n",
+        min = summary.min_coverage,
+        avg = summary.average_coverage,
+        median = summary.median_coverage,
+    ));
+    out.push_str(&format!(
+        "\n**Risk distribution:** low {} · acceptable {} · moderate {} · high {}\n",
+        d.low, d.acceptable, d.moderate, d.high,
+    ));
+    out
 }
 
 fn format_grouped_table_md(view: &AnalysisView<'_>) -> String {
@@ -296,7 +405,15 @@ mod tests {
     #[test]
     fn header_row_pipes_and_columns() {
         let result = make_multi_function_result();
-        let out = format_markdown(&make_view_default(&result), None, 8.0, false, false);
+        let out = format_markdown(
+            &make_view_default(&result),
+            None,
+            8.0,
+            false,
+            false,
+            false,
+            10,
+        );
         assert!(out.contains("| File | Function | CC | Cov% | CRAP | Risk |"));
         assert!(out.contains("|------|"));
     }
@@ -304,7 +421,15 @@ mod tests {
     #[test]
     fn empty_analysis_says_no_functions() {
         let result = make_empty_result();
-        let out = format_markdown(&make_view_default(&result), None, 8.0, false, false);
+        let out = format_markdown(
+            &make_view_default(&result),
+            None,
+            8.0,
+            false,
+            false,
+            false,
+            10,
+        );
         assert!(out.contains("No functions analyzed"));
         assert!(!out.contains("| File |"));
     }
@@ -313,7 +438,15 @@ mod tests {
     fn pipe_in_function_name_is_escaped() {
         let result =
             make_single_function_result("a|b", "src/lib.rs", 1, 100.0, 1.0, RiskLevel::Low, 8.0);
-        let out = format_markdown(&make_view_default(&result), None, 8.0, false, false);
+        let out = format_markdown(
+            &make_view_default(&result),
+            None,
+            8.0,
+            false,
+            false,
+            false,
+            10,
+        );
         assert!(out.contains("a\\|b"), "expected escaped pipe in: {out}");
     }
 
@@ -322,15 +455,32 @@ mod tests {
         // Even if the view is filtered, summary derives from view.full
         // (the gate keystone).
         let result = make_multi_function_result();
-        let out = format_markdown(&make_view_default(&result), None, 8.0, false, false);
-        assert!(out.contains("- **Result:** FAIL"));
-        assert!(out.contains("3 (2 above threshold 8)"));
+        let out = format_markdown(
+            &make_view_default(&result),
+            None,
+            8.0,
+            false,
+            false,
+            false,
+            10,
+        );
+        assert!(out.contains("**Result:** FAIL"));
+        assert!(out.contains("**Functions:** 3"));
+        assert!(out.contains("**Above threshold (8):** 2"));
     }
 
     #[test]
     fn full_markdown_snapshot() {
         let result = make_multi_function_result();
-        let out = format_markdown(&make_view_default(&result), None, 8.0, false, false);
+        let out = format_markdown(
+            &make_view_default(&result),
+            None,
+            8.0,
+            false,
+            false,
+            false,
+            10,
+        );
         insta::assert_snapshot!(out);
     }
 
@@ -367,7 +517,15 @@ mod tests {
             summary: make_multi_function_result().summary,
             passed: false,
         };
-        let out = format_markdown(&make_view_default(&result), None, 8.0, true, true);
+        let out = format_markdown(
+            &make_view_default(&result),
+            None,
+            8.0,
+            true,
+            true,
+            false,
+            10,
+        );
         insta::assert_snapshot!(out);
     }
 
@@ -384,13 +542,13 @@ mod tests {
                 ..Default::default()
             },
         );
-        let out = format_markdown(&view, None, 8.0, false, false);
+        let out = format_markdown(&view, None, 8.0, false, false, false, 10);
         assert!(out.contains("| File | Functions | Failing | Avg CRAP | Worst CRAP | Worst Fn |"));
-        // Per-function CC/Cov% absent
-        assert!(!out.contains("| CC |"));
-        assert!(!out.contains("| Cov% |"));
-        // Summary block intact (3 functions, 2 above threshold)
-        assert!(out.contains("3 (2 above threshold 8)"));
+        // Per-function CC/Cov% headers absent in the per-file aggregate table
+        assert!(!out.contains("| File | Function | CC |"));
+        // Summary block intact (3 functions, 2 above threshold 8)
+        assert!(out.contains("**Functions:** 3"));
+        assert!(out.contains("**Above threshold (8):** 2"));
     }
 
     #[test]
@@ -404,7 +562,7 @@ mod tests {
                 ..Default::default()
             },
         );
-        let out = format_markdown(&view, None, 8.0, false, false);
+        let out = format_markdown(&view, None, 8.0, false, false, false, 10);
         insta::assert_snapshot!(out);
     }
 
@@ -420,6 +578,8 @@ mod tests {
             8.0,
             false,
             false,
+            false,
+            10,
         );
         assert!(out.contains("## CRAP Scorecard"));
         // Status reflects the delta gate (new_violations > 0 → FAIL)
@@ -439,6 +599,8 @@ mod tests {
             8.0,
             false,
             false,
+            false,
+            10,
         );
         assert!(out.contains("### Regressions"));
         // parse_record went 15.0 → 22.0
@@ -456,6 +618,8 @@ mod tests {
             8.0,
             false,
             false,
+            false,
+            10,
         );
         assert!(out.contains("### New violations"));
         assert!(out.contains("new_fn"));
@@ -464,7 +628,15 @@ mod tests {
     #[test]
     fn no_baseline_means_no_scorecard_block() {
         let result = make_multi_function_result();
-        let out = format_markdown(&make_view_default(&result), None, 8.0, false, false);
+        let out = format_markdown(
+            &make_view_default(&result),
+            None,
+            8.0,
+            false,
+            false,
+            false,
+            10,
+        );
         assert!(!out.contains("CRAP Scorecard"));
         assert!(!out.contains("Delta status"));
     }
@@ -479,6 +651,8 @@ mod tests {
             8.0,
             false,
             false,
+            false,
+            10,
         );
         insta::assert_snapshot!(out);
     }

--- a/src/adapters/reporters/mod.rs
+++ b/src/adapters/reporters/mod.rs
@@ -96,6 +96,7 @@ pub(crate) mod test_fixtures {
                         moderate: 0,
                         high: 2,
                     },
+                    ..Default::default()
                 },
                 passed: false,
             }
@@ -162,6 +163,7 @@ pub(crate) mod test_fixtures {
                     moderate: 0,
                     high: 0,
                 },
+                ..Default::default()
             },
             passed: true,
         }
@@ -212,6 +214,7 @@ pub(crate) mod test_fixtures {
                     moderate: if risk == RiskLevel::Moderate { 1 } else { 0 },
                     high: if risk == RiskLevel::High { 1 } else { 0 },
                 },
+                ..Default::default()
             },
             passed: !exceeds,
         }
@@ -240,33 +243,11 @@ pub(crate) mod test_fixtures {
             8.0,
         );
 
+        let functions = vec![v1, v2, v3];
+        let summary = crate::domain::summary::compute_summary(&functions);
         AnalysisResult {
-            functions: vec![v1, v2, v3],
-            summary: AnalysisSummary {
-                total_functions: 3,
-                total_files: 3,
-                exceeding_threshold: 2,
-                average_crap: 21.07,
-                median_crap: 15.0,
-                max_crap: Some(CrapScore {
-                    value: 45.2,
-                    risk_level: RiskLevel::High,
-                }),
-                worst_function: Some(FunctionIdentity {
-                    file_path: "src/domain/crap.rs".to_string(),
-                    qualified_name: "complex_fn".to_string(),
-                    span: SourceSpan {
-                        start_line: 1,
-                        end_line: 10,
-                    },
-                }),
-                distribution: RiskDistribution {
-                    low: 1,
-                    acceptable: 0,
-                    moderate: 1,
-                    high: 1,
-                },
-            },
+            functions,
+            summary,
             passed: false,
         }
     }

--- a/src/adapters/reporters/snapshots/crap4rs__adapters__reporters__json__tests__full_json_snapshot.snap
+++ b/src/adapters/reporters/snapshots/crap4rs__adapters__reporters__json__tests__full_json_snapshot.snap
@@ -33,6 +33,8 @@ expression: v
     ],
     "passed": true,
     "summary": {
+      "average_complexity": 0.0,
+      "average_coverage": 0.0,
       "average_crap": 5.16,
       "distribution": {
         "acceptable": 1,
@@ -41,11 +43,15 @@ expression: v
         "moderate": 0
       },
       "exceeding_threshold": 0,
+      "max_complexity": 0,
       "max_crap": {
         "risk_level": "acceptable",
         "value": 5.16
       },
+      "median_complexity": 0.0,
+      "median_coverage": 0.0,
       "median_crap": 5.16,
+      "min_coverage": 0.0,
       "total_files": 1,
       "total_functions": 1,
       "worst_function": {
@@ -90,6 +96,8 @@ expression: v
       }
     ],
     "shown_summary": {
+      "average_complexity": 5.0,
+      "average_coverage": 80.0,
       "average_crap": 5.16,
       "distribution": {
         "acceptable": 1,
@@ -98,11 +106,15 @@ expression: v
         "moderate": 0
       },
       "exceeding_threshold": 0,
+      "max_complexity": 5,
       "max_crap": {
         "risk_level": "acceptable",
         "value": 5.16
       },
+      "median_complexity": 5.0,
+      "median_coverage": 80.0,
       "median_crap": 5.16,
+      "min_coverage": 80.0,
       "total_files": 1,
       "total_functions": 1,
       "worst_function": {

--- a/src/adapters/reporters/snapshots/crap4rs__adapters__reporters__markdown__tests__full_markdown_breakdown_snapshot.snap
+++ b/src/adapters/reporters/snapshots/crap4rs__adapters__reporters__markdown__tests__full_markdown_breakdown_snapshot.snap
@@ -2,21 +2,22 @@
 source: src/adapters/reporters/markdown.rs
 expression: out
 ---
-# crap4rs v0.2.1 — CRAP Score Analysis
+# crap4rs v0.2.2 — CRAP Score Analysis
+
+## Summary
+
+**Result:** FAIL · **Functions:** 3 · **Above threshold (8):** 2
+
+| Metric     | Worst | Average | Median |
+|------------|------:|--------:|-------:|
+| CRAP       | 45.20 |   21.07 |  15.00 |
+| Complexity |    20 |     9.3 |    6.0 |
+| Coverage   | 30.0% |   65.8% |  72.5% |
+
+**Risk distribution:** low 1 · acceptable 0 · moderate 1 · high 1
+
+## Failures (top 1 of 2 above threshold 8)
 
 | File | Function | CC | Cov% | CRAP | Risk |
 |------|----------|----|------|------|------|
 | src/lib.rs | risky_fn | 5 | 30.0 | 45.00 | high |
-  - L5 if-branch +1
-  - L10 for-loop +2
-
-_Legend: +1 = base structural increment. +N (nested) = +1 base plus +(N-1) from active nesting depth (if/else, match arms, while/for/loop, let-else diverging branches, closures)._
-
-## Summary
-
-- **Result:** FAIL
-- **Functions:** 3 (2 above threshold 8)
-- **Worst CRAP:** 45.2
-- **Average CRAP:** 21.1
-- **Median CRAP:** 15.0
-- **Distribution:** low 1 · acceptable 0 · moderate 1 · high 1

--- a/src/adapters/reporters/snapshots/crap4rs__adapters__reporters__markdown__tests__full_markdown_breakdown_snapshot.snap
+++ b/src/adapters/reporters/snapshots/crap4rs__adapters__reporters__markdown__tests__full_markdown_breakdown_snapshot.snap
@@ -21,3 +21,7 @@ expression: out
 | File | Function | CC | Cov% | CRAP | Risk |
 |------|----------|----|------|------|------|
 | src/lib.rs | risky_fn | 5 | 30.0 | 45.00 | high |
+  - L5 if-branch +1
+  - L10 for-loop +2
+
+_Legend: +1 = base structural increment. +N (nested) = +1 base plus +(N-1) from active nesting depth (if/else, match arms, while/for/loop, let-else diverging branches, closures)._

--- a/src/adapters/reporters/snapshots/crap4rs__adapters__reporters__markdown__tests__full_markdown_snapshot.snap
+++ b/src/adapters/reporters/snapshots/crap4rs__adapters__reporters__markdown__tests__full_markdown_snapshot.snap
@@ -2,19 +2,23 @@
 source: src/adapters/reporters/markdown.rs
 expression: out
 ---
-# crap4rs v0.2.1 — CRAP Score Analysis
+# crap4rs v0.2.2 — CRAP Score Analysis
+
+## Summary
+
+**Result:** FAIL · **Functions:** 3 · **Above threshold (8):** 2
+
+| Metric     | Worst | Average | Median |
+|------------|------:|--------:|-------:|
+| CRAP       | 45.20 |   21.07 |  15.00 |
+| Complexity |    20 |     9.3 |    6.0 |
+| Coverage   | 30.0% |   65.8% |  72.5% |
+
+**Risk distribution:** low 1 · acceptable 0 · moderate 1 · high 1
+
+## Failures (2 above threshold 8)
 
 | File | Function | CC | Cov% | CRAP | Risk |
 |------|----------|----|------|------|------|
 | src/domain/crap.rs | complex_fn | 20 | 30.0 | 45.20 | high |
 | src/adapters/coverage/mod.rs | parse_record | 6 | 72.5 | 15.00 | moderate |
-| src/lib.rs | simple_fn | 2 | 95.0 | 3.00 | low |
-
-## Summary
-
-- **Result:** FAIL
-- **Functions:** 3 (2 above threshold 8)
-- **Worst CRAP:** 45.2
-- **Average CRAP:** 21.1
-- **Median CRAP:** 15.0
-- **Distribution:** low 1 · acceptable 0 · moderate 1 · high 1

--- a/src/adapters/reporters/snapshots/crap4rs__adapters__reporters__markdown__tests__full_markdown_with_delta_snapshot.snap
+++ b/src/adapters/reporters/snapshots/crap4rs__adapters__reporters__markdown__tests__full_markdown_with_delta_snapshot.snap
@@ -2,22 +2,26 @@
 source: src/adapters/reporters/markdown.rs
 expression: out
 ---
-# crap4rs v0.2.1 — CRAP Score Analysis
+# crap4rs v0.2.2 — CRAP Score Analysis
+
+## Summary
+
+**Result:** FAIL · **Functions:** 3 · **Above threshold (8):** 2
+
+| Metric     | Worst | Average | Median |
+|------------|------:|--------:|-------:|
+| CRAP       | 30.00 |   18.33 |  22.00 |
+| Complexity |     0 |     0.0 |    0.0 |
+| Coverage   |  0.0% |    0.0% |   0.0% |
+
+**Risk distribution:** low 1 · acceptable 0 · moderate 0 · high 2
+
+## Failures (2 above threshold 8)
 
 | File | Function | CC | Cov% | CRAP | Risk |
 |------|----------|----|------|------|------|
 | src/adapters/baseline.rs | new_fn | 10 | 40.0 | 30.00 | high |
 | src/adapters/coverage/mod.rs | parse_record | 6 | 60.0 | 22.00 | high |
-| src/lib.rs | simple_fn | 2 | 95.0 | 3.00 | low |
-
-## Summary
-
-- **Result:** FAIL
-- **Functions:** 3 (2 above threshold 8)
-- **Worst CRAP:** 30.0
-- **Average CRAP:** 18.3
-- **Median CRAP:** 22.0
-- **Distribution:** low 1 · acceptable 0 · moderate 0 · high 2
 
 ## CRAP Scorecard
 

--- a/src/adapters/reporters/snapshots/crap4rs__adapters__reporters__markdown__tests__grouped_markdown_snapshot.snap
+++ b/src/adapters/reporters/snapshots/crap4rs__adapters__reporters__markdown__tests__grouped_markdown_snapshot.snap
@@ -2,19 +2,24 @@
 source: src/adapters/reporters/markdown.rs
 expression: out
 ---
-# crap4rs v0.2.1 — CRAP Score Analysis
+# crap4rs v0.2.2 — CRAP Score Analysis
+
+## Summary
+
+**Result:** FAIL · **Functions:** 3 · **Above threshold (8):** 2
+
+| Metric     | Worst | Average | Median |
+|------------|------:|--------:|-------:|
+| CRAP       | 45.20 |   21.07 |  15.00 |
+| Complexity |    20 |     9.3 |    6.0 |
+| Coverage   | 30.0% |   65.8% |  72.5% |
+
+**Risk distribution:** low 1 · acceptable 0 · moderate 1 · high 1
+
+## Per-file aggregates
 
 | File | Functions | Failing | Avg CRAP | Worst CRAP | Worst Fn |
 |------|-----------|---------|----------|------------|----------|
 | src/domain/crap.rs | 1 | 1 | 45.20 | 45.20 | complex_fn |
 | src/adapters/coverage/mod.rs | 1 | 1 | 15.00 | 15.00 | parse_record |
 | src/lib.rs | 1 | 0 | 3.00 | 3.00 | simple_fn |
-
-## Summary
-
-- **Result:** FAIL
-- **Functions:** 3 (2 above threshold 8)
-- **Worst CRAP:** 45.2
-- **Average CRAP:** 21.1
-- **Median CRAP:** 15.0
-- **Distribution:** low 1 · acceptable 0 · moderate 1 · high 1

--- a/src/adapters/reporters/snapshots/crap4rs__adapters__reporters__table__tests__delta_block_full_snapshot.snap
+++ b/src/adapters/reporters/snapshots/crap4rs__adapters__reporters__table__tests__delta_block_full_snapshot.snap
@@ -2,7 +2,7 @@
 source: src/adapters/reporters/table.rs
 expression: output
 ---
-crap4rs v0.2.1 — CRAP Score Analysis
+crap4rs v0.2.2 — CRAP Score Analysis
 
 +------------------------------+--------------+----+------+-------+------+
 | File                         | Function     | CC | Cov% | CRAP  | Risk |

--- a/src/adapters/reporters/snapshots/crap4rs__adapters__reporters__table__tests__full_table_snapshot.snap
+++ b/src/adapters/reporters/snapshots/crap4rs__adapters__reporters__table__tests__full_table_snapshot.snap
@@ -2,7 +2,7 @@
 source: src/adapters/reporters/table.rs
 expression: output
 ---
-crap4rs v0.2.1 — CRAP Score Analysis
+crap4rs v0.2.2 — CRAP Score Analysis
 
 +------------------------------+--------------+----+------+-------+----------+
 | File                         | Function     | CC | Cov% | CRAP  | Risk     |

--- a/src/adapters/reporters/snapshots/crap4rs__adapters__reporters__table__tests__grouped_table_snapshot.snap
+++ b/src/adapters/reporters/snapshots/crap4rs__adapters__reporters__table__tests__grouped_table_snapshot.snap
@@ -2,7 +2,7 @@
 source: src/adapters/reporters/table.rs
 expression: output
 ---
-crap4rs v0.2.1 — CRAP Score Analysis
+crap4rs v0.2.2 — CRAP Score Analysis
 
 +------------------------------+-----------+---------+----------+------------+--------------+
 | File                         | Functions | Failing | Avg CRAP | Worst CRAP | Worst Fn     |

--- a/src/adapters/reporters/table.rs
+++ b/src/adapters/reporters/table.rs
@@ -1341,6 +1341,7 @@ mod proptests {
                         moderate: 0,
                         high: 0,
                     },
+                    ..Default::default()
                 },
                 passed,
             }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -457,6 +457,24 @@ pub struct DisplayArgs {
     /// Only affects table output, and only when `--breakdown` is enabled.
     #[arg(long)]
     pub explain: bool,
+
+    /// Render the full per-function table in markdown output.
+    ///
+    /// By default `--format markdown` produces a compact summary plus a
+    /// top-N table (failures if any exist, otherwise the worst by CRAP).
+    /// This flag appends the legacy row-per-function table — useful when
+    /// piping into a longer document instead of a PR comment. Has no
+    /// effect on other output formats.
+    #[arg(long)]
+    pub md_full_table: bool,
+
+    /// Number of rows in the markdown top-N table (default 10).
+    ///
+    /// Bounds the failures list (or worst-by-CRAP list when nothing
+    /// exceeds threshold). The summary block is unaffected — its stats
+    /// always reflect the full unshapeable analysis.
+    #[arg(long, value_name = "N", default_value_t = 10)]
+    pub md_top: usize,
 }
 
 // ── Top-level CLI ───────────────────────────────────────────────────
@@ -675,6 +693,8 @@ fn run_inner() -> Result<bool> {
                 effective_threshold,
                 cli.display.breakdown,
                 cli.display.explain,
+                cli.display.md_full_table,
+                cli.display.md_top,
             ),
             FormatArg::Csv => reporters::format_csv(&view, delta_view.as_ref(), effective_metric),
         };

--- a/src/domain/delta.rs
+++ b/src/domain/delta.rs
@@ -607,6 +607,7 @@ mod tests {
                     moderate: 0,
                     high: 0,
                 },
+                ..Default::default()
             },
             passed: exceeding == 0,
         }

--- a/src/domain/summary.rs
+++ b/src/domain/summary.rs
@@ -23,14 +23,22 @@ where
     };
 
     let mut scores: Vec<f64> = Vec::new();
+    let mut complexities: Vec<u32> = Vec::new();
+    let mut finite_coverages: Vec<f64> = Vec::new();
     let mut files: std::collections::HashSet<&'a String> = std::collections::HashSet::new();
     let mut exceeding: usize = 0;
     let mut max_crap = None;
     let mut worst_function = None;
+    let mut max_complexity: u32 = 0;
 
     for v in verdicts {
         let score = v.scored.crap.value;
         scores.push(score);
+        complexities.push(v.scored.complexity);
+        let cov = v.scored.coverage_percent;
+        if cov.is_finite() {
+            finite_coverages.push(cov);
+        }
         files.insert(&v.scored.identity.file_path);
 
         if v.exceeds {
@@ -48,26 +56,25 @@ where
             max_crap = Some(score);
             worst_function = Some(v.scored.identity.clone());
         }
+        if v.scored.complexity > max_complexity {
+            max_complexity = v.scored.complexity;
+        }
     }
 
     let total_functions = scores.len();
     scores.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    complexities.sort_unstable();
+    finite_coverages.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
 
-    let average_crap = if total_functions > 0 {
-        scores.iter().sum::<f64>() / total_functions as f64
-    } else {
-        0.0
-    };
+    let average_crap = mean_f64(&scores, total_functions);
+    let median_crap = median_f64_sorted(&scores);
 
-    let median_crap = if total_functions > 0 {
-        if total_functions.is_multiple_of(2) {
-            (scores[total_functions / 2 - 1] + scores[total_functions / 2]) / 2.0
-        } else {
-            scores[total_functions / 2]
-        }
-    } else {
-        0.0
-    };
+    let average_complexity = mean_u32(&complexities, total_functions);
+    let median_complexity = median_u32_sorted(&complexities);
+
+    let min_coverage = finite_coverages.first().copied().unwrap_or(0.0);
+    let average_coverage = mean_f64(&finite_coverages, finite_coverages.len());
+    let median_coverage = median_f64_sorted(&finite_coverages);
 
     AnalysisSummary {
         total_functions,
@@ -83,6 +90,50 @@ where
         }),
         worst_function,
         distribution,
+        max_complexity,
+        average_complexity,
+        median_complexity,
+        min_coverage,
+        average_coverage,
+        median_coverage,
+    }
+}
+
+fn mean_f64(values: &[f64], count: usize) -> f64 {
+    if count == 0 {
+        return 0.0;
+    }
+    values.iter().sum::<f64>() / count as f64
+}
+
+fn mean_u32(values: &[u32], count: usize) -> f64 {
+    if count == 0 {
+        return 0.0;
+    }
+    values.iter().map(|v| *v as f64).sum::<f64>() / count as f64
+}
+
+fn median_f64_sorted(sorted: &[f64]) -> f64 {
+    if sorted.is_empty() {
+        return 0.0;
+    }
+    let n = sorted.len();
+    if n.is_multiple_of(2) {
+        (sorted[n / 2 - 1] + sorted[n / 2]) / 2.0
+    } else {
+        sorted[n / 2]
+    }
+}
+
+fn median_u32_sorted(sorted: &[u32]) -> f64 {
+    if sorted.is_empty() {
+        return 0.0;
+    }
+    let n = sorted.len();
+    if n.is_multiple_of(2) {
+        (sorted[n / 2 - 1] as f64 + sorted[n / 2] as f64) / 2.0
+    } else {
+        sorted[n / 2] as f64
     }
 }
 

--- a/src/domain/summary.rs
+++ b/src/domain/summary.rs
@@ -66,14 +66,14 @@ where
     complexities.sort_unstable();
     finite_coverages.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
 
-    let average_crap = mean_f64(&scores, total_functions);
+    let average_crap = mean_f64(&scores);
     let median_crap = median_f64_sorted(&scores);
 
-    let average_complexity = mean_u32(&complexities, total_functions);
+    let average_complexity = mean_u32(&complexities);
     let median_complexity = median_u32_sorted(&complexities);
 
     let min_coverage = finite_coverages.first().copied().unwrap_or(0.0);
-    let average_coverage = mean_f64(&finite_coverages, finite_coverages.len());
+    let average_coverage = mean_f64(&finite_coverages);
     let median_coverage = median_f64_sorted(&finite_coverages);
 
     AnalysisSummary {
@@ -99,18 +99,18 @@ where
     }
 }
 
-fn mean_f64(values: &[f64], count: usize) -> f64 {
-    if count == 0 {
+fn mean_f64(values: &[f64]) -> f64 {
+    if values.is_empty() {
         return 0.0;
     }
-    values.iter().sum::<f64>() / count as f64
+    values.iter().sum::<f64>() / values.len() as f64
 }
 
-fn mean_u32(values: &[u32], count: usize) -> f64 {
-    if count == 0 {
+fn mean_u32(values: &[u32]) -> f64 {
+    if values.is_empty() {
         return 0.0;
     }
-    values.iter().map(|v| *v as f64).sum::<f64>() / count as f64
+    values.iter().map(|v| *v as f64).sum::<f64>() / values.len() as f64
 }
 
 fn median_f64_sorted(sorted: &[f64]) -> f64 {

--- a/src/domain/types.rs
+++ b/src/domain/types.rs
@@ -248,7 +248,7 @@ pub struct FunctionVerdict {
 
 // ── Analysis Results ────────────────────────────────────────────────
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct RiskDistribution {
     pub low: usize,
     pub acceptable: usize,
@@ -256,7 +256,7 @@ pub struct RiskDistribution {
     pub high: usize,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct AnalysisSummary {
     pub total_functions: usize,
     pub total_files: usize,
@@ -266,6 +266,27 @@ pub struct AnalysisSummary {
     pub max_crap: Option<CrapScore>,
     pub worst_function: Option<FunctionIdentity>,
     pub distribution: RiskDistribution,
+    /// Highest complexity across analyzed functions. `0` when input is empty.
+    #[serde(default)]
+    pub max_complexity: u32,
+    /// Mean complexity across analyzed functions. `0.0` when input is empty.
+    #[serde(default)]
+    pub average_complexity: f64,
+    /// Median complexity across analyzed functions. `0.0` when input is empty.
+    #[serde(default)]
+    pub median_complexity: f64,
+    /// Minimum of finite `coverage_percent` values. `0.0` when no finite
+    /// values exist (NaN-only input or empty).
+    #[serde(default)]
+    pub min_coverage: f64,
+    /// Mean of finite `coverage_percent` values; NaN inputs excluded from
+    /// both numerator and denominator. `0.0` when no finite values exist.
+    #[serde(default)]
+    pub average_coverage: f64,
+    /// Median of finite `coverage_percent` values. `0.0` when no finite
+    /// values exist.
+    #[serde(default)]
+    pub median_coverage: f64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/domain/view.rs
+++ b/src/domain/view.rs
@@ -481,6 +481,7 @@ mod tests {
                     moderate: 0,
                     high: 0,
                 },
+                ..Default::default()
             },
             passed: true,
         }
@@ -1665,6 +1666,7 @@ mod proptests {
                     distribution: crate::domain::types::RiskDistribution {
                         low: 0, acceptable: 0, moderate: 0, high: 0,
                     },
+                    ..Default::default()
                 },
                 passed: true,
             };


### PR DESCRIPTION
## Summary

Bundles the two follow-ups surfaced during the mokumo PR #692 cross-repo wiring:

1. **Markdown reporter redesign** — summary-first, top-N spotlight, ~98% comment-size reduction
2. **Binstall metadata fix** — `cargo binstall crap4rs` now extracts the pre-built binary instead of falling back to a slow source build

Closes #101.

## Why

The scorecard composite action (#99) shipped to mokumo via PR #692 in the previous pipeline. The end-to-end wiring works, but the rendered sticky comment was 124 KB / ~700 rows on mokumo — every function in the analysis as a row. Reviewers asked for a summary-first format with stats for CRAP / Complexity / Coverage and a bounded top-N table.

In parallel, mokumo's CI surfaced the binstall metadata bug: `bin-dir = "."` resolves to an empty source path under cargo-binstall ≥ 1.x, so every install falls back to `cargo install` from source. Slow for everyone, fragile in CI when the binary already exists at the destination.

## What changed

### Markdown reporter

Default body shape is now:

```
# crap4rs vX.Y.Z — CRAP Score Analysis

## Summary

**Result:** PASS · **Functions:** 977 · **Above threshold (15):** 0

| Metric     | Worst | Average | Median |
|------------|------:|--------:|-------:|
| CRAP       | 14.01 |    2.18 |   1.00 |
| Complexity |    14 |     2.4 |    1.0 |
| Coverage   |  0.0% |   78.3% |  92.1% |

**Risk distribution:** low 854 · acceptable 95 · moderate 28 · high 0

## Top 10 worst by CRAP

| File | Function | CC | Cov% | CRAP | Risk |
| ... 10 rows ... |

_All functions are within threshold._
```

When violations exist, "Top 10 worst" becomes "Failures (top N of M above threshold)" sorted CRAP-desc. When clean, you get the worst-by-CRAP slice as a hot-spot heads-up.

### CLI

Two new flags in the `Display` group:

- `--md-full-table` — append the legacy row-per-function table after the summary. Useful when piping into a longer document instead of a PR comment.
- `--md-top N` (default 10) — bound the spotlight table size. The summary block always reflects the full unshapeable analysis.

### Domain

`AnalysisSummary` extended with:

```rust
pub max_complexity: u32,
pub average_complexity: f64,
pub median_complexity: f64,
pub min_coverage: f64,
pub average_coverage: f64,
pub median_coverage: f64,
```

JSON envelope additions are non-breaking — `schema_version` stays at `1`, and older baseline JSON deserializes cleanly via `#[serde(default)]`. Existing fields (`average_crap`, `median_crap`, `max_crap`, `worst_function`, `distribution`) preserved.

### Binstall fix

```diff
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }.tar.gz"
 pkg-fmt = "tgz"
-bin-dir = "."
+bin-dir = "{ bin }{ binary-ext }"
```

Once v0.2.2 ships, mokumo can drop the `rm -f $HOME/.cargo/bin/crap4rs` workaround in PR #692.

## Validation

Self-analysis on the PR's binary against its own LCOV (`cargo llvm-cov --lcov`):

| Format / flags | Bytes | Functions |
|---|---:|---:|
| `--format markdown` (default, redesigned) | 1,416 | 1,099 |
| `--format markdown --md-full-table` | 92,211 | 1,099 |

Self-CRAP gate (`--src src --strict --exclude "cli/**"`): 712 functions, 0 above threshold 15, worst 15.0 — PASS.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run` — 725 tests pass
- [x] Snapshot regeneration reviewed: `full_markdown_snapshot.snap`, `full_markdown_with_delta_snapshot.snap`, `full_markdown_breakdown_snapshot.snap`, `grouped_markdown_snapshot.snap` all reflect the new format. Table and JSON snapshots updated for the new `AnalysisSummary` fields.
- [x] Manual smoke: rendered against own LCOV in both failure and clean paths; verified `--md-full-table` preserves legacy output
- [ ] CI green (CRAP self-gate, mutation testing on `domain::view`, all standard quality gates)

After merge:
- [ ] User eyeballs the rendered scorecard via mokumo PR #692's next CI run
- [ ] Tag v0.2.2 to trigger the release workflow
- [ ] Mokumo can drop the `Free crap4rs path` workaround once v0.2.2 is on crates.io