### PR TITLE
ci(scorecard): dogfood PR binary + post sticky comment on PR runs

### DIFF
--- a/.github/actions/scorecard/README.md
+++ b/.github/actions/scorecard/README.md
@@ -84,6 +84,23 @@ jobs:
           comment-header: 'crap-scorecard'
 ```
 
+### Sticky comments and fork PRs
+
+GitHub issues a **read-only `GITHUB_TOKEN`** for `pull_request` events
+triggered from forks, regardless of the job-level `permissions:` block. The
+`comment-mode: sticky` step will silently no-op (or fail to post) on those
+runs. Same-repo branches are unaffected.
+
+If you need fork-PR coverage, two well-trodden options:
+
+- Switch the trigger to `pull_request_target` with hardened checkout (don't
+  check out untrusted code in the same job that holds write tokens).
+- Move the comment step to a separate `workflow_run`-triggered workflow
+  that has its own writable token.
+
+Most projects pick "no fork-PR sticky comments" until they have a concrete
+need — same-repo coverage is sufficient for internal review.
+
 ## Aggregator pattern — one row of a richer metrics comment
 
 Mokumo's metrics-delta bot wants coverage + CRAP + mutation + module size in
@@ -156,6 +173,34 @@ When the action is folded into the future
 [crap monorepo](https://github.com/breezy-bays-labs/ops/issues/231) it'll get
 a Marketplace listing with proper version tags; for now `@main` is the only
 moving ref and SHA-pinning is the safe default.
+
+## Pre-installed binary (advanced)
+
+When `version: latest` (the default) and a `crap4rs` binary is already on
+`PATH` before the action runs, the install step is **skipped** and the
+action uses the pre-installed binary. This supports two use cases:
+
+- **`moonrepo/setup-rust` bins.** If a prior step already installed
+  `crap4rs` via setup-rust's `bins:` parameter, the action respects it
+  rather than reinstalling.
+- **End-to-end self-dogfooding.** A workflow that builds `crap4rs` from
+  source and copies it to `~/.cargo/bin/` before invoking the action gets
+  the action to render via that binary — useful for the project's own CI
+  to validate the renderer against itself.
+
+When `version` is pinned to a specific tag (e.g. `version: '0.2.2'`), the
+action **always reinstalls** that exact version, ignoring whatever happens
+to be on `PATH`. Pinned-version semantics override pre-installed semantics.
+
+```yaml
+# Example: dogfood a workspace-local build
+- run: cargo build --release
+- run: install -m 0755 ./target/release/crap4rs "$HOME/.cargo/bin/crap4rs"
+- uses: breezy-bays-labs/crap4rs/.github/actions/scorecard@main
+  with:
+    coverage: lcov.info
+    # version defaults to 'latest' → install step short-circuits
+```
 
 ## Design notes
 

--- a/.github/actions/scorecard/action.yml
+++ b/.github/actions/scorecard/action.yml
@@ -135,14 +135,18 @@ runs:
         VERSION: ${{ inputs.version }}
       run: |
         set -euo pipefail
-        # No `--force`: skip reinstall if a matching version is already on
-        # PATH (e.g., from `moonrepo/setup-rust` bins or a user-supplied
-        # pre-step that prepends a workspace-local build of crap4rs onto
-        # PATH for end-to-end dogfooding).
-        if [ "$VERSION" = "latest" ]; then
+        # When `version: latest` and a `crap4rs` binary is already on PATH
+        # (e.g., from `moonrepo/setup-rust` bins or a workspace-local build
+        # prepended by a pre-step for end-to-end dogfooding), skip binstall
+        # and use the pre-installed binary as-is. Pinned versions always
+        # reinstall — callers asking for a specific version expect that
+        # version to be honored even if a different one is on PATH.
+        if [ "$VERSION" = "latest" ] && command -v crap4rs >/dev/null 2>&1; then
+          echo "Pre-installed crap4rs detected ($(crap4rs --version)); skipping binstall."
+        elif [ "$VERSION" = "latest" ]; then
           cargo binstall --no-confirm crap4rs
         else
-          cargo binstall --no-confirm "crap4rs@$VERSION"
+          cargo binstall --no-confirm --force "crap4rs@$VERSION"
         fi
         crap4rs --version
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,17 @@ jobs:
       # On pull_request runs we post a sticky comment so the rendered
       # scorecard is reviewable on the PR itself; push runs to main fall
       # back to `none` (no PR to comment on).
+      #
+      # Stage the PR binary as the pre-installed crap4rs so the action
+      # uses THIS PR's analyzer (not whatever crates.io publishes as
+      # latest). Without this, the smoke renders against the last
+      # released version and silently masks regressions in the binary.
+      - name: Stage PR binary as pre-installed crap4rs
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/.cargo/bin"
+          install -m 0755 ./target/release/crap4rs "$HOME/.cargo/bin/crap4rs"
+          "$HOME/.cargo/bin/crap4rs" --version
       - name: Dogfood the scorecard action
         id: crap
         uses: ./.github/actions/scorecard

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,9 @@ jobs:
     name: Scorecard action smoke (analysis-only)
     runs-on: ubuntu-latest
     needs: [coverage]
+    permissions:
+      pull-requests: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -204,6 +207,9 @@ jobs:
           esac
 
       # Layer (2): exercise the composite action's plumbing.
+      # On pull_request runs we post a sticky comment so the rendered
+      # scorecard is reviewable on the PR itself; push runs to main fall
+      # back to `none` (no PR to comment on).
       - name: Dogfood the scorecard action
         id: crap
         uses: ./.github/actions/scorecard
@@ -211,6 +217,8 @@ jobs:
           coverage: lcov.info
           src: src
           threshold: '25'
+          comment-mode: ${{ github.event_name == 'pull_request' && 'sticky' || 'none' }}
+          comment-header: 'crap-scorecard-self'
       - name: Assert action outputs are populated
         env:
           MARKDOWN: ${{ steps.crap.outputs.markdown }}


### PR DESCRIPTION
## Summary
The self-scorecard CI job now dogfoods the PR's own analyzer and posts the rendered markdown as a sticky PR comment, so format regressions surface on the PR that introduces them.

### Two coupled changes

**1. `action.yml` — short-circuit install when a local binary is on PATH** (composite action behavior fix)
The previous install step claimed in its comment that pre-installed binaries would be respected, but `cargo binstall --no-confirm crap4rs` without `--force` will still overwrite a pre-installed binary if its version differs from crates.io's latest. The new shell logic honors the documented intent:
- `version: latest` + `crap4rs` already on PATH → skip binstall (use the pre-installed binary)
- `version: latest` + nothing on PATH → binstall latest from crates.io (unchanged)
- pinned `version: <X>` → always reinstall with `--force` so callers get exactly the version they asked for

**2. `ci.yml` — stage the PR binary before invoking the action**
The smoke job already builds `./target/release/crap4rs` in Layer 1 to exercise the analyzer directly. Adds one step to `install -m 0755` that binary into `$HOME/.cargo/bin/` before invoking the action; the action's install step now short-circuits and the rendered scorecard comes from THIS PR's binary, not crates.io.

**3. Sticky comment wiring (carried from the original commit on this branch)**
- `comment-mode: ${{ github.event_name == 'pull_request' && 'sticky' || 'none' }}`
- `comment-header: 'crap-scorecard-self'` (distinct so it never collides with downstream consumer headers)
- `pull-requests: write` granted to the `scorecard-smoke` job only

## Test plan
- [ ] CI green on this PR
- [ ] `Stage PR binary as pre-installed crap4rs` step prints `crap4rs 0.2.2`
- [ ] `Dogfood the scorecard action` step's install log shows `Pre-installed crap4rs detected (crap4rs 0.2.2); skipping binstall.`
- [ ] Sticky comment appears on this PR with v0.2.2's summary-first markdown (CC/CRAP/Coverage stats table + risk distribution, top-10 failures section gated on violations)
- [ ] Re-running CI updates the same comment in place rather than creating a new one

## CodeRabbit advisory
The fork-PR commenting note from CodeRabbit is marked **"No change requested"** — sticky comments silently no-op on fork PRs because their `GITHUB_TOKEN` is read-only, but this is intended for same-repo branch validation. If we ever need fork PR coverage we'll switch to `pull_request_target` or a `workflow_run`-triggered job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)