### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-04-27
+
+The SARIF + API hardening milestone. Three breaking-but-paid-once changes
+ship together so v0.3.x can stay additive: SARIF v2.1.0 output with
+column-precise regions for GitHub Code Scanning (#70 / #105), the
+`FunctionVerdict.diagnostic` placeholder slot for the `/cut-the-crap`
+agent skill (#82), and `#[non_exhaustive]` on every public envelope type
+so future field additions land as minor releases.
+
 ### Added
 - **`--format sarif`** — emit SARIF v2.1.0 JSON for GitHub Code Scanning. Each function whose CRAP score exceeds the threshold becomes a SARIF `result` with `ruleId: "crap/threshold-exceeded"`, severity mapped from risk level (high → `error`, moderate → `warning`, acceptable & low → `note`), file path + start/end line, and a `partialFingerprints.functionIdentity` for cross-run dedup. SARIF output is a *gate translation*: results derive from the unshapeable analysis, so display flags (`--top`, `--sort-by`, `--only-failing`) do **not** alter SARIF output. `--no-fail` overrides the exit code only — the `results[]` array still reports every finding so PR annotations stay truthful. Pipe stdout into a `.sarif` file and upload via `github/codeql-action/upload-sarif@v3`. Closes #70.
 - **Column-precise SARIF regions** — `domain::types::SourceSpan` gains additive `start_column` / `end_column` fields (1-based; `0` means "unknown"). The Rust complexity adapter populates them from `proc_macro2::Span`, and `--format sarif` emits `region.startColumn` / `endColumn` only when both columns are known. GitHub Code Scanning now underlines the exact function range in the PR diff instead of highlighting the whole line. Adapters without column data (diff hunks) emit `0`, and the reporter omits the column keys to keep half-truths off the wire. JSON envelope `schema_version` is unchanged (additive via `#[serde(default)]`). Closes #105.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,7 +248,7 @@ dependencies = [
 
 [[package]]
 name = "crap4rs"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crap4rs"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2024"
 authors = ["Christopher Bays <cmbays@breezybayslabs.com>"]
 description = "CRAP score analyzer for Rust — find complex, under-tested functions"

--- a/src/adapters/reporters/snapshots/crap4rs__adapters__reporters__markdown__tests__full_markdown_breakdown_snapshot.snap
+++ b/src/adapters/reporters/snapshots/crap4rs__adapters__reporters__markdown__tests__full_markdown_breakdown_snapshot.snap
@@ -2,7 +2,7 @@
 source: src/adapters/reporters/markdown.rs
 expression: out
 ---
-# crap4rs v0.2.2 — CRAP Score Analysis
+# crap4rs v0.3.0 — CRAP Score Analysis
 
 ## Summary
 

--- a/src/adapters/reporters/snapshots/crap4rs__adapters__reporters__markdown__tests__full_markdown_snapshot.snap
+++ b/src/adapters/reporters/snapshots/crap4rs__adapters__reporters__markdown__tests__full_markdown_snapshot.snap
@@ -2,7 +2,7 @@
 source: src/adapters/reporters/markdown.rs
 expression: out
 ---
-# crap4rs v0.2.2 — CRAP Score Analysis
+# crap4rs v0.3.0 — CRAP Score Analysis
 
 ## Summary
 

--- a/src/adapters/reporters/snapshots/crap4rs__adapters__reporters__markdown__tests__full_markdown_with_delta_snapshot.snap
+++ b/src/adapters/reporters/snapshots/crap4rs__adapters__reporters__markdown__tests__full_markdown_with_delta_snapshot.snap
@@ -2,7 +2,7 @@
 source: src/adapters/reporters/markdown.rs
 expression: out
 ---
-# crap4rs v0.2.2 — CRAP Score Analysis
+# crap4rs v0.3.0 — CRAP Score Analysis
 
 ## Summary
 

--- a/src/adapters/reporters/snapshots/crap4rs__adapters__reporters__markdown__tests__grouped_markdown_snapshot.snap
+++ b/src/adapters/reporters/snapshots/crap4rs__adapters__reporters__markdown__tests__grouped_markdown_snapshot.snap
@@ -2,7 +2,7 @@
 source: src/adapters/reporters/markdown.rs
 expression: out
 ---
-# crap4rs v0.2.2 — CRAP Score Analysis
+# crap4rs v0.3.0 — CRAP Score Analysis
 
 ## Summary
 

--- a/src/adapters/reporters/snapshots/crap4rs__adapters__reporters__table__tests__delta_block_full_snapshot.snap
+++ b/src/adapters/reporters/snapshots/crap4rs__adapters__reporters__table__tests__delta_block_full_snapshot.snap
@@ -2,7 +2,7 @@
 source: src/adapters/reporters/table.rs
 expression: output
 ---
-crap4rs v0.2.2 — CRAP Score Analysis
+crap4rs v0.3.0 — CRAP Score Analysis
 
 +------------------------------+--------------+----+------+-------+------+
 | File                         | Function     | CC | Cov% | CRAP  | Risk |

--- a/src/adapters/reporters/snapshots/crap4rs__adapters__reporters__table__tests__full_table_snapshot.snap
+++ b/src/adapters/reporters/snapshots/crap4rs__adapters__reporters__table__tests__full_table_snapshot.snap
@@ -2,7 +2,7 @@
 source: src/adapters/reporters/table.rs
 expression: output
 ---
-crap4rs v0.2.2 — CRAP Score Analysis
+crap4rs v0.3.0 — CRAP Score Analysis
 
 +------------------------------+--------------+----+------+-------+----------+
 | File                         | Function     | CC | Cov% | CRAP  | Risk     |

--- a/src/adapters/reporters/snapshots/crap4rs__adapters__reporters__table__tests__grouped_table_snapshot.snap
+++ b/src/adapters/reporters/snapshots/crap4rs__adapters__reporters__table__tests__grouped_table_snapshot.snap
@@ -2,7 +2,7 @@
 source: src/adapters/reporters/table.rs
 expression: output
 ---
-crap4rs v0.2.2 — CRAP Score Analysis
+crap4rs v0.3.0 — CRAP Score Analysis
 
 +------------------------------+-----------+---------+----------+------------+--------------+
 | File                         | Functions | Failing | Avg CRAP | Worst CRAP | Worst Fn     |


### PR DESCRIPTION
## Summary

Cuts v0.3.0. Promotes \`[Unreleased]\` → \`[0.3.0] - 2026-04-27\` in CHANGELOG, bumps \`Cargo.toml\` 0.2.2 → 0.3.0, refreshes the seven version-bearing snapshots (markdown + table title lines).

## What's in v0.3.0

The breaking-but-paid-once SARIF + API hardening milestone:

- **SARIF v2.1.0 output** for GitHub Code Scanning (#70) with column-precise regions sourced from \`proc_macro2::Span\` (#105)
- **\`FunctionVerdict.diagnostic\` placeholder slot** (#82) — additive \`Option<Diagnostic>\` field; \`Diagnostic\` derives \`Default\` and carries type-level \`#[serde(default)]\` for forward-compat as #76 grows it
- **\`#[non_exhaustive]\` on every public envelope type** — \`SourceSpan\`, \`FunctionIdentity\`, \`ComplexityContributor\`, \`CrapScore\`, \`ScoredFunction\`, \`FunctionVerdict\`, \`RiskDistribution\`, \`AnalysisSummary\`, \`AnalysisResult\`, \`AnalysisDiagnostics\` — so v0.3.x field additions ship as minor releases

## Why now

PR #106 (#105) added public fields to \`SourceSpan\` without \`#[non_exhaustive]\`, which is FRU-breaking under cargo semver. PR #108 bundled the diagnostic slot + hardening so the major bump cost is paid once. v0.3.0 closes that arc.

## Release flow

Once this merges, tagging \`v0.3.0\` on the merge commit triggers \`.github/workflows/release.yml\`: cross-platform binary builds (linux-x86, macos-arm, macos-x86), \`cargo publish\` to crates.io, and a GitHub Release with auto-generated notes.

## Test plan
- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo nextest run\` — 759 / 759 pass
- [x] Snapshot diffs reviewed: only version-string changes (\`v0.2.2\` → \`v0.3.0\`) on the seven affected files
- [x] Cargo.lock updated to 0.3.0
- [ ] Tag and push after merge (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)