### PR TITLE
chore: #109 + #57 + #94 + #107 — gate honesty + analyze decomp + view docs + column convention

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,11 @@ jobs:
           name: lcov
       - run: cargo build --release
       - name: Run crap4rs against itself
-        run: ./target/release/crap4rs --coverage lcov.info --src src --strict --exclude "cli/**" --color always
+        # Lifted `--exclude "cli/**"` (closes #109): cli/ now passes the
+        # gate after the prepare_pipeline / count_cognitive_expr split
+        # (#121, #122) and core::analyze decomposition (#57). Worst CRAP
+        # across the codebase is well under the default threshold of 25.
+        run: ./target/release/crap4rs --coverage lcov.info --src src --strict --color always
 
   self-crap-view:
     name: domain/view.rs per-function CC <= 15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `nesting_depth` so domain helpers can answer span/nesting questions
   without re-walking the AST. Both fields default to `0` for
   forward-compat with older payloads.
+- **Breaking — JSON envelope `schema_version` 1 → 2.**
+  `ComplexityContributor.column` is now **1-based inclusive** (was
+  0-based), matching `SourceSpan::start_column` / `end_column` and the
+  SARIF spec. The bump is the wire signal that contributor column
+  semantics shifted; consumers reading `column` should add `1` to v1
+  values when comparing against v2. Baseline JSON files at v1 remain
+  loadable for `--baseline` delta calculations (matching is identity-
+  keyed, not column-keyed); `crap4rs --format json` now emits v2. The
+  CLI rejects baseline envelopes with unknown `schema_version` and
+  reports the accepted set (`[1, 2]`) in stderr. Closes #107.
+
+- `core::analyze` is now a thin facade over a private
+  `AnalysisContext` (`fn analyze(opts) -> AnalysisContext::new(opts).run()`).
+  Phase methods (`discover_sources`, `load_diff_data`, `parse_coverage`,
+  `extract_complexities`) hang off the context; diff-mode early-exit is
+  surfaced via `Option<AnalysisOutput>` from
+  `short_circuit_on_files` / `short_circuit_on_complexities` so the
+  top-level `run()` body stays flat. Public API (`analyze`,
+  `AnalyzeOptions`, `AnalysisOutput`) is unchanged; behavior is identical
+  (every existing test passes unmodified). Closes #57.
+
+- **Self-CRAP gate is honest again** — lifted `--exclude "cli/**"` from
+  the self-referential CRAP step in `.github/workflows/ci.yml`. The
+  exclusion was added during the M0 cli/ scaffolding sprint and outlived
+  its tracking issue; with the recent `prepare_pipeline` /
+  `count_cognitive_expr` splits (#121, #122) and `core::analyze`
+  decomposition (#57), the worst CRAP across the entire codebase is
+  13.0 — well under the strict-mode threshold of 15. The gate now
+  exercises every shipped `.rs` file. Closes #109.
+
+### Documentation
+- **`domain::view` public-surface rustdoc** — the canonical pure-domain
+  shaping primitive (`view::apply`) is now fully documented at the
+  module level (input contract, pipeline order
+  `filter → group? → sort → truncate`, gate-keystone invariant,
+  `should_render_view_line` predicate, `#[non_exhaustive]` extension
+  policy, `crap-core` extraction note) and per public item:
+  `ViewSpec`, `Filters`, `CoverageRange`, `SortKey`, `GroupKey`,
+  `GroupedView`, `AnalysisView`, `apply`, `should_render_view_line`,
+  `CoverageRangeError`. No code change. Closes #94.
 
 ## [0.3.0] - 2026-04-27
 

--- a/src/adapters/baseline.rs
+++ b/src/adapters/baseline.rs
@@ -10,8 +10,11 @@
 //! optionally `diagnostics` so that consumers can produce baseline
 //! envelopes that contain extra fields without breaking us.
 //!
-//! Schema version validation: only `schema_version == 1` is accepted
-//! today. Future schema bumps will need an explicit migration path.
+//! Schema version validation: `schema_version` 1 and 2 are both
+//! accepted (#107 bumped the current emit version 1 → 2 in 0.4.0; v1
+//! baselines remain loadable because delta matching is identity-keyed,
+//! not column-keyed). Future schema bumps will need an explicit
+//! migration path.
 
 use crate::domain::types::{AnalysisDiagnostics, AnalysisResult};
 use serde::Deserialize;
@@ -19,9 +22,15 @@ use std::fs::File;
 use std::io::{BufReader, ErrorKind};
 use std::path::Path;
 
-/// Currently-supported envelope schema version. Lockstep with
+/// Currently-emitted envelope schema version. Lockstep with
 /// `adapters::reporters::json::JsonEnvelope::schema_version`.
-pub const SUPPORTED_SCHEMA_VERSION: u32 = 1;
+pub const CURRENT_SCHEMA_VERSION: u32 = 2;
+
+/// Envelope schema versions accepted by the baseline loader. v1 stays
+/// loadable across the v0.3.x → v0.4.x boundary so users can keep their
+/// committed baseline JSON; the column-convention shift in v2 doesn't
+/// affect delta calculations (identity-keyed matching).
+pub const SUPPORTED_SCHEMA_VERSIONS: &[u32] = &[1, 2];
 
 /// On-disk shape we read. Mirrors the relevant subset of
 /// `JsonEnvelope`. `serde(default)` on optional fields keeps us
@@ -54,7 +63,12 @@ pub struct BaselineSnapshot {
 /// pre-formatted prose. The CLI translates these into user-facing
 /// stderr messages (keeps the adapter language-neutral for future
 /// `crap-core` extraction).
+///
+/// `#[non_exhaustive]` reserves namespace for future variants (e.g.,
+/// `MissingRequiredField`, `IncompatibleToolVersion`) without forcing a
+/// downstream major-version bump on every adapter error addition.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum BaselineError {
     #[error("baseline file not found: {path}")]
     NotFound { path: String },
@@ -71,9 +85,12 @@ pub enum BaselineError {
         source: serde_json::Error,
     },
     #[error(
-        "unsupported baseline schema_version: {found} (this build of crap4rs accepts {supported})"
+        "unsupported baseline schema_version: {found} (this build of crap4rs accepts {supported:?})"
     )]
-    UnsupportedSchemaVersion { found: u32, supported: u32 },
+    UnsupportedSchemaVersion {
+        found: u32,
+        supported: &'static [u32],
+    },
 }
 
 /// Load a crap4rs JSON envelope from disk and return the baseline
@@ -100,10 +117,10 @@ pub fn load(path: &Path) -> Result<BaselineSnapshot, BaselineError> {
             source,
         })?;
 
-    if envelope.schema_version != SUPPORTED_SCHEMA_VERSION {
+    if !SUPPORTED_SCHEMA_VERSIONS.contains(&envelope.schema_version) {
         return Err(BaselineError::UnsupportedSchemaVersion {
             found: envelope.schema_version,
-            supported: SUPPORTED_SCHEMA_VERSION,
+            supported: SUPPORTED_SCHEMA_VERSIONS,
         });
     }
 
@@ -247,8 +264,10 @@ mod tests {
 
     #[test]
     fn load_unsupported_schema_version_rejects() {
+        // Use a future-unsupported version (99) — both 1 and 2 are
+        // accepted today after the #107 column-convention bump.
         let json = r#"{
-            "schema_version": 2,
+            "schema_version": 99,
             "result": {
                 "functions": [],
                 "summary": {
@@ -264,11 +283,36 @@ mod tests {
         let err = load(file.path()).unwrap_err();
         match err {
             BaselineError::UnsupportedSchemaVersion {
-                found: 2,
-                supported: 1,
-            } => {}
-            other => panic!("expected UnsupportedSchemaVersion(2,1), got {other:?}"),
+                found: 99,
+                supported,
+            } => {
+                assert_eq!(supported, &[1, 2]);
+            }
+            other => panic!("expected UnsupportedSchemaVersion {{ found: 99, .. }}, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn load_v2_schema_version_accepted() {
+        // Post-#107: v2 baselines (1-based contributor columns) load
+        // alongside v1 baselines.
+        let json = r#"{
+            "schema_version": 2,
+            "tool_version": "0.4.0",
+            "result": {
+                "functions": [],
+                "summary": {
+                    "total_functions": 0, "total_files": 0, "exceeding_threshold": 0,
+                    "average_crap": 0.0, "median_crap": 0.0,
+                    "max_crap": null, "worst_function": null,
+                    "distribution": { "low": 0, "acceptable": 0, "moderate": 0, "high": 0 }
+                },
+                "passed": true
+            }
+        }"#;
+        let file = write_envelope(json);
+        let snapshot = load(file.path()).expect("v2 envelope should load");
+        assert_eq!(snapshot.tool_version, "0.4.0");
     }
 
     #[test]

--- a/src/adapters/complexity/mod.rs
+++ b/src/adapters/complexity/mod.rs
@@ -160,7 +160,10 @@ fn add_contributor(
     contributors.push(ComplexityContributor {
         kind,
         line: span.start().line,
-        column: Some(span.start().column as u32),
+        // syn `Span::start().column` is 0-based; `ComplexityContributor.column`
+        // is 1-based inclusive (aligned with `SourceSpan::start_column` and
+        // SARIF). +1 here is the only conversion site.
+        column: Some(span.start().column as u32 + 1),
         increment,
         end_line,
         nesting_depth,

--- a/src/adapters/reporters/json.rs
+++ b/src/adapters/reporters/json.rs
@@ -52,8 +52,11 @@ pub struct DeltaContext<'a> {
 /// declaration order is exactly:
 ///   schema_version, tool_version, language, timestamp, metric,
 ///   threshold, diff_ref, result, view
-/// Per ADR D2 the schema is additive: adding `view` keeps
-/// `schema_version` at 1.
+/// Per ADR D2 the schema is additive across minor versions; the
+/// `schema_version` bump from 1 → 2 in 0.4.0 reflects the
+/// `ComplexityContributor.column` 0-based → 1-based convention shift
+/// (#107). Older v1 baselines remain loadable for delta reporting
+/// (matching is identity-keyed, not column-keyed).
 #[derive(Serialize)]
 struct JsonEnvelope<'a> {
     schema_version: u32,
@@ -67,8 +70,8 @@ struct JsonEnvelope<'a> {
     view: ViewWire<'a>,
     /// Delta block. Present iff `--baseline` was passed; absent (key
     /// elided) otherwise so existing consumers see byte-identical
-    /// output for the no-delta case. Additive — `schema_version` stays
-    /// at 1 (ADR D2).
+    /// output for the no-delta case. Additive — does not itself bump
+    /// `schema_version` (ADR D2).
     #[serde(skip_serializing_if = "Option::is_none")]
     delta: Option<DeltaWire<'a>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -169,7 +172,7 @@ pub fn format_json(
     let delta_wire: Option<DeltaWire> = config.delta.as_ref().map(DeltaWire::from_context);
 
     let envelope = JsonEnvelope {
-        schema_version: 1,
+        schema_version: 2,
         tool_version: &config.tool_version,
         language: "rust",
         timestamp: &config.timestamp,
@@ -240,7 +243,7 @@ mod tests {
         let v = parse_json(&result, &default_config());
         let sv = v.get("schema_version").unwrap();
         assert!(sv.is_number());
-        assert_eq!(sv.as_u64(), Some(1));
+        assert_eq!(sv.as_u64(), Some(2));
     }
 
     #[test]

--- a/src/adapters/reporters/snapshots/crap4rs__adapters__reporters__json__tests__full_json_snapshot.snap
+++ b/src/adapters/reporters/snapshots/crap4rs__adapters__reporters__json__tests__full_json_snapshot.snap
@@ -68,7 +68,7 @@ expression: v
       }
     }
   },
-  "schema_version": 1,
+  "schema_version": 2,
   "threshold": 8.0,
   "timestamp": "2026-03-28T12:00:00Z",
   "tool_version": "0.1.0",

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -85,108 +85,230 @@ impl Default for AnalyzeOptions {
 
 /// Run CRAP analysis: discover files, extract complexity, parse coverage,
 /// match, score, and produce results with diagnostics.
+///
+/// Thin facade over a private `AnalysisContext`. Phase methods on the
+/// context compose the pipeline; diff-mode short-circuits are surfaced
+/// via `Option<AnalysisOutput>` so the top-level orchestration stays flat.
 pub fn analyze(options: &AnalyzeOptions) -> Result<AnalysisOutput> {
-    let src_canonical = canonicalize_src(&options.src);
-    let mut discovered = discover_sources(options)?;
-    let diff_data = load_diff_data(options, &src_canonical, &discovered.source_files)?;
+    AnalysisContext::new(options).run()
+}
 
-    if let Some(ref diff_result) = diff_data {
-        retain_changed_source_files(&mut discovered.source_files, &options.src, diff_result);
-        if discovered.source_files.is_empty() {
-            return Ok(empty_output_with_diagnostics(diagnostics_for_empty_result(
-                vec![],
-                discovered.files_found,
-                0,
-                0,
-            )));
+/// Mutable per-run context: bundles `&AnalyzeOptions` with the canonicalized
+/// source root so phase methods don't repeat that setup.
+///
+/// The pipeline phases are `&self`-methods that read options and produce
+/// fresh values; nothing is mutated on the context itself. Diff-mode
+/// short-circuits return `Option<AnalysisOutput>` — `Some(early)` signals
+/// "no work left, return this," `None` signals "continue."
+struct AnalysisContext<'a> {
+    options: &'a AnalyzeOptions,
+    src_canonical: PathBuf,
+}
+
+impl<'a> AnalysisContext<'a> {
+    fn new(options: &'a AnalyzeOptions) -> Self {
+        Self {
+            options,
+            src_canonical: canonicalize_src(&options.src),
         }
     }
 
-    let parse_output = parse_coverage(options, &src_canonical)?;
-    let extracted = extract_complexities(&discovered.source_files, &options.src, options.metric)?;
-    let mut all_complexities = extracted.all_complexities;
-    let functions_extracted = all_complexities.len();
+    fn run(&self) -> Result<AnalysisOutput> {
+        let mut discovered = self.discover_sources()?;
+        let diff_data = self.load_diff_data(&discovered.source_files)?;
 
-    if let Some(ref diff_result) = diff_data {
-        retain_changed_functions(&mut all_complexities, diff_result);
-        if all_complexities.is_empty() {
-            return Ok(empty_output_with_diagnostics(diagnostics_for_empty_result(
-                parse_output.diagnostics,
-                discovered.files_found,
-                extracted.files_unparseable,
-                functions_extracted,
-            )));
+        if let Some(early) = self.short_circuit_on_files(&mut discovered, diff_data.as_ref()) {
+            return Ok(early);
         }
+
+        let mut parse_output = self.parse_coverage()?;
+        let ExtractedComplexities {
+            mut all_complexities,
+            files_unparseable,
+        } = self.extract_complexities(&discovered.source_files)?;
+        let functions_extracted = all_complexities.len();
+
+        if let Some(early) = self.short_circuit_on_complexities(
+            &mut all_complexities,
+            diff_data.as_ref(),
+            &mut parse_output,
+            &discovered,
+            files_unparseable,
+            functions_extracted,
+        ) {
+            return Ok(early);
+        }
+
+        ensure_functions_extracted(&all_complexities, &self.options.src)?;
+
+        let matched = match_functions(
+            &all_complexities,
+            &parse_output.coverage,
+            parse_output.branches.as_ref(),
+        );
+
+        let functions_no_coverage = matched
+            .iter()
+            .filter(|(comp, _)| !parse_output.coverage.contains_key(&comp.identity.file_path))
+            .count();
+        let functions_matched = matched.len() - functions_no_coverage;
+
+        let resolver = ThresholdResolver::new(&self.options.threshold_config)?;
+        let mut result = score_and_summarize(&matched, &resolver)?;
+        populate_diagnostics(
+            &mut result.functions,
+            &parse_output.coverage,
+            self.options.compute_diagnostics,
+        );
+
+        let (files_analyzed, files_zero_coverage) = compute_file_coverage_stats(&result);
+
+        let diagnostics = AnalysisDiagnostics {
+            parse_diagnostics: parse_output.diagnostics,
+            files_found: discovered.files_found,
+            files_unparseable,
+            functions_extracted,
+            functions_matched,
+            functions_no_coverage,
+            files_analyzed,
+            files_zero_coverage,
+        };
+
+        debug_assert_eq!(
+            diagnostics.functions_matched + diagnostics.functions_no_coverage,
+            result.functions.len(),
+            "diagnostics counts must partition scored functions"
+        );
+
+        Ok(AnalysisOutput {
+            result,
+            diagnostics,
+        })
     }
 
-    ensure_functions_extracted(&all_complexities, &options.src)?;
+    fn discover_sources(&self) -> Result<DiscoveredSources> {
+        let source_files = discover_rust_files(
+            &self.options.src,
+            &self.options.exclude,
+            self.options.respect_gitignore,
+        )?;
+        let files_found = source_files.len();
+        ensure_source_files_found(&source_files, &self.options.src)?;
 
-    let matched = match_functions(
-        &all_complexities,
-        &parse_output.coverage,
-        parse_output.branches.as_ref(),
-    );
+        Ok(DiscoveredSources {
+            source_files,
+            files_found,
+        })
+    }
 
-    // Count functions with no LCOV data (file not in coverage map)
-    let functions_no_coverage = matched
-        .iter()
-        .filter(|(comp, _)| !parse_output.coverage.contains_key(&comp.identity.file_path))
-        .count();
-    let functions_matched = matched.len() - functions_no_coverage;
+    fn load_diff_data(
+        &self,
+        source_files: &[PathBuf],
+    ) -> Result<Option<std::collections::HashMap<String, FileChangeKind>>> {
+        self.options
+            .diff_ref
+            .as_deref()
+            .map(|diff_ref| {
+                compute_diff_regions(
+                    diff_ref,
+                    &self.src_canonical,
+                    &self.options.src,
+                    source_files,
+                )
+            })
+            .transpose()
+    }
 
-    // 5. Compile threshold overrides for glob matching
-    let resolver = ThresholdResolver::new(&options.threshold_config)?;
+    fn parse_coverage(&self) -> Result<ParseOutput> {
+        let coverage_data = std::fs::read_to_string(&self.options.coverage).with_context(|| {
+            format!(
+                "failed to read coverage file: {}",
+                self.options.coverage.display()
+            )
+        })?;
+        let parser = LcovParser::new(self.src_canonical.clone());
+        parser
+            .parse(&coverage_data)
+            .map_err(|e| anyhow::anyhow!("{e}"))
+    }
 
-    // 6. Score each function, produce verdicts, and build result
-    let mut result = score_and_summarize(&matched, &resolver)?;
+    fn extract_complexities(&self, source_files: &[PathBuf]) -> Result<ExtractedComplexities> {
+        let complexity_adapter = SynComplexityAdapter::new();
+        let mut all_complexities = Vec::new();
+        let mut files_unparseable = 0usize;
 
-    // 7. Populate `Diagnostic` for over-threshold verdicts when the
-    //    caller opts in. Pure-domain, runs only on exceeding verdicts.
-    populate_diagnostics(
-        &mut result.functions,
-        &parse_output.coverage,
-        options.compute_diagnostics,
-    );
+        for file_path in source_files {
+            let source = std::fs::read_to_string(file_path)
+                .with_context(|| format!("failed to read source file: {}", file_path.display()))?;
+            let relative = src_relative_path(file_path, &self.options.src);
 
-    let (files_analyzed, files_zero_coverage) = compute_file_coverage_stats(&result);
+            match complexity_adapter.extract(&source, &relative, self.options.metric) {
+                Ok(fns) => all_complexities.extend(fns),
+                Err(e) => {
+                    files_unparseable += 1;
+                    eprintln!("warning: skipping {relative}: {e}");
+                }
+            }
+        }
 
-    let diagnostics = AnalysisDiagnostics {
-        parse_diagnostics: parse_output.diagnostics,
-        files_found: discovered.files_found,
-        files_unparseable: extracted.files_unparseable,
-        functions_extracted,
-        functions_matched,
-        functions_no_coverage,
-        files_analyzed,
-        files_zero_coverage,
-    };
+        Ok(ExtractedComplexities {
+            all_complexities,
+            files_unparseable,
+        })
+    }
 
-    debug_assert_eq!(
-        diagnostics.functions_matched + diagnostics.functions_no_coverage,
-        result.functions.len(),
-        "diagnostics counts must partition scored functions"
-    );
+    /// Apply diff-mode file filtering and signal early-exit if nothing remains.
+    /// Returns `None` when there is no diff ref OR the filter still leaves
+    /// files to analyze; returns `Some(empty_output)` when the diff cleared
+    /// every source file.
+    fn short_circuit_on_files(
+        &self,
+        discovered: &mut DiscoveredSources,
+        diff_data: Option<&std::collections::HashMap<String, FileChangeKind>>,
+    ) -> Option<AnalysisOutput> {
+        let diff_result = diff_data?;
+        retain_changed_source_files(&mut discovered.source_files, &self.options.src, diff_result);
+        if !discovered.source_files.is_empty() {
+            return None;
+        }
+        Some(empty_output_with_diagnostics(diagnostics_for_empty_result(
+            vec![],
+            discovered.files_found,
+            0,
+            0,
+        )))
+    }
 
-    Ok(AnalysisOutput {
-        result,
-        diagnostics,
-    })
+    /// Apply diff-mode function filtering and signal early-exit if nothing
+    /// remains. Same `Option<AnalysisOutput>` signal as
+    /// [`Self::short_circuit_on_files`]; takes `parse_output` mutably so the
+    /// empty-result diagnostics can move out of `parse_output.diagnostics`
+    /// without cloning when this branch fires.
+    fn short_circuit_on_complexities(
+        &self,
+        complexities: &mut Vec<FunctionComplexity>,
+        diff_data: Option<&std::collections::HashMap<String, FileChangeKind>>,
+        parse_output: &mut ParseOutput,
+        discovered: &DiscoveredSources,
+        files_unparseable: usize,
+        functions_extracted: usize,
+    ) -> Option<AnalysisOutput> {
+        let diff_result = diff_data?;
+        retain_changed_functions(complexities, diff_result);
+        if !complexities.is_empty() {
+            return None;
+        }
+        Some(empty_output_with_diagnostics(diagnostics_for_empty_result(
+            std::mem::take(&mut parse_output.diagnostics),
+            discovered.files_found,
+            files_unparseable,
+            functions_extracted,
+        )))
+    }
 }
 
 fn canonicalize_src(src: &Path) -> PathBuf {
     src.canonicalize().unwrap_or_else(|_| src.to_path_buf())
-}
-
-fn discover_sources(options: &AnalyzeOptions) -> Result<DiscoveredSources> {
-    let source_files =
-        discover_rust_files(&options.src, &options.exclude, options.respect_gitignore)?;
-    let files_found = source_files.len();
-    ensure_source_files_found(&source_files, &options.src)?;
-
-    Ok(DiscoveredSources {
-        source_files,
-        files_found,
-    })
 }
 
 fn ensure_source_files_found(source_files: &[PathBuf], src: &Path) -> Result<()> {
@@ -200,18 +322,6 @@ fn ensure_source_files_found(source_files: &[PathBuf], src: &Path) -> Result<()>
     Ok(())
 }
 
-fn load_diff_data(
-    options: &AnalyzeOptions,
-    src_canonical: &Path,
-    source_files: &[PathBuf],
-) -> Result<Option<std::collections::HashMap<String, FileChangeKind>>> {
-    options
-        .diff_ref
-        .as_deref()
-        .map(|diff_ref| compute_diff_regions(diff_ref, src_canonical, &options.src, source_files))
-        .transpose()
-}
-
 fn retain_changed_source_files(
     source_files: &mut Vec<PathBuf>,
     src_root: &Path,
@@ -221,48 +331,6 @@ fn retain_changed_source_files(
         let rel = src_relative_path(path, src_root);
         diff_result.contains_key(&rel)
     });
-}
-
-fn parse_coverage(options: &AnalyzeOptions, src_canonical: &Path) -> Result<ParseOutput> {
-    let coverage_data = std::fs::read_to_string(&options.coverage).with_context(|| {
-        format!(
-            "failed to read coverage file: {}",
-            options.coverage.display()
-        )
-    })?;
-    let parser = LcovParser::new(src_canonical.to_path_buf());
-    parser
-        .parse(&coverage_data)
-        .map_err(|e| anyhow::anyhow!("{e}"))
-}
-
-fn extract_complexities(
-    source_files: &[PathBuf],
-    src_root: &Path,
-    metric: ComplexityMetric,
-) -> Result<ExtractedComplexities> {
-    let complexity_adapter = SynComplexityAdapter::new();
-    let mut all_complexities = Vec::new();
-    let mut files_unparseable = 0usize;
-
-    for file_path in source_files {
-        let source = std::fs::read_to_string(file_path)
-            .with_context(|| format!("failed to read source file: {}", file_path.display()))?;
-        let relative = src_relative_path(file_path, src_root);
-
-        match complexity_adapter.extract(&source, &relative, metric) {
-            Ok(fns) => all_complexities.extend(fns),
-            Err(e) => {
-                files_unparseable += 1;
-                eprintln!("warning: skipping {relative}: {e}");
-            }
-        }
-    }
-
-    Ok(ExtractedComplexities {
-        all_complexities,
-        files_unparseable,
-    })
 }
 
 fn retain_changed_functions(

--- a/src/domain/types.rs
+++ b/src/domain/types.rs
@@ -102,7 +102,11 @@ pub struct ComplexityContributor {
     pub kind: ContributorKind,
     /// 1-based line number of the construct's start (or signal token).
     pub line: usize,
-    /// 0-based column offset from syn Span, if available.
+    /// 1-based inclusive column of the construct's start, if available.
+    /// `None` when the source adapter has no column data (e.g., diff
+    /// hunks parse line ranges only). Aligned with `SourceSpan::start_column`
+    /// (also 1-based) and SARIF region semantics so consumers correlating
+    /// contributor positions with span positions see one convention.
     pub column: Option<u32>,
     /// How much this contributor added to the total.
     /// Cognitive: `1 + nesting_depth`. Cyclomatic: always 1.

--- a/src/domain/view.rs
+++ b/src/domain/view.rs
@@ -5,15 +5,69 @@
 //! ViewSpec → view::apply(&result, spec) → AnalysisView<'_>
 //! ```
 //!
-//! The View filters, sorts, and truncates findings to produce a shaped
-//! report. The keystone invariant is the **gate is unshapeable; only the
-//! display is shapeable**: `view.full` always borrows the original,
-//! unfiltered `AnalysisResult`, and exit-code logic must derive from
-//! `view.full.passed`, never from the post-shape `view.shown`.
+//! # Input contract
+//!
+//! `apply` borrows an `AnalysisResult` (already-thresholded function
+//! verdicts plus a precomputed summary and gate verdict) and a
+//! by-value `ViewSpec` (filter set, sort key, optional row limit,
+//! optional group-by key). Both inputs are pure domain types — no I/O
+//! happens inside the View layer.
+//!
+//! # Pipeline order
+//!
+//! `apply` runs phases in a fixed order:
+//!
+//! ```text
+//! filter → group? → sort → truncate
+//! ```
+//!
+//! 1. **Filter** — `Filters` AND-compose; `apply_filters` returns the
+//!    eligible (post-filter, pre-shape) borrow vector.
+//! 2. **Group** (optional) — when `spec.group_by.is_some()`, eligible
+//!    rows fan into `GroupedView::files` (file-level aggregates that
+//!    are independently sorted and truncated). Function-level `shown`
+//!    retains the un-truncated eligible set under grouping for
+//!    drill-down ergonomics.
+//! 3. **Sort** — function-level (or file-level under grouping) by
+//!    `SortKey`. `sort_by` is *stable* — callers rely on input-order
+//!    preservation on tied keys (BDD: `view.feature:122-128`).
+//! 4. **Truncate** — `limit` applies to whichever level was sorted in
+//!    step 3. `Some(0)` and `None` are treated identically as "no limit"
+//!    (`--top 0` ergonomic, BDD: `view.feature:213`).
+//!
+//! # Gate keystone — unshapeable
+//!
+//! **The gate is unshapeable; only the display is shapeable.**
+//! `view.full` always borrows the original, unfiltered `AnalysisResult`,
+//! and exit-code logic must derive from `view.full.passed`, never from
+//! the post-shape `view.shown` or `view.shown_summary`. This invariant
+//! lets reporters ship `--top`, `--only-failing`, `--coverage-range`,
+//! and `--group-by` without ever changing CI's verdict.
+//!
+//! # Display predicate
+//!
+//! [`should_render_view_line`] returns true iff the shaped view
+//! materially differs from the underlying analysis (rows filtered out,
+//! function-level rows truncated, or grouped files truncated). Reporters
+//! consult this predicate to decide whether to emit a "View:" subtitle
+//! line — sort-only or default-spec invocations skip the subtitle.
+//!
+//! # `#[non_exhaustive]` extension policy
+//!
+//! Every public type in this module is `#[non_exhaustive]` so additive
+//! extensions (new `SortKey` variants, new `GroupKey` aggregations, new
+//! `Filters` predicates, new `AnalysisView` aggregates) ship as minor
+//! version bumps without requiring downstream consumers to update match
+//! arms or struct literals. Construct with `Default` + struct-update
+//! syntax (`ViewSpec { sort: SortKey::Coverage, ..Default::default() }`)
+//! to stay forward-compatible.
+//!
+//! # `crap-core` extraction
 //!
 //! Pure domain code — no I/O, no external crates beyond `serde` and
 //! `thiserror` (mirrors `domain::types`). Future `crap-core` extraction
-//! takes this module whole.
+//! (ops#231) takes this module whole; LSP, web, and agent consumers all
+//! flow through `view::apply` as the canonical CRAP shaping surface.
 
 use crate::domain::summary::{FileSummary, compute_file_summaries, compute_summary};
 use crate::domain::types::{AnalysisResult, AnalysisSummary, FunctionVerdict};
@@ -21,11 +75,34 @@ use serde::Serialize;
 
 // ── Spec types ───────────────────────────────────────────────────────
 
+/// Caller-supplied shape for the View pipeline.
+///
+/// `Default::default()` produces a no-op spec: no filtering, CRAP
+/// descending, no row limit, no grouping. Construct with struct-update
+/// syntax to stay forward-compatible with future fields:
+///
+/// ```ignore
+/// let spec = ViewSpec {
+///     filters: Filters { only_failing: true, ..Default::default() },
+///     sort: SortKey::Coverage,
+///     limit: Some(10),
+///     ..Default::default()
+/// };
+/// ```
+///
+/// `#[non_exhaustive]` reserves namespace for additive fields (e.g.,
+/// future `min_complexity`, `risk_floor`, secondary sort) without
+/// breaking downstream callers.
 #[non_exhaustive]
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct ViewSpec {
+    /// Eligibility predicates — AND-composed. See [`Filters`].
     pub filters: Filters,
+    /// Ordering key. See [`SortKey`].
     pub sort: SortKey,
+    /// Maximum rows after sort. `None` and `Some(0)` mean "no limit"
+    /// (the `--top 0` ergonomic). When `group_by` is set, `limit`
+    /// shifts to the file level — function-level rows are not truncated.
     pub limit: Option<usize>,
     /// When set, the View carries a parallel per-key aggregation
     /// (`AnalysisView::grouped`). The function-level row list
@@ -50,10 +127,22 @@ pub enum GroupKey {
     File,
 }
 
+/// Eligibility predicates over a `FunctionVerdict`. AND-composed: a
+/// verdict is eligible iff every active filter admits it.
+///
+/// `Default::default()` admits all verdicts (no filtering).
+/// `#[non_exhaustive]` reserves namespace for future predicates
+/// (`min_complexity`, `risk_floor`, `path_glob`, etc.) without breaking
+/// downstream construction.
 #[non_exhaustive]
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct Filters {
+    /// When true, retain only verdicts where `exceeds == true`
+    /// (CRAP score strictly exceeds the threshold).
     pub only_failing: bool,
+    /// Inclusive coverage band. Verdicts with `coverage_percent` outside
+    /// the band are excluded; non-finite coverage (NaN, ±∞) is excluded
+    /// regardless of the band.
     pub coverage_range: Option<CoverageRange>,
 }
 
@@ -61,15 +150,22 @@ pub struct Filters {
 ///
 /// Both endpoints are validated to be in `[0.0, 100.0]` and `min <= max`
 /// at construction time; downstream consumers can rely on these
-/// invariants without re-checking.
+/// invariants without re-checking. Construct via [`CoverageRange::new`]
+/// — direct field initialization is intentionally blocked by
+/// `#[non_exhaustive]`.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, Serialize)]
 pub struct CoverageRange {
+    /// Lower bound (inclusive), in `[0.0, 100.0]`, finite, `<= max`.
     pub min: f64,
+    /// Upper bound (inclusive), in `[0.0, 100.0]`, finite, `>= min`.
     pub max: f64,
 }
 
 impl CoverageRange {
+    /// Construct a validated range. Returns [`CoverageRangeError`] when
+    /// either endpoint is outside `[0.0, 100.0]` (including non-finite),
+    /// or when `min > max`.
     pub fn new(min: f64, max: f64) -> Result<Self, CoverageRangeError> {
         if !is_in_unit_percent(min) {
             return Err(CoverageRangeError::OutOfRange { value: min });
@@ -100,6 +196,25 @@ pub enum CoverageRangeError {
     MinExceedsMax { min: f64, max: f64 },
 }
 
+/// Ordering key for the View pipeline's sort phase.
+///
+/// All sorts are *stable* (`sort_by`, not `sort_unstable_by`) so input
+/// order is preserved on tied keys. NaN-bearing keys (CRAP value,
+/// coverage percent) sort last under their respective orientation —
+/// non-NaN winners take the descending positions.
+///
+/// File-level interpretation under `--group-by file`:
+///
+/// | Variant       | File-level meaning              |
+/// |---------------|---------------------------------|
+/// | `Crap`        | `average_crap` descending       |
+/// | `Coverage`    | `average_coverage` ascending    |
+/// | `Complexity`  | `max_complexity` descending     |
+/// | `Path`        | `file_path` ascending           |
+///
+/// `#[non_exhaustive]` reserves namespace for future keys
+/// (e.g., risk-bucket, function-name) without forcing match-arm churn
+/// downstream.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
@@ -123,17 +238,39 @@ pub enum SortKey {
 /// `result` field already carries the same data). All shaping happens
 /// over `shown`; `eligible_count` is the post-filter, pre-truncate
 /// count; `truncated` records whether `limit` reduced the row set.
+///
+/// **Gate keystone:** exit-code logic must derive from
+/// `view.full.passed`, never from `view.shown` or
+/// `view.shown_summary`. Reporters consult [`should_render_view_line`]
+/// to decide whether to emit a "View:" subtitle for the shaped output.
+///
+/// `#[non_exhaustive]` reserves namespace for future per-view aggregates
+/// (e.g., per-risk-bucket counts, per-module fan-in) without breaking
+/// downstream pattern matches.
 #[non_exhaustive]
 #[derive(Debug, Serialize)]
 pub struct AnalysisView<'a> {
     /// Borrows the original analysis. `#[serde(skip)]` because the
     /// envelope's `result` already serializes the full analysis.
+    /// **Gate source of truth** — exit-code logic uses `full.passed`.
     #[serde(skip)]
     pub full: &'a AnalysisResult,
+    /// The spec that produced this view (echoed for JSON consumers).
     pub spec: ViewSpec,
+    /// Post-filter, pre-truncate row count. When grouping is active,
+    /// this is the function-level eligible count; the file-level
+    /// equivalent lives in [`GroupedView::eligible_count`].
     pub eligible_count: usize,
+    /// True iff `limit` dropped function-level rows. When grouping is
+    /// active, this is forced false (the function-level row list is
+    /// not truncated under grouping); see [`GroupedView::truncated`].
     pub truncated: bool,
+    /// Borrow vector over the shaped function rows. Order, count, and
+    /// truncation depend on `spec`.
     pub shown: Vec<&'a FunctionVerdict>,
+    /// Summary computed over `shown` only — useful for reporters that
+    /// want a "selected subset" header. **Not** the gate source: use
+    /// `full.summary` and `full.passed` for verdict logic.
     pub shown_summary: AnalysisSummary,
     /// Optional parallel grouping. Present iff `spec.group_by.is_some()`.
     /// When set, `shown` retains the *un-truncated* eligible function
@@ -147,20 +284,46 @@ pub struct AnalysisView<'a> {
 /// `eligible_count` and `truncated` mirror the function-level analogs
 /// but at the file level so consumers can render headers like
 /// "Showing 10 of 45 files" without recomputing.
+///
+/// `#[non_exhaustive]` reserves namespace for future per-group
+/// aggregates (e.g., risk-bucket totals, complexity histograms) without
+/// breaking downstream pattern matches.
 #[non_exhaustive]
 #[derive(Debug, Clone, Serialize)]
 pub struct GroupedView {
+    /// The key this view was grouped by (today: always `GroupKey::File`).
     pub key: GroupKey,
     /// Distinct files surviving the function-level filter pass —
     /// before `limit` truncates the file list.
     pub eligible_count: usize,
     /// True iff `limit` reduced the file list.
     pub truncated: bool,
+    /// Per-file aggregates, sorted and truncated per `spec.sort` and
+    /// `spec.limit` at the file level.
     pub files: Vec<FileSummary>,
 }
 
 // ── apply: filter → sort → truncate ──────────────────────────────────
 
+/// Apply a `ViewSpec` to an `AnalysisResult`, producing the shaped
+/// `AnalysisView`.
+///
+/// Phases run in fixed order: **filter → group? → sort → truncate**.
+/// See the module-level docs for the full pipeline contract.
+///
+/// The returned view borrows from `result`; `view.full == &result` is
+/// guaranteed (pointer-equal). The gate verdict (`view.full.passed`,
+/// `view.full.summary`) is *unshapeable* — it always reflects the
+/// pre-shape analysis, regardless of how aggressively the spec
+/// filters or truncates.
+///
+/// Stable sort: input order is preserved on tied sort keys. NaN-bearing
+/// keys sort last under their orientation.
+///
+/// `apply` is total — it never panics, even on NaN coverage or empty
+/// inputs. See the BDD harness `tests/features/view.feature` for the
+/// full behavioral contract and the property-test suite at the bottom
+/// of this module for the order/identity/summary/display invariants.
 pub fn apply<'a>(result: &'a AnalysisResult, spec: ViewSpec) -> AnalysisView<'a> {
     let eligible: Vec<&'a FunctionVerdict> = apply_filters(&result.functions, &spec.filters);
     let eligible_count = eligible.len();
@@ -368,11 +531,17 @@ fn truncate_to(shown: &mut Vec<&FunctionVerdict>, limit: Option<usize>) -> bool 
 // ── Display predicate ────────────────────────────────────────────────
 
 /// True iff the shaped view materially differs from the underlying
-/// analysis (rows filtered out OR rows truncated). Reporters use this
-/// to decide whether to emit a "View:" subtitle line.
+/// analysis. Returns `true` when any of:
 ///
-/// Default `ViewSpec` over a non-empty result returns `false` — the
-/// walking-skeleton invariant.
+/// - Filtering reduced the eligible row count
+///   (`eligible_count < full.functions.len()`),
+/// - The function-level `limit` truncated rows (`view.truncated`),
+/// - Grouping is active and the file-level `limit` truncated files.
+///
+/// Reporters use this to decide whether to emit a "View:" subtitle
+/// line. Default `ViewSpec` over a non-empty result returns `false` —
+/// the walking-skeleton invariant. Sort-only invocations also return
+/// `false`: changing order doesn't change information content.
 pub fn should_render_view_line(view: &AnalysisView<'_>) -> bool {
     view.eligible_count < view.full.functions.len()
         || view.truncated

--- a/tests/features/cli_ergonomics.feature
+++ b/tests/features/cli_ergonomics.feature
@@ -240,9 +240,10 @@ Feature: CLI ergonomics — shaping the report from the command line
     And `view.sort` is "complexity"
     And `view.limit` is 10
 
-  Scenario: schema_version remains 1 with the additive view block
+  Scenario: schema_version is 2 with the additive view block
+    # Bumped 1 → 2 in 0.4.0 by #107 (ComplexityContributor.column 0-based → 1-based).
     When the operator runs `crap4rs --coverage lcov.info --format json`
-    Then the JSON envelope's `schema_version` is the integer 1
+    Then the JSON envelope's `schema_version` is the integer 2
     And the JSON envelope key declaration order is `schema_version, tool_version, language, timestamp, metric, threshold, diff_ref, result, view`
 
   Scenario: agent consumer reads the JSON envelope to plan refactor scope

--- a/tests/features/format_advice.feature
+++ b/tests/features/format_advice.feature
@@ -7,7 +7,7 @@ Feature: --format advice (issue #76)
   agent skill (#77); secondary consumers are CI/SARIF and humans.
 
   The shape is **experimental** in v0.3.x and stabilises at v0.4.0
-  (schema_version stays at 1 throughout v0.3.x; bumps to 2 at v0.4.0).
+  (schema_version was 1 throughout v0.3.x; bumped to 2 at v0.4.0 by #107).
 
   Background:
     Given a project with a mix of over-threshold and under-threshold
@@ -24,7 +24,7 @@ Feature: --format advice (issue #76)
   Scenario: --format advice emits the canonical envelope on stdout
     When the operator runs `crap4rs --coverage lcov.info --format advice`
     Then stdout is parseable JSON
-    And the document carries top-level `schema_version` "1"
+    And the document carries top-level `schema_version` "2"
     And the document carries a top-level `view.shown[]` array
     And every `view.shown[].diagnostic` is either populated or absent
       (never `null`-with-fields-present)
@@ -212,8 +212,9 @@ Feature: --format advice (issue #76)
 
   # ── Stability (R4.1 / G1) ──────────────────────────────────────────
 
-  Scenario: schema_version stays at 1 throughout v0.3.x
+  Scenario: schema_version is 2 in v0.4.0+
+    # #107 bumped 1 → 2 to mark the column-convention shift.
     When the operator runs `crap4rs --coverage lcov.info --format advice`
-    Then the document's top-level `schema_version` is "1"
+    Then the document's top-level `schema_version` is "2"
     And the README "Output formats" section flags this shape as
       "experimental" until v0.4.0

--- a/tests/features/json_reporter.feature
+++ b/tests/features/json_reporter.feature
@@ -8,7 +8,7 @@ Feature: JSON reporter
   Scenario: JSON output contains a versioned envelope
     Given an analysis result
     When the JSON is formatted
-    Then the output contains "schema_version" with value 1
+    Then the output contains "schema_version" with value 2
     And the output contains "tool_version"
     And the output contains "language" with value "rust"
     And the output contains "timestamp" as an ISO 8601 string
@@ -25,7 +25,7 @@ Feature: JSON reporter
   Scenario: Schema version is an integer
     Given an analysis result
     When the JSON is formatted
-    Then "schema_version" is the integer 1
+    Then "schema_version" is the integer 2
 
   # ── Result Content ─────────────────────────────────────────────────
 

--- a/tests/format_advice_integration.rs
+++ b/tests/format_advice_integration.rs
@@ -84,7 +84,9 @@ end_of_record
 // ── Envelope shape ──────────────────────────────────────────────────
 
 #[test]
-fn advice_emits_schema_version_one_and_view_shown_array() {
+fn advice_emits_schema_version_two_and_view_shown_array() {
+    // schema_version was bumped 1 → 2 in 0.4.0 by #107
+    // (ComplexityContributor.column 0-based → 1-based).
     let tmp = tempfile::tempdir().expect("create tempdir");
     setup_dir(tmp.path(), FIXTURE_SRC, FIXTURE_LCOV);
 
@@ -101,7 +103,7 @@ fn advice_emits_schema_version_one_and_view_shown_array() {
     );
     let json = parse_json(&output);
 
-    assert_eq!(json["schema_version"], 1);
+    assert_eq!(json["schema_version"], 2);
     assert!(json["view"]["shown"].is_array());
 }
 

--- a/tests/view_integration.rs
+++ b/tests/view_integration.rs
@@ -217,7 +217,10 @@ fn default_view_eligible_count_equals_total_functions() {
 }
 
 #[test]
-fn schema_version_remains_one_with_additive_view() {
+fn schema_version_is_two_in_v0_4_0() {
+    // 0.4.0 bumped schema_version 1 → 2 via #107 (ComplexityContributor.column
+    // 0-based → 1-based). The view block stayed additive (ADR D2); the bump
+    // is for the column-convention shift, not the view block.
     let dir = tempfile::tempdir().unwrap();
     setup_dir(dir.path(), SIMPLE_SRC, SIMPLE_LCOV);
 
@@ -226,8 +229,8 @@ fn schema_version_remains_one_with_additive_view() {
     let v = parse_json(&output);
     assert_eq!(
         v["schema_version"].as_u64(),
-        Some(1),
-        "View block was added per ADR D2 additive rule; schema_version stays at 1"
+        Some(2),
+        "0.4.0 bumped schema_version 1 → 2 for the contributor-column 1-based convention shift"
     );
 }
 


### PR DESCRIPTION
## Summary

Four interlocking quality-of-life issues in one PR. They compose: #57 drops `core::analyze` CC from 14 → 10, which lets #109 lift `--exclude "cli/**"` from the self-CRAP gate; #107 bumps JSON `schema_version` 1 → 2 with proper `#[non_exhaustive]` hardening for the baseline error path; #94 documents `domain::view` (the gate-keystone primitive) at the module + public-item level.

Closes #109
Closes #57
Closes #94
Closes #107

## What ships

### #107 — 1-based column convention (Breaking, schema_version 1 → 2)
- `ComplexityContributor.column` is now **1-based inclusive** (was 0-based, syn-native), aligning with `SourceSpan::start_column` / `end_column` and the SARIF spec.
- Single +1 conversion site in `adapters/complexity/mod.rs`.
- JSON envelope `schema_version` bumps **1 → 2** as the wire signal.
- Baseline loader accepts `SUPPORTED_SCHEMA_VERSIONS = &[1, 2]` because delta matching is identity-keyed (not column-keyed), so committed v1 baseline files keep working across the v0.3.x → v0.4.x boundary.
- `BaselineError` gains `#[non_exhaustive]` (variant break needed it).

### #94 — view::apply rustdoc (Documentation only, no code change)
- Module-level rustdoc: input contract, pipeline order (filter → group? → sort → truncate), gate-keystone invariant, `should_render_view_line` predicate, `#[non_exhaustive]` extension policy, `crap-core` extraction note.
- Per-public-item docs throughout: `ViewSpec`, `Filters`, `CoverageRange`, `SortKey`, `GroupedView`, `AnalysisView`, `apply`, etc.

### #57 — core::analyze decomposition (CC 14 → 10, no public API change)
- `pub fn analyze()` is a one-liner: `AnalysisContext::new(options).run()`.
- Phase methods on `AnalysisContext`: `discover_sources`, `load_diff_data`, `parse_coverage`, `extract_complexities`.
- Diff-mode early-exit signaled via `Option<AnalysisOutput>` from `short_circuit_on_files` / `short_circuit_on_complexities` — keeps the top-level `run()` flat.
- Behavior identical: every existing test passes unmodified. Public API (`analyze`, `AnalyzeOptions`, `AnalysisOutput`) unchanged.

### #109 — Self-CRAP gate honesty restored
- Lifted `--exclude "cli/**"` from `.github/workflows/ci.yml` self-check.
- Worst CRAP across the entire codebase post-#57: **13.0** (under the strict-mode threshold of 15).
- Gate now exercises every shipped `.rs` file.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo nextest run`: 874/874 passing
- [x] Self-CRAP smoke (strict, no exclude): exit=0, 1047 functions, 0 over threshold (15), worst 13.0
- [x] `BaselineError` deserialization: rejection test uses `schema_version=99`; new `load_v2_schema_version_accepted` test
- [x] BDD features (`cli_ergonomics`, `format_advice`, `json_reporter`) updated to assert `schema_version: 2`
- [x] Snapshot test (`full_json_snapshot.snap`) updated to v2

🤖 Generated with [Claude Code](https://claude.com/claude-code)