### PR TITLE
fix(action): #128 — version-floor probe for scorecard-row format

### DIFF
--- a/.github/actions/scorecard/action.yml
+++ b/.github/actions/scorecard/action.yml
@@ -211,13 +211,23 @@ runs:
         # therefore false-negatives against the very versions that
         # support it. `sort -V` works on both GitHub-hosted Ubuntu and
         # macOS runners.
-        installed_version="$(crap4rs --version 2>/dev/null | awk '{print $2}')"
+        installed_version_raw="$(crap4rs --version 2>/dev/null | awk '{print $2}')"
+        installed_version="${installed_version_raw#v}"
         required_version="0.4.0"
-        if [ -n "$installed_version" ] \
+        # Validate against a strict semver shape before `sort -V`. `sort -V`
+        # treats non-numeric tokens (e.g. "unknown", "garbage") and `v`-prefixed
+        # tags as sorting after pure semver strings, so without this gate they
+        # would false-positive into the supported branch and skip the warning.
+        supports_scorecard_row=false
+        if [[ "$installed_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]] \
           && [ "$(printf '%s\n%s\n' "$required_version" "$installed_version" | sort -V | head -n1)" = "$required_version" ]; then
+          supports_scorecard_row=true
+        fi
+
+        if [ "$supports_scorecard_row" = true ]; then
           crap4rs "${common[@]}" --format scorecard-row --no-fail > "$row_json_file"
         else
-          echo "::warning::Installed crap4rs (${installed_version:-unknown}) is older than $required_version; outputs.row-json will be empty. Pin the action's 'version' input to '$required_version' or later for structured Row::CrapDelta output."
+          echo "::warning::Installed crap4rs (${installed_version:-unknown}) is older than $required_version or reports a non-semver version; outputs.row-json will be empty. Pin the action's 'version' input to '$required_version' or later for structured Row::CrapDelta output."
           : > "$row_json_file"
         fi
 

--- a/.github/actions/scorecard/action.yml
+++ b/.github/actions/scorecard/action.yml
@@ -199,22 +199,25 @@ runs:
 
         # Graceful probe: --format scorecard-row landed in crap4rs 0.4.0
         # (https://github.com/breezy-bays-labs/crap4rs/pull/119). Older
-        # releases — including crates.io's 0.3.0, which `cargo binstall
-        # crap4rs` resolves to until 0.4.0 publishes — don't recognize the
-        # value and clap exits non-zero. Probe the installed help text and
-        # emit an empty row-json with a workflow warning if the variant
-        # isn't supported, so consumers see the gap explicitly without
-        # the action turning red.
-        # `grep -q` exits as soon as it sees a match, which under
-        # `set -o pipefail` can SIGPIPE the upstream `crap4rs --help`
-        # and surface as a non-zero pipeline status — the probe would
-        # then false-negative even when the variant IS supported.
-        # Plain `grep ... >/dev/null` reads to EOF, no SIGPIPE.
-        if crap4rs --help 2>/dev/null | grep -- 'scorecard-row' >/dev/null; then
+        # releases don't recognize the value and clap exits non-zero, so
+        # we probe before invoking and degrade to an empty row-json with
+        # a workflow warning when unsupported.
+        #
+        # Probe by version, not `--help` text. crap4rs 0.4.0 replaced
+        # clap's `--format` ValueEnum with a custom FormatSpec parser so
+        # `--format` could accept `<format>:<file>` syntax (#100), and
+        # clap can't introspect a custom parser — `--help` no longer
+        # enumerates format names. Grepping `--help` for `scorecard-row`
+        # therefore false-negatives against the very versions that
+        # support it. `sort -V` works on both GitHub-hosted Ubuntu and
+        # macOS runners.
+        installed_version="$(crap4rs --version 2>/dev/null | awk '{print $2}')"
+        required_version="0.4.0"
+        if [ -n "$installed_version" ] \
+          && [ "$(printf '%s\n%s\n' "$required_version" "$installed_version" | sort -V | head -n1)" = "$required_version" ]; then
           crap4rs "${common[@]}" --format scorecard-row --no-fail > "$row_json_file"
         else
-          installed_version="$(crap4rs --version 2>/dev/null || echo 'unknown')"
-          echo "::warning::Installed crap4rs ($installed_version) lacks '--format scorecard-row'; outputs.row-json will be empty. Pin the action's 'version' input to '0.4.0' or later once it publishes for structured Row::CrapDelta output."
+          echo "::warning::Installed crap4rs (${installed_version:-unknown}) is older than $required_version; outputs.row-json will be empty. Pin the action's 'version' input to '$required_version' or later for structured Row::CrapDelta output."
           : > "$row_json_file"
         fi
 


### PR DESCRIPTION
## Summary

The composite scorecard action's `outputs.row-json` was silently emitted empty against crap4rs v0.4.0+, even though the binary fully supports `--format scorecard-row`. Surfaced by mokumo#817 (crap4rs detected as `0.4.0`, action emitted the `::warning::` and an empty artifact, while a direct invocation of the same binary produced a valid Row JSON).

## Root cause

The probe at `.github/actions/scorecard/action.yml` ran:

```bash
if crap4rs --help 2>/dev/null | grep -- 'scorecard-row' >/dev/null; then ...
```

This worked when `--format` was a plain `clap::ValueEnum` (clap auto-prints `[possible values: ...]`). #100 replaced `--format` with a custom `FormatSpec` parser so `--format` could accept `<format>:<file>` syntax — clap can't introspect a custom parser, so `--help` no longer enumerates format names, and the grep false-negatives against the very versions that support the format.

## Fix

Probe by version, not `--help` text:

- Parse `crap4rs --version` → `crap4rs 0.4.0 (sha date)` → `awk '{print $2}'` → `0.4.0`
- Compare against `0.4.0` floor using `sort -V`
- Empty / unparseable version → falls into the existing graceful-degradation branch (empty row-json + `::warning::`)

`sort -V` is available on both GitHub-hosted Ubuntu and macOS runners, so the same probe works on all action consumers.

## Test plan

- [x] Local probe simulation across `0.3.0`, `0.3.9`, `0.4.0`, `0.4.1`, `0.5.0`, `1.0.0`, empty string — supported/unsupported routing matches expectations.
- [ ] CI run against the dogfood PR binary (this PR's `scorecard.yml`) — `crap4rs 0.4.0` should now hit the supported branch and emit a non-empty `outputs.row-json`.
- [ ] mokumo#817 follow-up: drop the local workaround once this lands and re-check `outputs.row-json` end-to-end.

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced version detection mechanism for improved compatibility handling. The workflow step now gracefully manages unsupported versions and provides clearer feedback when limitations are encountered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->