### PR TITLE
release(workspace): #138 — release-checklist + CHANGELOG + MIGRATION + v0.5.0 version bumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,150 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-05-10
+
+The workspace-extraction milestone. `crap4rs` becomes one of three
+crates in a workspace alongside the new language-agnostic
+[`crap-core`](https://crates.io/crates/crap-core) library and the
+alpha [`crap4ts`](https://github.com/breezy-bays-labs/crap4ts) shell
+for the future TypeScript adapter. **No breaking changes for `cargo
+install crap4rs` users**; **no required source changes for `cargo add
+crap4rs` library users** — every v0.4 public path resolves through a
+backward-compatibility shim re-export (per
+[ADR D10](https://github.com/breezy-bays-labs/ops/tree/main/decisions/crap-rs)).
+
+The CLI binary, output formats, JSON envelope schema (version 2,
+unchanged), SARIF output, scorecard-row producer, and `/cut-the-crap`
+agent skill all behave identically to v0.4.0. The wire-envelope
+snapshot canary is byte-identical to the v0.4.0 baseline (the
+language-agnostic adapters relocated to `crap-core` but emit the same
+bytes).
+
+The repository renames from `breezy-bays-labs/crap4rs` to
+`breezy-bays-labs/crap-rs` shortly after this release ships. GitHub's
+auto-redirect carries existing URL references for at least one year.
+The crates.io package name `crap4rs` is unchanged.
+
+### Added
+- **`crap-core` 0.1.0** — language-agnostic shared library extracted
+  from crap4rs. Contains domain types (`AnalysisResult`,
+  `ScoredFunction`, `RiskLevel`, `ContributorKind`, CRAP formula,
+  delta + summary), port traits (`ComplexityPort`, `CoveragePort`,
+  `DiffPort`, `ParseDiagnostic`), the eight reporters (JSON, SARIF,
+  CSV, markdown, HTML, scorecard-row, table, advice-summary), the
+  baseline / config / diff adapters, the `walker` orchestration, and
+  the CLI dispatch shell. Designed for future TypeScript / multi-
+  language adapters to bind against the same domain core. See PRs
+  [#146](https://github.com/breezy-bays-labs/crap4rs/pull/146) (domain
+  + ports), [#149](https://github.com/breezy-bays-labs/crap4rs/pull/149)
+  (adapters), [#151](https://github.com/breezy-bays-labs/crap4rs/pull/151)
+  (core + cli).
+- **`crap4ts` 2.0.0-alpha.1** — TypeScript adapter shell crate
+  scaffolding the napi-rs `cdylib` + Rust `bin` surface for the future
+  Node.js / TypeScript binding. Walker and Istanbul coverage parser
+  are stub `unimplemented!()` adapters; the real walker pipeline ships
+  in a future pipeline. **NOT published to crates.io or npm**
+  (`package.json` is `"private": true` and release-publishing is
+  disabled). See PR
+  [#153](https://github.com/breezy-bays-labs/crap4rs/pull/153). The
+  v1.x line of the legacy TypeScript implementation at
+  [`breezy-bays-labs/crap4ts`](https://github.com/breezy-bays-labs/crap4ts)
+  enters maintenance-only mode.
+- **Mixed dispatch architecture (ADR D9)** — generics on data
+  containers (`AnalysisDiagnostics<P>`, `ParseOutput<P>`,
+  `AnalysisOutput<P>`, `BaselineSnapshot<P>`, `JsonConfig<'a, P>`,
+  `DeltaContext<'a, P>`); trait objects on port orchestration
+  (`&dyn ComplexityPort`, `&dyn CoveragePort<Diagnostic = P>`); free
+  functions for reporters preserved per
+  [`adapters.md`](https://github.com/breezy-bays-labs/ops) rule 1
+  (Reporter trait NOT introduced).
+- **Backward-compat shim modules (ADR D10)** — `crap4rs::domain::*`,
+  `crap4rs::ports::*`, `crap4rs::core::*`, `crap4rs::cli::*`, and
+  `crap4rs::adapters::{baseline, config, diff, reporters}::*` are
+  nested `pub mod` re-exports from `crap_core::*`. Type aliases
+  concretize the `<P>` parameter to `LcovParseDiagnostic` so v0.4
+  consumers' unparameterized usage keeps compiling.
+- **`crap4rs::parse_diagnostic::LcovParseDiagnostic`** — the LCOV-
+  specific concrete `ParseDiagnostic` impl, formerly named
+  `crap4rs::domain::types::ParseDiagnostic`. The old path is preserved
+  as a shim alias for v0.5.x; the alias drops at v1.0.
+
+### Changed
+- **MSRV: 1.88 → 1.93.** Building `crap4rs` from source now requires
+  `rustc >= 1.93`. `cargo binstall crap4rs` and pre-built release
+  artifacts are unaffected (they ship as binaries). The MSRV raise
+  tracks `oxc 0.129`, which the future TypeScript walker pipeline
+  needs; the v0.4 line held at `oxc 0.96` to keep MSRV at 1.88, but
+  the workspace settled the tension by raising MSRV during the build
+  phase (PR
+  [#155](https://github.com/breezy-bays-labs/crap4rs/pull/155)).
+- **`oxc` workspace pin: 0.96 → 0.129** (current at v0.5.0 ship).
+  Used only by the `crap4ts` shell crate at present.
+- **`crap4rs` package version: 0.4.0 → 0.5.0.** `crap-core` ships at
+  `0.1.0`; `crap4ts` ships at `2.0.0-alpha.1` (not published).
+- **Workspace layout.** Source files relocated:
+  - `crap4rs/src/domain/` → `crap-core/src/domain/`
+  - `crap4rs/src/ports/` → `crap-core/src/ports/`
+  - `crap4rs/src/adapters/{reporters,baseline,config,diff}/` →
+    `crap-core/src/adapters/{...}/`
+  - `crap4rs/src/core/` → `crap-core/src/core/`
+  - `crap4rs/src/cli/` → `crap-core/src/cli/`
+  - `crap4rs/src/adapters/{complexity, coverage}/` stay in
+    `crap4rs` (Rust-toolchain coupled; would fail the AST-purity gate
+    in `crap-core`).
+- **CI: self-CRAP runs twice** — once with `--src crates/crap-core/src`
+  and once with `--src crates/crap4rs/src`, both gating PR merge.
+  Mutation testing and BDD harness are split per crate. The wire-
+  envelope canary stays in `crap-core`'s test surface and is
+  intentionally excluded from `cargo mutants` runs.
+
+### Looking ahead — v1.0 narrowings (file followups now)
+The v0.5.0 shim re-exports preserve v0.4 paths but are explicitly
+provisional. Library consumers planning past v0.5.x should anticipate:
+
+- **Restored `#[non_exhaustive]` on 15+ result / diagnostic structs.**
+  Paused during the extraction (S2 struct-literal init in `cli` /
+  `core` / `adapters` blocked the attribute) and re-enabled at v1.0.
+  Tracked in
+  [#147](https://github.com/breezy-bays-labs/crap4rs/issues/147).
+- **Shim re-exports narrow.** Symbols that originated in `crap4rs` but
+  now live in `crap_core` (the domain types, port traits, reporters,
+  baseline / config / diff adapters, orchestrator, CLI dispatch) are
+  candidates for removal from `crap4rs::*`. Add `crap-core` as a
+  direct dependency now and import from there to avoid the v1.0
+  cliff. Full migration recipe in `MIGRATION.md`.
+- **`crap4rs::domain::types::ParseDiagnostic` alias drops.** Use
+  `crap4rs::parse_diagnostic::LcovParseDiagnostic` (concrete impl) or
+  `crap_core::ports::ParseDiagnostic` (the trait) directly.
+- **Type aliases concretizing `<P>` drop.** Aliases like
+  `crap4rs::ports::ParseOutput`,
+  `crap4rs::core::AnalysisOutput`,
+  `crap4rs::domain::types::AnalysisDiagnostics`, and
+  `crap4rs::adapters::baseline::BaselineSnapshot` hide the `<P:
+  ParseDiagnostic>` parameter; at v1.0 the parameter is visible to
+  consumers (concretize to `LcovParseDiagnostic` yourself or use a
+  generic).
+- **Rust-specific hardcoded strings in `crap_core::cli` parameterize
+  per language adapter** (`.rs` extension check, "LCOV" / "Rust"
+  diagnostic labels, clap `Box::leak` removal). Tracked in
+  [#152](https://github.com/breezy-bays-labs/crap4rs/issues/152).
+- **Tool-name parameterization in reporters** —
+  [#148](https://github.com/breezy-bays-labs/crap4rs/issues/148).
+- **LCOV-parser src divergence cleanup** —
+  [#150](https://github.com/breezy-bays-labs/crap4rs/issues/150).
+
+### Migration
+See `MIGRATION.md` for the per-consumer migration recipe. TL;DR:
+
+- **CLI users** (`cargo install crap4rs`): no action required.
+- **Library users** (`cargo add crap4rs`): no required changes;
+  recommended to add `crap-core = "0.1"` as a direct dependency and
+  migrate `crap4rs::{domain, ports, core, cli, adapters::{baseline,
+  config, diff, reporters}}::*` imports to `crap_core::*` to
+  future-proof for v1.0.
+- **Hardcoded `breezy-bays-labs/crap4rs` URLs** (workflows, READMEs):
+  no action required; GitHub auto-redirect carries them >= 1 year.
+
 ## [0.4.0] - 2026-05-04
 
 The agent-loop + multi-output milestone. Bundles 13 issues across three

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,7 +380,7 @@ dependencies = [
 
 [[package]]
 name = "crap4rs"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -48,7 +48,8 @@ use crap4rs::adapters::baseline::{load, BaselineSnapshot, BaselineError};
 Symbols that originally lived in `crap4rs` but now live in `crap-core`
 will require a direct `crap-core` dependency. The full list of types
 slated for narrowing is in the PR body for v0.5.0
-([crap4rs#138](https://github.com/breezy-bays-labs/crap4rs/pull/<S6>)),
+([crap4rs#156](https://github.com/breezy-bays-labs/crap4rs/pull/156),
+which closes [#138](https://github.com/breezy-bays-labs/crap4rs/issues/138)),
 but the headline categories are:
 
 | Category | v0.4 path | v0.5.0 path (still works) | Recommended v0.5.0+ path |

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,166 @@
+# Migration Guide
+
+Per-release migration notes for `crap4rs` consumers. Read the section
+that matches how you consume the tool.
+
+---
+
+## v0.5.0 (2026-05-10)
+
+v0.5.0 is the workspace-extraction release: `crap-core` becomes a
+language-agnostic foundation library and `crap4rs` narrows to the
+Rust-specific adapter. **There are no required source changes for
+existing v0.4 consumers** — backward-compatibility shim modules in
+`crap4rs::*` preserve every v0.4 import path.
+
+### For `cargo install crap4rs` consumers (CLI users)
+
+**No action required.** The `crap4rs` binary's command-line surface is
+unchanged in v0.5.0. `cargo install crap4rs` and `cargo binstall
+crap4rs` continue to install a working binary; the binstall artifact
+naming is unchanged.
+
+**Repo rename:** the upstream repository renames from
+`breezy-bays-labs/crap4rs` to `breezy-bays-labs/crap-rs` shortly after
+v0.5.0 ships. GitHub publishes an HTTP redirect that keeps existing
+URL references working for at least one year per GitHub's support
+policy. If your install script hardcodes a release-asset URL like
+`https://github.com/breezy-bays-labs/crap4rs/releases/download/...`,
+the redirect handles it — no action required. Updating the URL to
+`/crap-rs/` at your convenience is good hygiene but not blocking.
+
+### For `cargo add crap4rs` consumers (library users)
+
+**No required source changes at v0.5.0.** Every v0.4 path resolves
+through a shim re-export. The following imports all keep compiling:
+
+```rust
+use crap4rs::domain::types::{RiskLevel, ContributorKind, AnalysisResult, ScoredFunction};
+use crap4rs::domain::types::{ParseDiagnostic, AnalysisDiagnostics};
+use crap4rs::ports::{ComplexityPort, CoveragePort, DiffPort, ParseOutput};
+use crap4rs::core::{analyze, AnalyzeOptions, AnalysisOutput};
+use crap4rs::cli::{run, parse_args, Args, FormatArg};
+use crap4rs::adapters::reporters::{format_json, format_markdown, format_html};
+use crap4rs::adapters::baseline::{load, BaselineSnapshot, BaselineError};
+```
+
+**Recommended future-proofing.** At v1.0 the shim modules will narrow.
+Symbols that originally lived in `crap4rs` but now live in `crap-core`
+will require a direct `crap-core` dependency. The full list of types
+slated for narrowing is in the PR body for v0.5.0
+([crap4rs#138](https://github.com/breezy-bays-labs/crap4rs/pull/<S6>)),
+but the headline categories are:
+
+| Category | v0.4 path | v0.5.0 path (still works) | Recommended v0.5.0+ path |
+|---|---|---|---|
+| CRAP formula | `crap4rs::domain::crap::compute_crap` | same, via shim | `crap_core::domain::crap::compute_crap` |
+| Domain types (RiskLevel, ContributorKind, AnalysisResult, etc.) | `crap4rs::domain::types::*` | same, via shim | `crap_core::domain::types::*` |
+| Port traits | `crap4rs::ports::{ComplexityPort, CoveragePort, DiffPort}` | same, via shim | `crap_core::ports::*` |
+| Orchestrator | `crap4rs::core::{analyze, AnalyzeOptions}` | same, via shim | `crap_core::core::*` |
+| CLI dispatch | `crap4rs::cli::*` | same, via shim | `crap_core::cli::*` |
+| Reporters (markdown, HTML, SARIF, CSV, scorecard-row, advice) | `crap4rs::adapters::reporters::*` | same, via shim | `crap_core::adapters::reporters::*` |
+| Baseline / config / diff adapters | `crap4rs::adapters::{baseline, config, diff}::*` | same, via shim | `crap_core::adapters::{baseline, config, diff}::*` |
+
+**Migration recipe.**
+
+```toml
+# Cargo.toml — add crap-core alongside crap4rs.
+[dependencies]
+crap4rs  = "0.5"
+crap-core = "0.1"
+```
+
+```rust
+// Before (v0.4 paths, still work via shim):
+use crap4rs::domain::types::RiskLevel;
+use crap4rs::ports::ComplexityPort;
+
+// After (recommended for future-proofing):
+use crap_core::domain::types::RiskLevel;
+use crap_core::ports::ComplexityPort;
+```
+
+Stay on `crap4rs::adapters::{complexity, coverage}::*` for anything
+LCOV- or syn-specific (those are intentionally Rust-only and stay in
+`crap4rs`).
+
+**One v0.4-name rename to be aware of** (the alias drops at v1.0):
+
+| v0.4 name | v0.5 canonical name | v0.5 alias |
+|---|---|---|
+| `crap4rs::domain::types::ParseDiagnostic` | `crap4rs::parse_diagnostic::LcovParseDiagnostic` | `crap4rs::domain::types::ParseDiagnostic = LcovParseDiagnostic` (re-exported) |
+
+If you reference `ParseDiagnostic` by name in `crap4rs::domain::types`,
+either keep using the alias (it works in v0.5.x) or switch to
+`crap4rs::parse_diagnostic::LcovParseDiagnostic` (or
+`crap_core::ports::ParseDiagnostic` — the trait, distinct from the LCOV
+concrete impl).
+
+**Generic-parameter exposure at v1.0.** Some shim types in v0.5 are
+type aliases that hide the `<P: ParseDiagnostic>` parameter introduced
+in S2 (#134) by concretizing it to `LcovParseDiagnostic`:
+
+- `crap4rs::domain::types::AnalysisDiagnostics` (shim alias)
+  → `crap_core::domain::types::AnalysisDiagnostics<P>`
+- `crap4rs::ports::ParseOutput` (shim alias)
+  → `crap_core::ports::ParseOutput<P>`
+- `crap4rs::core::AnalysisOutput` (shim alias)
+  → `crap_core::core::AnalysisOutput<P>`
+- `crap4rs::adapters::baseline::BaselineSnapshot` (shim alias)
+  → `crap_core::adapters::baseline::BaselineSnapshot<P>`
+- `crap4rs::adapters::reporters::JsonConfig<'a>` (shim alias)
+  → `crap_core::adapters::reporters::json::JsonConfig<'a, P>`
+
+At v1.0 the `<P>` parameter will be visible to downstream consumers
+that import these types from `crap_core` directly. If you're writing
+new code, prefer the generic form against `crap_core::ports::ParseDiagnostic`
+as the bound — you can still concretize to `LcovParseDiagnostic` for
+the Rust adapter.
+
+### For hardcoded `breezy-bays-labs/crap4rs` URL references
+
+Many downstreams reference the repo by its URL — `mokumo` references
+`breezy-bays-labs/crap4rs/.github/actions/scorecard@v0.5.0` as a
+composite GitHub Action, READMEs link to issues, badges point at the
+Actions tab. GitHub's repo-rename auto-redirect carries all of these
+for at least one year:
+
+- `git clone https://github.com/breezy-bays-labs/crap4rs.git` redirects
+  to the new repo.
+- `uses: breezy-bays-labs/crap4rs/.github/actions/scorecard@v0.5.0` in
+  GitHub Actions resolves through the redirect.
+- README links to `https://github.com/breezy-bays-labs/crap4rs/...`
+  redirect to the new URL.
+
+**No immediate action is required**, but it is good hygiene to update
+hardcoded URLs to `breezy-bays-labs/crap-rs` within the next year. An
+example downstream update (mokumo-style):
+
+```diff
+# .github/workflows/quality.yml
+ scorecard:
+-  uses: breezy-bays-labs/crap4rs/.github/actions/scorecard@v0.5.0
++  uses: breezy-bays-labs/crap-rs/.github/actions/scorecard@v0.5.0
+```
+
+```diff
+# README.md
+-[CI](https://github.com/breezy-bays-labs/crap4rs/actions/workflows/ci.yml/badge.svg)
++[CI](https://github.com/breezy-bays-labs/crap-rs/actions/workflows/ci.yml/badge.svg)
+```
+
+The crates.io package name `crap4rs` is unchanged — the package is the
+unit of crates.io identity, the repo is just metadata. `cargo add
+crap4rs` keeps resolving exactly as before; only the GitHub-side URL
+changes.
+
+---
+
+## Cross-references
+
+- `CHANGELOG.md` — full v0.5.0 release notes (Added / Changed / Looking
+  ahead).
+- `release-checklist.md` — operational steps for cutting future releases.
+- crap4ts repo (`breezy-bays-labs/crap4ts`) — the v1.x-maintenance-only
+  TypeScript implementation; the v2.0 successor lives in this workspace
+  as the alpha `crates/crap4ts/` shell.

--- a/crates/crap4rs/Cargo.toml
+++ b/crates/crap4rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crap4rs"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/release-checklist.md
+++ b/release-checklist.md
@@ -34,8 +34,9 @@ symbol, record one of three dispositions:
   v0.5+ symbol; the alias drops at the next major.
 
 The full audit table for the v0.5.0 release lives in the PR body for
-[crap4rs#138](https://github.com/breezy-bays-labs/crap4rs/pull/<S6>) —
-copy that format for future audits. The audit is a CAO C2
+[crap4rs#156](https://github.com/breezy-bays-labs/crap4rs/pull/156)
+(which closes [#138](https://github.com/breezy-bays-labs/crap4rs/issues/138))
+— copy that format for future audits. The audit is a CAO C2
 future-proofing gate; library consumers read the resulting table to
 plan their migration ahead of the next major.
 
@@ -176,8 +177,16 @@ keeps its own `version`. Do not attempt to centralize it under
 
 ## Cross-references
 
-- `~/.claude/projects/-Users-cmbays-github-crap4rs/memory/feedback_release_tag_merge_commit.md`
-  — origin story of the tag-ordering rule (v0.4.0 misfire, 2026-05-04).
+- The tag-ordering rule has a documented origin: the v0.4.0 release on
+  2026-05-04, where the `v0.4.0` tag landed at the last commit before
+  PR [#127](https://github.com/breezy-bays-labs/crap4rs/pull/127)
+  merged (Cargo.toml = 0.3.0 at the tagged commit). The release
+  workflow built 0.3.0 binaries labelled as v0.4.0, uploaded them to
+  the v0.4.0 GitHub release, and `cargo publish` errored with
+  "version already exists." Recovery: delete release + tag, re-tag the
+  merge commit, push tag, workflow re-fires correctly. Encoded in the
+  "Standard release sequence" and "Release-with-rename sequence"
+  blocks above so future cuts don't repeat it.
 - `CHANGELOG.md` — entries follow [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.
 - `MIGRATION.md` — per-release migration notes for `cargo add crap4rs`
   library consumers.

--- a/release-checklist.md
+++ b/release-checklist.md
@@ -1,0 +1,183 @@
+# Release Checklist
+
+Operational steps for cutting a `crap4rs` / `crap-core` release from this
+workspace. The checklist encodes two load-bearing rules that surfaced
+during prior cuts:
+
+1. **Publish order is fixed** — `crap-core` must propagate to crates.io
+   before `crap4rs` can publish (the latter resolves
+   `crap-core = { workspace = true }` against crates.io, not the local
+   workspace).
+2. **The tag points at the commit with FINAL metadata** — `cargo publish`
+   reads `Cargo.toml` from the tagged commit; whatever `repository` URL,
+   `version`, and other manifest fields are present at that commit are
+   what land on crates.io permanently. If the release also renames the
+   repo or updates URLs, the tag goes on the post-rename URL-update
+   commit, NOT the release PR's merge commit (see auto-memory
+   `release_tag_merge_commit`).
+
+`crap4ts` is `"private": true` (npm) and release-publishing for it is
+disabled — it is never published from this checklist. Real walker work
+will revisit publish strategy in a future pipeline.
+
+## Re-export audit gate (before every minor release)
+
+Before bumping a minor version, audit
+`crates/crap4rs/src/lib.rs` and
+`crates/crap4rs/src/adapters/mod.rs` end-to-end. For every re-exported
+symbol, record one of three dispositions:
+
+- **stable** — the symbol stays as-is through the next major.
+- **narrowing** — the symbol will be removed or renamed at the next
+  major (typically because consumers should migrate to `crap_core::*`).
+- **alias-dropping** — a v0.4 / earlier name that aliases a renamed
+  v0.5+ symbol; the alias drops at the next major.
+
+The full audit table for the v0.5.0 release lives in the PR body for
+[crap4rs#138](https://github.com/breezy-bays-labs/crap4rs/pull/<S6>) —
+copy that format for future audits. The audit is a CAO C2
+future-proofing gate; library consumers read the resulting table to
+plan their migration ahead of the next major.
+
+## Standard release sequence (no rename)
+
+For releases that do NOT involve renaming the repo or updating any
+`Cargo.toml` `repository` URL:
+
+```bash
+# 0. Open a release PR with the version bump + CHANGELOG entry.
+# Wait for review + merge to main.
+
+# 1. Sync local main to the merge commit.
+git fetch origin
+git checkout main
+git pull --ff-only
+
+# 2. Verify the merge commit has the bumped version.
+git show HEAD:crates/crap4rs/Cargo.toml | rg '^version'
+# expect: version = "X.Y.Z"
+
+# 3. Tag the merge commit.
+git tag vX.Y.Z origin/main
+git push origin vX.Y.Z
+
+# 4. Publish in fixed order.
+cargo publish -p crap-core
+# wait ~30s for crates.io propagation
+cargo publish -p crap4rs
+# do NOT publish crap4ts (private)
+
+# 5. Verify GitHub release.yml ran on the tag push and binstall
+# artifacts uploaded successfully.
+gh release view vX.Y.Z --repo breezy-bays-labs/<repo>
+```
+
+## Release-with-rename sequence (v0.5.0 case)
+
+When the release also renames the repo or updates any `repository` URL
+in `Cargo.toml`, the tag MUST go on the post-rename URL-update commit,
+not on the release PR's merge commit. Otherwise crates.io permanently
+publishes manifests pointing at the old URL.
+
+```bash
+# 0. Release PR (this PR for v0.5.0) merges to main. Cargo.toml
+# repository URLs still point at the OLD repo at this point.
+
+# 1. Rename via GitHub UI:
+#    Settings -> Repository name -> breezy-bays-labs/<new-name>
+# GitHub publishes an HTTP redirect that carries old URLs for
+# >= 1 year per GitHub support policy.
+
+# 2. Update local working directory.
+mv ~/github/<old-name> ~/github/<new-name>
+cd ~/github/<new-name>
+# Update .cargo/config.toml if target-dir is an absolute path.
+git remote set-url origin git@github.com:breezy-bays-labs/<new-name>.git
+
+# 3. Push a follow-up commit on main that updates every
+# repository URL.
+git checkout main
+git pull --ff-only
+# Edit:
+#   - Cargo.toml (workspace root) -> repository
+#   - crates/<each>/Cargo.toml if repository is overridden (most use
+#     repository.workspace = true; one workspace-root edit suffices)
+#   - README.md badges + links pointing at github.com/breezy-bays-labs/<old-name>
+#   - .github/actions/scorecard/action.yml or other internal Action refs
+#     that reference the repo by name
+# Confirm:
+git grep -n 'breezy-bays-labs/<old-name>'
+# expect: no matches
+git add -p   # review every URL change
+git commit -m "chore(workspace): update repository URLs after rename"
+git push origin main
+
+# 4. Verify the URL-update commit before tagging.
+git show HEAD:Cargo.toml | rg '^repository'
+git show HEAD:crates/crap4rs/Cargo.toml | rg '^version|^repository'
+# expect (for v0.5.0):
+#   repository = "https://github.com/breezy-bays-labs/<new-name>"
+#   version    = "0.5.0"
+
+# 5. Tag THIS commit (the URL-update commit), NOT the release PR merge.
+git tag v0.5.0 origin/main
+git push origin v0.5.0
+
+# 6. Publish in fixed order.
+cargo publish -p crap-core
+# wait ~30s for crates.io propagation
+cargo publish -p crap4rs
+# do NOT publish crap4ts (private; alpha shell; no real walker yet)
+
+# 7. Verify release.yml ran on tag push.
+gh release view v0.5.0 --repo breezy-bays-labs/<new-name>
+```
+
+## Version bump locations
+
+For any release, edit the version in these places (use this list as a
+grep target):
+
+- `crates/crap4rs/Cargo.toml` — `version = "X.Y.Z"`
+- `crates/crap-core/Cargo.toml` — only if `crap-core` itself is being
+  released (semver-tied to `crap4rs` is one option, but currently
+  independent).
+- `crates/crap4ts/Cargo.toml` — only if the TS adapter graduates from
+  alpha; `2.0.0-alpha.N` bumps stay private until publish strategy is
+  revisited.
+
+Cargo workspace inheritance is per-field, not per-crate, so each crate
+keeps its own `version`. Do not attempt to centralize it under
+`[workspace.package]` — the three crates version independently.
+
+## Why the order matters
+
+- **`cargo publish -p crap-core` first**: `crap4rs/Cargo.toml` has
+  `crap-core = { workspace = true }` which resolves through the
+  workspace root. The workspace root pins
+  `crap-core = { path = "crates/crap-core", version = "0.1.0" }`. When
+  `crap4rs` publishes, cargo strips the `path = ` field and ships only
+  `version = "0.1.0"` — crates.io then resolves that against the
+  published registry, NOT the local workspace. If `crap-core` isn't
+  live on crates.io at publish time, `crap4rs`'s publish fails with
+  "no matching package named `crap-core`."
+- **~30s propagation wait**: crates.io's index updates eventually-
+  consistent. Empirically a ~30s wait after `cargo publish -p crap-core`
+  is sufficient; longer is fine. If `cargo publish -p crap4rs` errors
+  with "no matching package," wait another 30s and retry.
+- **Tag-the-final-metadata commit**: `cargo publish` packages
+  `Cargo.toml` from the tagged commit (technically: from `git HEAD`
+  during the publish invocation, but the tag is what gates the publish
+  workflow). If the tagged commit has stale `repository` URLs, those
+  URLs go on crates.io's package page permanently — they are not
+  edit-able post-publish. The repo-rename ceremony above is the
+  canonical example; the same rule applies to any in-flight
+  manifest-field change at release time.
+
+## Cross-references
+
+- `~/.claude/projects/-Users-cmbays-github-crap4rs/memory/feedback_release_tag_merge_commit.md`
+  — origin story of the tag-ordering rule (v0.4.0 misfire, 2026-05-04).
+- `CHANGELOG.md` — entries follow [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.
+- `MIGRATION.md` — per-release migration notes for `cargo add crap4rs`
+  library consumers.


### PR DESCRIPTION
## Summary

Final session of the `crap-rs/20260509-monorepo-migration` pipeline (S6 of 6). Ships the release ceremony for v0.5.0:

- `release-checklist.md` (new, workspace root) — operational steps for cutting future releases. Encodes the publish-order rule (`crap-core` → ~30s wait → `crap4rs`; `crap4ts` NOT published) and the tag-the-final-metadata-commit rule (origin: auto-memory `release_tag_merge_commit`, v0.4.0 misfire 2026-05-04). Includes a release-with-rename variant for the v0.5.0 case.
- `CHANGELOG.md` v0.5.0 entry — extracted `crap-core` 0.1.0 + `crap4ts` 2.0.0-alpha.1 (not published), mixed dispatch (ADR D9), shim re-exports (ADR D10), MSRV 1.88 → 1.93 (PR #155), and an explicit "Looking ahead — v1.0 narrowings" section flagging the known migrations.
- `MIGRATION.md` (new, workspace root) — per-consumer recipes for CLI users, library users, and downstreams with hardcoded `breezy-bays-labs/crap4rs` URL references. Carries the alias-drop / generic-parameter-exposure list so library consumers can plan v1.0.
- `crates/crap4rs/Cargo.toml` — `version = "0.4.0"` → `"0.5.0"`. `crap-core` stays `0.1.0`, `crap4ts` stays `2.0.0-alpha.1` (set in S5).
- `Cargo.lock` — refreshed for the version bump.

**No `.rs` source changes.** No publish, no tag, no repo rename. All operational steps are post-merge and documented below.

## Re-export audit (CAO C2 gate)

Read end-to-end of `crates/crap4rs/src/lib.rs` (102 lines), `crates/crap4rs/src/adapters/mod.rs`, and `crates/crap4rs/src/parse_diagnostic.rs`. Every public re-export in the v0.5 shim surface, with disposition for v1.0:

| Path | v0.5 status | v1.0 disposition |
|------|-------------|------------------|
| `crap4rs::adapters::complexity::*` (syn walker) | Rust-specific source module | stable (Rust-toolchain coupled; would fail AST-purity gate in crap-core) |
| `crap4rs::adapters::coverage::*` (LCOV parser) | Rust-specific source module | stable (Rust adapter only) |
| `crap4rs::adapters::config` | re-export of `crap_core::adapters::config` | narrows (consumers move to `crap_core::adapters::config`) |
| `crap4rs::adapters::diff` | re-export of `crap_core::adapters::diff` | narrows (consumers move to `crap_core::adapters::diff`) |
| `crap4rs::adapters::baseline::BaselineError` | re-export | narrows |
| `crap4rs::adapters::baseline::CURRENT_SCHEMA_VERSION` | re-export | narrows |
| `crap4rs::adapters::baseline::SUPPORTED_SCHEMA_VERSIONS` | re-export | narrows |
| `crap4rs::adapters::baseline::BaselineSnapshot` | shim alias (concretized over `LcovParseDiagnostic`) | alias-drops (generic `<P>` re-emerges in `crap_core`) |
| `crap4rs::adapters::baseline::load` | shim wrapper (concretized) | alias-drops (function moves to `crap_core::adapters::baseline::load::<P>`) |
| `crap4rs::adapters::reporters::format_csv` | re-export | narrows |
| `crap4rs::adapters::reporters::format_html` | re-export | narrows |
| `crap4rs::adapters::reporters::format_markdown` | re-export | narrows |
| `crap4rs::adapters::reporters::format_sarif` | re-export | narrows |
| `crap4rs::adapters::reporters::format_scorecard_row` | re-export | narrows |
| `crap4rs::adapters::reporters::format_table` | re-export | narrows |
| `crap4rs::adapters::reporters::format_table_with_explain` | re-export | narrows |
| `crap4rs::adapters::reporters::render_advice_summary` | re-export | narrows |
| `crap4rs::adapters::reporters::format_json` | shim wrapper (concretized) | alias-drops (function moves to `crap_core::adapters::reporters::json::format_json::<P>`) |
| `crap4rs::adapters::reporters::JsonConfig<'a>` | shim alias (concretized) | alias-drops |
| `crap4rs::adapters::reporters::json::format_json` | re-export | narrows |
| `crap4rs::adapters::reporters::json::JsonConfig<'a>` | shim alias (concretized) | alias-drops |
| `crap4rs::adapters::reporters::json::DeltaContext<'a>` | shim alias (concretized) | alias-drops |
| `crap4rs::parse_diagnostic::LcovParseDiagnostic` | new canonical name (LCOV-specific concrete impl) | stable (Rust adapter only) |
| `crap4rs::domain::crap` | re-export of `crap_core::domain::crap` (incl. `compute_crap`) | narrows |
| `crap4rs::domain::delta` | re-export of `crap_core::domain::delta` | narrows |
| `crap4rs::domain::diagnostic` | re-export of `crap_core::domain::diagnostic` | narrows |
| `crap4rs::domain::matching` | re-export of `crap_core::domain::matching` | narrows |
| `crap4rs::domain::summary` | re-export of `crap_core::domain::summary` | narrows |
| `crap4rs::domain::threshold` | re-export of `crap_core::domain::threshold` | narrows |
| `crap4rs::domain::view` | re-export of `crap_core::domain::view` | narrows |
| `crap4rs::domain::types::AnalysisResult` | re-export | narrows |
| `crap4rs::domain::types::AnalysisSummary` | re-export | narrows |
| `crap4rs::domain::types::BranchCoverage` | re-export | narrows |
| `crap4rs::domain::types::ComplexityContributor` | re-export | narrows |
| `crap4rs::domain::types::ComplexityMetric` | re-export | narrows |
| `crap4rs::domain::types::ContributorKind` | re-export | narrows |
| `crap4rs::domain::types::CoverageMetric` | re-export | narrows |
| `crap4rs::domain::types::CoverageRatio` | re-export | narrows |
| `crap4rs::domain::types::CrapError` | re-export | narrows |
| `crap4rs::domain::types::CrapScore` | re-export | narrows |
| `crap4rs::domain::types::Diagnostic` | re-export | narrows |
| `crap4rs::domain::types::FileChangeKind` | re-export | narrows |
| `crap4rs::domain::types::FunctionComplexity` | re-export | narrows |
| `crap4rs::domain::types::FunctionCoverage` | re-export | narrows |
| `crap4rs::domain::types::FunctionIdentity` | re-export | narrows |
| `crap4rs::domain::types::FunctionVerdict` | re-export | narrows |
| `crap4rs::domain::types::LineCoverage` | re-export | narrows |
| `crap4rs::domain::types::RiskDistribution` | re-export | narrows |
| `crap4rs::domain::types::RiskLevel` | re-export | narrows |
| `crap4rs::domain::types::ScoredFunction` | re-export | narrows |
| `crap4rs::domain::types::SourceSpan` | re-export | narrows |
| `crap4rs::domain::types::ParseDiagnostic` | shim alias of `LcovParseDiagnostic` | **alias-drops** (use `crap4rs::parse_diagnostic::LcovParseDiagnostic` or `crap_core::ports::ParseDiagnostic` trait) |
| `crap4rs::domain::types::AnalysisDiagnostics` | shim alias (concretized) | alias-drops (generic `<P>` re-emerges) |
| `crap4rs::ports::ComplexityPort` | re-export | narrows |
| `crap4rs::ports::CoveragePort` | re-export | narrows |
| `crap4rs::ports::DiffPort` | re-export | narrows |
| `crap4rs::ports::ParseDiagnostic` (trait) | re-export | narrows |
| `crap4rs::ports::ParseOutput` | shim alias (concretized) | alias-drops |
| `crap4rs::core::analyze` | re-export | narrows |
| `crap4rs::core::AnalyzeOptions` | re-export | narrows |
| `crap4rs::core::AnalysisOutput` | shim alias (concretized) | alias-drops |
| `crap4rs::cli::Cli` | re-export | narrows |
| `crap4rs::cli::Args` (alias of `Cli`) | re-export alias | narrows (v0.4 name alias) |
| `crap4rs::cli::ColorArg` | re-export | narrows |
| `crap4rs::cli::Command` | re-export | narrows |
| `crap4rs::cli::DeltaKindArg` | re-export | narrows |
| `crap4rs::cli::DeltaSortKeyArg` | re-export | narrows |
| `crap4rs::cli::DisplayArgs` | re-export | narrows |
| `crap4rs::cli::FilterArgs` | re-export | narrows |
| `crap4rs::cli::FormatArg` | re-export | narrows |
| `crap4rs::cli::FormatSpec` | re-export | narrows |
| `crap4rs::cli::GroupByArg` | re-export | narrows |
| `crap4rs::cli::InputArgs` | re-export | narrows |
| `crap4rs::cli::MetricArg` | re-export | narrows |
| `crap4rs::cli::OutputArgs` | re-export | narrows |
| `crap4rs::cli::ShellArg` | re-export | narrows |
| `crap4rs::cli::SortKeyArg` | re-export | narrows |
| `crap4rs::cli::parse_args` | re-export | narrows |
| `crap4rs::cli::run` | re-export | narrows |

Dispositions:
- **stable** = symbol stays in `crap4rs` through v1.0 (Rust-toolchain coupled).
- **narrows** = symbol planned for removal from `crap4rs::*`; consumers should import from `crap_core::*` directly (recommended now to avoid v1.0 cliff).
- **alias-drops** = the v0.4 name disappears at v1.0; consumers move to the canonical v0.5 path. Generic `<P>` parameter re-emerges where concretized aliases hid it.

Stable surface in `crap4rs` after v1.0 narrows: `crap4rs::adapters::{complexity, coverage}::*` (Rust-only adapters) and `crap4rs::parse_diagnostic::LcovParseDiagnostic`.

## Acceptance gates

- [x] `cargo build --workspace --release` passes (37.85s, 123 crates)
- [x] `cargo nextest run --workspace --all-targets` passes — **914 / 914 tests pass**
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps` passes
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo +1.93 check --workspace --all-targets` passes (MSRV floor)
- [x] `cargo deny check` — advisories ok, bans ok, licenses ok, sources ok
- [x] `crap-core::wire_envelope_snapshot::envelope` byte-identical to S5 baseline (zero `.rs` drift)
- [x] `crates/crap4rs/Cargo.toml` shows `version = "0.5.0"`
- [x] release-checklist.md, CHANGELOG.md (v0.5.0 entry), MIGRATION.md all present at workspace root
- [x] Re-export audit table assembled (above)

## Post-merge ceremony (ORDER CRITICAL)

```
1. GitHub UI rename: breezy-bays-labs/crap4rs → breezy-bays-labs/crap-rs.
   Settings → Repository name → save. GitHub publishes an HTTP redirect
   that carries old URLs for >= 1 year per GitHub support policy.

2. Local working directory:
     mv ~/github/crap4rs ~/github/crap-rs
     cd ~/github/crap-rs
     # .cargo/config.toml currently uses target-dir = "target" (relative)
     # — confirm; update only if it hardcodes an absolute path.
     git remote set-url origin git@github.com:breezy-bays-labs/crap-rs.git

3. Follow-up commit on main (separate; NOT in this PR):
     - Workspace root Cargo.toml repository → ".../crap-rs"
       (per-crate Cargo.tomls inherit via repository.workspace = true,
        so one workspace-root edit suffices; verify with
        git grep -n 'breezy-bays-labs/crap4rs')
     - README badges + links pointing at the GitHub repo URL
     - .github/actions/scorecard/action.yml or any other internal
       refs that name the repo
     - Verify: git grep -n 'breezy-bays-labs/crap4rs' returns no matches

4. **Tag v0.5.0 on the follow-up commit from step 3 — NOT on this PR's
   merge commit.** This PR's merge commit still has crap4rs URLs;
   tagging it would publish those URLs to crates.io permanently.
   Verify before pushing:
     git show <sha>:crates/crap4rs/Cargo.toml | rg '^version|^repository'
     # expect:
     #   version    = "0.5.0"
     #   repository = (inherited from workspace, points at .../crap-rs)
     git show <sha>:Cargo.toml | rg '^repository'
     # expect:
     #   repository = "https://github.com/breezy-bays-labs/crap-rs"
   Then:
     git tag v0.5.0 origin/main
     git push origin v0.5.0

5. Publish in fixed order:
     cargo publish -p crap-core
     # wait ~30s for crates.io propagation; longer is fine
     cargo publish -p crap4rs
     # do NOT publish crap4ts (alpha; npm package.json private:true;
     #   release-publishing disabled)

6. Verify GitHub release v0.5.0:
     gh release view v0.5.0 --repo breezy-bays-labs/crap-rs
     # release.yml auto-fires on tag push; binstall artifacts upload.
```

The rule and rationale live in `release-checklist.md` and the auto-memory `release_tag_merge_commit`. See also S5 lesson logged in `.workflow/phases/build/state.json`.

## Test Plan

- [x] All acceptance gates above pass locally on the worktree
- [ ] CI green on all required checks (PR-time)
- [ ] CodeRabbit / Gemini review pass — fold doc-tightening findings inline; defer substantive re-export-decision findings to a v1.0 follow-up issue
- [ ] Operational follow-up (post-merge): execute the 6-step ceremony above

Closes #138.