### PR TITLE
feat(advice): #76 — --format advice with AST-derived remediation hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`--format advice`** (experimental, schema_version=1) emits AST-derived
+  remediation hints alongside the standard JSON envelope: a per-function
+  `Diagnostic` with `coverage_gaps`, `complexity_drivers`,
+  `suggested_actions` (`AddTestsForLines`, `ExtractFunction`,
+  `SimplifyBranching`, `AcceptInherentComplexity`), and a flat
+  `root_cause` scalar. A grep-friendly summary line per over-threshold
+  function is written to stderr. Schema stabilises at v0.4.0. Closes #76.
+- **SARIF `result.properties.diagnostic`** — when `--format sarif` is
+  used, every result for an over-threshold verdict carries the same
+  diagnostic shape as `--format advice` so GitHub Code Scanning
+  consumers and the `/cut-the-crap` agent skill (#77) can read identical
+  advice from either entry point. SARIF output stays byte-identical for
+  runs without diagnostics.
+
+### Changed
+- `domain::types::ComplexityContributor` now records `end_line` and
+  `nesting_depth` so domain helpers can answer span/nesting questions
+  without re-walking the AST. Both fields default to `0` for
+  forward-compat with older payloads.
+
 ## [0.3.0] - 2026-04-27
 
 The SARIF + API hardening milestone. Three breaking-but-paid-once changes

--- a/README.md
+++ b/README.md
@@ -157,6 +157,45 @@ The shaping flags `--delta-top`, `--delta-sort` (`score-delta` (default) | `curr
 
 `--format markdown` produces GitHub-flavored Markdown (pipe-syntax table plus a Summary block) — paste it into a PR comment, an issue body, or a doc page. `--format csv` produces RFC 4180 CSV with a fixed header row, suitable for piping into spreadsheets, BI tools, or `awk`/`jq` pipelines that prefer tabular input. Both honor every shaping flag (`--top`, `--sort-by`, `--only-failing`, `--min-coverage` / `--max-coverage`).
 
+### Agent advice (`--format advice`) — experimental
+
+`--format advice` emits the same JSON envelope as `--format json`, but with a populated `Diagnostic` on every over-threshold `view.shown[]` entry. The diagnostic is AST-derived — coverage gaps, complexity drivers, suggested actions, and a flat `root_cause` scalar — so coding agents can read findings and propose remediations without re-walking the source.
+
+```jsonc
+{
+  "schema_version": 1,
+  "view": {
+    "shown": [{
+      "scored": { "identity": { "qualified_name": "branchy_fail", ... } },
+      "exceeds": true,
+      "diagnostic": {
+        "coverage_gaps": [{ "start": 11, "end": 19 }],
+        "complexity_drivers": [{ "kind": "if-branch", "line": 12, "nesting_depth": 1, ... }],
+        "suggested_actions": [
+          { "kind": "add_tests_for_lines", "lines": [...], "applicability": "unspecified" },
+          { "kind": "extract_function", "candidates": [
+            { "line_range": { "start": 12, "end": 16 }, "complexity_contribution": 3,
+              "branch_path": "if-branch", "kind": "deepest_nesting", "recommended": true },
+            ...
+          ], "applicability": "unspecified" }
+        ],
+        "root_cause": "both"
+      }
+    }]
+  }
+}
+```
+
+A grep-friendly stderr summary streams alongside stdout — one line per over-threshold function in `view.shown[]` order:
+
+```
+[crap=56.00] src/lib.rs:5-21 branchy_fail [actions: add_tests_for_lines,extract_function]
+```
+
+`--format sarif` carries the same `Diagnostic` shape under `result.properties.diagnostic`, so SARIF consumers (and the future `/cut-the-crap` agent skill) read the same advice as `--format advice`.
+
+> **Stability:** `--format advice` is **experimental in v0.3.x**. The shape may grow additively (new fields, new `SuggestedAction` variants under `#[non_exhaustive]`), but `schema_version` stays at `1` and existing fields will not change meaning. The shape stabilises at v0.4.0 with `schema_version: 2`.
+
 ### SARIF for GitHub Code Scanning (`--format sarif`)
 
 `--format sarif` emits SARIF v2.1.0 JSON. Pipe it into a `.sarif` file and upload via `github/codeql-action/upload-sarif@v3` — every function whose CRAP score exceeds the threshold becomes an inline annotation on the exact line range in the PR diff. Reviewers see the findings without running crap4rs themselves.

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ The shaping flags `--delta-top`, `--delta-sort` (`score-delta` (default) | `curr
 
 A grep-friendly stderr summary streams alongside stdout — one line per over-threshold function in `view.shown[]` order:
 
-```
+```text
 [crap=56.00] src/lib.rs:5-21 branchy_fail [actions: add_tests_for_lines,extract_function]
 ```
 

--- a/src/adapters/complexity/mod.rs
+++ b/src/adapters/complexity/mod.rs
@@ -703,7 +703,7 @@ impl<'ast> Visit<'ast> for CyclomaticCounter<'_> {
             self.bump(
                 ContributorKind::MatchArm,
                 arm.pat.span(),
-                arm.pat.span().end().line,
+                end_line_of(arm),
                 1,
             );
         }

--- a/src/adapters/complexity/mod.rs
+++ b/src/adapters/complexity/mod.rs
@@ -153,6 +153,8 @@ fn add_contributor(
     contributors: &mut Vec<ComplexityContributor>,
     kind: ContributorKind,
     span: Span,
+    end_line: usize,
+    nesting_depth: u32,
     increment: u32,
 ) {
     contributors.push(ComplexityContributor {
@@ -160,7 +162,17 @@ fn add_contributor(
         line: span.start().line,
         column: Some(span.start().column as u32),
         increment,
+        end_line,
+        nesting_depth,
     });
+}
+
+/// 1-based inclusive end line of a construct's full span. Used by the
+/// walker to record `end_line` for compound contributors (`if`, `match`,
+/// loop variants) so domain helpers can ask "does this contributor cover
+/// line N" when building the nesting hierarchy.
+fn end_line_of(item: &impl Spanned) -> usize {
+    item.span().end().line
 }
 
 fn span_of(item: &impl syn::spanned::Spanned) -> SourceSpan {
@@ -243,6 +255,8 @@ fn count_cognitive_stmt(
                         contributors,
                         ContributorKind::LetElse,
                         else_token.span,
+                        end_line_of(diverge.as_ref()),
+                        nesting,
                         1 + nesting,
                     );
                     total += 1 + nesting;
@@ -267,6 +281,8 @@ fn count_cognitive_expr(
                 contributors,
                 ContributorKind::Match,
                 expr_match.match_token.span,
+                end_line_of(expr_match),
+                nesting,
                 1 + nesting,
             );
             let mut total = 1 + nesting; // +1 structural, +nesting
@@ -284,6 +300,8 @@ fn count_cognitive_expr(
                 contributors,
                 ContributorKind::WhileLoop,
                 expr_while.while_token.span,
+                end_line_of(expr_while),
+                nesting,
                 1 + nesting,
             );
             let mut total = 1 + nesting;
@@ -296,6 +314,8 @@ fn count_cognitive_expr(
                 contributors,
                 ContributorKind::ForLoop,
                 expr_for.for_token.span,
+                end_line_of(expr_for),
+                nesting,
                 1 + nesting,
             );
             let mut total = 1 + nesting;
@@ -308,6 +328,8 @@ fn count_cognitive_expr(
                 contributors,
                 ContributorKind::Loop,
                 expr_loop.loop_token.span,
+                end_line_of(expr_loop),
+                nesting,
                 1 + nesting,
             );
             let mut total = 1 + nesting;
@@ -318,7 +340,7 @@ fn count_cognitive_expr(
             // count_cognitive_binary_chain handles all &&/|| operators in the tree.
             // count_cognitive_binary_operands walks the non-binary leaves so that
             // constructs like `?`, `if`, etc. inside binary expressions are also counted.
-            count_cognitive_binary_chain(bin, contributors)
+            count_cognitive_binary_chain(bin, nesting, contributors)
                 + count_cognitive_binary_operands(&bin.left, nesting, contributors)
                 + count_cognitive_binary_operands(&bin.right, nesting, contributors)
         }
@@ -327,6 +349,8 @@ fn count_cognitive_expr(
                 contributors,
                 ContributorKind::Try,
                 expr_try.question_token.span,
+                expr_try.question_token.span.end().line,
+                nesting,
                 1,
             );
             1 + count_cognitive_expr(&expr_try.expr, nesting, contributors)
@@ -336,6 +360,8 @@ fn count_cognitive_expr(
                 contributors,
                 ContributorKind::Break,
                 expr_break.break_token.span,
+                expr_break.break_token.span.end().line,
+                nesting,
                 1,
             );
             1
@@ -345,6 +371,8 @@ fn count_cognitive_expr(
                 contributors,
                 ContributorKind::Continue,
                 expr_continue.continue_token.span,
+                expr_continue.continue_token.span.end().line,
+                nesting,
                 1,
             );
             1
@@ -399,6 +427,8 @@ fn count_cognitive_if(
         contributors,
         ContributorKind::IfBranch,
         expr_if.if_token.span,
+        end_line_of(expr_if),
+        nesting,
         1 + nesting,
     );
     let mut total = 1 + nesting;
@@ -418,6 +448,8 @@ fn count_cognitive_if(
                     contributors,
                     ContributorKind::IfBranch,
                     else_if.if_token.span,
+                    end_line_of(else_if),
+                    nesting,
                     1,
                 );
                 total += 1;
@@ -452,6 +484,8 @@ fn count_cognitive_else(
                 contributors,
                 ContributorKind::IfBranch,
                 else_if.if_token.span,
+                end_line_of(else_if),
+                nesting,
                 1,
             );
             let mut total = 1;
@@ -474,6 +508,7 @@ fn count_cognitive_else(
 /// Same-operator sequences count as +1 total; operator switches add +1 each.
 fn count_cognitive_binary_chain(
     bin: &ExprBinary,
+    nesting: u32,
     contributors: &mut Vec<ComplexityContributor>,
 ) -> u32 {
     let ops = flatten_binary_ops(bin);
@@ -488,7 +523,14 @@ fn count_cognitive_binary_chain(
         match op {
             BoolOp::And | BoolOp::Or => {
                 if last_is_logical != Some(*op) {
-                    add_contributor(contributors, ContributorKind::LogicalOperator, *span, 1);
+                    add_contributor(
+                        contributors,
+                        ContributorKind::LogicalOperator,
+                        *span,
+                        span.end().line,
+                        nesting,
+                        1,
+                    );
                     total += 1; // New sequence or operator switch
                 }
                 last_is_logical = Some(*op);
@@ -576,6 +618,7 @@ fn count_cyclomatic_block(
 struct CyclomaticCounter<'a> {
     contributors: &'a mut Vec<ComplexityContributor>,
     total: u32,
+    nesting: u32,
 }
 
 impl<'a> CyclomaticCounter<'a> {
@@ -583,14 +626,28 @@ impl<'a> CyclomaticCounter<'a> {
         let mut counter = Self {
             contributors,
             total: 0,
+            nesting: 0,
         };
         counter.visit_block(block);
         counter.total
     }
 
-    fn bump(&mut self, kind: ContributorKind, span: Span, increment: u32) {
-        add_contributor(self.contributors, kind, span, increment);
+    fn bump(&mut self, kind: ContributorKind, span: Span, end_line: usize, increment: u32) {
+        add_contributor(
+            self.contributors,
+            kind,
+            span,
+            end_line,
+            self.nesting,
+            increment,
+        );
         self.total += increment;
+    }
+
+    fn with_nesting<F: FnOnce(&mut Self)>(&mut self, f: F) {
+        self.nesting += 1;
+        f(self);
+        self.nesting -= 1;
     }
 }
 
@@ -610,28 +667,50 @@ impl<'ast> Visit<'ast> for CyclomaticCounter<'_> {
 
         self.visit_expr(&init.expr);
         if let Some((else_token, diverge)) = &init.diverge {
-            self.bump(ContributorKind::LetElse, else_token.span, 1);
-            self.visit_expr(diverge);
+            self.bump(
+                ContributorKind::LetElse,
+                else_token.span,
+                end_line_of(diverge.as_ref()),
+                1,
+            );
+            self.with_nesting(|s| s.visit_expr(diverge));
         }
     }
 
     fn visit_expr_if(&mut self, expr_if: &'ast syn::ExprIf) {
-        self.bump(ContributorKind::IfBranch, expr_if.if_token.span, 1);
+        self.bump(
+            ContributorKind::IfBranch,
+            expr_if.if_token.span,
+            end_line_of(expr_if),
+            1,
+        );
         self.visit_expr(&expr_if.cond);
-        self.visit_block(&expr_if.then_branch);
+        self.with_nesting(|s| s.visit_block(&expr_if.then_branch));
         if let Some((_, else_branch)) = &expr_if.else_branch {
-            self.visit_expr(else_branch);
+            match else_branch.as_ref() {
+                // `else if` continues the chain at the same nesting level (matches
+                // cognitive's `count_cognitive_else` which does not bump nesting
+                // for the else-if construct itself, only for its body).
+                Expr::If(_) => self.visit_expr(else_branch),
+                // `else { ... }` opens a new block at +1 nesting.
+                _ => self.with_nesting(|s| s.visit_expr(else_branch)),
+            }
         }
     }
 
     fn visit_expr_match(&mut self, expr_match: &'ast syn::ExprMatch) {
         for arm in expr_match.arms.iter().skip(1) {
-            self.bump(ContributorKind::MatchArm, arm.pat.span(), 1);
+            self.bump(
+                ContributorKind::MatchArm,
+                arm.pat.span(),
+                arm.pat.span().end().line,
+                1,
+            );
         }
 
         self.visit_expr(&expr_match.expr);
         for arm in &expr_match.arms {
-            self.visit_arm(arm);
+            self.with_nesting(|s| s.visit_arm(arm));
         }
     }
 
@@ -643,41 +722,63 @@ impl<'ast> Visit<'ast> for CyclomaticCounter<'_> {
     }
 
     fn visit_expr_while(&mut self, expr_while: &'ast syn::ExprWhile) {
-        self.bump(ContributorKind::WhileLoop, expr_while.while_token.span, 1);
+        self.bump(
+            ContributorKind::WhileLoop,
+            expr_while.while_token.span,
+            end_line_of(expr_while),
+            1,
+        );
         self.visit_expr(&expr_while.cond);
-        self.visit_block(&expr_while.body);
+        self.with_nesting(|s| s.visit_block(&expr_while.body));
     }
 
     fn visit_expr_for_loop(&mut self, expr_for: &'ast syn::ExprForLoop) {
-        self.bump(ContributorKind::ForLoop, expr_for.for_token.span, 1);
+        self.bump(
+            ContributorKind::ForLoop,
+            expr_for.for_token.span,
+            end_line_of(expr_for),
+            1,
+        );
         self.visit_expr(&expr_for.expr);
-        self.visit_block(&expr_for.body);
+        self.with_nesting(|s| s.visit_block(&expr_for.body));
     }
 
     fn visit_expr_loop(&mut self, expr_loop: &'ast syn::ExprLoop) {
-        self.bump(ContributorKind::Loop, expr_loop.loop_token.span, 1);
-        self.visit_block(&expr_loop.body);
+        self.bump(
+            ContributorKind::Loop,
+            expr_loop.loop_token.span,
+            end_line_of(expr_loop),
+            1,
+        );
+        self.with_nesting(|s| s.visit_block(&expr_loop.body));
     }
 
     fn visit_expr_binary(&mut self, expr_binary: &'ast syn::ExprBinary) {
         if matches!(expr_binary.op, syn::BinOp::And(_) | syn::BinOp::Or(_)) {
-            self.bump(
-                ContributorKind::LogicalOperator,
-                binop_span(&expr_binary.op),
-                1,
-            );
+            let span = binop_span(&expr_binary.op);
+            self.bump(ContributorKind::LogicalOperator, span, span.end().line, 1);
         }
         self.visit_expr(&expr_binary.left);
         self.visit_expr(&expr_binary.right);
     }
 
     fn visit_expr_try(&mut self, expr_try: &'ast syn::ExprTry) {
-        self.bump(ContributorKind::Try, expr_try.question_token.span, 1);
+        self.bump(
+            ContributorKind::Try,
+            expr_try.question_token.span,
+            expr_try.question_token.span.end().line,
+            1,
+        );
         self.visit_expr(&expr_try.expr);
     }
 
     fn visit_expr_break(&mut self, expr_break: &'ast syn::ExprBreak) {
-        self.bump(ContributorKind::Break, expr_break.break_token.span, 1);
+        self.bump(
+            ContributorKind::Break,
+            expr_break.break_token.span,
+            expr_break.break_token.span.end().line,
+            1,
+        );
         if let Some(expr) = &expr_break.expr {
             self.visit_expr(expr);
         }
@@ -687,8 +788,16 @@ impl<'ast> Visit<'ast> for CyclomaticCounter<'_> {
         self.bump(
             ContributorKind::Continue,
             expr_continue.continue_token.span,
+            expr_continue.continue_token.span.end().line,
             1,
         );
+    }
+
+    fn visit_expr_closure(&mut self, expr_closure: &'ast syn::ExprClosure) {
+        // Closures count as deeper nesting for any constructs in their body
+        // (mirrors `count_cognitive_expr`'s `Expr::Closure` branch which
+        // recurses with `nesting + 1`).
+        self.with_nesting(|s| s.visit_expr(&expr_closure.body));
     }
 }
 
@@ -1416,6 +1525,133 @@ mod contributor_tests {
             f.contributors.is_empty(),
             "Closure with no branches should have no contributors, got: {:?}",
             f.contributors
+        );
+    }
+
+    // ── end_line + nesting_depth (issue #76 V1) ────────────────────────
+
+    #[test]
+    fn nested_if_records_construct_end_line_and_nesting_depth_cognitive() {
+        // contributors_fixture.rs::nested_if_fn spans lines 16..26 (inclusive).
+        // Outer `if x > 0` opens at line 17, closes at line 25. Inner
+        // `if y > 0` opens at line 18, closes at line 22. The walker
+        // records `end_line` from the full construct span so
+        // `extract_split_candidates` can ask "does this contributor cover
+        // line N" when reconstructing the nesting hierarchy.
+        let cs = contributors_for("nested_if_fn", ComplexityMetric::Cognitive);
+        assert_eq!(cs.len(), 2, "two if-branches expected");
+        let outer = &cs[0]; // sorted ascending by line
+        let inner = &cs[1];
+
+        assert_eq!(outer.nesting_depth, 0, "outer `if` is top-level");
+        assert_eq!(inner.nesting_depth, 1, "inner `if` is nested under outer");
+        assert!(
+            outer.end_line > outer.line,
+            "outer `if` is multi-line: line={} end_line={}",
+            outer.line,
+            outer.end_line
+        );
+        assert!(
+            outer.end_line >= inner.end_line,
+            "outer's range [{}, {}] must enclose inner's [{}, {}]",
+            outer.line,
+            outer.end_line,
+            inner.line,
+            inner.end_line,
+        );
+    }
+
+    #[test]
+    fn try_records_token_span_for_atomic_contributor() {
+        // `?` is a single-token contributor — `end_line == line`.
+        let cs = contributors_for("try_fn", ComplexityMetric::Cognitive);
+        assert_eq!(cs.len(), 1);
+        let try_c = &cs[0];
+        assert_eq!(try_c.kind, ContributorKind::Try);
+        assert_eq!(
+            try_c.end_line, try_c.line,
+            "atomic constructs have end_line == line"
+        );
+        assert_eq!(try_c.nesting_depth, 0);
+    }
+
+    #[test]
+    fn for_with_continue_threads_nesting_depth_cognitive() {
+        // for(nesting=0) { if(nesting=1) { continue(nesting=2); } }
+        let cs = contributors_for("for_with_continue_fn", ComplexityMetric::Cognitive);
+        let for_c = cs
+            .iter()
+            .find(|c| c.kind == ContributorKind::ForLoop)
+            .expect("ForLoop contributor missing");
+        let if_c = cs
+            .iter()
+            .find(|c| c.kind == ContributorKind::IfBranch)
+            .expect("IfBranch contributor missing");
+        let cont_c = cs
+            .iter()
+            .find(|c| c.kind == ContributorKind::Continue)
+            .expect("Continue contributor missing");
+
+        assert_eq!(for_c.nesting_depth, 0);
+        assert_eq!(if_c.nesting_depth, 1);
+        assert_eq!(cont_c.nesting_depth, 2);
+    }
+
+    #[test]
+    fn nested_if_records_nesting_depth_cyclomatic() {
+        // Cyclomatic must thread nesting_depth identically to cognitive so
+        // domain helpers can run on either metric's contributor list.
+        let cs = contributors_for("nested_if_fn", ComplexityMetric::Cyclomatic);
+        let mut ifs: Vec<_> = cs
+            .iter()
+            .filter(|c| c.kind == ContributorKind::IfBranch)
+            .collect();
+        ifs.sort_by_key(|c| c.line);
+        assert_eq!(ifs.len(), 2);
+        assert_eq!(ifs[0].nesting_depth, 0);
+        assert_eq!(ifs[1].nesting_depth, 1);
+        assert!(
+            ifs[0].end_line > ifs[0].line,
+            "cyclomatic if also records full construct span"
+        );
+    }
+
+    #[test]
+    fn for_with_continue_records_nesting_depth_cyclomatic() {
+        let cs = contributors_for("for_with_continue_fn", ComplexityMetric::Cyclomatic);
+        let for_c = cs
+            .iter()
+            .find(|c| c.kind == ContributorKind::ForLoop)
+            .unwrap();
+        let if_c = cs
+            .iter()
+            .find(|c| c.kind == ContributorKind::IfBranch)
+            .unwrap();
+        let cont_c = cs
+            .iter()
+            .find(|c| c.kind == ContributorKind::Continue)
+            .unwrap();
+        assert_eq!(for_c.nesting_depth, 0);
+        assert_eq!(if_c.nesting_depth, 1);
+        assert_eq!(cont_c.nesting_depth, 2);
+    }
+
+    #[test]
+    fn match_records_end_line_covering_arms_cognitive() {
+        // contributors_fixture.rs::match_fn spans lines 28..35 — the Match
+        // contributor's end_line should reach the closing `}` of the
+        // match expression, not just the `match` keyword.
+        let cs = contributors_for("match_fn", ComplexityMetric::Cognitive);
+        let match_c = cs
+            .iter()
+            .find(|c| c.kind == ContributorKind::Match)
+            .expect("Match contributor missing");
+        assert_eq!(match_c.nesting_depth, 0);
+        assert!(
+            match_c.end_line > match_c.line,
+            "match end_line must cover arms: line={} end_line={}",
+            match_c.line,
+            match_c.end_line
         );
     }
 

--- a/src/adapters/complexity/mod.rs
+++ b/src/adapters/complexity/mod.rs
@@ -1528,7 +1528,7 @@ mod contributor_tests {
         );
     }
 
-    // ── end_line + nesting_depth (issue #76 V1) ────────────────────────
+    // ── end_line + nesting_depth ───────────────────────────────────────
 
     #[test]
     fn nested_if_records_construct_end_line_and_nesting_depth_cognitive() {

--- a/src/adapters/reporters/advice_summary.rs
+++ b/src/adapters/reporters/advice_summary.rs
@@ -1,0 +1,199 @@
+//! Stderr summary reporter for `--format advice` (#76 V5).
+//!
+//! Format (S-8 locked):
+//! `[crap=N.NN] file:line-line qualified::name [actions: <kinds>]`
+//!
+//! One line per over-threshold function in `view.shown[]` order so
+//! humans glancing at CI logs see a deterministic, grep-friendly
+//! summary alongside the JSON envelope on stdout.
+//!
+//! Plain text rather than `comfy-table`: lines are not aligned across
+//! rows because column widths would shift the moment a long
+//! `qualified_name` appeared. Tools like `awk` and `grep` parse this
+//! stream more reliably without padding.
+
+use std::io::{self, Write};
+
+use crate::domain::types::FunctionVerdict;
+use crate::domain::view::AnalysisView;
+
+/// Render the stderr summary for `--format advice`. Writes one line
+/// per over-threshold verdict in `view.shown` order. Returns `Ok(())`
+/// even when no verdicts exceed (callers can always invoke this).
+pub fn render_summary(view: &AnalysisView<'_>, sink: &mut impl Write) -> io::Result<()> {
+    for verdict in &view.shown {
+        if !verdict.exceeds {
+            continue;
+        }
+        writeln!(sink, "{}", format_line(verdict))?;
+    }
+    Ok(())
+}
+
+fn format_line(verdict: &FunctionVerdict) -> String {
+    let identity = &verdict.scored.identity;
+    let span = &identity.span;
+    let actions = format_actions(verdict);
+    format!(
+        "[crap={crap:.2}] {file}:{start}-{end} {name} [actions: {actions}]",
+        crap = verdict.scored.crap.value,
+        file = identity.file_path,
+        start = span.start_line,
+        end = span.end_line,
+        name = identity.qualified_name,
+        actions = actions,
+    )
+}
+
+fn format_actions(verdict: &FunctionVerdict) -> String {
+    let Some(diag) = verdict.diagnostic.as_deref() else {
+        // No diagnostic populated (caller didn't request advice). Emit
+        // a sentinel so the line is still well-formed for grep/awk.
+        return "none".to_string();
+    };
+    if diag.suggested_actions.is_empty() {
+        return "none".to_string();
+    }
+    diag.suggested_actions
+        .iter()
+        .map(action_kind_label)
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn action_kind_label(action: &crate::domain::diagnostic::SuggestedAction) -> &'static str {
+    use crate::domain::diagnostic::SuggestedAction::*;
+    match action {
+        AddTestsForLines { .. } => "add_tests_for_lines",
+        ExtractFunction { .. } => "extract_function",
+        SimplifyBranching { .. } => "simplify_branching",
+        AcceptInherentComplexity { .. } => "accept_inherent_complexity",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::diagnostic::{
+        Applicability, Diagnostic, LineRange, ProposedSplit, RootCause, SplitKind, SuggestedAction,
+    };
+    use crate::domain::types::{
+        AnalysisResult, AnalysisSummary, ComplexityMetric, CrapScore, FunctionIdentity, RiskLevel,
+        ScoredFunction, SourceSpan,
+    };
+    use crate::domain::view::{self, ViewSpec};
+
+    fn make_result(verdicts: Vec<FunctionVerdict>) -> AnalysisResult {
+        AnalysisResult {
+            passed: verdicts.iter().all(|v| !v.exceeds),
+            functions: verdicts,
+            summary: AnalysisSummary::default(),
+        }
+    }
+
+    fn make_verdict(name: &str, file: &str, line_start: usize, line_end: usize) -> FunctionVerdict {
+        FunctionVerdict {
+            scored: ScoredFunction {
+                identity: FunctionIdentity {
+                    file_path: file.to_string(),
+                    qualified_name: name.to_string(),
+                    span: SourceSpan {
+                        start_line: line_start,
+                        end_line: line_end,
+                        start_column: 0,
+                        end_column: 0,
+                    },
+                },
+                complexity: 5,
+                complexity_metric: ComplexityMetric::Cognitive,
+                coverage_percent: 50.0,
+                crap: CrapScore {
+                    value: 12.34,
+                    risk_level: RiskLevel::Moderate,
+                },
+                contributors: vec![],
+            },
+            threshold: 5.0,
+            exceeds: true,
+            diagnostic: None,
+        }
+    }
+
+    #[test]
+    fn render_summary_emits_one_line_per_exceeding_verdict() {
+        let mut v = make_verdict("foo", "src/lib.rs", 10, 20);
+        v.diagnostic = Some(Box::new(Diagnostic {
+            coverage_gaps: vec![LineRange::new(11, 13)],
+            complexity_drivers: vec![],
+            suggested_actions: vec![
+                SuggestedAction::AddTestsForLines {
+                    lines: vec![LineRange::new(11, 13)],
+                    applicability: Applicability::default(),
+                },
+                SuggestedAction::ExtractFunction {
+                    candidates: vec![ProposedSplit {
+                        line_range: LineRange::new(11, 19),
+                        complexity_contribution: 4,
+                        branch_path: "if-branch".to_string(),
+                        kind: SplitKind::DeepestNesting,
+                        recommended: true,
+                    }],
+                    applicability: Applicability::default(),
+                },
+            ],
+            root_cause: RootCause::Both,
+        }));
+        let result = make_result(vec![v]);
+        let view = view::apply(&result, ViewSpec::default());
+        let mut sink = Vec::new();
+        render_summary(&view, &mut sink).unwrap();
+        let out = String::from_utf8(sink).unwrap();
+        assert_eq!(
+            out,
+            "[crap=12.34] src/lib.rs:10-20 foo [actions: add_tests_for_lines,extract_function]\n"
+        );
+    }
+
+    #[test]
+    fn render_summary_skips_passing_verdicts() {
+        let mut v = make_verdict("under", "src/lib.rs", 1, 5);
+        v.exceeds = false;
+        let result = make_result(vec![v]);
+        let view = view::apply(&result, ViewSpec::default());
+        let mut sink = Vec::new();
+        render_summary(&view, &mut sink).unwrap();
+        assert!(sink.is_empty());
+    }
+
+    #[test]
+    fn render_summary_emits_none_when_diagnostic_absent() {
+        // Defensive — `--format advice` always populates, but the
+        // formatter should still be well-formed if a caller skips the
+        // gate (e.g., direct API consumer).
+        let v = make_verdict("naked", "src/lib.rs", 1, 9);
+        let result = make_result(vec![v]);
+        let view = view::apply(&result, ViewSpec::default());
+        let mut sink = Vec::new();
+        render_summary(&view, &mut sink).unwrap();
+        let out = String::from_utf8(sink).unwrap();
+        assert_eq!(out, "[crap=12.34] src/lib.rs:1-9 naked [actions: none]\n");
+    }
+
+    #[test]
+    fn render_summary_preserves_view_shown_order() {
+        let mut a = make_verdict("a_first", "src/lib.rs", 1, 5);
+        a.scored.crap.value = 10.0;
+        let mut b = make_verdict("b_second", "src/lib.rs", 6, 10);
+        b.scored.crap.value = 30.0;
+        // Default sort = CRAP descending, so b should appear first.
+        let result = make_result(vec![a, b]);
+        let view = view::apply(&result, ViewSpec::default());
+        let mut sink = Vec::new();
+        render_summary(&view, &mut sink).unwrap();
+        let out = String::from_utf8(sink).unwrap();
+        let lines: Vec<&str> = out.lines().collect();
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].contains("b_second"));
+        assert!(lines[1].contains("a_first"));
+    }
+}

--- a/src/adapters/reporters/advice_summary.rs
+++ b/src/adapters/reporters/advice_summary.rs
@@ -1,6 +1,6 @@
-//! Stderr summary reporter for `--format advice` (#76 V5).
+//! Stderr summary reporter for `--format advice`.
 //!
-//! Format (S-8 locked):
+//! Format:
 //! `[crap=N.NN] file:line-line qualified::name [actions: <kinds>]`
 //!
 //! One line per over-threshold function in `view.shown[]` order so

--- a/src/adapters/reporters/markdown.rs
+++ b/src/adapters/reporters/markdown.rs
@@ -536,12 +536,16 @@ mod tests {
                     line: 12,
                     column: None,
                     increment: 1,
+                    end_line: 12,
+                    nesting_depth: 0,
                 },
                 ComplexityContributor {
                     kind: ContributorKind::Match,
                     line: 18,
                     column: None,
                     increment: 2, // nested → triggers legend
+                    end_line: 18,
+                    nesting_depth: 1,
                 },
             ],
         );
@@ -586,12 +590,16 @@ mod tests {
                     line: 5,
                     column: Some(4),
                     increment: 1,
+                    end_line: 5,
+                    nesting_depth: 0,
                 },
                 ComplexityContributor {
                     kind: ContributorKind::ForLoop,
                     line: 10,
                     column: Some(4),
                     increment: 2,
+                    end_line: 10,
+                    nesting_depth: 1,
                 },
             ],
         );

--- a/src/adapters/reporters/mod.rs
+++ b/src/adapters/reporters/mod.rs
@@ -1,11 +1,13 @@
 //! Output reporters — terminal table and JSON.
 
+pub mod advice_summary;
 pub mod csv;
 pub mod json;
 pub mod markdown;
 pub mod sarif;
 pub mod table;
 
+pub use advice_summary::render_summary as render_advice_summary;
 pub use csv::format_csv;
 pub use json::{JsonConfig, format_json};
 pub use markdown::format_markdown;

--- a/src/adapters/reporters/sarif.rs
+++ b/src/adapters/reporters/sarif.rs
@@ -79,12 +79,11 @@ fn result_for(verdict: &FunctionVerdict) -> SarifResult {
     );
     let fingerprint = format!("{}:{}", s.identity.file_path, s.identity.qualified_name);
 
-    // V6: SARIF `result.properties` is a free-form bag; we expose the
-    // crap4rs `Diagnostic` shape under `properties.diagnostic` so Code
-    // Scanning consumers (and downstream agent skills like #77) can
-    // read the same advice they'd get under `--format advice`. The
-    // shape under `properties` is byte-identical to `view.shown[]
-    // .diagnostic` because both go through the same `Serialize` impl.
+    // SARIF `result.properties` is a free-form bag; we expose the
+    // `Diagnostic` shape under `properties.diagnostic` so Code Scanning
+    // consumers can read the same advice they'd get under `--format
+    // advice`. The shape is byte-identical because both formats route
+    // through the same `Serialize` impl.
     let properties = verdict.diagnostic.as_deref().map(|diag| SarifProperties {
         diagnostic: serde_json::to_value(diag)
             .expect("Diagnostic Serialize impl is total (only owned strings, ints, vecs)"),
@@ -198,9 +197,9 @@ struct SarifResult {
     locations: Vec<SarifLocation>,
     #[serde(rename = "partialFingerprints")]
     partial_fingerprints: SarifPartialFingerprints,
-    /// V6 (#76): SARIF v2.1.0 §3.27.6 — `properties` is a free-form
-    /// extension bag. We omit it when there's no diagnostic so existing
-    /// consumers see byte-identical SARIF.
+    /// SARIF v2.1.0 §3.27.6 — `properties` is a free-form extension
+    /// bag. Omitted when no diagnostic so SARIF stays byte-identical
+    /// for non-advice runs.
     #[serde(skip_serializing_if = "Option::is_none")]
     properties: Option<SarifProperties>,
 }

--- a/src/adapters/reporters/sarif.rs
+++ b/src/adapters/reporters/sarif.rs
@@ -79,6 +79,17 @@ fn result_for(verdict: &FunctionVerdict) -> SarifResult {
     );
     let fingerprint = format!("{}:{}", s.identity.file_path, s.identity.qualified_name);
 
+    // V6: SARIF `result.properties` is a free-form bag; we expose the
+    // crap4rs `Diagnostic` shape under `properties.diagnostic` so Code
+    // Scanning consumers (and downstream agent skills like #77) can
+    // read the same advice they'd get under `--format advice`. The
+    // shape under `properties` is byte-identical to `view.shown[]
+    // .diagnostic` because both go through the same `Serialize` impl.
+    let properties = verdict.diagnostic.as_deref().map(|diag| SarifProperties {
+        diagnostic: serde_json::to_value(diag)
+            .expect("Diagnostic Serialize impl is total (only owned strings, ints, vecs)"),
+    });
+
     SarifResult {
         rule_id: RULE_ID,
         level,
@@ -94,6 +105,7 @@ fn result_for(verdict: &FunctionVerdict) -> SarifResult {
         partial_fingerprints: SarifPartialFingerprints {
             function_identity: fingerprint,
         },
+        properties,
     }
 }
 
@@ -186,6 +198,16 @@ struct SarifResult {
     locations: Vec<SarifLocation>,
     #[serde(rename = "partialFingerprints")]
     partial_fingerprints: SarifPartialFingerprints,
+    /// V6 (#76): SARIF v2.1.0 §3.27.6 — `properties` is a free-form
+    /// extension bag. We omit it when there's no diagnostic so existing
+    /// consumers see byte-identical SARIF.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    properties: Option<SarifProperties>,
+}
+
+#[derive(Serialize)]
+struct SarifProperties {
+    diagnostic: serde_json::Value,
 }
 
 #[derive(Serialize)]

--- a/src/adapters/reporters/table.rs
+++ b/src/adapters/reporters/table.rs
@@ -572,12 +572,16 @@ mod tests {
                 line: 5,
                 column: Some(4),
                 increment: 1,
+                end_line: 5,
+                nesting_depth: 0,
             },
             ComplexityContributor {
                 kind: ContributorKind::ForLoop,
                 line: 10,
                 column: Some(4),
                 increment: 2,
+                end_line: 10,
+                nesting_depth: 1,
             },
         ]
     }
@@ -589,6 +593,8 @@ mod tests {
             line: 3,
             column: Some(4),
             increment: 3,
+            end_line: 3,
+            nesting_depth: 2,
         }]
     }
 
@@ -810,6 +816,8 @@ mod tests {
                 line: 3,
                 column: Some(4),
                 increment: 1,
+                end_line: 3,
+                nesting_depth: 0,
             }],
         );
         let result = AnalysisResult {
@@ -843,12 +851,16 @@ mod tests {
                     line: 5,
                     column: Some(4),
                     increment: 1,
+                    end_line: 5,
+                    nesting_depth: 0,
                 },
                 ComplexityContributor {
                     kind: ContributorKind::ForLoop,
                     line: 20,
                     column: Some(4),
                     increment: 1,
+                    end_line: 20,
+                    nesting_depth: 0,
                 },
             ],
         );
@@ -882,6 +894,8 @@ mod tests {
                 line: 3,
                 column: Some(4),
                 increment: 1,
+                end_line: 3,
+                nesting_depth: 0,
             }],
         );
         let v2 = make_verdict_with_contributors(
@@ -899,6 +913,8 @@ mod tests {
                 line: 7,
                 column: Some(4),
                 increment: 1,
+                end_line: 7,
+                nesting_depth: 0,
             }],
         );
         let result = AnalysisResult {
@@ -947,6 +963,8 @@ mod tests {
                 line: 3,
                 column: Some(4),
                 increment: 1,
+                end_line: 3,
+                nesting_depth: 0,
             }],
         );
         let result = AnalysisResult {
@@ -1370,6 +1388,8 @@ mod proptests {
                 line,
                 column: None,
                 increment,
+                end_line: line,
+                nesting_depth: 0,
             })
     }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -715,6 +715,14 @@ fn run_inner() -> Result<bool> {
             FormatArg::Sarif => reporters::format_sarif(&view, env!("CARGO_PKG_VERSION")),
         };
         print!("{output}");
+
+        // V5: stderr summary for `--format advice` only. SARIF's primary
+        // deliverable is the `.sarif` file uploaded to Code Scanning;
+        // adding a stderr line stream there would noise up CI logs (F4).
+        if matches!(cli.output.format, FormatArg::Advice) {
+            let mut stderr = std::io::stderr();
+            let _ = reporters::render_advice_summary(&view, &mut stderr);
+        }
     }
 
     // Exit code derives from `view.full.passed` — i.e., the underlying

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -59,6 +59,8 @@ pub enum FormatArg {
     Csv,
     /// SARIF v2.1.0 — for GitHub Code Scanning (upload-sarif@v3)
     Sarif,
+    /// Agent-oriented JSON with Diagnostic remediation hints (experimental — stable from v0.4.0)
+    Advice,
 }
 
 /// Sort key for the displayed view (issue #68).
@@ -626,6 +628,7 @@ fn run_inner() -> Result<bool> {
         exclude: effective_exclude,
         respect_gitignore: !cli.filter.no_gitignore,
         diff_ref: cli.filter.diff.clone(),
+        compute_diagnostics: matches!(cli.output.format, FormatArg::Advice | FormatArg::Sarif),
         ..AnalyzeOptions::default()
     };
 
@@ -672,7 +675,7 @@ fn run_inner() -> Result<bool> {
                 cli.display.breakdown,
                 cli.display.explain,
             ),
-            FormatArg::Json => {
+            FormatArg::Json | FormatArg::Advice => {
                 let delta_ctx = delta_state
                     .as_ref()
                     .zip(delta_view.as_ref())

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -59,7 +59,7 @@ pub enum FormatArg {
     Csv,
     /// SARIF v2.1.0 — for GitHub Code Scanning (upload-sarif@v3)
     Sarif,
-    /// Agent-oriented JSON with Diagnostic remediation hints (experimental — stable from v0.4.0)
+    /// Agent-oriented JSON with Diagnostic remediation hints (experimental)
     Advice,
 }
 
@@ -716,9 +716,8 @@ fn run_inner() -> Result<bool> {
         };
         print!("{output}");
 
-        // V5: stderr summary for `--format advice` only. SARIF's primary
-        // deliverable is the `.sarif` file uploaded to Code Scanning;
-        // adding a stderr line stream there would noise up CI logs (F4).
+        // SARIF's primary deliverable is the `.sarif` file uploaded to
+        // Code Scanning; stderr lines would noise up CI logs.
         if matches!(cli.output.format, FormatArg::Advice) {
             let mut stderr = std::io::stderr();
             let _ = reporters::render_advice_summary(&view, &mut stderr);

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -140,9 +140,8 @@ pub fn analyze(options: &AnalyzeOptions) -> Result<AnalysisOutput> {
     // 6. Score each function, produce verdicts, and build result
     let mut result = score_and_summarize(&matched, &resolver)?;
 
-    // 7. Populate `Diagnostic` for over-threshold verdicts (#76 V4).
-    //    Runs only when the caller opts in (`--format advice` or
-    //    `--format sarif`). Pure-domain logic, bounded cost.
+    // 7. Populate `Diagnostic` for over-threshold verdicts when the
+    //    caller opts in. Pure-domain, runs only on exceeding verdicts.
     if options.compute_diagnostics {
         populate_diagnostics(&mut result.functions, &parse_output.coverage);
     }
@@ -421,6 +420,9 @@ fn populate_diagnostics(
     coverage: &std::collections::HashMap<String, Vec<LineCoverage>>,
 ) {
     for verdict in verdicts.iter_mut() {
+        if !verdict.exceeds {
+            continue;
+        }
         let lines = coverage
             .get(&verdict.scored.identity.file_path)
             .map(Vec::as_slice)

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -12,12 +12,13 @@ use crate::adapters::complexity::SynComplexityAdapter;
 use crate::adapters::coverage::LcovParser;
 use crate::adapters::diff::GitDiffAdapter;
 use crate::domain::crap::compute_crap;
+use crate::domain::diagnostic::compute_diagnostic;
 use crate::domain::matching::{match_functions, overlaps_any};
 use crate::domain::summary::compute_summary;
 use crate::domain::threshold::ThresholdConfig;
 use crate::domain::types::{
     AnalysisDiagnostics, AnalysisResult, ComplexityMetric, CoverageMetric, FileChangeKind,
-    FunctionComplexity, FunctionVerdict, ScoredFunction,
+    FunctionComplexity, FunctionVerdict, LineCoverage, ScoredFunction,
 };
 use crate::ports::{ComplexityPort, CoveragePort, DiffPort, ParseOutput};
 
@@ -40,6 +41,12 @@ pub struct AnalyzeOptions {
     pub respect_gitignore: bool,
     /// Git ref to diff against. When set, only changed functions are analyzed.
     pub diff_ref: Option<String>,
+    /// When `true`, populate `FunctionVerdict.diagnostic` for every
+    /// over-threshold verdict via `domain::diagnostic::compute_diagnostic`.
+    /// CLI sets this for `--format advice` and `--format sarif`. The
+    /// computation is pure-domain and bounded — runs only on exceeding
+    /// verdicts, so the cost scales with violations, not total functions.
+    pub compute_diagnostics: bool,
 }
 
 /// Full output from an analysis run, including both the scored results
@@ -71,6 +78,7 @@ impl Default for AnalyzeOptions {
             exclude: Vec::new(),
             respect_gitignore: true,
             diff_ref: None,
+            compute_diagnostics: false,
         }
     }
 }
@@ -130,7 +138,14 @@ pub fn analyze(options: &AnalyzeOptions) -> Result<AnalysisOutput> {
     let resolver = ThresholdResolver::new(&options.threshold_config)?;
 
     // 6. Score each function, produce verdicts, and build result
-    let result = score_and_summarize(&matched, &resolver)?;
+    let mut result = score_and_summarize(&matched, &resolver)?;
+
+    // 7. Populate `Diagnostic` for over-threshold verdicts (#76 V4).
+    //    Runs only when the caller opts in (`--format advice` or
+    //    `--format sarif`). Pure-domain logic, bounded cost.
+    if options.compute_diagnostics {
+        populate_diagnostics(&mut result.functions, &parse_output.coverage);
+    }
 
     let (files_analyzed, files_zero_coverage) = compute_file_coverage_stats(&result);
 
@@ -395,6 +410,23 @@ fn score_and_summarize(
         summary,
         passed,
     })
+}
+
+/// Populate `verdict.diagnostic` for every over-threshold verdict.
+/// `compute_diagnostic` returns `None` for passing verdicts, so the
+/// existing `skip_serializing_if = "Option::is_none"` keeps the JSON
+/// envelope clean for them.
+fn populate_diagnostics(
+    verdicts: &mut [FunctionVerdict],
+    coverage: &std::collections::HashMap<String, Vec<LineCoverage>>,
+) {
+    for verdict in verdicts.iter_mut() {
+        let lines = coverage
+            .get(&verdict.scored.identity.file_path)
+            .map(Vec::as_slice)
+            .unwrap_or(&[]);
+        verdict.diagnostic = compute_diagnostic(verdict, lines).map(Box::new);
+    }
 }
 
 /// Find the git repository root by running `git rev-parse --show-toplevel`.

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -142,9 +142,11 @@ pub fn analyze(options: &AnalyzeOptions) -> Result<AnalysisOutput> {
 
     // 7. Populate `Diagnostic` for over-threshold verdicts when the
     //    caller opts in. Pure-domain, runs only on exceeding verdicts.
-    if options.compute_diagnostics {
-        populate_diagnostics(&mut result.functions, &parse_output.coverage);
-    }
+    populate_diagnostics(
+        &mut result.functions,
+        &parse_output.coverage,
+        options.compute_diagnostics,
+    );
 
     let (files_analyzed, files_zero_coverage) = compute_file_coverage_stats(&result);
 
@@ -418,7 +420,11 @@ fn score_and_summarize(
 fn populate_diagnostics(
     verdicts: &mut [FunctionVerdict],
     coverage: &std::collections::HashMap<String, Vec<LineCoverage>>,
+    enabled: bool,
 ) {
+    if !enabled {
+        return;
+    }
     for verdict in verdicts.iter_mut() {
         if !verdict.exceeds {
             continue;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -588,6 +588,8 @@ pub fn with_branch(x: i32) -> &'static str {
             line: 5,
             column: Some(4),
             increment: 1,
+            end_line: 5,
+            nesting_depth: 0,
         };
         let comp = crate::domain::types::FunctionComplexity {
             identity: crate::domain::types::FunctionIdentity {

--- a/src/domain/diagnostic.rs
+++ b/src/domain/diagnostic.rs
@@ -1,0 +1,350 @@
+//! Shape C `Diagnostic` types — the AST-derived remediation hint emitted
+//! under `--format advice` (issue #76) and consumed by the
+//! `/cut-the-crap` agent skill (issue #77).
+//!
+//! Hexagonal note: this module is pure domain — no `syn`, no LCOV, no I/O.
+//! Helpers in V3 (`compute_diagnostic`, `extract_split_candidates`, …)
+//! land alongside these types so reporters can stay format-only.
+
+use serde::{Deserialize, Serialize};
+
+use crate::domain::types::{ComplexityContributor, ContributorKind};
+
+// ── Line range ──────────────────────────────────────────────────────
+
+/// Inclusive 1-based line range. Mirrors `SourceSpan`'s end-inclusive
+/// convention (per `.claude/rules/domain.md` §5) so coverage gaps and
+/// proposed splits address the same line space as `ComplexityContributor`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct LineRange {
+    pub start: usize,
+    pub end: usize,
+}
+
+impl LineRange {
+    pub fn new(start: usize, end: usize) -> Self {
+        Self { start, end }
+    }
+
+    /// True when `line` falls inside `[start, end]` (inclusive).
+    pub fn contains(&self, line: usize) -> bool {
+        self.start <= line && line <= self.end
+    }
+}
+
+// ── Root cause ──────────────────────────────────────────────────────
+
+/// Deterministic single-token classification of why a verdict exceeded
+/// the threshold. Derived from the action set per S-6 (locked in shape):
+///
+/// - `LowCoverage` when the only action is `AddTestsForLines`
+/// - `HighComplexity` when the only actions are split/simplify/accept
+/// - `Both` when both kinds of action coexist
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum RootCause {
+    #[default]
+    LowCoverage,
+    HighComplexity,
+    Both,
+}
+
+// ── Applicability ───────────────────────────────────────────────────
+
+/// Confidence in a `SuggestedAction`, matching `rustc`'s `Applicability`
+/// taxonomy so agents using rustc-shaped tooling can interpret crap4rs
+/// suggestions without translation. T2 (locked): the default is
+/// `Unspecified` because crap4rs does not verify the suggested change.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum Applicability {
+    MachineApplicable,
+    MaybeIncorrect,
+    HasPlaceholders,
+    #[default]
+    Unspecified,
+}
+
+// ── SplitKind ───────────────────────────────────────────────────────
+
+/// Which strategy produced a `ProposedSplit`. Priority order
+/// `DeepestNesting > HighestBranchCount > LargestSubblock` is enforced
+/// at dedup time (S-7). The default variant is `DeepestNesting` because
+/// that is the highest-priority strategy and the most useful candidate
+/// when only one is needed.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum SplitKind {
+    #[default]
+    DeepestNesting,
+    LargestSubblock,
+    HighestBranchCount,
+}
+
+// ── ProposedSplit ───────────────────────────────────────────────────
+
+/// One AST-derived candidate for `extract_function`. The split is named
+/// only by its line range (R6.3 — agents do prose, the CLI does
+/// coordinates).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct ProposedSplit {
+    pub line_range: LineRange,
+    /// Sum of contributor increments inside `line_range` (cognitive or
+    /// cyclomatic — the metric is recorded on `ScoredFunction`).
+    pub complexity_contribution: u32,
+    /// `/`-joined chain of `ContributorKind` Display strings, ascending
+    /// by nesting up to the split's `start_line`. AST-only, no prose.
+    pub branch_path: String,
+    pub kind: SplitKind,
+    /// Exactly one entry per non-empty candidate set carries
+    /// `recommended: true` (S-7).
+    pub recommended: bool,
+}
+
+// ── SuggestedAction ─────────────────────────────────────────────────
+
+/// One remediation step. Tagged-enum serialization (`{"kind": "…", …}`)
+/// keeps additive variants forward-compatible under `#[non_exhaustive]`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum SuggestedAction {
+    AddTestsForLines {
+        lines: Vec<LineRange>,
+        applicability: Applicability,
+    },
+    ExtractFunction {
+        candidates: Vec<ProposedSplit>,
+        applicability: Applicability,
+    },
+    SimplifyBranching {
+        drivers: Vec<ContributorKind>,
+        applicability: Applicability,
+    },
+    AcceptInherentComplexity {
+        applicability: Applicability,
+    },
+}
+
+// ── Diagnostic ──────────────────────────────────────────────────────
+
+/// Structured remediation hint attached to an over-threshold
+/// `FunctionVerdict` when `--format advice` (or `--format sarif`) is
+/// requested. Type-level `#[serde(default)]` lets older payloads (no
+/// new fields) deserialize, so schema_version stays at 1 across the
+/// v0.3.x experimental window.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+#[non_exhaustive]
+pub struct Diagnostic {
+    pub coverage_gaps: Vec<LineRange>,
+    pub complexity_drivers: Vec<ComplexityContributor>,
+    pub suggested_actions: Vec<SuggestedAction>,
+    pub root_cause: RootCause,
+}
+
+// ── Tests: serde round-trip + default ───────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn line_range_contains_inclusive_endpoints() {
+        let r = LineRange::new(10, 12);
+        assert!(r.contains(10));
+        assert!(r.contains(11));
+        assert!(r.contains(12));
+        assert!(!r.contains(9));
+        assert!(!r.contains(13));
+    }
+
+    #[test]
+    fn diagnostic_default_is_low_coverage_and_empty_vecs() {
+        let d = Diagnostic::default();
+        assert_eq!(d.root_cause, RootCause::LowCoverage);
+        assert!(d.coverage_gaps.is_empty());
+        assert!(d.complexity_drivers.is_empty());
+        assert!(d.suggested_actions.is_empty());
+    }
+
+    #[test]
+    fn diagnostic_deserializes_empty_object_to_default() {
+        // Type-level `#[serde(default)]` means `{}` round-trips through
+        // `Diagnostic::default()`. Pins the additive convention so future
+        // payloads adding fields don't break older readers.
+        let parsed: Diagnostic = serde_json::from_str("{}").unwrap();
+        assert_eq!(parsed, Diagnostic::default());
+    }
+
+    #[test]
+    fn root_cause_serializes_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&RootCause::LowCoverage).unwrap(),
+            "\"low_coverage\""
+        );
+        assert_eq!(
+            serde_json::to_string(&RootCause::HighComplexity).unwrap(),
+            "\"high_complexity\""
+        );
+        assert_eq!(serde_json::to_string(&RootCause::Both).unwrap(), "\"both\"");
+    }
+
+    #[test]
+    fn applicability_default_is_unspecified() {
+        assert_eq!(Applicability::default(), Applicability::Unspecified);
+        assert_eq!(
+            serde_json::to_string(&Applicability::default()).unwrap(),
+            "\"unspecified\""
+        );
+    }
+
+    #[test]
+    fn applicability_round_trips_all_variants() {
+        for variant in [
+            Applicability::MachineApplicable,
+            Applicability::MaybeIncorrect,
+            Applicability::HasPlaceholders,
+            Applicability::Unspecified,
+        ] {
+            let json = serde_json::to_string(&variant).unwrap();
+            let parsed: Applicability = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, variant);
+        }
+    }
+
+    #[test]
+    fn split_kind_default_is_deepest_nesting() {
+        assert_eq!(SplitKind::default(), SplitKind::DeepestNesting);
+    }
+
+    #[test]
+    fn split_kind_round_trips_all_variants() {
+        for variant in [
+            SplitKind::DeepestNesting,
+            SplitKind::LargestSubblock,
+            SplitKind::HighestBranchCount,
+        ] {
+            let json = serde_json::to_string(&variant).unwrap();
+            let parsed: SplitKind = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, variant);
+        }
+    }
+
+    #[test]
+    fn proposed_split_round_trips() {
+        let original = ProposedSplit {
+            line_range: LineRange::new(20, 35),
+            complexity_contribution: 7,
+            branch_path: "if-branch/match".to_string(),
+            kind: SplitKind::DeepestNesting,
+            recommended: true,
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        let parsed: ProposedSplit = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, original);
+    }
+
+    #[test]
+    fn suggested_action_serializes_with_kind_tag_add_tests() {
+        let action = SuggestedAction::AddTestsForLines {
+            lines: vec![LineRange::new(1, 5)],
+            applicability: Applicability::Unspecified,
+        };
+        let value: serde_json::Value = serde_json::to_value(&action).unwrap();
+        assert_eq!(value["kind"], "add_tests_for_lines");
+        assert!(value["lines"].is_array());
+        assert_eq!(value["applicability"], "unspecified");
+    }
+
+    #[test]
+    fn suggested_action_serializes_with_kind_tag_extract_function() {
+        let action = SuggestedAction::ExtractFunction {
+            candidates: vec![ProposedSplit {
+                line_range: LineRange::new(10, 20),
+                complexity_contribution: 4,
+                branch_path: "if-branch".to_string(),
+                kind: SplitKind::HighestBranchCount,
+                recommended: true,
+            }],
+            applicability: Applicability::Unspecified,
+        };
+        let value: serde_json::Value = serde_json::to_value(&action).unwrap();
+        assert_eq!(value["kind"], "extract_function");
+        assert!(value["candidates"].is_array());
+    }
+
+    #[test]
+    fn suggested_action_serializes_with_kind_tag_simplify_branching() {
+        let action = SuggestedAction::SimplifyBranching {
+            drivers: vec![ContributorKind::Match],
+            applicability: Applicability::Unspecified,
+        };
+        let value: serde_json::Value = serde_json::to_value(&action).unwrap();
+        assert_eq!(value["kind"], "simplify_branching");
+        assert_eq!(value["drivers"][0], "match");
+    }
+
+    #[test]
+    fn suggested_action_serializes_with_kind_tag_accept_inherent() {
+        let action = SuggestedAction::AcceptInherentComplexity {
+            applicability: Applicability::Unspecified,
+        };
+        let value: serde_json::Value = serde_json::to_value(&action).unwrap();
+        assert_eq!(value["kind"], "accept_inherent_complexity");
+    }
+
+    #[test]
+    fn suggested_action_round_trips_through_json() {
+        // Round-trip every variant to lock the tagged serde shape.
+        let actions = vec![
+            SuggestedAction::AddTestsForLines {
+                lines: vec![LineRange::new(3, 7)],
+                applicability: Applicability::MachineApplicable,
+            },
+            SuggestedAction::ExtractFunction {
+                candidates: vec![],
+                applicability: Applicability::MaybeIncorrect,
+            },
+            SuggestedAction::SimplifyBranching {
+                drivers: vec![ContributorKind::IfBranch, ContributorKind::Match],
+                applicability: Applicability::HasPlaceholders,
+            },
+            SuggestedAction::AcceptInherentComplexity {
+                applicability: Applicability::Unspecified,
+            },
+        ];
+        for original in actions {
+            let json = serde_json::to_string(&original).unwrap();
+            let parsed: SuggestedAction = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, original);
+        }
+    }
+
+    #[test]
+    fn diagnostic_round_trips_full_shape() {
+        let original = Diagnostic {
+            coverage_gaps: vec![LineRange::new(12, 14)],
+            complexity_drivers: vec![ComplexityContributor {
+                kind: ContributorKind::Match,
+                line: 20,
+                column: Some(4),
+                increment: 2,
+                end_line: 30,
+                nesting_depth: 1,
+            }],
+            suggested_actions: vec![SuggestedAction::AcceptInherentComplexity {
+                applicability: Applicability::Unspecified,
+            }],
+            root_cause: RootCause::HighComplexity,
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        let parsed: Diagnostic = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, original);
+    }
+}

--- a/src/domain/diagnostic.rs
+++ b/src/domain/diagnostic.rs
@@ -8,7 +8,9 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::domain::types::{ComplexityContributor, ContributorKind};
+use crate::domain::types::{
+    ComplexityContributor, ContributorKind, FunctionVerdict, LineCoverage, SourceSpan,
+};
 
 // ── Line range ──────────────────────────────────────────────────────
 
@@ -146,6 +148,380 @@ pub struct Diagnostic {
     pub complexity_drivers: Vec<ComplexityContributor>,
     pub suggested_actions: Vec<SuggestedAction>,
     pub root_cause: RootCause,
+}
+
+// ── Helpers: V3 (compute_diagnostic + sub-helpers) ──────────────────
+//
+// All helpers are pure: no I/O, no `syn`, no LCOV. They consume
+// already-parsed `FunctionVerdict` + `LineCoverage` slices and emit
+// AST-derived advice. Callers keep `compute_diagnostic` as the single
+// entry point; the others are `pub(crate)` so tests can pin them.
+
+/// Effective inclusive end line for a contributor. Older payloads (or
+/// adapters that pre-date V1) may have `end_line == 0` — fall back to
+/// `line` so the construct is treated as a single-line atomic.
+fn effective_end_line(c: &ComplexityContributor) -> usize {
+    if c.end_line >= c.line {
+        c.end_line
+    } else {
+        c.line
+    }
+}
+
+/// True when the construct spans multiple source lines.
+fn is_compound(c: &ComplexityContributor) -> bool {
+    effective_end_line(c) > c.line
+}
+
+/// Sum of contributor increments inside `range`. Each contributor is
+/// counted iff its `line` falls inside `[range.start, range.end]`.
+fn sum_increments_in(contributors: &[ComplexityContributor], range: LineRange) -> u32 {
+    contributors
+        .iter()
+        .filter(|c| range.contains(c.line))
+        .map(|c| c.increment)
+        .sum()
+}
+
+/// Count of contributors whose `line` falls strictly inside `range` —
+/// used by `pick_highest_branch_count` to score how many sub-decisions
+/// a compound contributor encloses.
+fn count_inner_contributors(
+    contributors: &[ComplexityContributor],
+    outer: &ComplexityContributor,
+) -> usize {
+    let outer_range = LineRange::new(outer.line, effective_end_line(outer));
+    contributors
+        .iter()
+        .filter(|c| {
+            // Skip the contributor itself.
+            !(c.line == outer.line && c.kind == outer.kind && c.column == outer.column)
+                && outer_range.contains(c.line)
+        })
+        .count()
+}
+
+/// True when a candidate range describes a meaningful extract target
+/// inside `span` — must be multi-line, strictly within the function,
+/// and carry at least one contributor.
+fn is_viable_split(range: LineRange, span: &SourceSpan, contribution: u32) -> bool {
+    range.start < range.end
+        && range.start >= span.start_line
+        && range.end <= span.end_line
+        && !(range.start == span.start_line && range.end == span.end_line)
+        && contribution >= 1
+}
+
+/// `/`-joined chain of `ContributorKind` Display strings for every
+/// contributor that **strictly encloses** `start_line` (i.e., starts
+/// before `start_line` and ends at or after it). Sorted by
+/// `nesting_depth` ascending so the path reads outermost → innermost.
+/// AST-derived only — never carries prose (R6.3).
+pub(crate) fn derive_branch_path(
+    contributors: &[ComplexityContributor],
+    start_line: usize,
+) -> String {
+    let mut enclosing: Vec<&ComplexityContributor> = contributors
+        .iter()
+        .filter(|c| c.line < start_line && start_line <= effective_end_line(c))
+        .collect();
+    enclosing.sort_by_key(|c| (c.nesting_depth, c.line));
+    enclosing
+        .iter()
+        .map(|c| c.kind.to_string())
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+/// Coalesce uncovered (`hits == 0`) lines inside `span` into inclusive
+/// ranges. Pre-condition: `line_coverage` may be unsorted; we sort by
+/// line before coalescing so adapters don't have to.
+pub(crate) fn derive_coverage_gaps(
+    line_coverage: &[LineCoverage],
+    span: &SourceSpan,
+) -> Vec<LineRange> {
+    let mut uncovered: Vec<usize> = line_coverage
+        .iter()
+        .filter(|lc| lc.hits == 0 && lc.line >= span.start_line && lc.line <= span.end_line)
+        .map(|lc| lc.line)
+        .collect();
+    uncovered.sort_unstable();
+    uncovered.dedup();
+
+    let mut gaps: Vec<LineRange> = Vec::new();
+    for line in uncovered {
+        match gaps.last_mut() {
+            Some(last) if last.end + 1 == line => last.end = line,
+            _ => gaps.push(LineRange::new(line, line)),
+        }
+    }
+    gaps
+}
+
+/// Pick the deepest-nested compound contributor as a split candidate.
+/// Tiebreaker: lowest `line` wins so the result is deterministic.
+pub(crate) fn pick_deepest_nesting(
+    contributors: &[ComplexityContributor],
+    span: &SourceSpan,
+) -> Option<ProposedSplit> {
+    let pick = contributors
+        .iter()
+        .filter(|c| is_compound(c) && c.nesting_depth > 0)
+        .max_by_key(|c| (c.nesting_depth, std::cmp::Reverse(c.line)))?;
+    let range = LineRange::new(pick.line, effective_end_line(pick));
+    let contribution = sum_increments_in(contributors, range);
+    if !is_viable_split(range, span, contribution) {
+        return None;
+    }
+    Some(ProposedSplit {
+        line_range: range,
+        complexity_contribution: contribution,
+        branch_path: derive_branch_path(contributors, range.start),
+        kind: SplitKind::DeepestNesting,
+        recommended: false,
+    })
+}
+
+/// Pick the compound contributor covering the largest source span.
+/// Tiebreaker: lowest `line` wins.
+pub(crate) fn pick_largest_subblock(
+    contributors: &[ComplexityContributor],
+    span: &SourceSpan,
+) -> Option<ProposedSplit> {
+    let pick = contributors
+        .iter()
+        .filter(|c| is_compound(c))
+        .max_by_key(|c| {
+            let span_len = effective_end_line(c) - c.line;
+            (span_len, std::cmp::Reverse(c.line))
+        })?;
+    let range = LineRange::new(pick.line, effective_end_line(pick));
+    let contribution = sum_increments_in(contributors, range);
+    if !is_viable_split(range, span, contribution) {
+        return None;
+    }
+    Some(ProposedSplit {
+        line_range: range,
+        complexity_contribution: contribution,
+        branch_path: derive_branch_path(contributors, range.start),
+        kind: SplitKind::LargestSubblock,
+        recommended: false,
+    })
+}
+
+/// Pick the compound contributor that encloses the most other
+/// contributors (densest decision cluster). Tiebreaker: lowest `line`.
+pub(crate) fn pick_highest_branch_count(
+    contributors: &[ComplexityContributor],
+    span: &SourceSpan,
+) -> Option<ProposedSplit> {
+    let pick = contributors
+        .iter()
+        .filter(|c| is_compound(c))
+        .max_by_key(|c| {
+            let count = count_inner_contributors(contributors, c);
+            (count, std::cmp::Reverse(c.line))
+        })?;
+    // Reject degenerate "no inner contributors" picks — that's a
+    // single-construct function, not a branch cluster.
+    if count_inner_contributors(contributors, pick) == 0 {
+        return None;
+    }
+    let range = LineRange::new(pick.line, effective_end_line(pick));
+    let contribution = sum_increments_in(contributors, range);
+    if !is_viable_split(range, span, contribution) {
+        return None;
+    }
+    Some(ProposedSplit {
+        line_range: range,
+        complexity_contribution: contribution,
+        branch_path: derive_branch_path(contributors, range.start),
+        kind: SplitKind::HighestBranchCount,
+        recommended: false,
+    })
+}
+
+/// Run all three selectors, dedup overlapping ranges by S-7 priority,
+/// and mark exactly one survivor `recommended: true`.
+pub(crate) fn extract_split_candidates(
+    contributors: &[ComplexityContributor],
+    span: &SourceSpan,
+) -> Vec<ProposedSplit> {
+    let raw: Vec<ProposedSplit> = [
+        pick_deepest_nesting(contributors, span),
+        pick_highest_branch_count(contributors, span),
+        pick_largest_subblock(contributors, span),
+    ]
+    .into_iter()
+    .flatten()
+    .collect();
+    dedup_splits(raw)
+}
+
+/// Priority weight for `SplitKind` (higher = wins under dedup).
+fn split_kind_priority(kind: SplitKind) -> u8 {
+    match kind {
+        SplitKind::DeepestNesting => 3,
+        SplitKind::HighestBranchCount => 2,
+        SplitKind::LargestSubblock => 1,
+    }
+}
+
+/// Dedup `splits` by `line_range`. When two candidates share the same
+/// range, the highest-priority `kind` wins (S-7:
+/// `DeepestNesting > HighestBranchCount > LargestSubblock`). Within
+/// the same kind, the lowest `start_line` wins. Exactly one survivor
+/// is marked `recommended: true` (highest priority overall).
+pub(crate) fn dedup_splits(splits: Vec<ProposedSplit>) -> Vec<ProposedSplit> {
+    let mut by_range: Vec<ProposedSplit> = Vec::new();
+    for split in splits {
+        match by_range
+            .iter()
+            .position(|existing| existing.line_range == split.line_range)
+        {
+            Some(idx) => {
+                let existing = &by_range[idx];
+                let new_priority = split_kind_priority(split.kind);
+                let existing_priority = split_kind_priority(existing.kind);
+                let replace = new_priority > existing_priority
+                    || (new_priority == existing_priority
+                        && split.line_range.start < existing.line_range.start);
+                if replace {
+                    by_range[idx] = split;
+                }
+            }
+            None => by_range.push(split),
+        }
+    }
+
+    by_range.sort_by_key(|s| {
+        (
+            std::cmp::Reverse(split_kind_priority(s.kind)),
+            s.line_range.start,
+        )
+    });
+
+    if let Some(first) = by_range.first_mut() {
+        first.recommended = true;
+    }
+    by_range
+}
+
+/// Strict-majority dominant contributor kind: returns `Some(kind)` when
+/// one kind accounts for **strictly more than 70%** of contributor
+/// count. Returns `None` for a flat function (zero contributors).
+///
+/// Linear scan rather than `HashMap` keeps `ContributorKind`'s public
+/// derives unchanged (no `Hash` requirement leaks into other crates).
+fn dominant_contributor_kind(contributors: &[ComplexityContributor]) -> Option<ContributorKind> {
+    if contributors.is_empty() {
+        return None;
+    }
+    let total = contributors.len();
+    let mut counts: Vec<(ContributorKind, usize)> = Vec::new();
+    for c in contributors {
+        match counts.iter_mut().find(|(k, _)| *k == c.kind) {
+            Some((_, n)) => *n += 1,
+            None => counts.push((c.kind, 1)),
+        }
+    }
+    counts
+        .into_iter()
+        .max_by_key(|(_, count)| *count)
+        .filter(|(_, count)| *count * 100 > total * 70)
+        .map(|(kind, _)| kind)
+}
+
+/// Build the `(suggested_actions, root_cause)` pair from gaps + splits
+/// + contributors. Action gating (locked F1):
+///
+/// 1. `gaps non-empty` → `AddTestsForLines`
+/// 2. `splits non-empty` → `ExtractFunction`
+/// 3. `splits empty AND >70% dominant kind` → `SimplifyBranching`
+/// 4. `no other action emitted` → `AcceptInherentComplexity`
+pub(crate) fn pick_actions(
+    coverage_gaps: &[LineRange],
+    splits: &[ProposedSplit],
+    contributors: &[ComplexityContributor],
+) -> (Vec<SuggestedAction>, RootCause) {
+    let mut actions: Vec<SuggestedAction> = Vec::new();
+
+    if !coverage_gaps.is_empty() {
+        actions.push(SuggestedAction::AddTestsForLines {
+            lines: coverage_gaps.to_vec(),
+            applicability: Applicability::default(),
+        });
+    }
+
+    if !splits.is_empty() {
+        actions.push(SuggestedAction::ExtractFunction {
+            candidates: splits.to_vec(),
+            applicability: Applicability::default(),
+        });
+    } else if let Some(dominant) = dominant_contributor_kind(contributors) {
+        actions.push(SuggestedAction::SimplifyBranching {
+            drivers: vec![dominant],
+            applicability: Applicability::default(),
+        });
+    }
+
+    let has_complexity_action = actions
+        .iter()
+        .any(|a| !matches!(a, SuggestedAction::AddTestsForLines { .. }));
+
+    if !has_complexity_action && coverage_gaps.is_empty() {
+        actions.push(SuggestedAction::AcceptInherentComplexity {
+            applicability: Applicability::default(),
+        });
+    }
+
+    let has_add_tests = actions
+        .iter()
+        .any(|a| matches!(a, SuggestedAction::AddTestsForLines { .. }));
+    let has_complexity = actions
+        .iter()
+        .any(|a| !matches!(a, SuggestedAction::AddTestsForLines { .. }));
+
+    let root_cause = match (has_add_tests, has_complexity) {
+        (true, true) => RootCause::Both,
+        (true, false) => RootCause::LowCoverage,
+        (false, _) => RootCause::HighComplexity,
+    };
+
+    (actions, root_cause)
+}
+
+/// Build a structured remediation hint for `verdict`. Returns `None`
+/// when the verdict is below threshold (R6.4 / F2 — no diagnostic for
+/// passing functions). When the verdict exceeds, the diagnostic is
+/// always populated with all four fields.
+///
+/// The `line_coverage` slice should hold every `DA:` entry from the
+/// LCOV file scoped to the verdict's source file; callers in
+/// `core::analyze` already have this in hand. Entries outside
+/// `verdict.scored.identity.span` are filtered out by
+/// `derive_coverage_gaps`.
+pub fn compute_diagnostic(
+    verdict: &FunctionVerdict,
+    line_coverage: &[LineCoverage],
+) -> Option<Diagnostic> {
+    if !verdict.exceeds {
+        return None;
+    }
+
+    let span = &verdict.scored.identity.span;
+    let contributors = verdict.scored.contributors.as_slice();
+
+    let coverage_gaps = derive_coverage_gaps(line_coverage, span);
+    let splits = extract_split_candidates(contributors, span);
+    let (suggested_actions, root_cause) = pick_actions(&coverage_gaps, &splits, contributors);
+
+    Some(Diagnostic {
+        coverage_gaps,
+        complexity_drivers: contributors.to_vec(),
+        suggested_actions,
+        root_cause,
+    })
 }
 
 // ── Tests: serde round-trip + default ───────────────────────────────
@@ -346,5 +722,630 @@ mod tests {
         let json = serde_json::to_string(&original).unwrap();
         let parsed: Diagnostic = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed, original);
+    }
+
+    // ── V3 helper tests ────────────────────────────────────────────
+
+    use crate::domain::types::{
+        ComplexityMetric, CrapScore, FunctionIdentity, FunctionVerdict, LineCoverage, RiskLevel,
+        ScoredFunction, SourceSpan,
+    };
+
+    fn make_contributor(
+        kind: ContributorKind,
+        line: usize,
+        end_line: usize,
+        increment: u32,
+        nesting_depth: u32,
+    ) -> ComplexityContributor {
+        ComplexityContributor {
+            kind,
+            line,
+            column: None,
+            increment,
+            end_line,
+            nesting_depth,
+        }
+    }
+
+    fn span_for(start: usize, end: usize) -> SourceSpan {
+        SourceSpan {
+            start_line: start,
+            end_line: end,
+            start_column: 0,
+            end_column: 0,
+        }
+    }
+
+    fn make_verdict(
+        contributors: Vec<ComplexityContributor>,
+        span: SourceSpan,
+        exceeds: bool,
+    ) -> FunctionVerdict {
+        FunctionVerdict {
+            scored: ScoredFunction {
+                identity: FunctionIdentity {
+                    file_path: "src/lib.rs".to_string(),
+                    qualified_name: "demo".to_string(),
+                    span,
+                },
+                complexity: contributors.iter().map(|c| c.increment).sum::<u32>().max(1),
+                complexity_metric: ComplexityMetric::Cognitive,
+                coverage_percent: 100.0,
+                crap: CrapScore {
+                    value: 50.0,
+                    risk_level: RiskLevel::High,
+                },
+                contributors,
+            },
+            threshold: 30.0,
+            exceeds,
+            diagnostic: None,
+        }
+    }
+
+    // derive_branch_path
+
+    #[test]
+    fn derive_branch_path_empty_for_top_level_construct() {
+        // Mirrors `single_if_fn`: a single if-branch at top level. Path is
+        // empty because nothing encloses line 9.
+        let contributors = vec![make_contributor(ContributorKind::IfBranch, 9, 13, 1, 0)];
+        assert_eq!(derive_branch_path(&contributors, 9), "");
+    }
+
+    #[test]
+    fn derive_branch_path_single_for_nested_if_inner_start() {
+        // Outer if [17, 25] depth 0 + inner if [18, 22] depth 1.
+        // start_line=18 picks the outer (encloses 18) but not the inner
+        // (it starts AT 18, doesn't enclose).
+        let contributors = vec![
+            make_contributor(ContributorKind::IfBranch, 17, 25, 1, 0),
+            make_contributor(ContributorKind::IfBranch, 18, 22, 2, 1),
+        ];
+        assert_eq!(derive_branch_path(&contributors, 18), "if-branch");
+    }
+
+    #[test]
+    fn derive_branch_path_chains_outer_to_inner_by_nesting_depth() {
+        // Mirrors `for_with_continue_fn`: ForLoop > IfBranch > Continue.
+        // Path for line 93 (the Continue) ascends ForLoop → IfBranch.
+        let contributors = vec![
+            make_contributor(ContributorKind::ForLoop, 91, 96, 1, 0),
+            make_contributor(ContributorKind::IfBranch, 92, 94, 2, 1),
+            make_contributor(ContributorKind::Continue, 93, 93, 3, 2),
+        ];
+        assert_eq!(derive_branch_path(&contributors, 93), "for-loop/if-branch");
+    }
+
+    #[test]
+    fn derive_branch_path_carries_no_prose_or_whitespace() {
+        // R6.3: no human prose, only `/`-joined ContributorKind discriminants.
+        let contributors = vec![
+            make_contributor(ContributorKind::Match, 10, 30, 1, 0),
+            make_contributor(ContributorKind::IfBranch, 15, 20, 2, 1),
+        ];
+        let path = derive_branch_path(&contributors, 17);
+        for component in path.split('/') {
+            assert!(
+                !component.contains(' '),
+                "branch_path component {component:?} contains whitespace"
+            );
+        }
+    }
+
+    // derive_coverage_gaps
+
+    #[test]
+    fn derive_coverage_gaps_returns_empty_for_full_coverage() {
+        let cov = vec![
+            LineCoverage { line: 5, hits: 1 },
+            LineCoverage { line: 6, hits: 3 },
+        ];
+        let gaps = derive_coverage_gaps(&cov, &span_for(1, 10));
+        assert!(gaps.is_empty());
+    }
+
+    #[test]
+    fn derive_coverage_gaps_coalesces_contiguous_uncovered_lines() {
+        let cov = vec![
+            LineCoverage { line: 5, hits: 0 },
+            LineCoverage { line: 6, hits: 0 },
+            LineCoverage { line: 7, hits: 0 },
+            LineCoverage { line: 9, hits: 0 },
+        ];
+        let gaps = derive_coverage_gaps(&cov, &span_for(1, 10));
+        assert_eq!(gaps, vec![LineRange::new(5, 7), LineRange::new(9, 9)]);
+    }
+
+    #[test]
+    fn derive_coverage_gaps_filters_lines_outside_span() {
+        let cov = vec![
+            LineCoverage { line: 1, hits: 0 },
+            LineCoverage { line: 5, hits: 0 },
+            LineCoverage { line: 99, hits: 0 },
+        ];
+        let gaps = derive_coverage_gaps(&cov, &span_for(4, 6));
+        assert_eq!(gaps, vec![LineRange::new(5, 5)]);
+    }
+
+    #[test]
+    fn derive_coverage_gaps_handles_unsorted_input() {
+        let cov = vec![
+            LineCoverage { line: 7, hits: 0 },
+            LineCoverage { line: 5, hits: 0 },
+            LineCoverage { line: 6, hits: 0 },
+        ];
+        let gaps = derive_coverage_gaps(&cov, &span_for(1, 10));
+        assert_eq!(gaps, vec![LineRange::new(5, 7)]);
+    }
+
+    // pick_deepest_nesting
+
+    #[test]
+    fn pick_deepest_nesting_picks_inner_if_in_nested_function() {
+        let contributors = vec![
+            make_contributor(ContributorKind::IfBranch, 17, 25, 1, 0),
+            make_contributor(ContributorKind::IfBranch, 18, 22, 2, 1),
+        ];
+        let split = pick_deepest_nesting(&contributors, &span_for(16, 26)).expect("viable");
+        assert_eq!(split.line_range, LineRange::new(18, 22));
+        assert_eq!(split.kind, SplitKind::DeepestNesting);
+        assert_eq!(split.complexity_contribution, 2);
+        assert_eq!(split.branch_path, "if-branch");
+        assert!(!split.recommended); // marked by dedup, not the selector
+    }
+
+    #[test]
+    fn pick_deepest_nesting_returns_none_for_flat_function() {
+        // Single top-level if has no nested constructs — DeepestNesting
+        // requires depth > 0.
+        let contributors = vec![make_contributor(ContributorKind::IfBranch, 9, 13, 1, 0)];
+        assert!(pick_deepest_nesting(&contributors, &span_for(8, 14)).is_none());
+    }
+
+    #[test]
+    fn pick_deepest_nesting_skips_atomic_continue() {
+        // for_with_continue_fn: Continue is depth 2 but single-line.
+        // Selector falls back to the deepest *compound* contributor.
+        let contributors = vec![
+            make_contributor(ContributorKind::ForLoop, 91, 96, 1, 0),
+            make_contributor(ContributorKind::IfBranch, 92, 94, 2, 1),
+            make_contributor(ContributorKind::Continue, 93, 93, 3, 2),
+        ];
+        let split = pick_deepest_nesting(&contributors, &span_for(89, 98)).expect("viable");
+        assert_eq!(split.line_range, LineRange::new(92, 94));
+    }
+
+    // pick_largest_subblock
+
+    #[test]
+    fn pick_largest_subblock_picks_outer_if_over_inner() {
+        let contributors = vec![
+            make_contributor(ContributorKind::IfBranch, 17, 25, 1, 0),
+            make_contributor(ContributorKind::IfBranch, 18, 22, 2, 1),
+        ];
+        let split = pick_largest_subblock(&contributors, &span_for(16, 30)).expect("viable");
+        assert_eq!(split.line_range, LineRange::new(17, 25));
+        assert_eq!(split.kind, SplitKind::LargestSubblock);
+    }
+
+    #[test]
+    fn pick_largest_subblock_returns_none_when_range_equals_full_function() {
+        // The sole compound construct covers the whole function — no
+        // viable extraction (would just be a self-rename).
+        let contributors = vec![make_contributor(ContributorKind::IfBranch, 1, 10, 1, 0)];
+        assert!(pick_largest_subblock(&contributors, &span_for(1, 10)).is_none());
+    }
+
+    // pick_highest_branch_count
+
+    #[test]
+    fn pick_highest_branch_count_picks_outer_with_inner_contributors() {
+        // outer if encloses inner if + inner continue = 2 inner;
+        // inner if encloses 1; continue encloses 0. Outer wins.
+        let contributors = vec![
+            make_contributor(ContributorKind::IfBranch, 91, 96, 1, 0),
+            make_contributor(ContributorKind::IfBranch, 92, 94, 2, 1),
+            make_contributor(ContributorKind::Continue, 93, 93, 3, 2),
+        ];
+        let split = pick_highest_branch_count(&contributors, &span_for(89, 98)).expect("viable");
+        assert_eq!(split.line_range, LineRange::new(91, 96));
+        assert_eq!(split.kind, SplitKind::HighestBranchCount);
+    }
+
+    #[test]
+    fn pick_highest_branch_count_returns_none_when_no_nested_contributors() {
+        // Single compound with nothing inside → degenerate, no candidate.
+        let contributors = vec![make_contributor(ContributorKind::IfBranch, 9, 13, 1, 0)];
+        assert!(pick_highest_branch_count(&contributors, &span_for(8, 14)).is_none());
+    }
+
+    // dedup_splits
+
+    #[test]
+    fn dedup_splits_keeps_highest_priority_for_duplicate_range() {
+        // Same range, three kinds. DeepestNesting wins under S-7.
+        let range = LineRange::new(10, 20);
+        let dn = ProposedSplit {
+            line_range: range,
+            complexity_contribution: 4,
+            branch_path: "match".to_string(),
+            kind: SplitKind::DeepestNesting,
+            recommended: false,
+        };
+        let hbc = ProposedSplit {
+            kind: SplitKind::HighestBranchCount,
+            ..dn.clone()
+        };
+        let lsb = ProposedSplit {
+            kind: SplitKind::LargestSubblock,
+            ..dn.clone()
+        };
+        let result = dedup_splits(vec![lsb, dn.clone(), hbc]);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].kind, SplitKind::DeepestNesting);
+        assert!(result[0].recommended);
+    }
+
+    #[test]
+    fn dedup_splits_keeps_highest_branch_count_over_largest_subblock() {
+        let range = LineRange::new(10, 20);
+        let hbc = ProposedSplit {
+            line_range: range,
+            complexity_contribution: 4,
+            branch_path: String::new(),
+            kind: SplitKind::HighestBranchCount,
+            recommended: false,
+        };
+        let lsb = ProposedSplit {
+            kind: SplitKind::LargestSubblock,
+            ..hbc.clone()
+        };
+        let result = dedup_splits(vec![lsb, hbc]);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].kind, SplitKind::HighestBranchCount);
+        assert!(result[0].recommended);
+    }
+
+    #[test]
+    fn dedup_splits_marks_exactly_one_recommended_when_distinct_ranges() {
+        let s1 = ProposedSplit {
+            line_range: LineRange::new(10, 20),
+            complexity_contribution: 2,
+            branch_path: String::new(),
+            kind: SplitKind::DeepestNesting,
+            recommended: false,
+        };
+        let s2 = ProposedSplit {
+            line_range: LineRange::new(30, 40),
+            kind: SplitKind::HighestBranchCount,
+            ..s1.clone()
+        };
+        let s3 = ProposedSplit {
+            line_range: LineRange::new(50, 60),
+            kind: SplitKind::LargestSubblock,
+            ..s1.clone()
+        };
+        let result = dedup_splits(vec![s3, s2, s1]);
+        assert_eq!(result.len(), 3);
+        let recommended_count = result.iter().filter(|s| s.recommended).count();
+        assert_eq!(recommended_count, 1);
+        // Highest priority survivor = DeepestNesting; sort puts it first.
+        assert!(result[0].recommended);
+        assert_eq!(result[0].kind, SplitKind::DeepestNesting);
+    }
+
+    #[test]
+    fn dedup_splits_empty_input_yields_empty() {
+        assert!(dedup_splits(vec![]).is_empty());
+    }
+
+    // pick_actions — covers the root_cause Examples table
+
+    #[test]
+    fn pick_actions_low_coverage_only() {
+        let gaps = vec![LineRange::new(5, 7)];
+        let (actions, root) = pick_actions(&gaps, &[], &[]);
+        assert_eq!(root, RootCause::LowCoverage);
+        assert_eq!(actions.len(), 1);
+        assert!(matches!(
+            actions[0],
+            SuggestedAction::AddTestsForLines { .. }
+        ));
+    }
+
+    #[test]
+    fn pick_actions_high_complexity_only_via_extract_function() {
+        let split = ProposedSplit {
+            line_range: LineRange::new(10, 20),
+            complexity_contribution: 3,
+            branch_path: String::new(),
+            kind: SplitKind::DeepestNesting,
+            recommended: true,
+        };
+        let (actions, root) = pick_actions(&[], &[split], &[]);
+        assert_eq!(root, RootCause::HighComplexity);
+        assert_eq!(actions.len(), 1);
+        assert!(matches!(
+            actions[0],
+            SuggestedAction::ExtractFunction { .. }
+        ));
+    }
+
+    #[test]
+    fn pick_actions_both_emits_both_actions() {
+        let gaps = vec![LineRange::new(5, 7)];
+        let split = ProposedSplit {
+            line_range: LineRange::new(10, 20),
+            complexity_contribution: 3,
+            branch_path: String::new(),
+            kind: SplitKind::DeepestNesting,
+            recommended: true,
+        };
+        let (actions, root) = pick_actions(&gaps, &[split], &[]);
+        assert_eq!(root, RootCause::Both);
+        assert_eq!(actions.len(), 2);
+        assert!(
+            actions
+                .iter()
+                .any(|a| matches!(a, SuggestedAction::AddTestsForLines { .. }))
+        );
+        assert!(
+            actions
+                .iter()
+                .any(|a| matches!(a, SuggestedAction::ExtractFunction { .. }))
+        );
+    }
+
+    #[test]
+    fn pick_actions_no_splits_no_gaps_falls_back_to_accept_inherent() {
+        let (actions, root) = pick_actions(&[], &[], &[]);
+        assert_eq!(root, RootCause::HighComplexity);
+        assert_eq!(actions.len(), 1);
+        assert!(matches!(
+            actions[0],
+            SuggestedAction::AcceptInherentComplexity { .. }
+        ));
+    }
+
+    #[test]
+    fn pick_actions_dominant_kind_emits_simplify_branching_when_no_splits() {
+        // Four IfBranch contributors out of five (80%) — dominant.
+        let mut contribs = vec![
+            make_contributor(ContributorKind::IfBranch, 1, 1, 1, 0),
+            make_contributor(ContributorKind::IfBranch, 2, 2, 1, 0),
+            make_contributor(ContributorKind::IfBranch, 3, 3, 1, 0),
+            make_contributor(ContributorKind::IfBranch, 4, 4, 1, 0),
+        ];
+        contribs.push(make_contributor(ContributorKind::Match, 5, 5, 1, 0));
+        let (actions, root) = pick_actions(&[], &[], &contribs);
+        assert_eq!(root, RootCause::HighComplexity);
+        assert!(
+            actions
+                .iter()
+                .any(|a| matches!(a, SuggestedAction::SimplifyBranching { .. }))
+        );
+    }
+
+    #[test]
+    fn pick_actions_simplify_branching_with_low_coverage_yields_both() {
+        let gaps = vec![LineRange::new(2, 3)];
+        let contribs = vec![
+            make_contributor(ContributorKind::IfBranch, 1, 1, 1, 0),
+            make_contributor(ContributorKind::IfBranch, 2, 2, 1, 0),
+            make_contributor(ContributorKind::IfBranch, 3, 3, 1, 0),
+            make_contributor(ContributorKind::IfBranch, 4, 4, 1, 0),
+        ];
+        let (actions, root) = pick_actions(&gaps, &[], &contribs);
+        assert_eq!(root, RootCause::Both);
+        assert!(
+            actions
+                .iter()
+                .any(|a| matches!(a, SuggestedAction::AddTestsForLines { .. }))
+        );
+        assert!(
+            actions
+                .iter()
+                .any(|a| matches!(a, SuggestedAction::SimplifyBranching { .. }))
+        );
+    }
+
+    #[test]
+    fn pick_actions_extract_function_takes_precedence_over_simplify() {
+        // Even though IfBranch is 100% dominant, splits are non-empty so
+        // we emit ExtractFunction (concrete) and skip SimplifyBranching.
+        let contribs = vec![
+            make_contributor(ContributorKind::IfBranch, 1, 5, 1, 0),
+            make_contributor(ContributorKind::IfBranch, 2, 4, 2, 1),
+        ];
+        let split = ProposedSplit {
+            line_range: LineRange::new(2, 4),
+            complexity_contribution: 2,
+            branch_path: "if-branch".to_string(),
+            kind: SplitKind::DeepestNesting,
+            recommended: true,
+        };
+        let (actions, _) = pick_actions(&[], &[split], &contribs);
+        assert!(
+            !actions
+                .iter()
+                .any(|a| matches!(a, SuggestedAction::SimplifyBranching { .. }))
+        );
+    }
+
+    // compute_diagnostic — orchestrator
+
+    #[test]
+    fn compute_diagnostic_returns_none_for_passing_verdict() {
+        let verdict = make_verdict(vec![], span_for(1, 10), false);
+        assert!(compute_diagnostic(&verdict, &[]).is_none());
+    }
+
+    #[test]
+    fn compute_diagnostic_returns_some_for_exceeding_verdict() {
+        let verdict = make_verdict(
+            vec![
+                make_contributor(ContributorKind::IfBranch, 17, 25, 1, 0),
+                make_contributor(ContributorKind::IfBranch, 18, 22, 2, 1),
+            ],
+            span_for(16, 26),
+            true,
+        );
+        let diag = compute_diagnostic(&verdict, &[]).expect("diagnostic populated");
+        assert!(diag.coverage_gaps.is_empty());
+        assert_eq!(diag.complexity_drivers.len(), 2);
+        assert!(!diag.suggested_actions.is_empty());
+    }
+
+    #[test]
+    fn compute_diagnostic_low_coverage_only_emits_add_tests() {
+        // Flat function (no contributors) with uncovered lines — only
+        // path is AddTestsForLines.
+        let verdict = make_verdict(vec![], span_for(1, 10), true);
+        let cov = vec![LineCoverage { line: 5, hits: 0 }];
+        let diag = compute_diagnostic(&verdict, &cov).expect("populated");
+        assert_eq!(diag.root_cause, RootCause::LowCoverage);
+        assert_eq!(diag.coverage_gaps, vec![LineRange::new(5, 5)]);
+        assert_eq!(diag.suggested_actions.len(), 1);
+        assert!(matches!(
+            diag.suggested_actions[0],
+            SuggestedAction::AddTestsForLines { .. }
+        ));
+    }
+
+    #[test]
+    fn compute_diagnostic_full_coverage_no_splits_falls_back_to_accept_inherent() {
+        let verdict = make_verdict(vec![], span_for(1, 10), true);
+        let diag = compute_diagnostic(&verdict, &[]).expect("populated");
+        assert_eq!(diag.root_cause, RootCause::HighComplexity);
+        assert_eq!(diag.suggested_actions.len(), 1);
+        assert!(matches!(
+            diag.suggested_actions[0],
+            SuggestedAction::AcceptInherentComplexity { .. }
+        ));
+    }
+
+    #[test]
+    fn compute_diagnostic_extract_function_carries_recommended_marker() {
+        let verdict = make_verdict(
+            vec![
+                make_contributor(ContributorKind::IfBranch, 17, 25, 1, 0),
+                make_contributor(ContributorKind::IfBranch, 18, 22, 2, 1),
+            ],
+            span_for(16, 30),
+            true,
+        );
+        let diag = compute_diagnostic(&verdict, &[]).expect("populated");
+        let ef = diag
+            .suggested_actions
+            .iter()
+            .find_map(|a| match a {
+                SuggestedAction::ExtractFunction { candidates, .. } => Some(candidates),
+                _ => None,
+            })
+            .expect("ExtractFunction emitted");
+        assert!(!ef.is_empty());
+        let recommended_count = ef.iter().filter(|s| s.recommended).count();
+        assert_eq!(recommended_count, 1);
+    }
+}
+
+// ── Property tests ──────────────────────────────────────────────────
+
+#[cfg(test)]
+mod proptests {
+    use super::*;
+    use proptest::prelude::*;
+
+    fn arb_split_kind() -> impl Strategy<Value = SplitKind> {
+        prop_oneof![
+            Just(SplitKind::DeepestNesting),
+            Just(SplitKind::LargestSubblock),
+            Just(SplitKind::HighestBranchCount),
+        ]
+    }
+
+    fn arb_proposed_split() -> impl Strategy<Value = ProposedSplit> {
+        (1usize..200, 1usize..200, 0u32..50, arb_split_kind()).prop_map(
+            |(start, len, contribution, kind)| ProposedSplit {
+                line_range: LineRange::new(start, start + len),
+                complexity_contribution: contribution,
+                branch_path: String::new(),
+                kind,
+                recommended: false,
+            },
+        )
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(256))]
+
+        /// Non-empty `dedup_splits` output always has exactly one
+        /// recommended entry (S-7).
+        #[test]
+        fn dedup_splits_has_exactly_one_recommended_when_non_empty(
+            splits in proptest::collection::vec(arb_proposed_split(), 1..10)
+        ) {
+            let result = dedup_splits(splits);
+            if !result.is_empty() {
+                let count = result.iter().filter(|s| s.recommended).count();
+                prop_assert_eq!(count, 1);
+            }
+        }
+
+        /// `dedup_splits` is idempotent — running it again on its own
+        /// output produces the same result.
+        #[test]
+        fn dedup_splits_is_idempotent(
+            splits in proptest::collection::vec(arb_proposed_split(), 0..10)
+        ) {
+            let once = dedup_splits(splits);
+            let twice = dedup_splits(once.clone());
+            prop_assert_eq!(once, twice);
+        }
+
+        /// `derive_branch_path` produces no whitespace and no commas —
+        /// only `/` as separator (R6.3 — AST-derived chains only).
+        #[test]
+        fn branch_path_carries_no_whitespace_or_commas(
+            depths in proptest::collection::vec(0u32..6, 0..10)
+        ) {
+            // Synthesize a fake nested chain: each contributor encloses
+            // line 100 with strictly lower start lines.
+            let contributors: Vec<ComplexityContributor> = depths
+                .iter()
+                .enumerate()
+                .map(|(i, depth)| {
+                    let start = 50 + i;
+                    ComplexityContributor {
+                        kind: ContributorKind::IfBranch,
+                        line: start,
+                        column: None,
+                        increment: 1,
+                        end_line: 200,
+                        nesting_depth: *depth,
+                    }
+                })
+                .collect();
+            let path = derive_branch_path(&contributors, 100);
+            prop_assert!(!path.contains(' '));
+            prop_assert!(!path.contains(','));
+        }
+
+        /// `dedup_splits` sorts by priority (highest first), so
+        /// `result[0].kind` always has the maximum priority.
+        #[test]
+        fn dedup_splits_sorts_by_priority_descending(
+            splits in proptest::collection::vec(arb_proposed_split(), 1..10)
+        ) {
+            let result = dedup_splits(splits);
+            for window in result.windows(2) {
+                prop_assert!(
+                    split_kind_priority(window[0].kind)
+                        >= split_kind_priority(window[1].kind)
+                );
+            }
+        }
     }
 }

--- a/src/domain/diagnostic.rs
+++ b/src/domain/diagnostic.rs
@@ -1,10 +1,5 @@
-//! Shape C `Diagnostic` types — the AST-derived remediation hint emitted
-//! under `--format advice` (issue #76) and consumed by the
-//! `/cut-the-crap` agent skill (issue #77).
-//!
-//! Hexagonal note: this module is pure domain — no `syn`, no LCOV, no I/O.
-//! Helpers in V3 (`compute_diagnostic`, `extract_split_candidates`, …)
-//! land alongside these types so reporters can stay format-only.
+//! Structured remediation hints (`Diagnostic`) attached to over-threshold
+//! verdicts. Pure domain — no `syn`, no LCOV, no I/O.
 
 use serde::{Deserialize, Serialize};
 
@@ -38,11 +33,9 @@ impl LineRange {
 // ── Root cause ──────────────────────────────────────────────────────
 
 /// Deterministic single-token classification of why a verdict exceeded
-/// the threshold. Derived from the action set per S-6 (locked in shape):
-///
-/// - `LowCoverage` when the only action is `AddTestsForLines`
-/// - `HighComplexity` when the only actions are split/simplify/accept
-/// - `Both` when both kinds of action coexist
+/// the threshold. `LowCoverage` when the only action is `AddTestsForLines`;
+/// `HighComplexity` when the only actions are split/simplify/accept;
+/// `Both` when both kinds of action coexist.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
@@ -57,8 +50,8 @@ pub enum RootCause {
 
 /// Confidence in a `SuggestedAction`, matching `rustc`'s `Applicability`
 /// taxonomy so agents using rustc-shaped tooling can interpret crap4rs
-/// suggestions without translation. T2 (locked): the default is
-/// `Unspecified` because crap4rs does not verify the suggested change.
+/// suggestions without translation. The default is `Unspecified` because
+/// crap4rs does not verify the suggested change.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
@@ -74,9 +67,9 @@ pub enum Applicability {
 
 /// Which strategy produced a `ProposedSplit`. Priority order
 /// `DeepestNesting > HighestBranchCount > LargestSubblock` is enforced
-/// at dedup time (S-7). The default variant is `DeepestNesting` because
-/// that is the highest-priority strategy and the most useful candidate
-/// when only one is needed.
+/// at dedup time. The default variant is `DeepestNesting` because that
+/// is the highest-priority strategy and the most useful candidate when
+/// only one is needed.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
@@ -90,8 +83,7 @@ pub enum SplitKind {
 // ── ProposedSplit ───────────────────────────────────────────────────
 
 /// One AST-derived candidate for `extract_function`. The split is named
-/// only by its line range (R6.3 — agents do prose, the CLI does
-/// coordinates).
+/// only by its line range — agents do prose, the CLI does coordinates.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct ProposedSplit {
@@ -104,7 +96,7 @@ pub struct ProposedSplit {
     pub branch_path: String,
     pub kind: SplitKind,
     /// Exactly one entry per non-empty candidate set carries
-    /// `recommended: true` (S-7).
+    /// `recommended: true`.
     pub recommended: bool,
 }
 
@@ -137,9 +129,8 @@ pub enum SuggestedAction {
 
 /// Structured remediation hint attached to an over-threshold
 /// `FunctionVerdict` when `--format advice` (or `--format sarif`) is
-/// requested. Type-level `#[serde(default)]` lets older payloads (no
-/// new fields) deserialize, so schema_version stays at 1 across the
-/// v0.3.x experimental window.
+/// requested. Type-level `#[serde(default)]` lets older payloads
+/// deserialize when fields are added under `#[non_exhaustive]`.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default)]
 #[non_exhaustive]
@@ -150,16 +141,16 @@ pub struct Diagnostic {
     pub root_cause: RootCause,
 }
 
-// ── Helpers: V3 (compute_diagnostic + sub-helpers) ──────────────────
+// ── Helpers: compute_diagnostic + sub-helpers ───────────────────────
 //
 // All helpers are pure: no I/O, no `syn`, no LCOV. They consume
 // already-parsed `FunctionVerdict` + `LineCoverage` slices and emit
 // AST-derived advice. Callers keep `compute_diagnostic` as the single
 // entry point; the others are `pub(crate)` so tests can pin them.
 
-/// Effective inclusive end line for a contributor. Older payloads (or
-/// adapters that pre-date V1) may have `end_line == 0` — fall back to
-/// `line` so the construct is treated as a single-line atomic.
+/// Effective inclusive end line for a contributor. Older payloads may
+/// carry `end_line == 0`; fall back to `line` so the construct is
+/// treated as a single-line atomic.
 fn effective_end_line(c: &ComplexityContributor) -> usize {
     if c.end_line >= c.line {
         c.end_line
@@ -216,7 +207,7 @@ fn is_viable_split(range: LineRange, span: &SourceSpan, contribution: u32) -> bo
 /// contributor that **strictly encloses** `start_line` (i.e., starts
 /// before `start_line` and ends at or after it). Sorted by
 /// `nesting_depth` ascending so the path reads outermost → innermost.
-/// AST-derived only — never carries prose (R6.3).
+/// AST-derived only — never carries prose.
 pub(crate) fn derive_branch_path(
     contributors: &[ComplexityContributor],
     start_line: usize,
@@ -341,7 +332,7 @@ pub(crate) fn pick_highest_branch_count(
     })
 }
 
-/// Run all three selectors, dedup overlapping ranges by S-7 priority,
+/// Run all three selectors, dedup overlapping ranges by `SplitKind`
 /// and mark exactly one survivor `recommended: true`.
 pub(crate) fn extract_split_candidates(
     contributors: &[ComplexityContributor],
@@ -368,8 +359,8 @@ fn split_kind_priority(kind: SplitKind) -> u8 {
 }
 
 /// Dedup `splits` by `line_range`. When two candidates share the same
-/// range, the highest-priority `kind` wins (S-7:
-/// `DeepestNesting > HighestBranchCount > LargestSubblock`). Within
+/// range, the highest-priority `kind` wins
+/// (`DeepestNesting > HighestBranchCount > LargestSubblock`). Within
 /// the same kind, the lowest `start_line` wins. Exactly one survivor
 /// is marked `recommended: true` (highest priority overall).
 pub(crate) fn dedup_splits(splits: Vec<ProposedSplit>) -> Vec<ProposedSplit> {
@@ -380,13 +371,9 @@ pub(crate) fn dedup_splits(splits: Vec<ProposedSplit>) -> Vec<ProposedSplit> {
             .position(|existing| existing.line_range == split.line_range)
         {
             Some(idx) => {
-                let existing = &by_range[idx];
                 let new_priority = split_kind_priority(split.kind);
-                let existing_priority = split_kind_priority(existing.kind);
-                let replace = new_priority > existing_priority
-                    || (new_priority == existing_priority
-                        && split.line_range.start < existing.line_range.start);
-                if replace {
+                let existing_priority = split_kind_priority(by_range[idx].kind);
+                if new_priority > existing_priority {
                     by_range[idx] = split;
                 }
             }
@@ -433,7 +420,7 @@ fn dominant_contributor_kind(contributors: &[ComplexityContributor]) -> Option<C
 }
 
 /// Build the `(suggested_actions, root_cause)` pair from gaps + splits
-/// + contributors. Action gating (locked F1):
+/// + contributors. Action gating:
 ///
 /// 1. `gaps non-empty` → `AddTestsForLines`
 /// 2. `splits non-empty` → `ExtractFunction`
@@ -475,9 +462,7 @@ pub(crate) fn pick_actions(
         });
     }
 
-    let has_add_tests = actions
-        .iter()
-        .any(|a| matches!(a, SuggestedAction::AddTestsForLines { .. }));
+    let has_add_tests = !coverage_gaps.is_empty();
     let has_complexity = actions
         .iter()
         .any(|a| !matches!(a, SuggestedAction::AddTestsForLines { .. }));
@@ -492,7 +477,7 @@ pub(crate) fn pick_actions(
 }
 
 /// Build a structured remediation hint for `verdict`. Returns `None`
-/// when the verdict is below threshold (R6.4 / F2 — no diagnostic for
+/// when the verdict is below threshold (no diagnostic for
 /// passing functions). When the verdict exceeds, the diagnostic is
 /// always populated with all four fields.
 ///
@@ -724,7 +709,7 @@ mod tests {
         assert_eq!(parsed, original);
     }
 
-    // ── V3 helper tests ────────────────────────────────────────────
+    // ── Helper tests ───────────────────────────────────────────────
 
     use crate::domain::types::{
         ComplexityMetric, CrapScore, FunctionIdentity, FunctionVerdict, LineCoverage, RiskLevel,
@@ -965,7 +950,7 @@ mod tests {
 
     #[test]
     fn dedup_splits_keeps_highest_priority_for_duplicate_range() {
-        // Same range, three kinds. DeepestNesting wins under S-7.
+        // Same range, three kinds. DeepestNesting wins by priority.
         let range = LineRange::new(10, 20);
         let dn = ProposedSplit {
             line_range: range,
@@ -1282,7 +1267,7 @@ mod proptests {
         #![proptest_config(ProptestConfig::with_cases(256))]
 
         /// Non-empty `dedup_splits` output always has exactly one
-        /// recommended entry (S-7).
+        /// recommended entry.
         #[test]
         fn dedup_splits_has_exactly_one_recommended_when_non_empty(
             splits in proptest::collection::vec(arb_proposed_split(), 1..10)
@@ -1306,7 +1291,7 @@ mod proptests {
         }
 
         /// `derive_branch_path` produces no whitespace and no commas —
-        /// only `/` as separator (R6.3 — AST-derived chains only).
+        /// only `/` as separator (AST-derived chains only).
         #[test]
         fn branch_path_carries_no_whitespace_or_commas(
             depths in proptest::collection::vec(0u32..6, 0..10)

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -1,5 +1,6 @@
 pub mod crap;
 pub mod delta;
+pub mod diagnostic;
 pub mod matching;
 pub mod summary;
 pub mod threshold;

--- a/src/domain/types.rs
+++ b/src/domain/types.rs
@@ -281,34 +281,20 @@ pub struct FunctionVerdict {
     /// Structured remediation hint, populated by `--format advice` (#76)
     /// and consumed by the `/cut-the-crap` agent skill (#77). `None` for
     /// default invocations; reporters render it when present.
+    ///
+    /// Boxed so that `FunctionVerdict` (and `FunctionChange::Modified`,
+    /// which carries two of them) stay small — most verdicts have no
+    /// diagnostic, and the boxed pointer keeps `Option<…>` at 8 bytes.
+    /// `Box<T>` is transparent to serde, so the JSON shape is unchanged.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub diagnostic: Option<Diagnostic>,
+    pub diagnostic: Option<Box<Diagnostic>>,
 }
 
-/// Structured remediation hint attached to a verdict.
-///
-/// Placeholder for #82 — populated by #76 (`--format advice`) and consumed
-/// by the `/cut-the-crap` reference skill (#77). Fields are intentionally
-/// minimal in v0.3.0; #76 widens them additively under `#[non_exhaustive]`.
-///
-/// Derives `Default` so external consumers can build a `Diagnostic` and
-/// spread it via the `..` rest pattern even though it is `#[non_exhaustive]`.
-/// The default `summary` is the empty string, matching the "no advice yet"
-/// shape that v0.3.0 ships with.
-///
-/// Carries type-level `#[serde(default)]` so deserialization stays
-/// forward-compatible as #76 grows the type: any new field added under
-/// `#[non_exhaustive]` will fall back to its `Default` value when missing
-/// from older JSON payloads, instead of failing the deserialize. This is
-/// the type-level analogue of the per-field `#[serde(default)]` discipline
-/// `AnalysisSummary` uses on its additive fields.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(default)]
-#[non_exhaustive]
-pub struct Diagnostic {
-    /// Single-line headline (e.g., "complexity is the driver — extract decision branches").
-    pub summary: String,
-}
+// `Diagnostic` is defined in `crate::domain::diagnostic` (issue #76 V2).
+// Re-export here so existing imports of `domain::types::Diagnostic` keep
+// resolving — `FunctionVerdict.diagnostic` and reporter call sites continue
+// to compile unchanged.
+pub use crate::domain::diagnostic::Diagnostic;
 
 // ── Analysis Results ────────────────────────────────────────────────
 
@@ -616,25 +602,7 @@ mod tests {
         assert_eq!(CoverageMetric::default(), CoverageMetric::Line);
     }
 
-    #[test]
-    fn diagnostic_deserializes_empty_object_to_default() {
-        // Pins the type-level `#[serde(default)]` convention: future
-        // additive fields must be tolerated as missing-from-payload, so
-        // `{}` round-trips through `Diagnostic::default()`. If a future
-        // diff drops the annotation or adds a non-Default field, this
-        // test fails before the regression reaches downstream consumers.
-        let parsed: Diagnostic = serde_json::from_str("{}").unwrap();
-        assert_eq!(parsed, Diagnostic::default());
-        assert_eq!(parsed.summary, "");
-    }
-
-    #[test]
-    fn diagnostic_round_trips_summary() {
-        let original = Diagnostic {
-            summary: "extract decision branches".to_string(),
-        };
-        let json = serde_json::to_string(&original).unwrap();
-        let parsed: Diagnostic = serde_json::from_str(&json).unwrap();
-        assert_eq!(parsed, original);
-    }
+    // The `Diagnostic` placeholder that lived here in v0.3.0 has moved to
+    // `crate::domain::diagnostic` (issue #76 V2). Round-trip + default tests
+    // for the full Shape C type live alongside that module.
 }

--- a/src/domain/types.rs
+++ b/src/domain/types.rs
@@ -90,17 +90,33 @@ impl fmt::Display for ContributorKind {
 }
 
 /// A single construct that contributed to a function's complexity score.
+///
+/// `end_line` and `nesting_depth` are populated by walkers that have access
+/// to AST structure; deserialization tolerates older payloads via
+/// `#[serde(default)]` (missing → `0`). Reporters and helpers that consume
+/// these fields treat `end_line == 0` as "use `line` instead", since a
+/// real source position is always >= 1.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct ComplexityContributor {
     pub kind: ContributorKind,
-    /// 1-based line number of the construct.
+    /// 1-based line number of the construct's start (or signal token).
     pub line: usize,
     /// 0-based column offset from syn Span, if available.
     pub column: Option<u32>,
     /// How much this contributor added to the total.
     /// Cognitive: `1 + nesting_depth`. Cyclomatic: always 1.
     pub increment: u32,
+    /// 1-based inclusive end line of the construct. For atomic constructs
+    /// (`?`, `break`, `continue`, single logical operator), equals `line`.
+    /// For compound constructs (`if`, `match`, `for`, etc.), covers the
+    /// full span including bodies.
+    #[serde(default)]
+    pub end_line: usize,
+    /// How deeply this construct is nested under other complexity-bearing
+    /// constructs (0 = top-level statement of the function body).
+    #[serde(default)]
+    pub nesting_depth: u32,
 }
 
 // ── Complexity Metric ────────────────────────────────────────────────
@@ -488,11 +504,15 @@ mod contributor_tests {
             line: 42,
             column: Some(4),
             increment: 2,
+            end_line: 50,
+            nesting_depth: 1,
         };
         assert_eq!(c.kind, ContributorKind::Match);
         assert_eq!(c.line, 42);
         assert_eq!(c.column, Some(4));
         assert_eq!(c.increment, 2);
+        assert_eq!(c.end_line, 50);
+        assert_eq!(c.nesting_depth, 1);
     }
 
     #[test]
@@ -502,9 +522,30 @@ mod contributor_tests {
             line: 10,
             column: None,
             increment: 1,
+            end_line: 10,
+            nesting_depth: 2,
         };
         assert!(c.column.is_none());
         assert_eq!(c.increment, 1);
+        assert_eq!(c.nesting_depth, 2);
+    }
+
+    #[test]
+    fn complexity_contributor_deserializes_without_new_fields() {
+        // Pins the additive convention: older v0.3.0 JSON payloads (which did
+        // not carry `end_line` / `nesting_depth`) must still deserialize so
+        // schema_version=1 stays compatible across the v0.3.x series.
+        let json = r#"{
+            "kind": "if-branch",
+            "line": 7,
+            "column": null,
+            "increment": 1
+        }"#;
+        let parsed: ComplexityContributor = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.kind, ContributorKind::IfBranch);
+        assert_eq!(parsed.line, 7);
+        assert_eq!(parsed.end_line, 0); // sentinel = "unknown / fall back to line"
+        assert_eq!(parsed.nesting_depth, 0);
     }
 }
 

--- a/src/domain/types.rs
+++ b/src/domain/types.rs
@@ -278,22 +278,17 @@ pub struct FunctionVerdict {
     pub scored: ScoredFunction,
     pub threshold: f64,
     pub exceeds: bool,
-    /// Structured remediation hint, populated by `--format advice` (#76)
-    /// and consumed by the `/cut-the-crap` agent skill (#77). `None` for
-    /// default invocations; reporters render it when present.
-    ///
-    /// Boxed so that `FunctionVerdict` (and `FunctionChange::Modified`,
-    /// which carries two of them) stay small — most verdicts have no
-    /// diagnostic, and the boxed pointer keeps `Option<…>` at 8 bytes.
-    /// `Box<T>` is transparent to serde, so the JSON shape is unchanged.
+    /// Structured remediation hint, populated when `--format advice` or
+    /// `--format sarif` is requested. Boxed so `FunctionVerdict` (and
+    /// `FunctionChange::Modified`, which carries two of them) stay small
+    /// — most verdicts have no diagnostic, and the boxed pointer keeps
+    /// `Option<…>` at 8 bytes. `Box<T>` is transparent to serde, so the
+    /// JSON shape is unchanged.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub diagnostic: Option<Box<Diagnostic>>,
 }
 
-// `Diagnostic` is defined in `crate::domain::diagnostic` (issue #76 V2).
-// Re-export here so existing imports of `domain::types::Diagnostic` keep
-// resolving — `FunctionVerdict.diagnostic` and reporter call sites continue
-// to compile unchanged.
+// Re-exported here so `domain::types::Diagnostic` paths keep resolving.
 pub use crate::domain::diagnostic::Diagnostic;
 
 // ── Analysis Results ────────────────────────────────────────────────
@@ -601,8 +596,4 @@ mod tests {
     fn coverage_metric_default_is_line() {
         assert_eq!(CoverageMetric::default(), CoverageMetric::Line);
     }
-
-    // The `Diagnostic` placeholder that lived here in v0.3.0 has moved to
-    // `crate::domain::diagnostic` (issue #76 V2). Round-trip + default tests
-    // for the full Shape C type live alongside that module.
 }

--- a/tests/features/format_advice.feature
+++ b/tests/features/format_advice.feature
@@ -89,19 +89,19 @@ Feature: --format advice (issue #76)
   Scenario: Each ProposedSplit carries the five wire fields
     Given an over-threshold function with high complexity
     When the operator runs `crap4rs --coverage lcov.info --format advice`
-    Then for every `proposed_splits[]` entry, all of the following keys
-      are present and non-null: `line_range`, `complexity_contribution`,
-      `branch_path`, `kind`, `recommended`
+    Then for every `extract_function.candidates[]` entry, all of the
+      following keys are present and non-null: `line_range`,
+      `complexity_contribution`, `branch_path`, `kind`, `recommended`
     And `kind` is one of "deepest_nesting", "largest_subblock",
       "highest_branch_count"
 
   Scenario: Exactly one ProposedSplit per function has recommended:true
-    Given an over-threshold function whose `ExtractFunction.candidates`
+    Given an over-threshold function whose `extract_function.candidates`
       list is non-empty
     When the operator runs `crap4rs --coverage lcov.info --format advice`
     Then exactly one entry in that function's `candidates` has
-      `recommended` "true"
-    And every other entry has `recommended` "false"
+      `recommended` true
+    And every other entry has `recommended` false
 
   Scenario Outline: De-duplication priority for same-line-range candidates
     Given the walker emits multiple split candidates that resolve to the
@@ -154,9 +154,7 @@ Feature: --format advice (issue #76)
     When the operator runs `crap4rs --coverage lcov.info --format advice --min-coverage 80`
     Then `view.shown[]` contains only entries where
       `verdict.scored.coverage_percent >= 80`
-    And each surviving entry carries a `diagnostic` whose
-      `suggested_actions[]` favors `extract_function` over
-      `add_tests_for_lines` (because adding tests will not help)
+    And each surviving entry carries a populated `diagnostic`
 
   Scenario: --format advice composes with --no-fail
     Given exceeding functions exist

--- a/tests/features/format_advice.feature
+++ b/tests/features/format_advice.feature
@@ -1,0 +1,221 @@
+Feature: --format advice (issue #76)
+
+  The advice format emits the canonical JSON envelope with each
+  over-threshold `FunctionVerdict` carrying a populated `Diagnostic`:
+  AST-derived `coverage_gaps`, `complexity_drivers`, `suggested_actions`,
+  and a flat `root_cause` scalar. Primary consumer is the `/cut-the-crap`
+  agent skill (#77); secondary consumers are CI/SARIF and humans.
+
+  The shape is **experimental** in v0.3.x and stabilises at v0.4.0
+  (schema_version stays at 1 throughout v0.3.x; bumps to 2 at v0.4.0).
+
+  Background:
+    Given a project with a mix of over-threshold and under-threshold
+      functions
+    And the over-threshold set contains:
+      | shape                                                            |
+      | a function with low coverage and acceptable complexity           |
+      | a function with high complexity and full coverage                |
+      | a function with both low coverage and high complexity            |
+      | a function with high complexity and zero viable split candidates |
+
+  # ── Envelope shape ─────────────────────────────────────────────────
+
+  Scenario: --format advice emits the canonical envelope on stdout
+    When the operator runs `crap4rs --coverage lcov.info --format advice`
+    Then stdout is parseable JSON
+    And the document carries top-level `schema_version` "1"
+    And the document carries a top-level `view.shown[]` array
+    And every `view.shown[].diagnostic` is either populated or absent
+      (never `null`-with-fields-present)
+
+  Scenario: --format advice exit code matches --format json
+    Given exceeding functions exist
+    When the operator runs `crap4rs --coverage lcov.info --format advice`
+    Then the exit code is 1
+
+  # ── Diagnostic gating (R6.4 / F2) ──────────────────────────────────
+
+  Scenario: Under-threshold functions carry no Diagnostic
+    When the operator runs `crap4rs --coverage lcov.info --format advice`
+    Then for every `view.shown[]` entry where `verdict.exceeds == false`,
+      `verdict.diagnostic` key is absent from the serialised JSON
+
+  Scenario: Over-threshold functions always carry a Diagnostic
+    When the operator runs `crap4rs --coverage lcov.info --format advice`
+    Then for every `view.shown[]` entry where `verdict.exceeds == true`,
+      `verdict.diagnostic` is populated with all four fields:
+      `coverage_gaps`, `complexity_drivers`, `suggested_actions`,
+      `root_cause`
+
+  # ── SuggestedAction taxonomy (R1.3) ────────────────────────────────
+
+  Scenario: Low coverage emits AddTestsForLines
+    Given an over-threshold function with coverage < 100% and acceptable
+      complexity
+    When the operator runs `crap4rs --coverage lcov.info --format advice`
+    Then `verdict.diagnostic.suggested_actions[]` contains one entry with
+      `kind` "add_tests_for_lines"
+    And that entry carries `lines: Vec<LineRange>` matching the uncovered
+      ranges in the function's span
+    And that entry carries an `applicability` field
+
+  Scenario: High complexity with viable splits emits ExtractFunction
+    Given an over-threshold function with full coverage and high
+      complexity
+    When the operator runs `crap4rs --coverage lcov.info --format advice`
+    Then `verdict.diagnostic.suggested_actions[]` contains one entry with
+      `kind` "extract_function"
+    And that entry carries a non-empty `candidates: Vec<ProposedSplit>`
+    And no `add_tests_for_lines` action is emitted for this function
+
+  Scenario: Both low coverage and high complexity emit both actions
+    Given an over-threshold function with coverage < 100% and high
+      complexity
+    When the operator runs `crap4rs --coverage lcov.info --format advice`
+    Then `verdict.diagnostic.suggested_actions[]` contains both
+      `add_tests_for_lines` and `extract_function` entries
+
+  Scenario: High complexity with zero viable splits falls back to AcceptInherentComplexity
+    Given an over-threshold function with full coverage and high
+      complexity but no extractable subexpression
+    When the operator runs `crap4rs --coverage lcov.info --format advice`
+    Then `verdict.diagnostic.suggested_actions[]` contains exactly one
+      entry with `kind` "accept_inherent_complexity"
+    And no `extract_function` action is emitted for this function
+
+  # ── ProposedSplit shape (R1.4) ─────────────────────────────────────
+
+  Scenario: Each ProposedSplit carries the five wire fields
+    Given an over-threshold function with high complexity
+    When the operator runs `crap4rs --coverage lcov.info --format advice`
+    Then for every `proposed_splits[]` entry, all of the following keys
+      are present and non-null: `line_range`, `complexity_contribution`,
+      `branch_path`, `kind`, `recommended`
+    And `kind` is one of "deepest_nesting", "largest_subblock",
+      "highest_branch_count"
+
+  Scenario: Exactly one ProposedSplit per function has recommended:true
+    Given an over-threshold function whose `ExtractFunction.candidates`
+      list is non-empty
+    When the operator runs `crap4rs --coverage lcov.info --format advice`
+    Then exactly one entry in that function's `candidates` has
+      `recommended` "true"
+    And every other entry has `recommended` "false"
+
+  Scenario Outline: De-duplication priority for same-line-range candidates
+    Given the walker emits multiple split candidates that resolve to the
+      same `line_range` with kinds <kinds_present>
+    When the operator runs `crap4rs --coverage lcov.info --format advice`
+    Then the surviving candidate at that `line_range` has `kind`
+      <surviving_kind>
+
+    Examples:
+      | kinds_present                                              | surviving_kind         |
+      | "deepest_nesting" + "highest_branch_count"                 | "deepest_nesting"      |
+      | "deepest_nesting" + "largest_subblock"                     | "deepest_nesting"      |
+      | "highest_branch_count" + "largest_subblock"                | "highest_branch_count" |
+      | "deepest_nesting" + "highest_branch_count" + "largest_subblock" | "deepest_nesting"  |
+
+  # ── root_cause derivation (R1.2) ───────────────────────────────────
+
+  Scenario Outline: root_cause is derived deterministically from the action set
+    Given an over-threshold function whose `suggested_actions[]`
+      contains <actions_present>
+    When the operator runs `crap4rs --coverage lcov.info --format advice`
+    Then `verdict.diagnostic.root_cause` is <root_cause>
+
+    Examples:
+      | actions_present                                  | root_cause        |
+      | "add_tests_for_lines" only                       | "low_coverage"    |
+      | "extract_function" only                          | "high_complexity" |
+      | "simplify_branching" only                        | "high_complexity" |
+      | "accept_inherent_complexity" only                | "high_complexity" |
+      | "add_tests_for_lines" + "extract_function"       | "both"            |
+      | "add_tests_for_lines" + "simplify_branching"     | "both"            |
+
+  # ── Composition with View flags (R2.1) ─────────────────────────────
+
+  Scenario: --format advice composes with --top
+    Given six exceeding functions
+    When the operator runs `crap4rs --coverage lcov.info --format advice --top 3`
+    Then `view.shown[]` length is 3
+    And every entry in `view.shown[]` carries a populated `diagnostic`
+
+  Scenario: --format advice composes with --sort-by coverage
+    Given several exceeding functions with varying coverage
+    When the operator runs `crap4rs --coverage lcov.info --format advice --sort-by coverage`
+    Then `view.shown[]` is ordered by `verdict.scored.coverage_percent`
+      ascending
+    And every entry's `diagnostic` is populated
+
+  Scenario: --format advice composes with --min-coverage / --max-coverage
+    Given a mix of over-threshold functions across the coverage spectrum
+    When the operator runs `crap4rs --coverage lcov.info --format advice --min-coverage 80`
+    Then `view.shown[]` contains only entries where
+      `verdict.scored.coverage_percent >= 80`
+    And each surviving entry carries a `diagnostic` whose
+      `suggested_actions[]` favors `extract_function` over
+      `add_tests_for_lines` (because adding tests will not help)
+
+  Scenario: --format advice composes with --no-fail
+    Given exceeding functions exist
+    When the operator runs `crap4rs --coverage lcov.info --format advice --no-fail`
+    Then the exit code is 0
+    But every exceeding function still carries a populated `diagnostic`
+      — advice reports findings, the gate decides exit code
+
+  # ── Stderr summary (R5.2 / S-8) ────────────────────────────────────
+
+  Scenario: --format advice emits a one-line-per-function summary on stderr
+    Given exceeding functions exist
+    When the operator runs `crap4rs --coverage lcov.info --format advice`
+    Then stdout is parseable JSON
+    And stderr contains one line per over-threshold function in the form
+      `[crap=N.NN] file:line-line qualified::name [actions: …]`
+    And stderr lines are ordered to match `view.shown[]`
+
+  Scenario: stdout stays JSON-only when --format advice is set
+    When the operator runs `crap4rs --coverage lcov.info --format advice`
+    Then stdout contains no human-readable prose, banners, or table
+      borders
+    And stdout is parseable as a single JSON value
+
+  Scenario: --format json without advice emits no stderr summary
+    When the operator runs `crap4rs --coverage lcov.info --format json`
+    Then stderr is empty (apart from operational warnings, if any)
+    And stdout's `view.shown[].diagnostic` keys are absent
+
+  # ── Naming / determinism (R6.3) ────────────────────────────────────
+
+  Scenario: Diagnostic carries no prose, no human names, no LLM-shaped guesses
+    When the operator runs `crap4rs --coverage lcov.info --format advice`
+    Then no `diagnostic.suggested_actions[]` entry contains a `rationale`
+      string field
+    And no `proposed_splits[]` entry contains a `name` field, an
+      `extracted_name` field, or any natural-language description
+    And every `branch_path` is a `/`-joined chain of
+      `ContributorKind` discriminants only
+
+  Scenario: Same input produces byte-identical advice JSON
+    When the operator runs `crap4rs --coverage lcov.info --format advice`
+      twice with the same coverage file
+    Then both stdout bytes are identical
+    And both stderr summaries are identical
+
+  # ── Naming conflict (R6.6 / A1) ────────────────────────────────────
+
+  Scenario: --explain is NOT an alias of --format advice
+    Given the project has at least one over-threshold function
+    When the operator runs `crap4rs --coverage lcov.info --explain`
+    Then stdout is the human-readable breakdown legend (PR #59
+      semantics), not the advice JSON
+    And the `--explain` flag does not populate `view.shown[].diagnostic`
+
+  # ── Stability (R4.1 / G1) ──────────────────────────────────────────
+
+  Scenario: schema_version stays at 1 throughout v0.3.x
+    When the operator runs `crap4rs --coverage lcov.info --format advice`
+    Then the document's top-level `schema_version` is "1"
+    And the README "Output formats" section flags this shape as
+      "experimental" until v0.4.0

--- a/tests/features/sarif_reporter.feature
+++ b/tests/features/sarif_reporter.feature
@@ -137,12 +137,12 @@ Feature: SARIF reporter (issue #70)
 
   Scenario: properties.diagnostic mirrors the advice wire shape
     Given an exceeding function whose `Diagnostic` contains an
-      `extract_function` action with two `proposed_splits[]`
+      `extract_function` action with two `candidates[]`
     When the operator runs `crap4rs --coverage lcov.info --format sarif`
     Then the SARIF result for that function has
       `properties.diagnostic.suggested_actions[]` with `kind`
-      "extract_function" and a non-empty `candidates: Vec<ProposedSplit>`
-    And exactly one `candidates[].recommended` is "true"
+      "extract_function" and a non-empty `candidates[]`
+    And exactly one `candidates[].recommended` is true
 
   Scenario: --format sarif does NOT emit the stderr advice summary
     Given exceeding functions exist

--- a/tests/features/sarif_reporter.feature
+++ b/tests/features/sarif_reporter.feature
@@ -123,3 +123,36 @@ Feature: SARIF reporter (issue #70)
       string "{file_path}:{qualified_name}"
     And running the same command twice produces byte-identical SARIF
       (no timestamp, no run-scoped IDs)
+
+  # ── Diagnostic enrichment (issue #76) ──────────────────────────────
+
+  Scenario: result.properties.diagnostic populated when Diagnostic is computed
+    Given exceeding functions exist
+    When the operator runs `crap4rs --coverage lcov.info --format sarif`
+    Then every `runs[0].results[].properties.diagnostic` carries the
+      same `coverage_gaps`, `complexity_drivers`, `suggested_actions`,
+      and `root_cause` fields the JSON envelope's
+      `view.shown[].diagnostic` would carry under
+      `crap4rs --format advice`
+
+  Scenario: properties.diagnostic mirrors the advice wire shape
+    Given an exceeding function whose `Diagnostic` contains an
+      `extract_function` action with two `proposed_splits[]`
+    When the operator runs `crap4rs --coverage lcov.info --format sarif`
+    Then the SARIF result for that function has
+      `properties.diagnostic.suggested_actions[]` with `kind`
+      "extract_function" and a non-empty `candidates: Vec<ProposedSplit>`
+    And exactly one `candidates[].recommended` is "true"
+
+  Scenario: --format sarif does NOT emit the stderr advice summary
+    Given exceeding functions exist
+    When the operator runs `crap4rs --coverage lcov.info --format sarif`
+    Then stderr contains no per-function summary lines
+      (the stderr summary fires only on `--format advice`)
+
+  Scenario: SARIF determinism preserved with diagnostic enrichment
+    Given the same coverage file across two runs
+    When the operator runs `crap4rs --coverage lcov.info --format sarif`
+      twice
+    Then both `.sarif` outputs are byte-identical, including the
+      `properties.diagnostic` block on every result

--- a/tests/format_advice_integration.rs
+++ b/tests/format_advice_integration.rs
@@ -1,9 +1,6 @@
-//! Integration tests for `--format advice` (issue #76 V4).
-//!
-//! Each test transcribes one or more scenarios from
-//! `tests/features/format_advice.feature`. The behavior contract there
-//! is the spec; this file is the executable form (cucumber-rs not yet
-//! adopted — see crap4rs#115 follow-up).
+//! Integration tests for `--format advice`. Each test transcribes one
+//! or more scenarios from `tests/features/format_advice.feature` (the
+//! executable form pending cucumber-rs adoption).
 
 use std::path::Path;
 use std::process::Command;
@@ -410,7 +407,22 @@ fn same_input_produces_byte_identical_advice_json() {
             "advice",
         ],
     );
-    assert_eq!(first.stdout, second.stdout);
+    // The envelope `timestamp` field is a wall-clock seconds value; two
+    // sequential runs that straddle a second boundary diverge there
+    // without any change to the analysis content. Strip it before
+    // comparing so the determinism assertion is about the analysis.
+    let first_json = strip_envelope_timestamp(&first.stdout);
+    let second_json = strip_envelope_timestamp(&second.stdout);
+    assert_eq!(first_json, second_json);
+}
+
+fn strip_envelope_timestamp(stdout: &[u8]) -> serde_json::Value {
+    let raw = std::str::from_utf8(stdout).expect("stdout is utf-8");
+    let mut value: serde_json::Value = serde_json::from_str(raw).expect("stdout is valid JSON");
+    if let Some(obj) = value.as_object_mut() {
+        obj.remove("timestamp");
+    }
+    value
 }
 
 // ── Stderr summary (V5 / S-8) ───────────────────────────────────────
@@ -542,4 +554,142 @@ fn branch_path_is_kebab_case_kind_chain_no_prose() {
             }
         }
     }
+}
+
+// ── View composition (--top, --sort-by, --min-coverage with advice) ─
+
+const MULTI_FIXTURE_SRC: &str = "\
+pub fn passing_a() -> i32 { 1 }
+pub fn passing_b() -> i32 { 2 }
+pub fn failing_a(x: i32) -> i32 { if x > 0 { if x > 5 { 1 } else { 2 } } else { 3 } }
+pub fn failing_b(x: i32) -> i32 { if x > 0 { if x > 5 { 1 } else { 2 } } else { 3 } }
+pub fn failing_c(x: i32) -> i32 { if x > 0 { if x > 5 { 1 } else { 2 } } else { 3 } }
+";
+
+const MULTI_FIXTURE_LCOV: &str = "\
+SF:lib.rs
+DA:1,1
+DA:2,1
+DA:3,0
+DA:4,0
+DA:5,0
+end_of_record
+";
+
+#[test]
+fn advice_composes_with_top_truncates_shown_and_keeps_diagnostics() {
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    setup_dir(tmp.path(), MULTI_FIXTURE_SRC, MULTI_FIXTURE_LCOV);
+
+    let output = run(
+        tmp.path(),
+        &[
+            "--threshold",
+            "5",
+            "--no-gitignore",
+            "--no-fail",
+            "--format",
+            "advice",
+            "--top",
+            "2",
+        ],
+    );
+    let json = parse_json(&output);
+    let shown = json["view"]["shown"].as_array().expect("shown is array");
+    assert_eq!(shown.len(), 2, "--top 2 must truncate to 2 rows");
+    let exceeding: Vec<_> = shown
+        .iter()
+        .filter(|e| e["exceeds"].as_bool().unwrap_or(false))
+        .collect();
+    assert!(!exceeding.is_empty());
+    for entry in exceeding {
+        assert!(
+            entry.get("diagnostic").is_some(),
+            "exceeding entries under --top must still carry diagnostic: {entry}"
+        );
+    }
+}
+
+#[test]
+fn advice_composes_with_sort_by_coverage_orders_ascending() {
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    setup_dir(tmp.path(), MULTI_FIXTURE_SRC, MULTI_FIXTURE_LCOV);
+
+    let output = run(
+        tmp.path(),
+        &[
+            "--threshold",
+            "5",
+            "--no-gitignore",
+            "--no-fail",
+            "--format",
+            "advice",
+            "--sort-by",
+            "coverage",
+        ],
+    );
+    let json = parse_json(&output);
+    let shown = json["view"]["shown"].as_array().expect("shown is array");
+    let coverages: Vec<f64> = shown
+        .iter()
+        .map(|e| e["scored"]["coverage_percent"].as_f64().unwrap())
+        .collect();
+    assert!(
+        coverages.windows(2).all(|w| w[0] <= w[1]),
+        "--sort-by coverage must order ascending: {coverages:?}"
+    );
+}
+
+#[test]
+fn advice_composes_with_min_coverage_filters_lower_rows() {
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    setup_dir(tmp.path(), MULTI_FIXTURE_SRC, MULTI_FIXTURE_LCOV);
+
+    let output = run(
+        tmp.path(),
+        &[
+            "--threshold",
+            "5",
+            "--no-gitignore",
+            "--no-fail",
+            "--format",
+            "advice",
+            "--min-coverage",
+            "50",
+        ],
+    );
+    let json = parse_json(&output);
+    let shown = json["view"]["shown"].as_array().expect("shown is array");
+    for entry in shown {
+        let cov = entry["scored"]["coverage_percent"].as_f64().unwrap();
+        assert!(
+            cov >= 50.0,
+            "--min-coverage 50 must filter out rows below: got {cov}"
+        );
+    }
+}
+
+// ── --format sarif must NOT emit stderr advice summary ──────────────
+
+#[test]
+fn sarif_format_emits_no_advice_summary_on_stderr() {
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    setup_dir(tmp.path(), FIXTURE_SRC, FIXTURE_LCOV);
+
+    let output = run(
+        tmp.path(),
+        &[
+            "--threshold",
+            "5",
+            "--no-gitignore",
+            "--no-fail",
+            "--format",
+            "sarif",
+        ],
+    );
+    let stderr = String::from_utf8(output.stderr).expect("stderr utf-8");
+    assert!(
+        !stderr.lines().any(|l| l.starts_with("[crap=")),
+        "no advice summary lines should appear under --format sarif; stderr:\n{stderr}"
+    );
 }

--- a/tests/format_advice_integration.rs
+++ b/tests/format_advice_integration.rs
@@ -413,6 +413,94 @@ fn same_input_produces_byte_identical_advice_json() {
     assert_eq!(first.stdout, second.stdout);
 }
 
+// ── Stderr summary (V5 / S-8) ───────────────────────────────────────
+
+#[test]
+fn advice_emits_stderr_summary_one_line_per_exceeding_function() {
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    setup_dir(tmp.path(), FIXTURE_SRC, FIXTURE_LCOV);
+
+    let output = run(
+        tmp.path(),
+        &[
+            "--threshold",
+            "5",
+            "--no-gitignore",
+            "--no-fail",
+            "--format",
+            "advice",
+        ],
+    );
+    let stderr = String::from_utf8(output.stderr).expect("stderr utf-8");
+
+    let summary_lines: Vec<&str> = stderr.lines().filter(|l| l.starts_with("[crap=")).collect();
+    assert!(
+        !summary_lines.is_empty(),
+        "expected at least one summary line, got stderr:\n{stderr}"
+    );
+    for line in &summary_lines {
+        assert!(line.contains("[actions:"), "missing actions tag: {line}");
+        assert!(line.contains("lib.rs"), "expected lib.rs in path: {line}");
+        assert!(
+            line.contains(" branchy_fail "),
+            "expected qualified_name: {line}"
+        );
+    }
+}
+
+#[test]
+fn json_format_emits_no_advice_summary_on_stderr() {
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    setup_dir(tmp.path(), FIXTURE_SRC, FIXTURE_LCOV);
+
+    let output = run(
+        tmp.path(),
+        &[
+            "--threshold",
+            "5",
+            "--no-gitignore",
+            "--no-fail",
+            "--format",
+            "json",
+        ],
+    );
+    let stderr = String::from_utf8(output.stderr).expect("stderr utf-8");
+    assert!(
+        !stderr.lines().any(|l| l.starts_with("[crap=")),
+        "no advice summary lines should appear under --format json; stderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn advice_stderr_summary_is_byte_identical_across_runs() {
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    setup_dir(tmp.path(), FIXTURE_SRC, FIXTURE_LCOV);
+
+    let first = run(
+        tmp.path(),
+        &[
+            "--threshold",
+            "5",
+            "--no-gitignore",
+            "--no-fail",
+            "--format",
+            "advice",
+        ],
+    );
+    let second = run(
+        tmp.path(),
+        &[
+            "--threshold",
+            "5",
+            "--no-gitignore",
+            "--no-fail",
+            "--format",
+            "advice",
+        ],
+    );
+    assert_eq!(first.stderr, second.stderr);
+}
+
 // ── R6.3 — branch_path is AST-only, no prose ────────────────────────
 
 #[test]

--- a/tests/format_advice_integration.rs
+++ b/tests/format_advice_integration.rs
@@ -1,0 +1,457 @@
+//! Integration tests for `--format advice` (issue #76 V4).
+//!
+//! Each test transcribes one or more scenarios from
+//! `tests/features/format_advice.feature`. The behavior contract there
+//! is the spec; this file is the executable form (cucumber-rs not yet
+//! adopted — see crap4rs#115 follow-up).
+
+use std::path::Path;
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_crap4rs");
+
+fn setup_dir(dir: &Path, src_content: &str, lcov_content: &str) {
+    let src = dir.join("src");
+    std::fs::create_dir_all(&src).expect("create src dir");
+    std::fs::write(src.join("lib.rs"), src_content).expect("write lib.rs fixture");
+    std::fs::write(dir.join("lcov.info"), lcov_content).expect("write lcov.info fixture");
+}
+
+fn run(dir: &Path, extra_args: &[&str]) -> std::process::Output {
+    Command::new(BINARY)
+        .current_dir(dir)
+        .args(["--coverage", "lcov.info", "--src", "src"])
+        .args(extra_args)
+        .output()
+        .expect("failed to run crap4rs binary")
+}
+
+fn parse_json(output: &std::process::Output) -> serde_json::Value {
+    let out = String::from_utf8_lossy(&output.stdout).into_owned();
+    serde_json::from_str(&out)
+        .unwrap_or_else(|e| panic!("stdout was not valid JSON: {e}\nraw stdout:\n{out}"))
+}
+
+// Fixture: a high-complexity uncovered function (failing) + a simple
+// covered function (passing). Lines align with the LCOV file so coverage
+// gaps are deterministic.
+const FIXTURE_SRC: &str = "\
+pub fn simple_pass() -> i32 {
+    42
+}
+
+pub fn branchy_fail(x: i32, y: i32) -> i32 {
+    if x > 0 {
+        if y > 0 {
+            1
+        } else {
+            0
+        }
+    } else if x < 0 {
+        if y > 0 {
+            -1
+        } else {
+            -2
+        }
+    } else {
+        0
+    }
+}
+";
+
+const FIXTURE_LCOV: &str = "\
+SF:lib.rs
+DA:1,1
+DA:2,1
+DA:3,1
+DA:5,0
+DA:6,0
+DA:7,0
+DA:8,0
+DA:9,0
+DA:10,0
+DA:11,0
+DA:12,0
+DA:13,0
+DA:14,0
+DA:15,0
+DA:16,0
+DA:17,0
+DA:18,0
+DA:19,0
+DA:20,0
+DA:21,0
+end_of_record
+";
+
+// ── Envelope shape ──────────────────────────────────────────────────
+
+#[test]
+fn advice_emits_schema_version_one_and_view_shown_array() {
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    setup_dir(tmp.path(), FIXTURE_SRC, FIXTURE_LCOV);
+
+    let output = run(
+        tmp.path(),
+        &[
+            "--threshold",
+            "5",
+            "--no-gitignore",
+            "--no-fail",
+            "--format",
+            "advice",
+        ],
+    );
+    let json = parse_json(&output);
+
+    assert_eq!(json["schema_version"], 1);
+    assert!(json["view"]["shown"].is_array());
+}
+
+#[test]
+fn advice_exit_code_matches_json_when_exceeding() {
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    setup_dir(tmp.path(), FIXTURE_SRC, FIXTURE_LCOV);
+
+    let advice = run(
+        tmp.path(),
+        &["--threshold", "5", "--no-gitignore", "--format", "advice"],
+    );
+    let json_out = run(
+        tmp.path(),
+        &["--threshold", "5", "--no-gitignore", "--format", "json"],
+    );
+    assert_eq!(advice.status.code(), json_out.status.code());
+    assert_eq!(advice.status.code(), Some(1));
+}
+
+// ── Diagnostic gating ───────────────────────────────────────────────
+
+#[test]
+fn under_threshold_verdicts_omit_diagnostic_key_in_serialized_json() {
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    setup_dir(tmp.path(), FIXTURE_SRC, FIXTURE_LCOV);
+
+    let output = run(
+        tmp.path(),
+        &[
+            "--threshold",
+            "5",
+            "--no-gitignore",
+            "--no-fail",
+            "--format",
+            "advice",
+        ],
+    );
+    let json = parse_json(&output);
+    let shown = json["view"]["shown"].as_array().expect("shown array");
+
+    for entry in shown {
+        let exceeds = entry["exceeds"].as_bool().unwrap_or(false);
+        if !exceeds {
+            assert!(
+                entry.get("diagnostic").is_none(),
+                "under-threshold verdict serialized a diagnostic key: {entry}"
+            );
+        }
+    }
+}
+
+#[test]
+fn over_threshold_verdicts_carry_all_four_diagnostic_fields() {
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    setup_dir(tmp.path(), FIXTURE_SRC, FIXTURE_LCOV);
+
+    let output = run(
+        tmp.path(),
+        &[
+            "--threshold",
+            "5",
+            "--no-gitignore",
+            "--no-fail",
+            "--format",
+            "advice",
+        ],
+    );
+    let json = parse_json(&output);
+    let shown = json["view"]["shown"].as_array().expect("shown array");
+    let exceeding: Vec<_> = shown
+        .iter()
+        .filter(|e| e["exceeds"].as_bool().unwrap_or(false))
+        .collect();
+    assert!(
+        !exceeding.is_empty(),
+        "fixture must produce at least one exceeding verdict"
+    );
+
+    for verdict in exceeding {
+        let diag = verdict
+            .get("diagnostic")
+            .unwrap_or_else(|| panic!("over-threshold verdict missing diagnostic: {verdict}"));
+        for field in [
+            "coverage_gaps",
+            "complexity_drivers",
+            "suggested_actions",
+            "root_cause",
+        ] {
+            assert!(
+                diag.get(field).is_some(),
+                "diagnostic missing field {field}: {diag}"
+            );
+        }
+    }
+}
+
+// ── SuggestedAction taxonomy ────────────────────────────────────────
+
+#[test]
+fn low_coverage_high_complexity_emits_both_actions_and_root_cause_both() {
+    // The fixture's branchy_fail is uncovered AND complex, so it should
+    // emit both AddTestsForLines and ExtractFunction; root_cause = both.
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    setup_dir(tmp.path(), FIXTURE_SRC, FIXTURE_LCOV);
+
+    let output = run(
+        tmp.path(),
+        &[
+            "--threshold",
+            "5",
+            "--no-gitignore",
+            "--no-fail",
+            "--format",
+            "advice",
+        ],
+    );
+    let json = parse_json(&output);
+    let shown = json["view"]["shown"].as_array().unwrap();
+    let branchy = shown
+        .iter()
+        .find(|e| e["scored"]["identity"]["qualified_name"] == "branchy_fail")
+        .expect("branchy_fail in shown");
+    let diag = branchy.get("diagnostic").expect("diagnostic populated");
+
+    assert_eq!(diag["root_cause"], "both");
+
+    let kinds: Vec<&str> = diag["suggested_actions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|a| a["kind"].as_str().unwrap())
+        .collect();
+    assert!(
+        kinds.contains(&"add_tests_for_lines"),
+        "expected add_tests_for_lines action, got {kinds:?}"
+    );
+    assert!(
+        kinds.contains(&"extract_function"),
+        "expected extract_function action, got {kinds:?}"
+    );
+}
+
+// ── ProposedSplit shape ─────────────────────────────────────────────
+
+#[test]
+fn proposed_split_carries_five_wire_fields_and_exactly_one_recommended() {
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    setup_dir(tmp.path(), FIXTURE_SRC, FIXTURE_LCOV);
+
+    let output = run(
+        tmp.path(),
+        &[
+            "--threshold",
+            "5",
+            "--no-gitignore",
+            "--no-fail",
+            "--format",
+            "advice",
+        ],
+    );
+    let json = parse_json(&output);
+    let shown = json["view"]["shown"].as_array().unwrap();
+    let branchy = shown
+        .iter()
+        .find(|e| e["scored"]["identity"]["qualified_name"] == "branchy_fail")
+        .unwrap();
+
+    let extract = branchy["diagnostic"]["suggested_actions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|a| a["kind"] == "extract_function")
+        .expect("ExtractFunction emitted");
+    let candidates = extract["candidates"].as_array().unwrap();
+    assert!(
+        !candidates.is_empty(),
+        "candidates non-empty for high-complexity fn"
+    );
+
+    for cand in candidates {
+        for field in [
+            "line_range",
+            "complexity_contribution",
+            "branch_path",
+            "kind",
+            "recommended",
+        ] {
+            assert!(
+                cand.get(field).is_some(),
+                "ProposedSplit missing field {field}: {cand}"
+            );
+        }
+        let kind = cand["kind"].as_str().unwrap();
+        assert!(
+            matches!(
+                kind,
+                "deepest_nesting" | "largest_subblock" | "highest_branch_count"
+            ),
+            "unexpected kind: {kind}"
+        );
+    }
+
+    let recommended_count = candidates
+        .iter()
+        .filter(|c| c["recommended"].as_bool().unwrap_or(false))
+        .count();
+    assert_eq!(
+        recommended_count, 1,
+        "exactly one candidate must be recommended"
+    );
+}
+
+// ── Composition with View flags ─────────────────────────────────────
+
+#[test]
+fn advice_composes_with_no_fail() {
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    setup_dir(tmp.path(), FIXTURE_SRC, FIXTURE_LCOV);
+
+    let output = run(
+        tmp.path(),
+        &[
+            "--threshold",
+            "5",
+            "--no-gitignore",
+            "--no-fail",
+            "--format",
+            "advice",
+        ],
+    );
+    assert_eq!(output.status.code(), Some(0), "--no-fail forces exit 0");
+
+    let json = parse_json(&output);
+    let shown = json["view"]["shown"].as_array().unwrap();
+    let exceeding: Vec<_> = shown
+        .iter()
+        .filter(|e| e["exceeds"].as_bool().unwrap_or(false))
+        .collect();
+    assert!(
+        !exceeding.is_empty(),
+        "no-fail must not strip exceeding verdicts"
+    );
+    for v in exceeding {
+        assert!(v.get("diagnostic").is_some());
+    }
+}
+
+// ── Naming conflict (R6.6 / A1) ─────────────────────────────────────
+
+#[test]
+fn json_format_without_advice_has_no_diagnostic_keys() {
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    setup_dir(tmp.path(), FIXTURE_SRC, FIXTURE_LCOV);
+
+    let output = run(
+        tmp.path(),
+        &[
+            "--threshold",
+            "5",
+            "--no-gitignore",
+            "--no-fail",
+            "--format",
+            "json",
+        ],
+    );
+    let json = parse_json(&output);
+    let shown = json["view"]["shown"].as_array().unwrap();
+    for entry in shown {
+        assert!(
+            entry.get("diagnostic").is_none(),
+            "default --format json must not populate diagnostic; got {entry}"
+        );
+    }
+}
+
+// ── Stability / determinism ────────────────────────────────────────
+
+#[test]
+fn same_input_produces_byte_identical_advice_json() {
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    setup_dir(tmp.path(), FIXTURE_SRC, FIXTURE_LCOV);
+
+    let first = run(
+        tmp.path(),
+        &[
+            "--threshold",
+            "5",
+            "--no-gitignore",
+            "--no-fail",
+            "--format",
+            "advice",
+        ],
+    );
+    let second = run(
+        tmp.path(),
+        &[
+            "--threshold",
+            "5",
+            "--no-gitignore",
+            "--no-fail",
+            "--format",
+            "advice",
+        ],
+    );
+    assert_eq!(first.stdout, second.stdout);
+}
+
+// ── R6.3 — branch_path is AST-only, no prose ────────────────────────
+
+#[test]
+fn branch_path_is_kebab_case_kind_chain_no_prose() {
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    setup_dir(tmp.path(), FIXTURE_SRC, FIXTURE_LCOV);
+
+    let output = run(
+        tmp.path(),
+        &[
+            "--threshold",
+            "5",
+            "--no-gitignore",
+            "--no-fail",
+            "--format",
+            "advice",
+        ],
+    );
+    let json = parse_json(&output);
+    let shown = json["view"]["shown"].as_array().unwrap();
+    for entry in shown {
+        let Some(diag) = entry.get("diagnostic") else {
+            continue;
+        };
+        for action in diag["suggested_actions"].as_array().unwrap() {
+            if action["kind"] != "extract_function" {
+                continue;
+            }
+            for cand in action["candidates"].as_array().unwrap() {
+                let path = cand["branch_path"].as_str().unwrap();
+                assert!(
+                    !path.contains(' '),
+                    "branch_path contains whitespace (prose suspicion): {path:?}"
+                );
+                assert!(
+                    !path.contains(','),
+                    "branch_path contains comma (prose suspicion): {path:?}"
+                );
+            }
+        }
+    }
+}

--- a/tests/sarif_reporter_integration.rs
+++ b/tests/sarif_reporter_integration.rs
@@ -322,3 +322,125 @@ fn sarif_partial_fingerprint_format() {
         );
     }
 }
+
+// ── #76 V6: properties.diagnostic enrichment ────────────────────────
+//
+// Amendment scenarios from `tests/features/sarif_reporter.feature`.
+// Under `--format sarif`, every result for an over-threshold verdict
+// carries `properties.diagnostic` with the same shape as
+// `view.shown[].diagnostic` under `--format advice`.
+
+#[test]
+fn sarif_results_carry_properties_diagnostic_under_format_sarif() {
+    let dir = tempfile::tempdir().unwrap();
+    setup_dir(dir.path(), FIXTURE_SRC, FIXTURE_LCOV);
+    let output = run(dir.path(), &["--threshold", "8", "--format", "sarif"]);
+    let v = parse_json(&output);
+    let results = v["runs"][0]["results"].as_array().unwrap();
+    assert!(!results.is_empty(), "fixture must produce findings");
+    for r in results {
+        let diag = r["properties"]["diagnostic"]
+            .as_object()
+            .unwrap_or_else(|| panic!("missing properties.diagnostic on result: {r}"));
+        for field in [
+            "coverage_gaps",
+            "complexity_drivers",
+            "suggested_actions",
+            "root_cause",
+        ] {
+            assert!(
+                diag.contains_key(field),
+                "properties.diagnostic missing field {field}: {diag:?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn sarif_properties_diagnostic_shape_matches_advice_format() {
+    let dir = tempfile::tempdir().unwrap();
+    setup_dir(dir.path(), FIXTURE_SRC, FIXTURE_LCOV);
+
+    let sarif = parse_json(&run(dir.path(), &["--threshold", "8", "--format", "sarif"]));
+    let advice = parse_json(&run(
+        dir.path(),
+        &[
+            "--threshold",
+            "8",
+            "--no-fail",
+            "--format",
+            "advice",
+            "--sort-by",
+            "path",
+        ],
+    ));
+
+    // Build (qualified_name → diagnostic) maps from each side, then
+    // assert byte-equal Diagnostic shapes for every overlapping fn.
+    use std::collections::HashMap;
+
+    let mut sarif_diags: HashMap<String, serde_json::Value> = HashMap::new();
+    for r in sarif["runs"][0]["results"].as_array().unwrap() {
+        let fp = r["partialFingerprints"]["functionIdentity"]
+            .as_str()
+            .unwrap();
+        let qn = fp.split(':').next_back().unwrap().to_string();
+        sarif_diags.insert(qn, r["properties"]["diagnostic"].clone());
+    }
+
+    let mut advice_diags: HashMap<String, serde_json::Value> = HashMap::new();
+    for v in advice["view"]["shown"].as_array().unwrap() {
+        if !v["exceeds"].as_bool().unwrap_or(false) {
+            continue;
+        }
+        let qn = v["scored"]["identity"]["qualified_name"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        advice_diags.insert(qn, v["diagnostic"].clone());
+    }
+
+    assert!(!sarif_diags.is_empty());
+    for (qn, advice_diag) in &advice_diags {
+        let sarif_diag = sarif_diags
+            .get(qn)
+            .unwrap_or_else(|| panic!("SARIF missing result for {qn}"));
+        assert_eq!(
+            sarif_diag, advice_diag,
+            "SARIF properties.diagnostic must match --format advice for {qn}"
+        );
+    }
+}
+
+#[test]
+fn sarif_omits_properties_when_no_diagnostic() {
+    // `--format sarif` always populates diagnostics for exceeding fns
+    // (compute_diagnostics flips on for both Advice and Sarif), so the
+    // skip path only fires when no result is over-threshold. This test
+    // pins the structural skip behavior with the all-passing fixture.
+    let dir = tempfile::tempdir().unwrap();
+    setup_dir(dir.path(), PASSING_SRC, PASSING_LCOV);
+    let v = parse_json(&run(dir.path(), &["--threshold", "8", "--format", "sarif"]));
+    let results = v["runs"][0]["results"].as_array().unwrap();
+    assert!(results.is_empty(), "no exceeding fns in passing fixture");
+}
+
+#[test]
+fn sarif_byte_identical_with_diagnostic_enrichment_across_runs() {
+    let dir = tempfile::tempdir().unwrap();
+    setup_dir(dir.path(), FIXTURE_SRC, FIXTURE_LCOV);
+    let first = stdout_str(&run(dir.path(), &["--threshold", "8", "--format", "sarif"]));
+    let second = stdout_str(&run(dir.path(), &["--threshold", "8", "--format", "sarif"]));
+    assert_eq!(
+        first, second,
+        "SARIF with diagnostic enrichment must be byte-deterministic"
+    );
+    // Verify diagnostic actually present (otherwise this would pass
+    // trivially even if V6 broke).
+    let v: serde_json::Value = serde_json::from_str(&first).unwrap();
+    let results = v["runs"][0]["results"].as_array().unwrap();
+    assert!(!results.is_empty());
+    for r in results {
+        assert!(r["properties"]["diagnostic"].is_object());
+    }
+}

--- a/tests/sarif_reporter_integration.rs
+++ b/tests/sarif_reporter_integration.rs
@@ -381,11 +381,11 @@ fn sarif_properties_diagnostic_shape_matches_advice_format() {
 
     let mut sarif_diags: HashMap<String, serde_json::Value> = HashMap::new();
     for r in sarif["runs"][0]["results"].as_array().unwrap() {
-        let fp = r["partialFingerprints"]["functionIdentity"]
+        let key = r["partialFingerprints"]["functionIdentity"]
             .as_str()
-            .unwrap();
-        let qn = fp.split(':').next_back().unwrap().to_string();
-        sarif_diags.insert(qn, r["properties"]["diagnostic"].clone());
+            .unwrap()
+            .to_string();
+        sarif_diags.insert(key, r["properties"]["diagnostic"].clone());
     }
 
     let mut advice_diags: HashMap<String, serde_json::Value> = HashMap::new();
@@ -393,11 +393,9 @@ fn sarif_properties_diagnostic_shape_matches_advice_format() {
         if !v["exceeds"].as_bool().unwrap_or(false) {
             continue;
         }
-        let qn = v["scored"]["identity"]["qualified_name"]
-            .as_str()
-            .unwrap()
-            .to_string();
-        advice_diags.insert(qn, v["diagnostic"].clone());
+        let file = v["scored"]["identity"]["file_path"].as_str().unwrap();
+        let qn = v["scored"]["identity"]["qualified_name"].as_str().unwrap();
+        advice_diags.insert(format!("{file}:{qn}"), v["diagnostic"].clone());
     }
 
     assert!(!sarif_diags.is_empty());


### PR DESCRIPTION
## Summary

Populates `FunctionVerdict.diagnostic` with AST-derived structured advice, exposed via two CLI surfaces:

- `--format advice` — agent-oriented JSON envelope (stdout) + grep-friendly per-function summary (stderr)
- `--format sarif` — diagnostic carried under `result.properties.diagnostic` for GitHub Code Scanning + the future `/cut-the-crap` agent skill (#77)

`schema_version` stays at `1` throughout v0.3.x; the shape stabilises at v0.4.0. CLI-side precursor to #77 — releases bundle there.

## What ships

- `src/domain/diagnostic.rs` (new, ~1300 lines) — Shape C types (`Diagnostic`, `RootCause`, `SuggestedAction`, `ProposedSplit`, `SplitKind`, `Applicability`, `LineRange`) + helpers (`compute_diagnostic`, `extract_split_candidates`, `dedup_splits`, `pick_actions`, `derive_branch_path`, `derive_coverage_gaps`). Pure domain — no `syn`, no LCOV, no I/O. Type-level `#[serde(default)]` + `#[non_exhaustive]` discipline gives forward-compatible additive evolution.
- `src/adapters/complexity/` — walker now persists `end_line` + `nesting_depth` on every contributor (already computed; previously discarded). Older payloads keep deserializing via `#[serde(default)]`.
- `src/cli/mod.rs` + `src/core/mod.rs` — `FormatArg::Advice` variant + lazy `compute_diagnostics: bool` gate. CLI translates format names; domain stays unaware. `compute_diagnostic` runs only on exceeding verdicts when the gate is set.
- `src/adapters/reporters/advice_summary.rs` (new) + `src/adapters/reporters/sarif.rs` — stderr summary fires only on `--format advice`; SARIF carries the same diagnostic under `result.properties.diagnostic` (byte-identical shape).

## Tests

- 50 unit tests + 4 property tests (256 cases each) in `domain/diagnostic.rs`
- 17 integration tests in `tests/format_advice_integration.rs` (envelope shape, gating, taxonomy, ProposedSplit shape, recommended marker, view-flag composition with `--top`/`--sort-by`/`--min-coverage`/`--no-fail`, format separation, no-prose contract, byte-identity determinism, SARIF stderr negative)
- 16 SARIF integration tests (4 amendment scenarios pin `properties.diagnostic` enrichment, cross-format byte-equality, omission when no diagnostic, byte-identity across runs)
- Walker fixture + property tests for the new `end_line`/`nesting_depth` fields
- `.feature` files (`format_advice.feature` 22 scenarios, `sarif_reporter.feature` +4 amendment scenarios) committed as design contracts; cucumber-rs adoption tracked at #115

Total: **839/839 passing**, clippy clean, fmt clean.

## Self-CRAP gate

`cargo run -- --coverage lcov.info --threshold 30` on this branch:

```
Summary: 974 functions | 0 above threshold (30) | worst: 24.0 | PASS
```

`compute_diagnostic` itself: cx=4, cov=100%, crap≈4.

## Architectural decisions

- **ADR D7 amendment** — locked Shape C, F1 action gating, dedup priority (DeepestNesting > HighestBranchCount > LargestSubblock), lazy gate plumbing. See `ops/decisions/crap4rs/adr-view-abstraction.md`.
- **`AnalyzeOptions.compute_diagnostics: bool`** — clean plumbing decision. Domain doesn't know CLI format names.
- **`Option<Box<Diagnostic>>`** for `large_enum_variant` discipline. Box is transparent to serde.
- **No prose anywhere** in the wire shape — only line ranges and AST-derived `branch_path` strings. Agents do prose; the CLI does coordinates.

## Review fixes applied (this PR)

- Stripped wall-clock `timestamp` from byte-identity comparison (CEng caught flaky-by-construction test under second-boundary CI runs).
- Dropped dead tiebreaker branch in `dedup_splits` (code-simplifier).
- Inlined `has_add_tests` from input in `pick_actions` (code-simplifier).
- Added explicit `if !verdict.exceeds { continue; }` guard in `populate_diagnostics` matching the doc comment (code-simplifier).
- Added 4 integration tests pinning view-flag composition + SARIF stderr negative (CEng + pr-test-analyzer).
- Stripped session-stage tokens from production code comments per global comment-hygiene rule (comment-analyzer).
- Added F1 action gating rule to ADR D7 amendment (CAO).

## Follow-ups (filed)

- **#115** — adopt cucumber-rs to execute `.feature` files literally (`type:research`, `priority:later`)
- **#116** — trait method default-impl boundary handling (`type:task`, `priority:later`)
- **#117** — `ProposedSplit` ergonomics: raw AST node references (`type:research`, `priority:later`)
- **#77** (existing) — `/cut-the-crap` agent skill consumes this output; releases bundle there before v0.3.1.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo nextest run` — 839/839 pass
- [x] `cargo llvm-cov --lcov && cargo run -- --coverage lcov.info --threshold 30` — PASS, 0 exceeders
- [x] `cargo run -- --coverage lcov.info --format advice | jq '.view.shown[0].diagnostic'` populates fields
- [x] `cargo run -- --coverage lcov.info --format sarif | jq '.runs[0].results[0].properties.diagnostic'` matches advice shape
- [x] `cargo run -- --coverage lcov.info --format advice 2>&1 1>/dev/null | head` — stderr summary lines present
- [x] `cargo run -- --coverage lcov.info --format sarif 2>&1 1>/dev/null` — no stderr summary
- [x] `cargo run -- --coverage lcov.info --explain` — human breakdown legend, no Diagnostic JSON

## Anchors

- Issue: #76
- Plan: `~/Github/ops/workspace/crap4rs/20260501-format-advice/impl-plan.md`
- Shape: `~/Github/ops/workspace/crap4rs/20260501-format-advice/shaping.md`
- Breadboard: `~/Github/ops/workspace/crap4rs/20260501-format-advice/breadboard.md`
- ADR D7 (amended): `~/Github/ops/decisions/crap4rs/adr-view-abstraction.md`

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced experimental `--format advice` output providing remediation hints including coverage gaps, complexity drivers, suggested actions, and root cause analysis.
  * SARIF format now enriched with diagnostic insights for functions exceeding thresholds.
  * Added grep-friendly stderr summary for quick scanning of results.

* **Documentation**
  * Updated documentation for new advice format and SARIF enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->