### PR TITLE
feat: SARIF v2.1.0 output for GitHub Code Scanning (#70)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`--format sarif`** — emit SARIF v2.1.0 JSON for GitHub Code Scanning. Each function whose CRAP score exceeds the threshold becomes a SARIF `result` with `ruleId: "crap/threshold-exceeded"`, severity mapped from risk level (high → `error`, moderate → `warning`, acceptable & low → `note`), file path + start/end line, and a `partialFingerprints.functionIdentity` for cross-run dedup. SARIF output is a *gate translation*: results derive from the unshapeable analysis, so display flags (`--top`, `--sort-by`, `--only-failing`) do **not** alter SARIF output. `--no-fail` overrides the exit code only — the `results[]` array still reports every finding so PR annotations stay truthful. Pipe stdout into a `.sarif` file and upload via `github/codeql-action/upload-sarif@v3`. Closes #70.
+
 ## [0.2.2] - 2026-04-26
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -157,6 +157,43 @@ The shaping flags `--delta-top`, `--delta-sort` (`score-delta` (default) | `curr
 
 `--format markdown` produces GitHub-flavored Markdown (pipe-syntax table plus a Summary block) — paste it into a PR comment, an issue body, or a doc page. `--format csv` produces RFC 4180 CSV with a fixed header row, suitable for piping into spreadsheets, BI tools, or `awk`/`jq` pipelines that prefer tabular input. Both honor every shaping flag (`--top`, `--sort-by`, `--only-failing`, `--min-coverage` / `--max-coverage`).
 
+### SARIF for GitHub Code Scanning (`--format sarif`)
+
+`--format sarif` emits SARIF v2.1.0 JSON. Pipe it into a `.sarif` file and upload via `github/codeql-action/upload-sarif@v3` — every function whose CRAP score exceeds the threshold becomes an inline annotation on the exact line range in the PR diff. Reviewers see the findings without running crap4rs themselves.
+
+| Risk level     | SARIF `level` |
+| -------------- | ------------- |
+| `high`         | `error`       |
+| `moderate`     | `warning`     |
+| `acceptable`   | `note`        |
+| `low`          | `note`        |
+
+Unlike the table / JSON / Markdown / CSV reporters, SARIF is a **gate translation**, not a display: it iterates the unshapeable analysis. `--top`, `--sort-by`, `--only-failing`, and `--baseline` do **not** alter SARIF output — PR annotations must reflect truth, not a presentation choice. `--no-fail` overrides the exit code only; the `results[]` array still lists every finding.
+
+```yaml
+# .github/workflows/crap-scan.yml
+name: crap-scan
+on: pull_request
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write   # required for upload-sarif
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@cargo-llvm-cov
+      - run: cargo llvm-cov --lcov --output-path lcov.info
+      - uses: cargo-bins/cargo-binstall@main
+      - run: cargo binstall -y crap4rs
+      # Always emit SARIF, even on failure, so annotations land on the PR.
+      - run: crap4rs --coverage lcov.info --format sarif --no-fail > crap.sarif
+      - uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: crap.sarif
+```
+
 ## Shell completions
 
 Print a completion script for your shell to stdout — the subcommand does no file I/O, so redirect it wherever your shell expects completions:

--- a/src/adapters/reporters/mod.rs
+++ b/src/adapters/reporters/mod.rs
@@ -3,11 +3,13 @@
 pub mod csv;
 pub mod json;
 pub mod markdown;
+pub mod sarif;
 pub mod table;
 
 pub use csv::format_csv;
 pub use json::{JsonConfig, format_json};
 pub use markdown::format_markdown;
+pub use sarif::format_sarif;
 pub use table::{format_table, format_table_with_explain};
 
 #[cfg(test)]

--- a/src/adapters/reporters/sarif.rs
+++ b/src/adapters/reporters/sarif.rs
@@ -290,4 +290,99 @@ mod tests {
             "src/lib.rs:MyType::method"
         );
     }
+
+    #[test]
+    fn schema_uri_and_top_level_shape() {
+        let result = make_multi_function_result();
+        let view = make_view_default(&result);
+        let v = parse(&format_sarif(&view, "0.2.2"));
+        assert_eq!(
+            v["$schema"],
+            "https://json.schemastore.org/sarif-2.1.0.json"
+        );
+        assert_eq!(v["version"], "2.1.0");
+        assert_eq!(v["runs"][0]["tool"]["driver"]["name"], "crap4rs");
+        assert_eq!(v["runs"][0]["tool"]["driver"]["version"], "0.2.2");
+    }
+
+    #[test]
+    fn rule_definition_present_on_every_run() {
+        // The rule must be defined on the run regardless of whether any
+        // result references it, so consumers can introspect the schema.
+        let empty = make_empty_result();
+        let v = parse(&format_sarif(&make_view_default(&empty), "0.2.2"));
+        let rules = v["runs"][0]["tool"]["driver"]["rules"].as_array().unwrap();
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0]["id"], "crap/threshold-exceeded");
+        assert_eq!(rules[0]["name"], "ThresholdExceeded");
+    }
+
+    #[test]
+    fn full_sarif_snapshot() {
+        let result = make_multi_function_result();
+        let view = make_view_default(&result);
+        let out = format_sarif(&view, "0.2.2");
+        insta::assert_snapshot!(out);
+    }
+}
+
+#[cfg(test)]
+mod proptests {
+    use super::*;
+    use crate::adapters::reporters::test_fixtures::make_view_default;
+    use crate::test_strategies::arb_analysis_result;
+    use proptest::prelude::*;
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(256))]
+
+        #[test]
+        fn prop_format_sarif_always_valid_json(result in arb_analysis_result()) {
+            let view = make_view_default(&result);
+            let out = format_sarif(&view, "0.2.2");
+            let _: serde_json::Value = serde_json::from_str(&out)
+                .expect("format_sarif must produce parseable JSON");
+        }
+
+        #[test]
+        fn prop_sarif_results_count_matches_exceeders(result in arb_analysis_result()) {
+            let view = make_view_default(&result);
+            let out = format_sarif(&view, "0.2.2");
+            let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+            let results = v["runs"][0]["results"].as_array().unwrap();
+            let expected = result.functions.iter().filter(|fv| fv.exceeds).count();
+            prop_assert_eq!(results.len(), expected);
+        }
+
+        #[test]
+        fn prop_every_result_has_mandatory_sarif_fields(result in arb_analysis_result()) {
+            let view = make_view_default(&result);
+            let out = format_sarif(&view, "0.2.2");
+            let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+            for r in v["runs"][0]["results"].as_array().unwrap() {
+                prop_assert!(r["ruleId"].is_string());
+                prop_assert!(r["level"].is_string());
+                prop_assert!(r["message"]["text"].is_string());
+                prop_assert!(r["locations"].is_array());
+                prop_assert!(r["locations"][0]["physicalLocation"]["artifactLocation"]["uri"].is_string());
+                prop_assert!(r["locations"][0]["physicalLocation"]["region"]["startLine"].is_u64());
+                prop_assert!(r["locations"][0]["physicalLocation"]["region"]["endLine"].is_u64());
+                prop_assert!(r["partialFingerprints"]["functionIdentity"].is_string());
+            }
+        }
+
+        #[test]
+        fn prop_severity_is_one_of_three_values(result in arb_analysis_result()) {
+            let view = make_view_default(&result);
+            let out = format_sarif(&view, "0.2.2");
+            let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+            for r in v["runs"][0]["results"].as_array().unwrap() {
+                let level = r["level"].as_str().unwrap();
+                prop_assert!(
+                    matches!(level, "error" | "warning" | "note"),
+                    "unexpected level: {}", level
+                );
+            }
+        }
+    }
 }

--- a/src/adapters/reporters/sarif.rs
+++ b/src/adapters/reporters/sarif.rs
@@ -1,0 +1,293 @@
+//! SARIF v2.1.0 reporter — for GitHub Code Scanning.
+//!
+//! Pure formatting function. SARIF is a *gate translation*, not a
+//! display: results derive from `view.full.functions.iter().filter(|v|
+//! v.exceeds)` so PR annotations reflect the unshapeable gate. Filters,
+//! sorts, and truncations from the View are intentionally ignored.
+
+use serde::Serialize;
+
+use crate::domain::types::{FunctionVerdict, RiskLevel};
+use crate::domain::view::AnalysisView;
+
+const SCHEMA_URI: &str = "https://json.schemastore.org/sarif-2.1.0.json";
+const RULE_ID: &str = "crap/threshold-exceeded";
+const TOOL_NAME: &str = "crap4rs";
+const TOOL_INFO_URI: &str = "https://github.com/breezy-bays-labs/crap4rs";
+const RULE_HELP_URI: &str = "https://github.com/breezy-bays-labs/crap4rs#crap-formula";
+
+/// Format an `AnalysisView` as SARIF v2.1.0 JSON.
+///
+/// One SARIF `result` per `FunctionVerdict` whose `exceeds == true`,
+/// iterating the *full* analysis (not the shaped slice). `tool_version`
+/// is threaded through to `runs[0].tool.driver.version`.
+pub fn format_sarif(view: &AnalysisView<'_>, tool_version: &str) -> String {
+    let results: Vec<SarifResult> = view
+        .full
+        .functions
+        .iter()
+        .filter(|v| v.exceeds)
+        .map(result_for)
+        .collect();
+
+    let log = SarifLog {
+        schema: SCHEMA_URI,
+        version: "2.1.0",
+        runs: vec![SarifRun {
+            tool: SarifTool {
+                driver: SarifDriver {
+                    name: TOOL_NAME,
+                    version: tool_version.to_string(),
+                    information_uri: TOOL_INFO_URI,
+                    rules: vec![rule()],
+                },
+            },
+            results,
+        }],
+    };
+
+    serde_json::to_string_pretty(&log)
+        .expect("SARIF serialization is infallible — all fields are owned strings or numbers")
+}
+
+fn rule() -> SarifRule {
+    SarifRule {
+        id: RULE_ID,
+        name: "ThresholdExceeded",
+        short_description: SarifText {
+            text: "Function CRAP score exceeds the configured threshold.",
+        },
+        full_description: SarifText {
+            text: "Functions whose CRAP score (complexity * complexity * (1 - coverage)^3 + complexity) \
+                   exceeds the threshold are change-risk hot spots: cover them first, then extract \
+                   sub-functions if complexity remains the driver.",
+        },
+        help_uri: RULE_HELP_URI,
+    }
+}
+
+fn result_for(verdict: &FunctionVerdict) -> SarifResult {
+    let s = &verdict.scored;
+    let level = severity_for(s.crap.risk_level);
+    let message = format!(
+        "Function `{}` has CRAP {:.2} (complexity={}, coverage={:.1}%) which exceeds threshold {:.1}",
+        s.identity.qualified_name,
+        s.crap.value,
+        s.complexity,
+        s.coverage_percent,
+        verdict.threshold,
+    );
+    let fingerprint = format!("{}:{}", s.identity.file_path, s.identity.qualified_name);
+
+    SarifResult {
+        rule_id: RULE_ID,
+        level,
+        message: SarifText { text: message },
+        locations: vec![SarifLocation {
+            physical_location: SarifPhysicalLocation {
+                artifact_location: SarifArtifactLocation {
+                    uri: s.identity.file_path.clone(),
+                },
+                region: SarifRegion {
+                    start_line: s.identity.span.start_line,
+                    end_line: s.identity.span.end_line,
+                },
+            },
+        }],
+        partial_fingerprints: SarifPartialFingerprints {
+            function_identity: fingerprint,
+        },
+    }
+}
+
+fn severity_for(risk: RiskLevel) -> &'static str {
+    match risk {
+        RiskLevel::High => "error",
+        RiskLevel::Moderate => "warning",
+        RiskLevel::Acceptable | RiskLevel::Low => "note",
+    }
+}
+
+// ── SARIF v2.1.0 envelope structs ───────────────────────────────────────
+//
+// Internal-only: serialization shape is not part of any public API. The
+// public contract is the JSON schema (sarif-2.1.0.json), not these
+// structs. `text` and message strings hold borrowed `&'static str` where
+// possible; only per-result fields own their data.
+
+#[derive(Serialize)]
+struct SarifText<S: Serialize> {
+    text: S,
+}
+
+#[derive(Serialize)]
+struct SarifLog {
+    #[serde(rename = "$schema")]
+    schema: &'static str,
+    version: &'static str,
+    runs: Vec<SarifRun>,
+}
+
+#[derive(Serialize)]
+struct SarifRun {
+    tool: SarifTool,
+    results: Vec<SarifResult>,
+}
+
+#[derive(Serialize)]
+struct SarifTool {
+    driver: SarifDriver,
+}
+
+#[derive(Serialize)]
+struct SarifDriver {
+    name: &'static str,
+    version: String,
+    #[serde(rename = "informationUri")]
+    information_uri: &'static str,
+    rules: Vec<SarifRule>,
+}
+
+#[derive(Serialize)]
+struct SarifRule {
+    id: &'static str,
+    name: &'static str,
+    #[serde(rename = "shortDescription")]
+    short_description: SarifText<&'static str>,
+    #[serde(rename = "fullDescription")]
+    full_description: SarifText<&'static str>,
+    #[serde(rename = "helpUri")]
+    help_uri: &'static str,
+}
+
+#[derive(Serialize)]
+struct SarifResult {
+    #[serde(rename = "ruleId")]
+    rule_id: &'static str,
+    level: &'static str,
+    message: SarifText<String>,
+    locations: Vec<SarifLocation>,
+    #[serde(rename = "partialFingerprints")]
+    partial_fingerprints: SarifPartialFingerprints,
+}
+
+#[derive(Serialize)]
+struct SarifLocation {
+    #[serde(rename = "physicalLocation")]
+    physical_location: SarifPhysicalLocation,
+}
+
+#[derive(Serialize)]
+struct SarifPhysicalLocation {
+    #[serde(rename = "artifactLocation")]
+    artifact_location: SarifArtifactLocation,
+    region: SarifRegion,
+}
+
+#[derive(Serialize)]
+struct SarifArtifactLocation {
+    uri: String,
+}
+
+#[derive(Serialize)]
+struct SarifRegion {
+    #[serde(rename = "startLine")]
+    start_line: usize,
+    #[serde(rename = "endLine")]
+    end_line: usize,
+}
+
+#[derive(Serialize)]
+struct SarifPartialFingerprints {
+    #[serde(rename = "functionIdentity")]
+    function_identity: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adapters::reporters::test_fixtures::*;
+    use crate::domain::types::RiskLevel;
+
+    fn parse(json: &str) -> serde_json::Value {
+        serde_json::from_str(json).expect("format_sarif must produce valid JSON")
+    }
+
+    #[test]
+    fn empty_result_produces_empty_results_array() {
+        let result = make_empty_result();
+        let view = make_view_default(&result);
+        let v = parse(&format_sarif(&view, "test-version"));
+        assert_eq!(v["version"], "2.1.0");
+        assert_eq!(v["runs"][0]["results"].as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn single_exceeder_produces_one_result() {
+        let result = make_single_function_result(
+            "complex_fn",
+            "src/lib.rs",
+            10,
+            30.0,
+            30.0,
+            RiskLevel::High,
+            8.0,
+        );
+        let view = make_view_default(&result);
+        let v = parse(&format_sarif(&view, "test-version"));
+        let results = v["runs"][0]["results"].as_array().unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0]["ruleId"], "crap/threshold-exceeded");
+        assert_eq!(results[0]["level"], "error");
+    }
+
+    #[test]
+    fn severity_mapping_covers_all_risk_levels() {
+        // Build four verdicts, one per RiskLevel, each exceeding threshold.
+        // The severity mapping is the contract:
+        //   High → error, Moderate → warning, Acceptable → note, Low → note.
+        // (Low normally doesn't exceed in production, but the mapping must
+        // still be defined defensively.)
+        use crate::domain::types::{AnalysisResult, AnalysisSummary};
+        let v_high = make_verdict("h", "src/h.rs", 10, 0.0, 30.0, RiskLevel::High, 8.0);
+        let v_mod = make_verdict("m", "src/m.rs", 6, 50.0, 15.0, RiskLevel::Moderate, 8.0);
+        let v_acc = make_verdict("a", "src/a.rs", 3, 70.0, 9.0, RiskLevel::Acceptable, 8.0);
+        let v_low = make_verdict("l", "src/l.rs", 2, 95.0, 8.5, RiskLevel::Low, 8.0);
+        let result = AnalysisResult {
+            functions: vec![v_high, v_mod, v_acc, v_low],
+            summary: AnalysisSummary {
+                total_functions: 4,
+                ..Default::default()
+            },
+            passed: false,
+        };
+        let view = make_view_default(&result);
+        let v = parse(&format_sarif(&view, "test-version"));
+        let results = v["runs"][0]["results"].as_array().unwrap();
+        let levels: Vec<&str> = results
+            .iter()
+            .map(|r| r["level"].as_str().unwrap())
+            .collect();
+        assert_eq!(levels, vec!["error", "warning", "note", "note"]);
+    }
+
+    #[test]
+    fn partial_fingerprints_use_file_and_qualified_name() {
+        let result = make_single_function_result(
+            "MyType::method",
+            "src/lib.rs",
+            10,
+            0.0,
+            30.0,
+            RiskLevel::High,
+            8.0,
+        );
+        let view = make_view_default(&result);
+        let v = parse(&format_sarif(&view, "test-version"));
+        let r0 = &v["runs"][0]["results"][0];
+        assert_eq!(
+            r0["partialFingerprints"]["functionIdentity"],
+            "src/lib.rs:MyType::method"
+        );
+    }
+}

--- a/src/adapters/reporters/snapshots/crap4rs__adapters__reporters__sarif__tests__full_sarif_snapshot.snap
+++ b/src/adapters/reporters/snapshots/crap4rs__adapters__reporters__sarif__tests__full_sarif_snapshot.snap
@@ -1,0 +1,81 @@
+---
+source: src/adapters/reporters/sarif.rs
+assertion_line: 322
+expression: out
+---
+{
+  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "crap4rs",
+          "version": "0.2.2",
+          "informationUri": "https://github.com/breezy-bays-labs/crap4rs",
+          "rules": [
+            {
+              "id": "crap/threshold-exceeded",
+              "name": "ThresholdExceeded",
+              "shortDescription": {
+                "text": "Function CRAP score exceeds the configured threshold."
+              },
+              "fullDescription": {
+                "text": "Functions whose CRAP score (complexity * complexity * (1 - coverage)^3 + complexity) exceeds the threshold are change-risk hot spots: cover them first, then extract sub-functions if complexity remains the driver."
+              },
+              "helpUri": "https://github.com/breezy-bays-labs/crap4rs#crap-formula"
+            }
+          ]
+        }
+      },
+      "results": [
+        {
+          "ruleId": "crap/threshold-exceeded",
+          "level": "warning",
+          "message": {
+            "text": "Function `parse_record` has CRAP 15.00 (complexity=6, coverage=72.5%) which exceeds threshold 8.0"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/adapters/coverage/mod.rs"
+                },
+                "region": {
+                  "startLine": 1,
+                  "endLine": 10
+                }
+              }
+            }
+          ],
+          "partialFingerprints": {
+            "functionIdentity": "src/adapters/coverage/mod.rs:parse_record"
+          }
+        },
+        {
+          "ruleId": "crap/threshold-exceeded",
+          "level": "error",
+          "message": {
+            "text": "Function `complex_fn` has CRAP 45.20 (complexity=20, coverage=30.0%) which exceeds threshold 8.0"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/domain/crap.rs"
+                },
+                "region": {
+                  "startLine": 1,
+                  "endLine": 10
+                }
+              }
+            }
+          ],
+          "partialFingerprints": {
+            "functionIdentity": "src/domain/crap.rs:complex_fn"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -513,6 +513,11 @@ INVESTIGATION PATTERNS:
   # then invoke it by name. CLI flags override preset values.
   crap4rs --coverage lcov.info --view ci
 
+  # GitHub Code Scanning: emit SARIF and let upload-sarif annotate the PR
+  # diff inline. Use --no-fail so the gate exit code doesn't skip the
+  # upload step on regressions.
+  crap4rs --coverage lcov.info --format sarif --no-fail > crap.sarif
+
 COMPARING TWO ANALYSES (issue #81):
   # Capture a baseline (e.g., from main):
   crap4rs --coverage lcov.info --format json > baseline.json

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -57,6 +57,8 @@ pub enum FormatArg {
     Markdown,
     /// RFC 4180 CSV — one row per function, no summary
     Csv,
+    /// SARIF v2.1.0 — for GitHub Code Scanning (upload-sarif@v3)
+    Sarif,
 }
 
 /// Sort key for the displayed view (issue #68).
@@ -697,6 +699,12 @@ fn run_inner() -> Result<bool> {
                 cli.display.md_top,
             ),
             FormatArg::Csv => reporters::format_csv(&view, delta_view.as_ref(), effective_metric),
+            // SARIF is a gate translation, not a display: it iterates
+            // `view.full.functions` internally regardless of how the View
+            // was shaped. `--top`, `--sort-by`, `--only-failing`, and
+            // `--baseline` do NOT alter SARIF output — PR annotations
+            // must reflect truth.
+            FormatArg::Sarif => reporters::format_sarif(&view, env!("CARGO_PKG_VERSION")),
         };
         print!("{output}");
     }
@@ -1148,6 +1156,12 @@ mod tests {
     fn format_json() {
         let cli = parse(&["--coverage", "lcov.info", "--format", "json"]).unwrap();
         assert!(matches!(cli.output.format, FormatArg::Json));
+    }
+
+    #[test]
+    fn format_sarif() {
+        let cli = parse(&["--coverage", "lcov.info", "--format", "sarif"]).unwrap();
+        assert!(matches!(cli.output.format, FormatArg::Sarif));
     }
 
     #[test]

--- a/tests/features/sarif_reporter.feature
+++ b/tests/features/sarif_reporter.feature
@@ -1,0 +1,109 @@
+Feature: SARIF reporter (issue #70)
+
+  The SARIF reporter formats CRAP analysis results as SARIF v2.1.0 JSON
+  for GitHub Code Scanning. It is a *gate translation*, not a display:
+  results derive from the unshapeable analysis (`view.full.functions`),
+  not the filtered/sorted/truncated `view.shown`. PR annotations must
+  reflect truth, not a presentation choice.
+
+  Background:
+    Given a project with several functions whose CRAP scores cross the
+    threshold
+
+  # ── Envelope shape ─────────────────────────────────────────────────
+
+  Scenario: --format sarif emits SARIF v2.1.0 JSON
+    When the operator runs `crap4rs --coverage lcov.info --format sarif`
+    Then stdout is parseable JSON
+    And the document has top-level "$schema" "https://json.schemastore.org/sarif-2.1.0.json"
+    And the document has top-level "version" "2.1.0"
+    And `runs[0].tool.driver.name` is "crap4rs"
+    And `runs[0].tool.driver.version` matches the binary version
+    And `runs[0].tool.driver.rules[0].id` is "crap/threshold-exceeded"
+
+  Scenario: One result per exceeding function
+    When the operator runs `crap4rs --coverage lcov.info --format sarif`
+    Then `runs[0].results[]` length equals the number of functions where
+      `exceeds == true` in the full analysis
+    And every result has a `ruleId`, `level`, `message.text`, a single
+      `locations[0].physicalLocation`, and `partialFingerprints.functionIdentity`
+
+  Scenario: Empty results when no function exceeds the threshold
+    Given every function is below the threshold
+    When the operator runs `crap4rs --coverage lcov.info --format sarif`
+    Then `runs[0].results[]` is the empty array
+    And the rule definition is still present on `runs[0].tool.driver.rules`
+
+  # ── Severity mapping ───────────────────────────────────────────────
+
+  Scenario Outline: Risk level maps to SARIF severity
+    Given an exceeding function with risk level <risk>
+    When the operator runs `crap4rs --coverage lcov.info --format sarif`
+    Then the result for that function has `level` <sarif_level>
+
+    Examples:
+      | risk       | sarif_level |
+      | high       | "error"     |
+      | moderate   | "warning"   |
+      | acceptable | "note"      |
+      | low        | "note"      |
+
+  # ── Gate keystone: SARIF iterates the FULL analysis ────────────────
+
+  Scenario: --top does NOT truncate SARIF results
+    Given six exceeding functions
+    When the operator runs `crap4rs --coverage lcov.info --format sarif --top 2`
+    Then `runs[0].results[]` length is 6
+    And the View shaping (limit / truncated) does not appear in the SARIF
+      output — SARIF has no `view` block, only the unshapeable gate
+
+  Scenario: --only-failing does NOT shrink SARIF results
+    Given the analysis contains both passing and exceeding functions
+    When the operator runs `crap4rs --coverage lcov.info --format sarif --only-failing`
+    Then `runs[0].results[]` length equals the number of exceeding
+      functions, identical to the run without `--only-failing`
+
+  Scenario: --sort-by does NOT reorder SARIF results
+    Given several exceeding functions
+    When the operator runs `crap4rs --coverage lcov.info --format sarif --sort-by coverage`
+    Then `runs[0].results[]` is in the order produced by iterating
+      `view.full.functions`, not the View's display sort
+
+  # ── Exit code semantics ────────────────────────────────────────────
+
+  Scenario: Exit code is unchanged by --format sarif
+    Given exceeding functions exist
+    When the operator runs `crap4rs --coverage lcov.info --format sarif`
+    Then the exit code is 1
+    And stdout is non-empty SARIF JSON
+
+  Scenario: --no-fail still emits the truth in SARIF
+    Given exceeding functions exist
+    When the operator runs `crap4rs --coverage lcov.info --format sarif --no-fail`
+    Then the exit code is 0
+    But `runs[0].results[]` still lists every exceeding function — SARIF
+      reports findings, the gate decides exit code
+
+  # ── Location format (GitHub-compatible) ────────────────────────────
+
+  Scenario: Artifact URI is the repo-relative file path
+    When the operator runs `crap4rs --coverage lcov.info --format sarif`
+    Then every `result.locations[0].physicalLocation.artifactLocation.uri`
+      is the same repo-relative path the table reporter uses
+    And the path does not begin with "file://" or "/"
+
+  Scenario: Region carries the full line range from the analysis
+    When the operator runs `crap4rs --coverage lcov.info --format sarif`
+    Then every `result.locations[0].physicalLocation.region.startLine`
+      equals the function's `span.start_line` (1-based)
+    And every region's `endLine` equals the function's `span.end_line`
+      (inclusive)
+
+  # ── Fingerprints (GitHub dedup) ────────────────────────────────────
+
+  Scenario: partialFingerprints stable across runs and rebases
+    When the operator runs `crap4rs --coverage lcov.info --format sarif`
+    Then every result's `partialFingerprints.functionIdentity` is the
+      string "{file_path}:{qualified_name}"
+    And running the same command twice produces byte-identical SARIF
+      (no timestamp, no run-scoped IDs)

--- a/tests/sarif_reporter_integration.rs
+++ b/tests/sarif_reporter_integration.rs
@@ -1,0 +1,277 @@
+//! Integration tests for `--format sarif` (issue #70).
+//!
+//! Drives the binary end-to-end. SARIF is a gate translation: the
+//! contract is that results derive from the unshapeable
+//! `view.full.functions` regardless of display flags (`--top`,
+//! `--sort-by`, `--only-failing`). These tests pin that contract.
+
+use std::path::Path;
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_crap4rs");
+
+fn setup_dir(dir: &Path, src_content: &str, lcov_content: &str) {
+    let src = dir.join("src");
+    std::fs::create_dir_all(&src).expect("create src dir");
+    std::fs::write(src.join("lib.rs"), src_content).expect("write lib.rs fixture");
+    std::fs::write(dir.join("lcov.info"), lcov_content).expect("write lcov.info fixture");
+}
+
+fn run(dir: &Path, extra_args: &[&str]) -> std::process::Output {
+    Command::new(BINARY)
+        .current_dir(dir)
+        .args(["--coverage", "lcov.info", "--src", "src"])
+        .args(extra_args)
+        .output()
+        .expect("failed to run crap4rs binary")
+}
+
+fn stdout_str(output: &std::process::Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn parse_json(output: &std::process::Output) -> serde_json::Value {
+    let out = stdout_str(output);
+    serde_json::from_str(&out)
+        .unwrap_or_else(|e| panic!("stdout was not valid JSON: {e}\nraw stdout:\n{out}"))
+}
+
+/// 6 functions: 3 trivial (covered, low CRAP), 3 branchy (uncovered, high CRAP).
+const FIXTURE_SRC: &str = "\
+pub fn passing_a() -> i32 { 1 }
+pub fn passing_b() -> i32 { 2 }
+pub fn passing_c() -> i32 { 3 }
+pub fn failing_a(x: i32) -> i32 { if x > 0 { if x > 5 { 1 } else { 2 } } else { 3 } }
+pub fn failing_b(x: i32) -> i32 { if x > 0 { if x > 5 { 1 } else { 2 } } else { 3 } }
+pub fn failing_c(x: i32) -> i32 { if x > 0 { if x > 5 { 1 } else { 2 } } else { 3 } }
+";
+
+const FIXTURE_LCOV: &str = "\
+SF:lib.rs
+DA:1,1
+DA:2,1
+DA:3,1
+DA:4,0
+DA:5,0
+DA:6,0
+end_of_record
+";
+
+/// All-passing fixture (3 trivial fns, fully covered) for the empty-results case.
+const PASSING_SRC: &str = "\
+pub fn passing_a() -> i32 { 1 }
+pub fn passing_b() -> i32 { 2 }
+pub fn passing_c() -> i32 { 3 }
+";
+
+const PASSING_LCOV: &str = "\
+SF:lib.rs
+DA:1,1
+DA:2,1
+DA:3,1
+end_of_record
+";
+
+// ── Envelope shape ─────────────────────────────────────────────────
+
+#[test]
+fn sarif_envelope_has_v2_1_0_shape() {
+    let dir = tempfile::tempdir().unwrap();
+    setup_dir(dir.path(), FIXTURE_SRC, FIXTURE_LCOV);
+    let output = run(dir.path(), &["--threshold", "8", "--format", "sarif"]);
+
+    let v = parse_json(&output);
+    assert_eq!(
+        v["$schema"], "https://json.schemastore.org/sarif-2.1.0.json",
+        "schema URI"
+    );
+    assert_eq!(v["version"], "2.1.0", "SARIF version");
+    assert_eq!(v["runs"][0]["tool"]["driver"]["name"], "crap4rs");
+    let version = v["runs"][0]["tool"]["driver"]["version"]
+        .as_str()
+        .expect("version must be a string");
+    assert!(!version.is_empty(), "version must not be empty");
+    assert_eq!(
+        v["runs"][0]["tool"]["driver"]["rules"][0]["id"],
+        "crap/threshold-exceeded"
+    );
+}
+
+#[test]
+fn sarif_results_match_exceeders_in_full_analysis() {
+    let dir = tempfile::tempdir().unwrap();
+    setup_dir(dir.path(), FIXTURE_SRC, FIXTURE_LCOV);
+    let output = run(dir.path(), &["--threshold", "8", "--format", "sarif"]);
+
+    let v = parse_json(&output);
+    let results = v["runs"][0]["results"].as_array().unwrap();
+    // 3 branchy functions exceed; 3 trivial ones are below.
+    assert_eq!(results.len(), 3, "expected 3 exceeders, got {results:?}");
+    for r in results {
+        assert!(r["ruleId"].is_string());
+        assert!(r["level"].is_string());
+        assert!(r["message"]["text"].is_string());
+        assert!(r["locations"][0]["physicalLocation"]["artifactLocation"]["uri"].is_string());
+        assert!(r["locations"][0]["physicalLocation"]["region"]["startLine"].is_u64());
+        assert!(r["locations"][0]["physicalLocation"]["region"]["endLine"].is_u64());
+        assert!(r["partialFingerprints"]["functionIdentity"].is_string());
+    }
+}
+
+#[test]
+fn sarif_empty_results_when_nothing_exceeds() {
+    let dir = tempfile::tempdir().unwrap();
+    setup_dir(dir.path(), PASSING_SRC, PASSING_LCOV);
+    let output = run(dir.path(), &["--threshold", "8", "--format", "sarif"]);
+
+    let v = parse_json(&output);
+    let results = v["runs"][0]["results"].as_array().unwrap();
+    assert_eq!(results.len(), 0, "expected empty results");
+    // Rule must still be present so consumers can introspect.
+    let rules = v["runs"][0]["tool"]["driver"]["rules"].as_array().unwrap();
+    assert_eq!(rules.len(), 1);
+    assert_eq!(rules[0]["id"], "crap/threshold-exceeded");
+}
+
+// ── Gate keystone: SARIF iterates the FULL analysis ────────────────
+
+#[test]
+fn sarif_top_does_not_truncate() {
+    let dir = tempfile::tempdir().unwrap();
+    setup_dir(dir.path(), FIXTURE_SRC, FIXTURE_LCOV);
+    let baseline = run(dir.path(), &["--threshold", "8", "--format", "sarif"]);
+    let with_top = run(
+        dir.path(),
+        &["--threshold", "8", "--format", "sarif", "--top", "1"],
+    );
+    assert_eq!(
+        stdout_str(&baseline),
+        stdout_str(&with_top),
+        "--top must not affect SARIF output"
+    );
+}
+
+#[test]
+fn sarif_only_failing_does_not_shrink() {
+    let dir = tempfile::tempdir().unwrap();
+    setup_dir(dir.path(), FIXTURE_SRC, FIXTURE_LCOV);
+    let baseline = run(dir.path(), &["--threshold", "8", "--format", "sarif"]);
+    let only_failing = run(
+        dir.path(),
+        &["--threshold", "8", "--format", "sarif", "--only-failing"],
+    );
+    assert_eq!(
+        stdout_str(&baseline),
+        stdout_str(&only_failing),
+        "--only-failing must not affect SARIF output"
+    );
+}
+
+#[test]
+fn sarif_sort_by_does_not_reorder() {
+    let dir = tempfile::tempdir().unwrap();
+    setup_dir(dir.path(), FIXTURE_SRC, FIXTURE_LCOV);
+    let baseline = run(dir.path(), &["--threshold", "8", "--format", "sarif"]);
+    let sorted = run(
+        dir.path(),
+        &[
+            "--threshold",
+            "8",
+            "--format",
+            "sarif",
+            "--sort-by",
+            "coverage",
+        ],
+    );
+    assert_eq!(
+        stdout_str(&baseline),
+        stdout_str(&sorted),
+        "--sort-by must not reorder SARIF results"
+    );
+}
+
+// ── Exit code semantics ────────────────────────────────────────────
+
+#[test]
+fn sarif_exit_code_unchanged_by_format() {
+    let dir = tempfile::tempdir().unwrap();
+    setup_dir(dir.path(), FIXTURE_SRC, FIXTURE_LCOV);
+    let output = run(dir.path(), &["--threshold", "8", "--format", "sarif"]);
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "exceeding functions exit 1 regardless of --format"
+    );
+    assert!(!stdout_str(&output).is_empty());
+}
+
+#[test]
+fn sarif_no_fail_overrides_exit_but_still_lists_findings() {
+    let dir = tempfile::tempdir().unwrap();
+    setup_dir(dir.path(), FIXTURE_SRC, FIXTURE_LCOV);
+    let output = run(
+        dir.path(),
+        &["--threshold", "8", "--format", "sarif", "--no-fail"],
+    );
+    assert_eq!(output.status.code(), Some(0), "--no-fail exits 0");
+    let v = parse_json(&output);
+    let results = v["runs"][0]["results"].as_array().unwrap();
+    assert_eq!(
+        results.len(),
+        3,
+        "--no-fail must not hide findings — gate is exit code, SARIF reports truth"
+    );
+}
+
+// ── Location format ────────────────────────────────────────────────
+
+#[test]
+fn sarif_artifact_uri_is_repo_relative_no_scheme() {
+    let dir = tempfile::tempdir().unwrap();
+    setup_dir(dir.path(), FIXTURE_SRC, FIXTURE_LCOV);
+    let output = run(dir.path(), &["--threshold", "8", "--format", "sarif"]);
+    let v = parse_json(&output);
+    for r in v["runs"][0]["results"].as_array().unwrap() {
+        let uri = r["locations"][0]["physicalLocation"]["artifactLocation"]["uri"]
+            .as_str()
+            .unwrap();
+        assert!(
+            !uri.starts_with("file://"),
+            "uri must not be a file:// URL: {uri}"
+        );
+        assert!(!uri.starts_with('/'), "uri must be repo-relative: {uri}");
+        assert!(uri.ends_with(".rs"), "expected .rs path, got {uri}");
+    }
+}
+
+// ── Determinism (fingerprint stability) ────────────────────────────
+
+#[test]
+fn sarif_byte_identical_across_runs() {
+    let dir = tempfile::tempdir().unwrap();
+    setup_dir(dir.path(), FIXTURE_SRC, FIXTURE_LCOV);
+    let first = stdout_str(&run(dir.path(), &["--threshold", "8", "--format", "sarif"]));
+    let second = stdout_str(&run(dir.path(), &["--threshold", "8", "--format", "sarif"]));
+    assert_eq!(first, second, "SARIF must be byte-deterministic");
+}
+
+#[test]
+fn sarif_partial_fingerprint_format() {
+    let dir = tempfile::tempdir().unwrap();
+    setup_dir(dir.path(), FIXTURE_SRC, FIXTURE_LCOV);
+    let output = run(dir.path(), &["--threshold", "8", "--format", "sarif"]);
+    let v = parse_json(&output);
+    for r in v["runs"][0]["results"].as_array().unwrap() {
+        let fp = r["partialFingerprints"]["functionIdentity"]
+            .as_str()
+            .unwrap();
+        let uri = r["locations"][0]["physicalLocation"]["artifactLocation"]["uri"]
+            .as_str()
+            .unwrap();
+        let expected_prefix = format!("{uri}:");
+        assert!(
+            fp.starts_with(&expected_prefix),
+            "fingerprint {fp:?} should start with {expected_prefix:?}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #70

First of six v0.3.0 — CI Integration milestone issues. Sequence: #70
(this) → #82 → #76 → #77 → #71 → #100 → cut v0.3.0.

## Summary

Adds `--format sarif` that emits SARIF v2.1.0 JSON for upload via
`github/codeql-action/upload-sarif@v3`. Each function whose CRAP score
exceeds the threshold becomes a SARIF `result` with `ruleId:
\"crap/threshold-exceeded\"`, severity mapped from risk level, file
path + start/end line range, and a `partialFingerprints.functionIdentity`
for cross-run dedup.

## The keystone

SARIF is a **gate translation**, not a display. Results derive from
`view.full.functions.iter().filter(|v| v.exceeds)`, *not* the shaped
`view.shown`. Display flags (`--top`, `--sort-by`, `--only-failing`)
produce byte-identical SARIF output. `--no-fail` overrides the exit
code only — the `results[]` array still lists every finding, so PR
annotations stay truthful even when the gate is bypassed.

This contract is pinned by three integration tests that compare full
stdout byte-for-byte:
- \`sarif_top_does_not_truncate\`
- \`sarif_only_failing_does_not_shrink\`
- \`sarif_sort_by_does_not_reorder\`

## Severity mapping

| Risk level   | SARIF \`level\` |
| ------------ | ------------- |
| \`high\`       | \`error\`       |
| \`moderate\`   | \`warning\`     |
| \`acceptable\` | \`note\`        |
| \`low\`        | \`note\`        |

## What landed

- \`src/adapters/reporters/sarif.rs\` — pure formatting fn
  \`format_sarif(&AnalysisView, tool_version) -> String\`. No domain
  changes. Mirrors \`format_csv\`'s shape (single primitive parameter
  beyond the view, no config struct).
- \`FormatArg::Sarif\` clap variant + dispatch arm passing
  \`env!(\"CARGO_PKG_VERSION\")\` as the tool version.
- 12 unit tests (4 contract, 4 property at 256 cases each, 1 snapshot,
  3 envelope shape).
- 11 hand-asserted integration tests in
  \`tests/sarif_reporter_integration.rs\`.
- Companion Gherkin spec at \`tests/features/sarif_reporter.feature\`
  (10 scenarios + 1 outline).
- README \"SARIF for GitHub Code Scanning\" subsection with severity
  table and copy-pasteable GitHub Actions workflow.
- CHANGELOG \`[Unreleased]\` Added entry.
- \`crap4rs --help\` after_help SARIF example.

## Quality gates

- ✅ \`cargo fmt --check && cargo clippy --all-targets -- -D warnings\` clean
- ✅ \`cargo nextest run\` — 750/750 pass (1 pre-existing leaky test, unrelated)
- ✅ Self-CRAP at strict (15) — every fn in \`adapters/reporters/sarif.rs\` is CC ≤ 2, coverage 100%, CRAP ≤ 2.0
- ✅ \`cargo mutants --file src/adapters/reporters/sarif.rs\` — 4/4 viable mutants caught, 2 unviable, 0 missed
- ✅ Architecture: \`sarif.rs\` imports \`serde::Serialize\` + \`crate::domain::types\` + \`crate::domain::view\`. No \`core\`, no \`ports\`, no inward imports.

## End-to-end smoke (self-scan)

Ran \`crap4rs --coverage \$(self-lcov) --threshold 15 --format sarif\`
on this branch's source. Exit 1, 1 result for the pre-existing
\`run_inner\` function (CRAP 22.01 → \`level: warning\`), file location
\`cli/mod.rs\` lines 564-732, fingerprint
\`cli/mod.rs:run_inner\`. Output is parseable JSON conforming to SARIF
v2.1.0 mandatory structure.

## Manual upload smoke (deferred follow-up)

I did **not** stand up a throwaway repo to upload the SARIF and watch
GitHub render the annotations — recommended dogfooding path is via
mokumo CI on next sync (it already runs the crap-scorecard composite
action, so adding a parallel \`upload-sarif\` step is a one-line
change). If reviewer prefers, happy to open a follow-up issue for the
mokumo-side validation.

## Test plan

- [x] \`--format sarif\` produces parseable SARIF v2.1.0 JSON
- [x] One result per exceeding function; empty array when none exceed
- [x] Severity mapping: high → error, moderate → warning, acceptable & low → note
- [x] \`tool.driver\` carries crap4rs name, version, rule definition (always)
- [x] \`--top\` / \`--sort-by\` / \`--only-failing\` produce byte-identical output (gate keystone)
- [x] \`--no-fail\` overrides exit only; results[] still lists findings
- [x] \`partialFingerprints.functionIdentity = \"{file_path}:{qualified_name}\"\`
- [x] Two consecutive runs produce byte-identical SARIF
- [x] Artifact URI is repo-relative, no \`file://\` scheme
- [x] CI workflow example documented in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)