### PR TITLE
feat(action): #112 — expose outputs.row-json

### DIFF
--- a/.github/actions/scorecard/README.md
+++ b/.github/actions/scorecard/README.md
@@ -200,9 +200,13 @@ PR [#119](https://github.com/breezy-bays-labs/crap4rs/pull/119)):
   run: |
     # Concatenate Row JSONs into a Scorecard, render however the
     # aggregator likes (a custom markdown layout, a Check Run summary,
-    # a Slack message, ...).
-    printf '%s\n' "$CRAP_ROW" > /tmp/crap-row.json
-    jq -r '"### " + .label + " — **" + .status + "** — " + .delta_text' /tmp/crap-row.json
+    # a Slack message, ...). Guard against the documented version-gap
+    # window (crap4rs < 0.4.0) where row-json is empty — `jq` would
+    # otherwise error on a non-JSON input.
+    if [ -n "$CRAP_ROW" ]; then
+      printf '%s\n' "$CRAP_ROW" > /tmp/crap-row.json
+      jq -r '"### " + .label + " — **" + .status + "** — " + .delta_text' /tmp/crap-row.json
+    fi
 ```
 
 `outputs.markdown` remains available unchanged — existing consumers

--- a/.github/actions/scorecard/README.md
+++ b/.github/actions/scorecard/README.md
@@ -152,12 +152,70 @@ owns the comment.
 
 | Name | Notes |
 |---|---|
-| `markdown` | The rendered scorecard — drop into aggregator comments |
+| `markdown` | The rendered scorecard — drop into aggregator comments verbatim |
+| `row-json` | Mokumo `Row::CrapDelta` JSON object — for aggregators that re-render with full layout control. See [Structured row output](#structured-row-output-outputsrow-json) |
 | `json-envelope-path` | Path to the full JSON envelope on the runner |
 | `analysis-passed` | `true` / `false` |
 | `delta-passed` | `true` / `false`, or empty string when no baseline |
 | `new-violations` | Count of functions exceeding threshold but not in baseline |
 | `regressions` | Count of modified functions whose CRAP increased above rendering precision |
+
+## Structured row output (`outputs.row-json`)
+
+`outputs.row-json` is the raw stdout of `crap4rs --format scorecard-row` —
+one mokumo `Row::CrapDelta` JSON object, conforming to the locked
+[scorecard schema](https://github.com/breezy-bays-labs/mokumo/blob/main/.config/scorecard/schema.json)
+(the `CrapDelta` member of `definitions/Row` `oneOf`). No envelope, no
+metadata wrapper — the JSON object is the contract.
+
+Use `outputs.row-json` when an aggregator workflow re-renders the
+scorecard with full layout control. Use `outputs.markdown` when posting
+the scorecard verbatim into a sticky comment.
+
+Producer-side status policy (Red/Yellow/Green) lives in `crap4rs`
+([crap4rs#111](https://github.com/breezy-bays-labs/crap4rs/issues/111),
+PR [#119](https://github.com/breezy-bays-labs/crap4rs/pull/119)):
+
+- **Red** — at least one new threshold violation landed.
+- **Yellow** — no new violations, but at least one modified function's
+  CRAP score regressed.
+- **Green** — otherwise.
+
+### Aggregator pattern — consume `row-json` and re-render
+
+```yaml
+- uses: breezy-bays-labs/crap4rs/.github/actions/scorecard@main
+  id: crap
+  with:
+    coverage: /tmp/head.lcov
+    baseline: /tmp/baseline.json
+    comment-mode: 'none'           # outputs only — aggregator owns the comment
+
+- name: Aggregate scorecard rows
+  id: agg
+  shell: bash
+  env:
+    CRAP_ROW: ${{ steps.crap.outputs.row-json }}
+    # ... other producers' rows here ...
+  run: |
+    # Concatenate Row JSONs into a Scorecard, render however the
+    # aggregator likes (a custom markdown layout, a Check Run summary,
+    # a Slack message, ...).
+    printf '%s\n' "$CRAP_ROW" > /tmp/crap-row.json
+    jq -r '"### " + .label + " — **" + .status + "** — " + .delta_text' /tmp/crap-row.json
+```
+
+`outputs.markdown` remains available unchanged — existing consumers
+(e.g. mokumo's `crap-scorecard` job in `quality.yml`) continue to read
+it without modification.
+
+### Version requirement
+
+`outputs.row-json` is populated for **`crap4rs ≥ 0.4.0`**. With older
+releases the action emits an empty string and prints a workflow
+warning; the rest of the action (`outputs.markdown`, gates, sticky
+comment) keeps working. Pin the `version` input to `0.4.0` or later
+once it publishes if your workflow consumes `row-json`.
 
 ## Pinning
 

--- a/.github/actions/scorecard/action.yml
+++ b/.github/actions/scorecard/action.yml
@@ -205,7 +205,12 @@ runs:
         # emit an empty row-json with a workflow warning if the variant
         # isn't supported, so consumers see the gap explicitly without
         # the action turning red.
-        if crap4rs --help 2>/dev/null | grep -q -- 'scorecard-row'; then
+        # `grep -q` exits as soon as it sees a match, which under
+        # `set -o pipefail` can SIGPIPE the upstream `crap4rs --help`
+        # and surface as a non-zero pipeline status — the probe would
+        # then false-negative even when the variant IS supported.
+        # Plain `grep ... >/dev/null` reads to EOF, no SIGPIPE.
+        if crap4rs --help 2>/dev/null | grep -- 'scorecard-row' >/dev/null; then
           crap4rs "${common[@]}" --format scorecard-row --no-fail > "$row_json_file"
         else
           installed_version="$(crap4rs --version 2>/dev/null || echo 'unknown')"

--- a/.github/actions/scorecard/action.yml
+++ b/.github/actions/scorecard/action.yml
@@ -77,6 +77,15 @@ outputs:
   markdown:
     description: 'The rendered markdown scorecard. Consume directly in aggregator bots.'
     value: ${{ steps.run.outputs.markdown }}
+  row-json:
+    description: |
+      The mokumo `Row::CrapDelta` JSON object emitted by `crap4rs --format scorecard-row`.
+      Conforms to the locked scorecard schema published at
+      https://github.com/breezy-bays-labs/mokumo/blob/main/.config/scorecard/schema.json
+      (the `CrapDelta` member of `definitions/Row` `oneOf`). Consume in aggregator workflows
+      that re-render the scorecard with full layout control instead of parsing `outputs.markdown`.
+      Producer-side status policy lives in crap4rs (see PR #119).
+    value: ${{ steps.run.outputs.row_json }}
   json-envelope-path:
     description: 'Path to the full JSON envelope on the runner — pass to downstream tooling.'
     value: ${{ steps.run.outputs.envelope_path }}
@@ -166,6 +175,7 @@ runs:
         set -euo pipefail
         envelope="$RUNNER_TEMP/crap4rs-envelope.json"
         markdown_file="$RUNNER_TEMP/crap4rs-scorecard.md"
+        row_json_file="$RUNNER_TEMP/crap4rs-row.json"
         common=(--coverage "$COVERAGE" --src "$SRC" --threshold "$THRESHOLD")
         [ -n "$CONFIG" ] && common+=(--config "$CONFIG")
         if [ -n "$BASELINE" ]; then
@@ -177,14 +187,31 @@ runs:
         # gates would have tripped. The hard gating happens in the dedicated
         # gate step below, gated by the analysis-gate / delta-gate inputs.
         #
-        # Two-pass note: we run crap4rs twice — once for JSON, once for
-        # markdown — because the analyzer doesn't yet support multi-format
-        # output in a single invocation. The cost is one extra LCOV parse +
-        # CRAP recompute (cheap relative to runner setup); the user-visible
-        # latency is dominated by `cargo binstall crap4rs` upstream. Tracked
-        # in https://github.com/breezy-bays-labs/crap4rs/issues/100.
+        # Three-pass note: we run crap4rs three times — once each for JSON,
+        # markdown, and scorecard-row — because the analyzer doesn't yet
+        # support multi-format output in a single invocation. The cost is two
+        # extra LCOV parses + CRAP recomputes (cheap relative to runner
+        # setup); the user-visible latency is dominated by
+        # `cargo binstall crap4rs` upstream. Tracked in
+        # https://github.com/breezy-bays-labs/crap4rs/issues/100.
         crap4rs "${common[@]}" --format json --no-fail > "$envelope"
         crap4rs "${common[@]}" --format markdown --no-fail > "$markdown_file"
+
+        # Graceful probe: --format scorecard-row landed in crap4rs 0.4.0
+        # (https://github.com/breezy-bays-labs/crap4rs/pull/119). Older
+        # releases — including crates.io's 0.3.0, which `cargo binstall
+        # crap4rs` resolves to until 0.4.0 publishes — don't recognize the
+        # value and clap exits non-zero. Probe the installed help text and
+        # emit an empty row-json with a workflow warning if the variant
+        # isn't supported, so consumers see the gap explicitly without
+        # the action turning red.
+        if crap4rs --help 2>/dev/null | grep -q -- 'scorecard-row'; then
+          crap4rs "${common[@]}" --format scorecard-row --no-fail > "$row_json_file"
+        else
+          installed_version="$(crap4rs --version 2>/dev/null || echo 'unknown')"
+          echo "::warning::Installed crap4rs ($installed_version) lacks '--format scorecard-row'; outputs.row-json will be empty. Pin the action's 'version' input to '0.4.0' or later once it publishes for structured Row::CrapDelta output."
+          : > "$row_json_file"
+        fi
 
         # Parse the envelope. jq is preinstalled on GitHub-hosted runners.
         analysis_passed=$(jq -r '.result.passed' "$envelope")
@@ -203,6 +230,17 @@ runs:
           echo "markdown<<__CRAP_SCORECARD_EOF__"
           cat "$markdown_file"
           echo "__CRAP_SCORECARD_EOF__"
+        } >> "$GITHUB_OUTPUT"
+
+        # Multi-line output: file the row-json via a distinct heredoc sentinel.
+        # The file is the raw stdout of `crap4rs --format scorecard-row` —
+        # one mokumo Row::CrapDelta JSON object, no envelope wrapping. The
+        # sentinel must not appear in the JSON; pretty-printed CrapDelta
+        # never contains it.
+        {
+          echo "row_json<<__CRAP_SCORECARD_ROW_EOF__"
+          cat "$row_json_file"
+          echo "__CRAP_SCORECARD_ROW_EOF__"
         } >> "$GITHUB_OUTPUT"
 
         # Surface a compact summary in the job log so failures are obvious


### PR DESCRIPTION
Closes #112

Builds on the producer landed in PR #119 (crap4rs#111, `--format scorecard-row`). Exposes the structured mokumo `Row::CrapDelta` JSON object as a sibling of `outputs.markdown`, so aggregator workflows can ingest the locked Row contract instead of parsing markdown.

## Diff (2 files, +103 / -7)

`.github/actions/scorecard/action.yml`
- New `outputs.row-json` declaration with description linking to the locked mokumo schema (`definitions/Row → CrapDelta` member of `oneOf`).
- New `row_json_file` capture path.
- Third invocation: `crap4rs "${common[@]}" --format scorecard-row --no-fail > "$row_json_file"`, gated by a help-text probe (see Version-gap handling below).
- Heredoc-delimited `GITHUB_OUTPUT` block with distinct sentinel `__CRAP_SCORECARD_ROW_EOF__`.
- Two-pass → three-pass comment update; #100 reference preserved.

`.github/actions/scorecard/README.md`
- New row in the Outputs table.
- New `## Structured row output (outputs.row-json)` section: contract description, when to use markdown vs row-json, status policy (Red/Yellow/Green) cross-referenced to crap4rs#111 + PR #119, aggregator-pattern snippet showing `jq` consumption.
- Version-requirement note (`crap4rs ≥ 0.4.0`).

## Version-gap handling

`--format scorecard-row` landed on `main` in PR #119 but isn't on crates.io until `0.4.0` publishes. The action installs `latest` by default, which `cargo binstall` resolves to `0.3.0` until `0.4.0` ships. To avoid breaking same-window consumers (mokumo's `crap-scorecard` job in `quality.yml` is the concrete one — pinned to `@main`, no `version` input), the third invocation probes for `scorecard-row` support before invoking it:

```bash
if crap4rs --help 2>/dev/null | grep -q -- 'scorecard-row'; then
  crap4rs "${common[@]}" --format scorecard-row --no-fail > "$row_json_file"
else
  echo "::warning::Installed crap4rs (...) lacks '--format scorecard-row'; outputs.row-json will be empty. Pin 'version: 0.4.0' or later..."
  : > "$row_json_file"
fi
```

`outputs.row-json` is empty during the version-gap window; everything else stays green. Once `0.4.0` publishes, callers pinning `version: '0.4.0'` (or leaving `latest`) get structured row output without further action changes.

## Sample consumption

```yaml
- uses: breezy-bays-labs/crap4rs/.github/actions/scorecard@main
  id: crap
  with:
    coverage: /tmp/head.lcov
    baseline: /tmp/baseline.json
    comment-mode: 'none'

- name: Aggregate scorecard rows
  env:
    CRAP_ROW: ${{ steps.crap.outputs.row-json }}
  run: |
    printf '%s\n' "$CRAP_ROW" > /tmp/crap-row.json
    jq -r '"### " + .label + " — **" + .status + "** — " + .delta_text' /tmp/crap-row.json
```

## Acceptance criteria

- [x] `outputs.markdown` unchanged.
- [x] `outputs.row-json` set from `crap4rs --format scorecard-row` against the same coverage + baseline inputs.
- [x] Both outputs available simultaneously (one action invocation).
- [x] README documents the new output, when to consume it, links the Row contract, links the producer (PR #119).
- [x] Backward compatible: existing consumers (mokumo `crap-scorecard`) continue to read `outputs.markdown` without changes; row-json gracefully empty on pre-0.4.0 crap4rs rather than failing.

## Out of scope

- Multi-format single-run consolidation (#100). Three-pass is intentional for now.
- Mokumo aggregator wiring + `comment-mode: sticky → none` cutover (mokumo#650 follow-up).
- Cutting `crap4rs 0.4.0` (lands after #113 docs).

## Test plan

- [ ] CI green on this branch (the action lints itself transitively via crap4rs's own CI dogfooding step at `ci.yml:226`, which pre-installs the PR binary so `--format scorecard-row` is available).
- [ ] Inspect the dogfood step's `Assert action outputs are populated` output to confirm `row-json` is non-empty and is valid JSON.
- [ ] CodeRabbit YAML review for the heredoc-delimited output pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)