### PR TITLE
chore: post-rename URL update (crap4rs → crap-rs)

### DIFF
--- a/.github/actions/scorecard/README.md
+++ b/.github/actions/scorecard/README.md
@@ -22,7 +22,7 @@ for a future release of this action — see ops
 [#231](https://github.com/breezy-bays-labs/ops/issues/231).
 
 ```yaml
-- uses: breezy-bays-labs/crap4rs/.github/actions/scorecard@main
+- uses: breezy-bays-labs/crap-rs/.github/actions/scorecard@main
   with:
     language: auto                 # rust | typescript | auto (infers from extension)
     coverage: lcov.info
@@ -33,7 +33,7 @@ for a future release of this action — see ops
 ```yaml
 - uses: actions/checkout@v4
 - run: cargo llvm-cov --workspace --lcov --output-path lcov.info
-- uses: breezy-bays-labs/crap4rs/.github/actions/scorecard@main
+- uses: breezy-bays-labs/crap-rs/.github/actions/scorecard@main
   id: crap
   with:
     coverage: lcov.info
@@ -74,7 +74,7 @@ jobs:
         run: cargo llvm-cov --workspace --lcov --output-path /tmp/head.lcov
 
       # 3. Render the scorecard, post sticky comment.
-      - uses: breezy-bays-labs/crap4rs/.github/actions/scorecard@main
+      - uses: breezy-bays-labs/crap-rs/.github/actions/scorecard@main
         with:
           coverage: /tmp/head.lcov
           baseline: /tmp/baseline.json
@@ -108,7 +108,7 @@ one sticky comment. This action contributes the CRAP rows; the aggregator
 owns the comment.
 
 ```yaml
-- uses: breezy-bays-labs/crap4rs/.github/actions/scorecard@main
+- uses: breezy-bays-labs/crap-rs/.github/actions/scorecard@main
   id: crap
   with:
     coverage: /tmp/head.lcov
@@ -184,7 +184,7 @@ PR [#119](https://github.com/breezy-bays-labs/crap4rs/pull/119)):
 ### Aggregator pattern — consume `row-json` and re-render
 
 ```yaml
-- uses: breezy-bays-labs/crap4rs/.github/actions/scorecard@main
+- uses: breezy-bays-labs/crap-rs/.github/actions/scorecard@main
   id: crap
   with:
     coverage: /tmp/head.lcov
@@ -228,7 +228,7 @@ workflows** so a regression in the action can't break your CI without you
 noticing:
 
 ```yaml
-uses: breezy-bays-labs/crap4rs/.github/actions/scorecard@<sha>
+uses: breezy-bays-labs/crap-rs/.github/actions/scorecard@<sha>
 ```
 
 When the action is folded into the future
@@ -258,7 +258,7 @@ to be on `PATH`. Pinned-version semantics override pre-installed semantics.
 # Example: dogfood a workspace-local build
 - run: cargo build --release
 - run: install -m 0755 ./target/release/crap4rs "$HOME/.cargo/bin/crap4rs"
-- uses: breezy-bays-labs/crap4rs/.github/actions/scorecard@main
+- uses: breezy-bays-labs/crap-rs/.github/actions/scorecard@main
   with:
     coverage: lcov.info
     # version defaults to 'latest' → install step short-circuits

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 edition = "2024"
 rust-version = "1.93"
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/breezy-bays-labs/crap4rs"
+repository = "https://github.com/breezy-bays-labs/crap-rs"
 authors = ["Christopher Bays <cmbays@breezybayslabs.com>"]
 
 # ── Workspace dependency catalog ──────────────────────────────────────

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # crap4rs
 
-[![CI](https://github.com/breezy-bays-labs/crap4rs/actions/workflows/ci.yml/badge.svg)](https://github.com/breezy-bays-labs/crap4rs/actions/workflows/ci.yml)
+[![CI](https://github.com/breezy-bays-labs/crap-rs/actions/workflows/ci.yml/badge.svg)](https://github.com/breezy-bays-labs/crap-rs/actions/workflows/ci.yml)
 [![crates.io](https://img.shields.io/crates/v/crap4rs.svg)](https://crates.io/crates/crap4rs)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](#license)
 
@@ -396,8 +396,8 @@ When more than half of analyzed files show 0% coverage, `crap4rs` will print a w
 cargo install crap4rs
 
 # Or clone and build
-git clone https://github.com/breezy-bays-labs/crap4rs.git
-cd crap4rs
+git clone https://github.com/breezy-bays-labs/crap-rs.git
+cd crap-rs
 cargo build --release
 ```
 

--- a/packages/crap4ts/README.md
+++ b/packages/crap4ts/README.md
@@ -26,7 +26,7 @@ The `v1.x-maintenance-announcement` release on [`breezy-bays-labs/crap4ts`](http
 
 ## Why a v2
 
-The v2 analyzer shares its CRAP formula, scorecard envelope, and reporter shapes with [`crap4rs`](https://github.com/breezy-bays-labs/crap4rs) by linking the same `crap-core` Rust library. That gives TypeScript projects identical analysis semantics to Rust projects (per-function complexity, line-range matching against coverage data, deltas vs a baseline, JSON / Markdown / SARIF / HTML / scorecard-row reporters) — at native speed, with no separate engine to maintain.
+The v2 analyzer shares its CRAP formula, scorecard envelope, and reporter shapes with [`crap4rs`](https://github.com/breezy-bays-labs/crap-rs) by linking the same `crap-core` Rust library. That gives TypeScript projects identical analysis semantics to Rust projects (per-function complexity, line-range matching against coverage data, deltas vs a baseline, JSON / Markdown / SARIF / HTML / scorecard-row reporters) — at native speed, with no separate engine to maintain.
 
 ## Tracking
 

--- a/skills/cut-the-crap/README.md
+++ b/skills/cut-the-crap/README.md
@@ -5,8 +5,8 @@ Reference Claude Code skill for crap4rs. Drives over-threshold functions below t
 ## Install
 
 ```bash
-git clone https://github.com/breezy-bays-labs/crap4rs
-cp -r crap4rs/skills/cut-the-crap ~/.claude/skills/
+git clone https://github.com/breezy-bays-labs/crap-rs
+cp -r crap-rs/skills/cut-the-crap ~/.claude/skills/
 ```
 
 Or, if you already have the repo checked out, run `cp -r skills/cut-the-crap ~/.claude/skills/` from the repo root.


### PR DESCRIPTION
## Summary

Updates live, forward-looking URL references following the `breezy-bays-labs/crap4rs → breezy-bays-labs/crap-rs` rename. The rename happened immediately after PR #156 (S6 — release ceremony) merged; this PR's commit is what gets tagged as `v0.5.0`.

5 files, +14/−14 lines. Doc-only — no `.rs` source, no `Cargo.toml` dependency changes.

## What this changes

| File | Change |
|------|--------|
| `Cargo.toml` (workspace root) | `[workspace.package]` `repository` URL |
| `README.md` | CI badge + git-clone install URL |
| `.github/actions/scorecard/README.md` | 8 `uses:` template examples (`@main` ×7, `@<sha>` ×1) |
| `packages/crap4ts/README.md` | repo link on line 29 |
| `skills/cut-the-crap/README.md` | git-clone install commands |

## What's intentionally NOT changed

Historical references stay as `crap4rs` URLs (GitHub auto-redirect carries them ≥1 year per GH policy):

- `CHANGELOG.md`, `MIGRATION.md`, `release-checklist.md` — these document the v0.5.0 cut at time of writing
- `docs/scorecard-row-contract.md` — historical PR/issue backlinks (#119, #120, #111)
- `.github/actions/scorecard/action.yml` lines 196,201 — code comments with historical issue links
- `.github/actions/scorecard/README.md` lines 176-177 — historical PR references
- `packages/crap4ts/README.md` line 33 — `[crap4rs#137]` historical issue link

## Tag-the-correct-commit rule

`v0.5.0` will be tagged on **this PR's merge commit**, NOT on PR #156's `0ef10c8` merge. Reason:

- `cargo publish` reads `Cargo.toml`'s `repository` field from the tagged commit
- `0ef10c8` still has `repository = ".../crap4rs"` (stale)
- This PR's merge commit will have `repository = ".../crap-rs"` (correct)
- Tagging `0ef10c8` would publish the stale URL to crates.io permanently

Captured in `release-checklist.md` § "Tag-the-correct-commit rule" (the `renaming release` path).

## Verification before pushing the tag

```
git show <merge-sha>:crates/crap4rs/Cargo.toml | rg '^version|^repository'
# expect:
#   version = "0.5.0"
#   (repository inherits from workspace; workspace Cargo.toml has crap-rs URL)
git show <merge-sha>:Cargo.toml | rg '^repository'
# expect: repository = "https://github.com/breezy-bays-labs/crap-rs"
```

## Test plan

- [x] All 5 affected files updated; remaining `crap4rs` refs verified as intentional historical references
- [ ] CI green (build, test, MSRV 1.93, deny, AST-purity, docs, crap4ts-build matrix)
- [ ] Wire-envelope canary byte-identical (no `.rs` changes)
- [ ] After merge: tag `v0.5.0` on merge commit; verify version + repository fields before pushing tag
- [ ] After tag push: `cargo publish -p crap-core` → wait ~30s → `cargo publish -p crap4rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)