### PR TITLE
feat(crap4ts): #137 — add crap4ts shell crate + napi-rs cdylib config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,50 @@ jobs:
       # `.config/nextest.toml` and they run via `cargo test`.
       - run: cargo test --test json_reporter_cucumber
 
+  crap4ts-build:
+    # Per-platform build check for the new `crap4ts` shell crate (S5,
+    # #137). Two artifacts share the crate: the standalone `crap4ts`
+    # bin (default features) and the `libcrap4ts` cdylib used by the
+    # napi-rs Node binding (`--features napi-binding --lib`). Both
+    # need to compile cleanly on every platform the workspace claims
+    # to support so the v2 walker pipeline (follow-up) doesn't
+    # discover platform-link surprises after the fact.
+    #
+    # The macOS dynamic_lookup link arg comes from `napi_build::setup()`
+    # in `crates/crap4ts/build.rs`; on the bin target (without the
+    # `napi-binding` feature) there are no napi symbols to resolve,
+    # which is why the bin builds with default features only.
+    #
+    # Coverage of the bin path is already in the `test` job's
+    # `cargo nextest run --workspace --all-targets`; this job is the
+    # cdylib-specific gate. linux-arm is best-effort: GitHub-hosted
+    # arm64 Linux runners are still rolling out, so the matrix targets
+    # the three platforms with stable hosted runners. See follow-up
+    # tracker for linux-arm coverage.
+    name: crap4ts build (${{ matrix.name }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            name: linux-x86
+          - os: macos-latest
+            name: macos-arm
+          - os: macos-15-intel
+            name: macos-x86
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: crap4ts-${{ matrix.name }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Build crap4ts bin (default features)
+        run: cargo build --package crap4ts --release
+      - name: Build crap4ts cdylib (napi-binding feature)
+        run: cargo build --package crap4ts --features napi-binding --lib --release
+
   coverage:
     name: Coverage
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "ansi-str"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -173,15 +179,27 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "bytecount"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cfg-if"
@@ -278,6 +296,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "console"
 version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,6 +341,21 @@ checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "convert_case"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "cow-utils"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "417bef24afe1460300965a25ff4a24b8b45ad011948302ec221e8a0a81eb2c79"
 
 [[package]]
 name = "crap-core"
@@ -364,6 +411,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "crap4ts"
+version = "2.0.0-alpha.1"
+dependencies = [
+ "crap-core",
+ "napi",
+ "napi-build",
+ "napi-derive",
+ "oxc",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -410,6 +470,12 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "ctor"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "400a21f1014a968ec518c7ccdf9b4a4ed0cac8c56ccb6d604f8b91f00110501e"
 
 [[package]]
 name = "cucumber"
@@ -485,7 +551,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
- "convert_case",
+ "convert_case 0.10.0",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -524,6 +590,12 @@ checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
+
+[[package]]
+name = "dragonbox_ecma"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d742b56656e8b14d63e7ea9806597b1849ae25412584c8adf78c0f67bd985e66"
 
 [[package]]
 name = "either"
@@ -780,6 +852,9 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "heck"
@@ -1036,6 +1111,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
+name = "libloading"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1087,6 +1172,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "napi"
+version = "3.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e55037284865448ecf329baa86a4d05401f647ebde99f5747b640d32c2c5226"
+dependencies = [
+ "bitflags",
+ "ctor",
+ "futures",
+ "napi-build",
+ "napi-sys",
+ "nohash-hasher",
+ "rustc-hash",
+]
+
+[[package]]
+name = "napi-build"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d376940fd5b723c6893cd1ee3f33abbfd86acb1cd1ec079f3ab04a2a3bc4d3b1"
+
+[[package]]
+name = "napi-derive"
+version = "3.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ba740fe4c9524d86fd90798fd8ccdb23402b3eef7e7c30897a8a369b529fcf"
+dependencies = [
+ "convert_case 0.11.0",
+ "ctor",
+ "napi-derive-backend",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "napi-derive-backend"
+version = "5.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d5af30503edf933ce7377cf6d4c877a62b0f1107ea05585f1b5e430e88d5baf"
+dependencies = [
+ "convert_case 0.11.0",
+ "proc-macro2",
+ "quote",
+ "semver",
+ "syn",
+]
+
+[[package]]
+name = "napi-sys"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eb602b84d7c1edae45e50bbf1374696548f36ae179dfa667f577e384bb90c2b"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1115,6 +1263,12 @@ dependencies = [
  "memchr",
  "nom 8.0.0",
 ]
+
+[[package]]
+name = "nonmax"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
 
 [[package]]
 name = "num"
@@ -1214,6 +1368,215 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
+name = "owo-colors"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
+
+[[package]]
+name = "oxc"
+version = "0.96.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2de9d29ee93972a681161c620c428c87adc2137d8bdd0c010eb076251e8c474"
+dependencies = [
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_diagnostics",
+ "oxc_parser",
+ "oxc_regular_expression",
+ "oxc_span",
+ "oxc_syntax",
+]
+
+[[package]]
+name = "oxc-miette"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4356a61f2ed4c9b3610245215fbf48970eb277126919f87db9d0efa93a74245c"
+dependencies = [
+ "cfg-if",
+ "owo-colors",
+ "oxc-miette-derive",
+ "textwrap",
+ "thiserror",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
+name = "oxc-miette-derive"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b237422b014f8f8fff75bb9379e697d13f8d57551a22c88bebb39f073c1bf696"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "oxc_allocator"
+version = "0.96.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71ef2dba21be1ce515378b2b7143eaa2a912f9e6ffe162ae20639d56f53d60e3"
+dependencies = [
+ "allocator-api2",
+ "bumpalo",
+ "hashbrown 0.16.1",
+ "oxc_data_structures",
+ "rustc-hash",
+]
+
+[[package]]
+name = "oxc_ast"
+version = "0.96.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fad9195311a1961bb6ef1de0ce6a52147bccea50b5a40423b7b44e8448ed4fc"
+dependencies = [
+ "bitflags",
+ "oxc_allocator",
+ "oxc_ast_macros",
+ "oxc_data_structures",
+ "oxc_diagnostics",
+ "oxc_estree",
+ "oxc_regular_expression",
+ "oxc_span",
+ "oxc_syntax",
+]
+
+[[package]]
+name = "oxc_ast_macros"
+version = "0.96.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f03da6fac191c0817a32ae1a7dde27fd27d98732c61fcaeb55a99a4d543ba49"
+dependencies = [
+ "phf",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "oxc_data_structures"
+version = "0.96.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5f5171d7b8bc907a1b29e557d14f8478509a2154272d56db9ee8aed6bfe8dec"
+
+[[package]]
+name = "oxc_diagnostics"
+version = "0.96.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ef2bf6a713fd27bc65812d695bdfde3f8fcef735f00b861258518346642721b"
+dependencies = [
+ "cow-utils",
+ "oxc-miette",
+ "percent-encoding",
+]
+
+[[package]]
+name = "oxc_ecmascript"
+version = "0.96.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f908100cb2759dd2f42ca33d95ea158b8d78e2591b577757729fc9a4a4c63bc3"
+dependencies = [
+ "cow-utils",
+ "num-bigint",
+ "num-traits",
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_span",
+ "oxc_syntax",
+]
+
+[[package]]
+name = "oxc_estree"
+version = "0.96.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5644d3399116ff3f0cfb81f9a790c4b8173b504ed52274ecc757b57f30098ad1"
+
+[[package]]
+name = "oxc_index"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3e6120999627ec9703025eab7c9f410ebb7e95557632a8902ca48210416c2b"
+dependencies = [
+ "nonmax",
+ "serde",
+]
+
+[[package]]
+name = "oxc_parser"
+version = "0.96.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e080498b7a4456a63111f9c65b4dd1b98147955347854b809b6ad4cc5d6a0c0a"
+dependencies = [
+ "bitflags",
+ "cow-utils",
+ "memchr",
+ "num-bigint",
+ "num-traits",
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_data_structures",
+ "oxc_diagnostics",
+ "oxc_ecmascript",
+ "oxc_regular_expression",
+ "oxc_span",
+ "oxc_syntax",
+ "rustc-hash",
+ "seq-macro",
+]
+
+[[package]]
+name = "oxc_regular_expression"
+version = "0.96.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb87ab0b072e1e97d8101cb1678204bc3873d84f13255ae5aa088f1b85f7a8e1"
+dependencies = [
+ "bitflags",
+ "oxc_allocator",
+ "oxc_ast_macros",
+ "oxc_diagnostics",
+ "oxc_span",
+ "phf",
+ "rustc-hash",
+ "unicode-id-start",
+]
+
+[[package]]
+name = "oxc_span"
+version = "0.96.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41422232cfd9915d31dbb76ba2e5ae212884cad232e37203bdcb15bd1466951d"
+dependencies = [
+ "compact_str",
+ "oxc-miette",
+ "oxc_allocator",
+ "oxc_ast_macros",
+ "oxc_estree",
+]
+
+[[package]]
+name = "oxc_syntax"
+version = "0.96.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea81736f2343df141c7d8de78a91d155be4f712dfa6cd1bdd9a8b4f0676f01f"
+dependencies = [
+ "bitflags",
+ "cow-utils",
+ "dragonbox_ecma",
+ "nonmax",
+ "oxc_allocator",
+ "oxc_ast_macros",
+ "oxc_data_structures",
+ "oxc_estree",
+ "oxc_index",
+ "oxc_span",
+ "phf",
+ "unicode-id-start",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1268,6 +1631,49 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project"
@@ -1526,6 +1932,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1566,6 +1978,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1596,6 +2014,12 @@ name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
@@ -1656,6 +2080,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1689,6 +2119,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -1908,6 +2344,12 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "unicode-id-start"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81b79ad29b5e19de4260020f8919b443b2ef0277d242ce532ec7b7a2cc8b6007"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "crates/crap-core",
     "crates/crap4rs",
+    "crates/crap4ts",
 ]
 
 [workspace.package]
@@ -32,6 +33,22 @@ clap_complete_nushell = "4"
 # ── AST parsing for complexity analysis (Rust adapter only) ──
 syn = { version = "2", features = ["full", "parsing", "visit"] }
 proc-macro2 = { version = "1", features = ["span-locations"] }
+
+# ── AST parsing for TypeScript adapter (crap4ts only) ──
+# oxc 0.96 is the last release that keeps MSRV at Rust 1.88; 0.97+
+# bumped to 1.89 and 0.127+ to 1.93. S5 ships the walker as a stub —
+# the dep is wired so the cdylib link surface is locked in, but no
+# oxc APIs are exercised yet. The real walker lands in a follow-up
+# pipeline and will revisit the pin then.
+oxc = "0.96"
+
+# ── napi-rs bindings for the Node.js cdylib (crap4ts only) ──
+# napi 3.x is the current stable line (MSRV 1.88). napi_build::setup()
+# emits the macOS `-undefined dynamic_lookup` link arg automatically,
+# so no `.cargo/config.toml` rustflags are needed.
+napi = { version = "3", default-features = false, features = ["napi9"] }
+napi-derive = "3"
+napi-build = "2"
 
 # ── Serialization ──
 serde = { version = "1", features = ["derive"] }

--- a/crates/crap4ts/Cargo.toml
+++ b/crates/crap4ts/Cargo.toml
@@ -1,0 +1,65 @@
+[package]
+name = "crap4ts"
+version = "2.0.0-alpha.1"
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "TypeScript adapter for crap-rs (CRAP score analyzer) — ALPHA: oxc walker not yet shipped"
+keywords = ["crap", "complexity", "coverage", "typescript", "quality"]
+categories = ["development-tools::testing", "command-line-utilities"]
+
+# Single-crate cdylib + bin (CAO A3). The cdylib artifact powers the
+# napi-rs Node.js binding; the bin artifact is the standalone CLI that
+# mirrors crap4rs/src/main.rs. Both share `src/adapters/*`.
+[lib]
+name = "crap4ts"
+crate-type = ["cdylib", "rlib"]
+path = "src/lib.rs"
+
+[[bin]]
+name = "crap4ts"
+path = "src/main.rs"
+
+[features]
+# Default build is the standalone `crap4ts` CLI binary — no napi-rs
+# linkage, no Node-provided symbols at link time. The napi binding is
+# only relevant when producing the `.node` cdylib, so it lives behind
+# a feature that the cdylib build (and only the cdylib build) flips
+# on. Without this split the `crap4ts` bin would fail to link with
+# "Undefined symbols: _napi_create_function …" because `napi_build`'s
+# macOS `-undefined dynamic_lookup` directive only applies to the
+# `cdylib` crate-type, not to the bin.
+default = []
+napi-binding = ["dep:napi", "dep:napi-derive"]
+
+[dependencies]
+# Language-agnostic foundation: domain types, port traits, CLI shell.
+crap-core = { workspace = true }
+
+# TypeScript AST parsing (stubbed in S5 — wired so the dep graph + license
+# allowlist are settled before the real walker lands).
+oxc = { workspace = true }
+
+# napi-rs Node.js bindings. Optional / behind the `napi-binding`
+# feature — see the [features] block above for why. `napi-build` in
+# `[build-dependencies]` stays unconditional because its `setup()`
+# only emits link directives for the cdylib crate-type, so it's a
+# safe no-op for the standalone bin build.
+napi = { workspace = true, optional = true }
+napi-derive = { workspace = true, optional = true }
+
+# Serialization — IstanbulParseDiagnostic implements `ParseDiagnostic`
+# which requires `Serialize + DeserializeOwned`.
+serde = { workspace = true }
+
+[dev-dependencies]
+# Used by `parse_diagnostic` round-trip tests. The production code path
+# doesn't depend on serde_json — `IstanbulParseDiagnostic` derives serde
+# traits for the envelope, the JSON serialization happens up in
+# crap-core's reporter layer.
+serde_json = { workspace = true }
+
+[build-dependencies]
+napi-build = { workspace = true }

--- a/crates/crap4ts/build.rs
+++ b/crates/crap4ts/build.rs
@@ -1,0 +1,108 @@
+//! Build script — runs the napi-rs build hook AND embeds git commit hash
+//! + build date into the binary.
+//!
+//! Two responsibilities:
+//!
+//! 1. `napi_build::setup()` — emits per-platform link directives
+//!    required for the napi-rs cdylib. Notably on macOS this prints
+//!    `cargo:rustc-cdylib-link-arg=-undefined dynamic_lookup`, which
+//!    is what lets the `.node`/`.dylib` link against Node-provided
+//!    `napi_*` symbols at runtime instead of at link time.
+//! 2. `CRAP4TS_LONG_VERSION` — same shape as crap4rs's `build.rs`.
+//!    Clap picks this up via `long_version = env!("CRAP4TS_LONG_VERSION")`
+//!    and displays it for `--version`.
+//!
+//! Output examples:
+//!   - Source build with git: `2.0.0-alpha.1 (abc1234 2026-05-10)`
+//!   - Built without git:     `2.0.0-alpha.1 (2026-05-10)`
+
+use std::env;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn git_hash() -> String {
+    Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|o| {
+            if o.status.success() {
+                String::from_utf8(o.stdout).ok()
+            } else {
+                None
+            }
+        })
+        .map(|s| s.trim().to_string())
+        .unwrap_or_default()
+}
+
+fn build_date_from_secs(secs: i64) -> String {
+    // Civil date from Unix timestamp — Hinnant's algorithm
+    // https://howardhinnant.github.io/date_algorithms.html
+    let days = secs / 86400;
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    format!("{y:04}-{m:02}-{d:02}")
+}
+
+fn build_date() -> String {
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64;
+    build_date_from_secs(secs)
+}
+
+fn format_long_version(version: &str, hash: &str, date: &str) -> String {
+    if hash.is_empty() {
+        format!("{version} ({date})")
+    } else {
+        format!("{version} ({hash} {date})")
+    }
+}
+
+fn main() {
+    // napi-rs cdylib link-arg setup. Must run first so the printed
+    // `cargo::` directives reach cargo before any subsequent prints.
+    napi_build::setup();
+
+    let version = env::var("CARGO_PKG_VERSION").unwrap_or_default();
+    let long_version = format_long_version(&version, &git_hash(), &build_date());
+
+    println!("cargo:rustc-env=CRAP4TS_LONG_VERSION={long_version}");
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    println!("cargo:rerun-if-changed=.git/refs/heads/");
+}
+
+// ── Unit tests ────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_long_version_with_hash() {
+        let v = format_long_version("2.0.0-alpha.1", "abc1234", "2026-05-10");
+        assert_eq!(v, "2.0.0-alpha.1 (abc1234 2026-05-10)");
+    }
+
+    #[test]
+    fn format_long_version_empty_hash_returns_date_only() {
+        let v = format_long_version("2.0.0-alpha.1", "", "2026-05-10");
+        assert_eq!(v, "2.0.0-alpha.1 (2026-05-10)");
+    }
+
+    #[test]
+    fn build_date_known_epoch() {
+        // 2026-05-10 00:00:00 UTC = 1746835200 seconds
+        assert_eq!(build_date_from_secs(1_746_835_200), "2026-05-10");
+    }
+}

--- a/crates/crap4ts/src/adapters/coverage/mod.rs
+++ b/crates/crap4ts/src/adapters/coverage/mod.rs
@@ -1,0 +1,63 @@
+//! Istanbul JSON coverage parser — STUB.
+//!
+//! The real implementation will deserialize `coverage-final.json`
+//! (Istanbul's per-file `statementMap` / `s` / `branchMap` / `b`
+//! shape) into `ParseOutput<IstanbulParseDiagnostic>`, mirroring
+//! `crates/crap4rs/src/adapters/coverage/mod.rs`. It lands in the
+//! follow-up `crap-rs/2026XXXX-typescript-adapter` pipeline.
+//!
+//! ALPHA: invoking `parse(...)` runtime-panics with `unimplemented!`.
+//! The struct exists so the trait bound is wired and the binary's
+//! `--help` / `--version` paths (which never call into `parse`) work
+//! today.
+
+use crap_core::domain::types::CrapError;
+use crap_core::ports::{CoveragePort, ParseOutput};
+use std::path::PathBuf;
+
+use crate::parse_diagnostic::IstanbulParseDiagnostic;
+
+/// Istanbul JSON coverage parser — stub. Implements `CoveragePort`
+/// with `Diagnostic = IstanbulParseDiagnostic` so the binary's
+/// `crap_core::cli::run` dispatch picks it up.
+pub struct IstanbulCoverage {
+    /// Source root the parser will eventually use to canonicalise the
+    /// per-file `path` field that Istanbul emits. Stored but unused in
+    /// alpha — the real parser will consume it.
+    _root: PathBuf,
+}
+
+impl IstanbulCoverage {
+    pub fn new(root: PathBuf) -> Self {
+        Self { _root: root }
+    }
+}
+
+impl CoveragePort for IstanbulCoverage {
+    type Diagnostic = IstanbulParseDiagnostic;
+
+    fn parse(&self, _data: &str) -> Result<ParseOutput<Self::Diagnostic>, CrapError> {
+        unimplemented!(
+            "Istanbul JSON parser lands in the typescript-adapter follow-up pipeline (see crap4rs#137)"
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn istanbul_coverage_constructible() {
+        let _c = IstanbulCoverage::new(PathBuf::from("/tmp"));
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "Istanbul JSON parser lands in the typescript-adapter follow-up pipeline"
+    )]
+    fn istanbul_coverage_parse_unimplemented() {
+        let c = IstanbulCoverage::new(PathBuf::from("/tmp"));
+        let _ = c.parse("");
+    }
+}

--- a/crates/crap4ts/src/adapters/mod.rs
+++ b/crates/crap4ts/src/adapters/mod.rs
@@ -1,0 +1,18 @@
+//! crap4ts adapters — TypeScript-specific bindings for the language-
+//! agnostic `crap_core` analyzer.
+//!
+//! Two stubs live here in S5; both runtime-panic via `unimplemented!()`
+//! and will be filled in by the follow-up TypeScript-adapter pipeline:
+//!
+//! - **`walker`**: `oxc`-based AST walker that will extract per-function
+//!   cognitive / cyclomatic complexity from `.ts`/`.tsx` sources.
+//! - **`coverage`**: Istanbul JSON coverage parser
+//!   (`coverage-final.json`) that will convert vitest / jest coverage
+//!   into `ParseOutput<IstanbulParseDiagnostic>`.
+//!
+//! Both modules are TypeScript / oxc-toolchain coupled and live in
+//! `crap4ts/src/adapters/` rather than `crap-core` — see the
+//! `ast-purity` CI gate that bans `oxc` imports from `crap-core/src/`.
+
+pub mod coverage;
+pub mod walker;

--- a/crates/crap4ts/src/adapters/walker/mod.rs
+++ b/crates/crap4ts/src/adapters/walker/mod.rs
@@ -1,0 +1,64 @@
+//! Oxc-based TypeScript complexity walker — STUB.
+//!
+//! The real implementation will use `oxc::parser` to walk the AST and
+//! count decision points for cognitive / cyclomatic complexity, mirror-
+//! ing `crates/crap4rs/src/adapters/complexity/mod.rs`. It lands in
+//! the follow-up `crap-rs/2026XXXX-typescript-adapter` pipeline (see
+//! breezy-bays-labs/crap4rs#137 follow-up).
+//!
+//! ALPHA: invoking `extract(...)` runtime-panics with `unimplemented!`.
+//! The struct exists so the trait bound is wired and the binary's
+//! `--help` / `--version` paths (which never call into `extract`)
+//! work today.
+
+use crap_core::domain::types::{ComplexityMetric, CrapError, FunctionComplexity};
+use crap_core::ports::ComplexityPort;
+
+/// Oxc-based complexity extractor — stub. Implements `ComplexityPort`
+/// so the binary's `crap_core::cli::run` dispatch picks it up.
+pub struct OxcWalker {
+    _private: (),
+}
+
+impl OxcWalker {
+    pub fn new() -> Self {
+        Self { _private: () }
+    }
+}
+
+impl Default for OxcWalker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ComplexityPort for OxcWalker {
+    fn extract(
+        &self,
+        _source: &str,
+        _file_path: &str,
+        _metric: ComplexityMetric,
+    ) -> Result<Vec<FunctionComplexity>, CrapError> {
+        unimplemented!(
+            "oxc walker lands in the typescript-adapter follow-up pipeline (see crap4rs#137)"
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn oxc_walker_constructible() {
+        let _w = OxcWalker::new();
+        let _w2 = OxcWalker::default();
+    }
+
+    #[test]
+    #[should_panic(expected = "oxc walker lands in the typescript-adapter follow-up pipeline")]
+    fn oxc_walker_extract_unimplemented() {
+        let w = OxcWalker::new();
+        let _ = w.extract("", "stub.ts", ComplexityMetric::Cognitive);
+    }
+}

--- a/crates/crap4ts/src/lib.rs
+++ b/crates/crap4ts/src/lib.rs
@@ -1,0 +1,65 @@
+//! crap4ts — TypeScript adapter binding for the language-agnostic
+//! `crap_core` analyzer.
+//!
+//! ALPHA: the oxc complexity walker and Istanbul JSON coverage parser
+//! are stubs that `unimplemented!()`. The real TS pipeline lands in a
+//! follow-up (`crap-rs/2026XXXX-typescript-adapter`) — S5 here ships
+//! only the structural shell so the workspace layout, cdylib + bin
+//! crate-type combo, license allowlist, and CI surface are settled
+//! before the walker work begins.
+//!
+//! Unlike `crap4rs`, this crate has no v0.4 history and therefore no
+//! backward-compat shim modules — its public surface starts fresh at
+//! v2.0.0-alpha.1.
+
+pub mod adapters;
+pub mod parse_diagnostic;
+
+// ── napi-rs cdylib entry point ───────────────────────────────────────
+//
+// Behind the `napi-binding` feature so the standalone `crap4ts` bin
+// (which links the lib via `use crap4ts::...`) doesn't pull in
+// unresolved Node-provided `_napi_*` symbols at link time.
+// `napi_build`'s macOS `-undefined dynamic_lookup` directive only
+// covers the cdylib crate-type — the bin target would fail to link
+// otherwise. Cdylib consumers build with `cargo build --package
+// crap4ts --features napi-binding`.
+//
+// A single exported function exists so the `.node` artifact produced
+// by the cdylib has something to bind to (and `cargo build --features
+// napi-binding` exercises the napi_derive proc-macro chain). No
+// analysis logic is wired through napi yet — real bindings ship with
+// the walker.
+
+#[cfg(feature = "napi-binding")]
+use napi_derive::napi;
+
+/// Returns a human-readable alpha-status string. Exposed to JS as
+/// `alphaStatus()` (napi-rs converts snake_case → camelCase) when the
+/// `napi-binding` feature is enabled. Always callable from Rust so
+/// non-napi consumers (and tests) can verify the message.
+#[cfg(feature = "napi-binding")]
+#[napi]
+pub fn alpha_status() -> String {
+    alpha_status_message().to_string()
+}
+
+/// Backing constant for the alpha-status message. Lifted out so the
+/// non-napi path (the bin's default build, unit tests) can assert on
+/// the same string without touching napi at all.
+pub const fn alpha_status_message() -> &'static str {
+    "crap4ts@2 alpha — oxc walker not yet implemented"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn alpha_status_message_is_stable() {
+        assert_eq!(
+            alpha_status_message(),
+            "crap4ts@2 alpha — oxc walker not yet implemented"
+        );
+    }
+}

--- a/crates/crap4ts/src/main.rs
+++ b/crates/crap4ts/src/main.rs
@@ -1,0 +1,25 @@
+//! Thin TypeScript adapter binary — wires `crap_core::cli::run<P>` with
+//! the oxc/Istanbul ports (currently stubs).
+//!
+//! Mirrors `crates/crap4rs/src/main.rs` exactly so future maintenance
+//! sees one shape. ALPHA: invoking the real analysis path runtime-
+//! panics inside the walker / coverage parser stubs. `--help` and
+//! `--version` work because clap dispatch lives in `crap_core::cli`.
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use crap4ts::adapters::coverage::IstanbulCoverage;
+use crap4ts::adapters::walker::OxcWalker;
+
+fn main() -> ExitCode {
+    let cli = crap_core::cli::parse_args(env!("CARGO_PKG_VERSION"), env!("CRAP4TS_LONG_VERSION"));
+    let src = cli
+        .input
+        .src
+        .clone()
+        .unwrap_or_else(|| PathBuf::from("src"));
+    let coverage = IstanbulCoverage::new(src.canonicalize().unwrap_or(src));
+    let complexity = OxcWalker::new();
+    crap_core::cli::run(cli, &complexity, &coverage, env!("CARGO_PKG_VERSION"))
+}

--- a/crates/crap4ts/src/parse_diagnostic.rs
+++ b/crates/crap4ts/src/parse_diagnostic.rs
@@ -1,0 +1,93 @@
+//! Istanbul-specific parse-diagnostic type for the TypeScript adapter.
+//!
+//! Implements `crap_core::ports::ParseDiagnostic` so it can flow through
+//! the language-agnostic `AnalysisDiagnostics<P>` and `ParseOutput<P>`
+//! shapes. Mirrors `crap4rs::parse_diagnostic::LcovParseDiagnostic` —
+//! the variants are Istanbul-flavoured placeholders. The Istanbul JSON
+//! parser is a stub in S5, so these variants are not constructed by
+//! any code path today; they exist so the trait bound + serde
+//! envelope are real (not phantom) before the parser lands.
+
+use crap_core::ports::ParseDiagnostic;
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// Non-fatal issues encountered during Istanbul JSON coverage parsing.
+///
+/// ALPHA: no code path constructs these variants yet — the Istanbul
+/// parser at `crate::adapters::coverage::IstanbulCoverage` runtime-
+/// panics. The variants are picked to mirror the shape of LCOV's
+/// `MalformedRecord` / `EmptySourceFile` so the JSON envelope
+/// surfaced for downstream consumers (Scorecard action, mokumo) is
+/// structurally consistent across adapters.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum IstanbulParseDiagnostic {
+    /// A JSON document was structurally invalid (parse error).
+    MalformedJson {
+        /// 1-based line number in the input where parsing failed, if
+        /// the parser surfaces one. `0` is used when the parser cannot
+        /// localise the error.
+        line_number: usize,
+        /// Short description from the underlying parser.
+        content: String,
+    },
+    /// A coverage record was missing a required field.
+    MissingField {
+        /// The dotted JSON path of the missing field
+        /// (e.g. `path`, `s`, `b`, `fnMap`).
+        field: String,
+    },
+}
+
+impl fmt::Display for IstanbulParseDiagnostic {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MalformedJson {
+                line_number,
+                content,
+            } => write!(f, "line {line_number}: malformed JSON: {content}"),
+            Self::MissingField { field } => {
+                write!(f, "missing required field: {field}")
+            }
+        }
+    }
+}
+
+impl ParseDiagnostic for IstanbulParseDiagnostic {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_diagnostic_display_malformed_json() {
+        let d = IstanbulParseDiagnostic::MalformedJson {
+            line_number: 12,
+            content: "expected `,` or `}`".to_string(),
+        };
+        assert_eq!(
+            d.to_string(),
+            "line 12: malformed JSON: expected `,` or `}`"
+        );
+    }
+
+    #[test]
+    fn parse_diagnostic_display_missing_field() {
+        let d = IstanbulParseDiagnostic::MissingField {
+            field: "path".to_string(),
+        };
+        assert_eq!(d.to_string(), "missing required field: path");
+    }
+
+    #[test]
+    fn parse_diagnostic_serde_round_trip() {
+        let d = IstanbulParseDiagnostic::MalformedJson {
+            line_number: 3,
+            content: "unexpected end of input".to_string(),
+        };
+        let s = serde_json::to_string(&d).unwrap();
+        let back: IstanbulParseDiagnostic = serde_json::from_str(&s).unwrap();
+        assert_eq!(d, back);
+    }
+}

--- a/deny.toml
+++ b/deny.toml
@@ -27,6 +27,12 @@ allow = [
   "ISC",
   "Unicode-3.0",
   "MPL-2.0",
+  # Added in S5 (#137): oxc 0.96 pulls `dragonbox_ecma`, whose license
+  # expression is `Apache-2.0 WITH LLVM-exception OR BSL-1.0`. The
+  # `WITH LLVM-exception` variant is not in the cargo-deny SPDX
+  # allowlist by default, so we satisfy the OR via BSL-1.0 (Boost
+  # Software License — OSI-approved, FSF-Free, permissive).
+  "BSL-1.0",
 ]
 confidence-threshold = 0.93
 

--- a/packages/crap4ts/README.md
+++ b/packages/crap4ts/README.md
@@ -1,0 +1,34 @@
+# crap4ts (alpha)
+
+**This package is alpha and not yet published to npm.** It's a scaffold for the upcoming `crap4ts@2.x` line — a Rust-powered CRAP (Change Risk Anti-Patterns) score analyzer for TypeScript, distributed as a [napi-rs](https://napi.rs/) Node addon backed by the [oxc](https://oxc.rs/) parser.
+
+## Status
+
+| Component | Status |
+|---|---|
+| Workspace skeleton, Cargo wiring, CI build | landed in [crap4rs#137](https://github.com/breezy-bays-labs/crap4rs/issues/137) |
+| `oxc`-based TypeScript walker | not yet implemented (`unimplemented!()`) |
+| Istanbul JSON coverage parser | not yet implemented (`unimplemented!()`) |
+| napi-rs Node bindings beyond the `alphaStatus()` placeholder | not yet implemented |
+| npm publish | gated on the items above |
+
+The `package.json` is intentionally marked `"private": true` so `npm publish` is a no-op until the walker lands.
+
+## For working CRAP analysis on TypeScript today
+
+Use the previous, JavaScript-implemented analyzer:
+
+```
+npm install --save-dev crap4ts@1
+```
+
+The `v1.x-maintenance-announcement` release on [`breezy-bays-labs/crap4ts`](https://github.com/breezy-bays-labs/crap4ts) documents the deprecation timeline.
+
+## Why a v2
+
+The v2 analyzer shares its CRAP formula, scorecard envelope, and reporter shapes with [`crap4rs`](https://github.com/breezy-bays-labs/crap4rs) by linking the same `crap-core` Rust library. That gives TypeScript projects identical analysis semantics to Rust projects (per-function complexity, line-range matching against coverage data, deltas vs a baseline, JSON / Markdown / SARIF / HTML / scorecard-row reporters) — at native speed, with no separate engine to maintain.
+
+## Tracking
+
+- Skeleton + scaffolding: [crap4rs#137](https://github.com/breezy-bays-labs/crap4rs/issues/137)
+- Follow-up walker / parser pipeline: tracked separately (see the issue thread for the pipeline name once filed).

--- a/packages/crap4ts/index.js
+++ b/packages/crap4ts/index.js
@@ -1,0 +1,6 @@
+// ALPHA — the crap4ts@2 walker has not yet shipped. This package is a
+// scaffold only. For working CRAP analysis on TypeScript today, use
+// crap4ts@1.x. See breezy-bays-labs/crap4rs#137 for the v2 plan.
+throw new Error(
+  'crap4ts@2 is in alpha — the oxc walker has not yet shipped. Use crap4ts@1.x for now.',
+);

--- a/packages/crap4ts/package.json
+++ b/packages/crap4ts/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "crap4ts",
+  "version": "2.0.0-alpha.1",
+  "description": "TypeScript adapter for crap-rs. ALPHA: walker not yet implemented; depends on the in-progress oxc parser. For working CRAP analysis on TS today, see crap4ts@1.x.",
+  "main": "index.js",
+  "private": true,
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/breezy-bays-labs/crap4rs.git",
+    "directory": "packages/crap4ts"
+  },
+  "license": "MIT OR Apache-2.0",
+  "engines": {
+    "node": ">=18"
+  }
+}


### PR DESCRIPTION
## Summary

S5 of the `crap-rs/20260509-monorepo-migration` pipeline. Adds a third workspace member, `crates/crap4ts/`, as the TypeScript adapter shell, plus an unpublished npm wrapper at `packages/crap4ts/`. The `oxc` walker (`OxcWalker`) and Istanbul JSON coverage parser (`IstanbulCoverage`) are stubs that `unimplemented!()` — the real TS pipeline lands in a follow-up. `--help` and `--version` work today; invoking real analysis runtime-panics with a message that points back to this issue.

Single-crate `cdylib` + `bin` (CAO A3): the same Cargo.toml declares both crate-types so the napi-rs `.node`/`.dylib` artifact and the standalone `crap4ts` CLI share `src/adapters/*`. The standalone bin uses default features (no napi linkage); the cdylib uses `--features napi-binding --lib` so the macOS `-undefined dynamic_lookup` link directive emitted by `napi_build::setup()` covers the only target that actually references Node-provided `napi_*` symbols.

## Side-deliverable order (CAO C4)

The maintenance-mode banner on `breezy-bays-labs/crap4ts` has landed before this PR merges, so npm consumers of `crap4ts@1.x` see the v2 announcement first:

- **Banner PR (merged)**: https://github.com/breezy-bays-labs/crap4ts/pull/38 (merge commit `6d71f9c`)
- **GH release (cut)**: https://github.com/breezy-bays-labs/crap4ts/releases/tag/v1.x-maintenance-announcement

## Pin versions used

| Crate | Version | MSRV | License |
|---|---|---|---|
| `oxc` | `0.96` | 1.88.0 | MIT |
| `napi` | `3` (resolved 3.x) | 1.88 | MIT |
| `napi-derive` | `3` | 1.88 | MIT |
| `napi-build` | `2` | 1.88 | MIT |

`oxc` is intentionally pinned to **0.96**, not the current latest (0.129). 0.97+ bumped MSRV to 1.89, 0.127+ bumped it to 1.93 — both above the workspace's declared `rust-version = "1.88"`. The real walker pipeline will revisit the pin (likely alongside an MSRV bump that gets discussed with the orchestrator first).

`deny.toml` gains **`BSL-1.0`** in the license allowlist: `oxc_syntax` transitively pulls `dragonbox_ecma`, whose SPDX expression is `Apache-2.0 WITH LLVM-exception OR BSL-1.0`. The `WITH LLVM-exception` form isn't matched by the existing `Apache-2.0` allowance under cargo-deny's strict matching, so the OR is satisfied via BSL-1.0 (OSI-approved, FSF-Free, permissive — same enforcement-class as the existing allowlist entries).

## Acceptance gates (local results)

| # | Gate | Result | Notes |
|---|---|---|---|
| 1 | `cargo build --workspace` | pass | crap4ts compiles clean |
| 2 | `cargo nextest run --workspace --all-targets` | pass | 914 tests (8 new in crap4ts) |
| 3 | `crap4ts --help` | pass | clap dispatch works |
| 4 | `crap4ts --coverage <lcov> --src ...` panics with `unimplemented!()` | pass | message references `crap4rs#137` |
| 5 | `cargo build --package crap4ts --features napi-binding --lib --release` produces `libcrap4ts.dylib` | pass | 453K on macOS-arm, contains napi binding |
| 6 | `packages/crap4ts/package.json` has `"private": true` | pass | |
| 7 | `cargo +1.88 check --workspace --all-targets` | pass | no MSRV bump; oxc 0.96 pinned for this |
| 8 | `cargo deny check` | pass | BSL-1.0 added to allowlist |
| 9 | AST-purity grep on `crates/crap-core/src/` | pass | zero matches |
| 10 | Wire-envelope snapshot byte-identical to S4 | pass | `wire_envelope_snapshot__envelope.snap` untouched |
| 11 | `cargo clippy --workspace --all-targets -- -D warnings` | pass | |
| 12 | `cargo fmt --check` | pass | |
| 13 | `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps` | pass | |

## CI

The PR adds a new `crap4ts-build` matrix job (linux-x86 + macos-arm + macos-x86) that builds both the bin (default features) and the cdylib (`--features napi-binding --lib`) in release mode. The existing `test`, `clippy`, `fmt`, `coverage`, `self-check`, `self-crap-view`, `mutants`, `scorecard-smoke`, `msrv`, `deny`, `ast-purity`, `docs`, and `crap4ts-build` jobs all consume the workspace via `--workspace` or per-crate flags — no broader CI surgery needed.

**linux-arm caveat**: the matrix omits linux-arm because GitHub-hosted arm64 Linux runners are still rolling out across the org's billing tier. The orchestrator will want to file a follow-up to extend the matrix once the runner is available (or once the v2 walker pipeline ships and we have a real CI need for it).

## Lessons captured locally

1. **napi-rs cdylib link surface vs the bin target**: when a crate has BOTH `crate-type = ["cdylib", "rlib"]` AND a `[[bin]]` that imports the lib, `cargo build` will try to link the bin against the napi-emitted symbols too. `napi_build::setup()`'s `rustc-cdylib-link-arg=...` directives only apply to the cdylib, not the bin. Feature-gating the `#[napi]` block (default off) is the cleanest fix — keeps the bin oblivious to napi entirely.
2. **`napi_build::setup()` already emits macOS `-undefined dynamic_lookup`** for the cdylib — no `.cargo/config.toml` rustflags are needed.
3. **oxc has an aggressive MSRV cadence**: every 10 minor versions tends to bump MSRV by one. The dep needs an MSRV-aware pin in any workspace with a declared `rust-version`.

## Follow-ups (surfaced for orchestrator to file)

1. **linux-arm runner coverage** in the `crap4ts-build` matrix once arm64 Linux is available.
2. **Per-crate self-CRAP run for crap4ts** in CI — the brief asked we explicitly NOT add it in S5 (the stubs panic on any real coverage data), so revisit once the walker ships.
3. **Toggle `napi-binding` feature in the CI cdylib step** — currently the job builds with the feature explicitly; once napi-binding becomes the default for cdylib consumers (post-walker), simplify the invocation.
4. **`crap4ts` standalone-bin UX**: today the bin's `--help` text is the literal long_about string from `crap_core::cli`, which says "for Rust codebases". After the walker lands, the help text should mention TypeScript.

## Test plan

- [x] `cargo build --workspace` succeeds
- [x] `cargo nextest run --workspace --all-targets` passes (914 tests)
- [x] `cargo run --bin crap4ts -- --help` prints clap help
- [x] `cargo run --bin crap4ts -- --coverage <faux-lcov> --src crates/crap4ts/src` panics with `unimplemented! ... see crap4rs#137`
- [x] `cargo build --package crap4ts --features napi-binding --lib --release` produces a Mach-O cdylib (`libcrap4ts.dylib`, ~453K with napi binding)
- [x] `cargo +1.88 check --workspace --all-targets` passes
- [x] `cargo deny check` passes (BSL-1.0 added)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] AST-purity grep on `crates/crap-core/src/` matches zero lines

Closes #137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)