### PR TITLE
chore: raise MSRV 1.88 → 1.93; bump oxc 0.96 → 0.129

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,12 +327,14 @@ jobs:
     # missed dev-dep MSRV blockers (cucumber 0.22 needs 1.88, jsonschema
     # → idna → icu chain needs 1.86). `--all-targets` exercises the
     # full target set (lib, bin, tests) and surfaces those.
-    name: MSRV (1.88)
+    # Bumped 1.88 → 1.93 to unlock current oxc (the TS walker dep) and
+    # avoid the running carry-cost of holding oxc back across releases.
+    name: MSRV (1.93)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.88
+      - uses: dtolnay/rust-toolchain@1.93
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: crap4rs-msrv

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,9 +182,6 @@ name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
-dependencies = [
- "allocator-api2",
-]
 
 [[package]]
 name = "bytecount"
@@ -593,9 +590,9 @@ dependencies = [
 
 [[package]]
 name = "dragonbox_ecma"
-version = "0.0.5"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d742b56656e8b14d63e7ea9806597b1849ae25412584c8adf78c0f67bd985e66"
+checksum = "fd8e701084c37e7ef62d3f9e453b618130cbc0ef3573847785952a3ac3f746bf"
 
 [[package]]
 name = "either"
@@ -852,6 +849,12 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
 ]
@@ -1375,9 +1378,9 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "oxc"
-version = "0.96.0"
+version = "0.129.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2de9d29ee93972a681161c620c428c87adc2137d8bdd0c010eb076251e8c474"
+checksum = "b91000d43bf6ff9c4898de564768b7ea0a6971e5ed6b038573bc2ae6aa6edb6b"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -1416,22 +1419,21 @@ dependencies = [
 
 [[package]]
 name = "oxc_allocator"
-version = "0.96.0"
+version = "0.129.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71ef2dba21be1ce515378b2b7143eaa2a912f9e6ffe162ae20639d56f53d60e3"
+checksum = "6ae84cda3381ab6f90bcab6325d1874ac4bbd71232f2200dc6e866123c8cc4ef"
 dependencies = [
  "allocator-api2",
- "bumpalo",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "oxc_data_structures",
  "rustc-hash",
 ]
 
 [[package]]
 name = "oxc_ast"
-version = "0.96.0"
+version = "0.129.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fad9195311a1961bb6ef1de0ce6a52147bccea50b5a40423b7b44e8448ed4fc"
+checksum = "b4104077919ef54c3ae15f8923a0e44f636c2721dfc11cf168404804af2b726e"
 dependencies = [
  "bitflags",
  "oxc_allocator",
@@ -1441,14 +1443,15 @@ dependencies = [
  "oxc_estree",
  "oxc_regular_expression",
  "oxc_span",
+ "oxc_str",
  "oxc_syntax",
 ]
 
 [[package]]
 name = "oxc_ast_macros"
-version = "0.96.0"
+version = "0.129.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f03da6fac191c0817a32ae1a7dde27fd27d98732c61fcaeb55a99a4d543ba49"
+checksum = "a8004e158aa037d7e14ea85fccbcf4a320c3412ad9da9a3df5df85c52ee5585f"
 dependencies = [
  "phf",
  "proc-macro2",
@@ -1458,15 +1461,15 @@ dependencies = [
 
 [[package]]
 name = "oxc_data_structures"
-version = "0.96.0"
+version = "0.129.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f5171d7b8bc907a1b29e557d14f8478509a2154272d56db9ee8aed6bfe8dec"
+checksum = "0df39892508c04e3d44ccbf7e384fb35bac3750f39984f7cef47949dc321571a"
 
 [[package]]
 name = "oxc_diagnostics"
-version = "0.96.0"
+version = "0.129.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ef2bf6a713fd27bc65812d695bdfde3f8fcef735f00b861258518346642721b"
+checksum = "c4312c021972d746e1bb06051d1e887b80ad2b98f772b7b2aec204ddf585779c"
 dependencies = [
  "cow-utils",
  "oxc-miette",
@@ -1475,24 +1478,25 @@ dependencies = [
 
 [[package]]
 name = "oxc_ecmascript"
-version = "0.96.0"
+version = "0.129.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f908100cb2759dd2f42ca33d95ea158b8d78e2591b577757729fc9a4a4c63bc3"
+checksum = "9db328a0a6163105e188e2ff4620fb4a065daf2001e4a7318b3342605bacaa9e"
 dependencies = [
  "cow-utils",
  "num-bigint",
  "num-traits",
  "oxc_allocator",
  "oxc_ast",
+ "oxc_regular_expression",
  "oxc_span",
  "oxc_syntax",
 ]
 
 [[package]]
 name = "oxc_estree"
-version = "0.96.0"
+version = "0.129.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5644d3399116ff3f0cfb81f9a790c4b8173b504ed52274ecc757b57f30098ad1"
+checksum = "db4f0258b3b9994f27bb11e1bc8fdedd6a22281307e53148ac76d72e61c93481"
 
 [[package]]
 name = "oxc_index"
@@ -1506,9 +1510,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_parser"
-version = "0.96.0"
+version = "0.129.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e080498b7a4456a63111f9c65b4dd1b98147955347854b809b6ad4cc5d6a0c0a"
+checksum = "2fcb901b425989d315e1c536f561d6f92260731a1e1c1418c1ba4cc203167124"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -1522,6 +1526,7 @@ dependencies = [
  "oxc_ecmascript",
  "oxc_regular_expression",
  "oxc_span",
+ "oxc_str",
  "oxc_syntax",
  "rustc-hash",
  "seq-macro",
@@ -1529,15 +1534,16 @@ dependencies = [
 
 [[package]]
 name = "oxc_regular_expression"
-version = "0.96.0"
+version = "0.129.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb87ab0b072e1e97d8101cb1678204bc3873d84f13255ae5aa088f1b85f7a8e1"
+checksum = "e2825d55dd483df5d641087ab515547bee282639ecff26a32e66356cd273b40d"
 dependencies = [
  "bitflags",
  "oxc_allocator",
  "oxc_ast_macros",
  "oxc_diagnostics",
  "oxc_span",
+ "oxc_str",
  "phf",
  "rustc-hash",
  "unicode-id-start",
@@ -1545,22 +1551,35 @@ dependencies = [
 
 [[package]]
 name = "oxc_span"
-version = "0.96.0"
+version = "0.129.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41422232cfd9915d31dbb76ba2e5ae212884cad232e37203bdcb15bd1466951d"
+checksum = "dff4df78f3fd004daf1dd0301cac40b34451c42e56dd46f7a7dcefd0cc582ef3"
 dependencies = [
  "compact_str",
  "oxc-miette",
  "oxc_allocator",
  "oxc_ast_macros",
  "oxc_estree",
+ "oxc_str",
+]
+
+[[package]]
+name = "oxc_str"
+version = "0.129.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0273521fbd4655da9c5b2f659f4cc7f2e5370a573b54d37a4456c336c7bc8af6"
+dependencies = [
+ "compact_str",
+ "hashbrown 0.17.1",
+ "oxc_allocator",
+ "oxc_estree",
 ]
 
 [[package]]
 name = "oxc_syntax"
-version = "0.96.0"
+version = "0.129.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea81736f2343df141c7d8de78a91d155be4f712dfa6cd1bdd9a8b4f0676f01f"
+checksum = "0dcdc65090dfc024c9f0d156ff0e1f9b139b7954552cd6c8de02bd6d2362679f"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -1568,10 +1587,10 @@ dependencies = [
  "nonmax",
  "oxc_allocator",
  "oxc_ast_macros",
- "oxc_data_structures",
  "oxc_estree",
  "oxc_index",
  "oxc_span",
+ "oxc_str",
  "phf",
  "unicode-id-start",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 
 [workspace.package]
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.93"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/breezy-bays-labs/crap4rs"
 authors = ["Christopher Bays <cmbays@breezybayslabs.com>"]
@@ -35,15 +35,17 @@ syn = { version = "2", features = ["full", "parsing", "visit"] }
 proc-macro2 = { version = "1", features = ["span-locations"] }
 
 # ── AST parsing for TypeScript adapter (crap4ts only) ──
-# oxc 0.96 is the last release that keeps MSRV at Rust 1.88; 0.97+
-# bumped to 1.89 and 0.127+ to 1.93. S5 ships the walker as a stub —
-# the dep is wired so the cdylib link surface is locked in, but no
-# oxc APIs are exercised yet. The real walker lands in a follow-up
-# pipeline and will revisit the pin then.
-oxc = "0.96"
+# oxc 0.129 is the current latest. Earlier versions (0.96–0.126)
+# had progressively-lower MSRV floors (1.88–1.92); 0.127+ requires
+# Rust 1.93, which matches the workspace floor. The walker is still
+# a stub (crap4ts adapters `unimplemented!()`); the dep is wired so
+# the cdylib link surface is locked in. Real walker lands in a
+# follow-up pipeline.
+oxc = "0.129"
 
 # ── napi-rs bindings for the Node.js cdylib (crap4ts only) ──
-# napi 3.x is the current stable line (MSRV 1.88). napi_build::setup()
+# napi 3.x is the current stable line (MSRV 1.88; workspace floor is
+# higher at 1.93). napi_build::setup()
 # emits the macOS `-undefined dynamic_lookup` link arg automatically,
 # so no `.cargo/config.toml` rustflags are needed.
 napi = { version = "3", default-features = false, features = ["napi9"] }

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -47,13 +47,13 @@ pre-push:
       run: cargo deny check
       timeout: 60s
     msrv:
-      # Pre-flight gate. `cargo +1.88 check --workspace --all-targets`
+      # Pre-flight gate. `cargo +1.93 check --workspace --all-targets`
       # exercises every crate's full target set (lib, bin, tests,
       # examples) under the declared MSRV. Lib-only `cargo check`
       # silently misses dev-dep MSRV breaks (cucumber 0.22 needs
-      # 1.88, which the audit's lib-only check did not catch); the
-      # `--all-targets` flag is what surfaces them.
-      run: cargo +1.88 check --workspace --all-targets
+      # 1.88, oxc 0.127+ needs 1.93); the `--all-targets` flag is
+      # what surfaces them.
+      run: cargo +1.93 check --workspace --all-targets
       timeout: 180s
     test:
       run: cargo nextest run --workspace --all-targets


### PR DESCRIPTION
## Summary

Raises the workspace MSRV from **1.88 → 1.93** and bumps `oxc` from **0.96 → 0.129** in lockstep. This unblocks tracking current oxc on the TS walker side (S5 had to pin oxc 0.96 because 0.97+ bumped MSRV to 1.89, 0.127+ to 1.93). 1.93 is a Rust tier-1 stable release as of 2026-02, and pinning the workspace there gives the project a steadier floor to hold across the next several quarterly releases.

## What changes

- `[workspace.package]` `rust-version`: `1.88` → `1.93`
- `[workspace.dependencies]` `oxc`: `0.96` → `0.129` (33 minor releases unlocked)
- `cargo update --workspace` refreshes 14 transitive pins (the oxc family + `dragonbox_ecma 0.0.5 → 0.1.12`). No other crate moved past its major-version cap.
- CI `msrv` job: `dtolnay/rust-toolchain@1.88` → `@1.93`; display name updated.
- `lefthook.yml` `msrv` pre-push hook: `cargo +1.88` → `cargo +1.93`.

## What's intentionally unchanged

- **No `.rs` source edits.** Public API surface unchanged; v0.4 → v0.5 shim modules unaffected.
- **Wire-envelope snapshot** at `crates/crap-core/tests/snapshots/wire_envelope_snapshot__envelope.snap` — byte-identical (canary unchanged, as expected for a pin-only PR).
- **cucumber** stays at `0.22`. 0.23 is available, but cucumber's own MSRV (1.88) doesn't pressure the bump and a cucumber major-line jump can ripple into the BDD harness — saving that for a focused PR if/when needed.
- **`deny.toml` allowlist** — `dragonbox_ecma 0.1.12` still uses `Apache-2.0 WITH LLVM-exception OR BSL-1.0`, and `ryu` (already in the graph via `serde_json`) is `Apache-2.0 OR BSL-1.0`. The BSL-1.0 entry added in S5 stays load-bearing.

## Local verification (all green at 1.93)

| Gate | Result |
|---|---|
| `cargo +1.93 check --workspace --all-targets` | pass |
| `cargo nextest run --workspace --all-targets` | pass (914/914) |
| `cargo clippy --workspace --all-targets -- -D warnings` | pass |
| `cargo fmt --check` | pass |
| `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps` | pass |
| `cargo deny check` | pass (advisories + bans + licenses + sources) |
| `cargo build --package crap4ts --features napi-binding --lib --release` | produces `libcrap4ts.dylib` (453K, unchanged size) |
| `cargo run --bin crap4ts -- --help` | prints help |

## Test plan

- [x] Local: 914/914 tests pass at 1.93
- [ ] CI: all 18 jobs green, including new MSRV (1.93) gate
- [ ] Wire-envelope canary byte-identical
- [ ] `cargo deny check` green on linux runner (licenses + advisories)
- [ ] crap4ts-build matrix green on all three platforms with newer oxc

## Future bookkeeping

- The S5 PR body's "Pins" table referenced `oxc 0.96 (NOT latest 0.129 — MSRV pressure)`. After this PR merges, the daily-board card + S5 closeout note for the migration pipeline should both be amended to record the new pin (history is in `observations.md` regardless). Non-blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded the minimum supported Rust version (MSRV) from 1.88 to 1.93
  * Updated project dependencies to versions compatible with the new Rust requirement
  * Updated CI/CD pipeline and local development tooling to validate against Rust 1.93

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/breezy-bays-labs/crap4rs/pull/155)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->