### PR TITLE
fix(crap-core): #150 — late-bind coverage adapter via factory closure

### DIFF
--- a/crates/crap-core/src/cli/mod.rs
+++ b/crates/crap-core/src/cli/mod.rs
@@ -622,14 +622,20 @@ pub struct Cli {
 
 // ── Entry point ─────────────────────────────────────────────────────
 
-/// Parse process args and produce a `Cli`. Splits in half from `run`
-/// so the binary `main.rs` can consult `cli.input.src` (config-aware)
-/// before constructing its `LcovParser` (which needs the source root
-/// at construction time per the LCOV adapter's path-stripping
-/// invariant). `run` then consumes the parsed `Cli` directly.
+/// Parse process args into `Cli`, splicing the adapter's runtime
+/// metadata into clap's help / `--version` output.
 ///
-/// `tool_version` (e.g. `crap4rs`'s `0.4.0`) and `long_version`
-/// (e.g. `0.4.0 (abc1234 2026-05-09)`) are spliced into clap's help
+/// Split out from `run` purely to keep the parse step monomorphic and
+/// off the binary's hot path on `--help` / `--version` (clap intercepts
+/// those before `parse_args` returns). The adapter binary supplies its
+/// coverage adapter to `run` as a factory closure that's invoked once
+/// after CLI/config-file merging resolves the effective source root —
+/// pre-construction was the #150 footgun, since
+/// `cli.input.src` is the raw CLI value (`None` if the caller put
+/// `src = "…"` only in `crap4rs.toml`).
+///
+/// `tool_version` (e.g. `crap4rs`'s `0.5.0`) and `long_version`
+/// (e.g. `0.5.0 (abc1234 2026-05-09)`) are spliced into clap's help
 /// and `--version` output at runtime so the binary's build-script
 /// metadata reaches the help text — the derive macro's `version`
 /// reads `CARGO_PKG_VERSION` at lib-crate compile time (crap-core's
@@ -685,22 +691,43 @@ fn build_command(tool_version: &str, long_version: &str) -> clap::Command {
         .long_version(long_version_static)
 }
 
-/// Run the CRAP CLI pipeline end-to-end. Generic over `P:
-/// ParseDiagnostic` so the same orchestrator drives every adapter
-/// crate's binary (per ADR D9, mixed-dispatch).
+/// Run the CRAP CLI pipeline end-to-end.
+///
+/// Takes a `coverage_factory` closure rather than a constructed
+/// coverage adapter so the parser receives the effective source root
+/// *after* CLI / config-file / preset merging — pre-construction
+/// canonicalized against the bare CLI value (or the default `src`) and
+/// the LCOV parser silently stripped the wrong prefix from `SF:`
+/// records (#150). The factory is invoked once inside `run` after
+/// `merge_effective_inputs` resolves the final `src`, receives the
+/// **canonicalized** effective source root (so adapter factories stay
+/// dumb — orchestration owns the canonicalize concern), and is
+/// short-circuited entirely on the `completions` subcommand (clap's
+/// `--help` / `--version` exit even earlier, inside `parse_args`).
+///
+/// Generic over `P: ParseDiagnostic` so the same orchestrator drives
+/// every adapter crate's binary (per ADR D9, mixed-dispatch). The
+/// `'static` bound on `P` is the standard trait-object well-formedness
+/// requirement when the closure returns `Box<dyn …>`; concrete adapter
+/// diagnostic types (`LcovParseDiagnostic`, `IstanbulParseDiagnostic`)
+/// satisfy it trivially.
 ///
 /// `tool_version` is the binary's own version (e.g. `crap4rs`'s
-/// `CARGO_PKG_VERSION` resolves to `0.4.0`, not crap-core's `0.1.0`).
+/// `CARGO_PKG_VERSION` resolves to `0.5.0`, not crap-core's `0.1.0`).
 /// It feeds the JSON envelope's `tool_version` field, the SARIF run
 /// metadata, the markdown header, the HTML report header, and clap's
 /// long-version splice when the caller threads it through.
-pub fn run<P: ParseDiagnostic + std::fmt::Display>(
+pub fn run<P, F>(
     cli: Cli,
     complexity: &dyn ComplexityPort,
-    coverage: &dyn CoveragePort<Diagnostic = P>,
+    coverage_factory: F,
     tool_version: &str,
-) -> ExitCode {
-    match run_inner(cli, complexity, coverage, tool_version) {
+) -> ExitCode
+where
+    P: ParseDiagnostic + std::fmt::Display + 'static,
+    F: FnOnce(&Path) -> Box<dyn CoveragePort<Diagnostic = P>>,
+{
+    match run_inner(cli, complexity, coverage_factory, tool_version) {
         Ok(true) => ExitCode::from(0),
         Ok(false) => ExitCode::from(1),
         Err(e) => {
@@ -710,18 +737,22 @@ pub fn run<P: ParseDiagnostic + std::fmt::Display>(
     }
 }
 
-fn run_inner<P: ParseDiagnostic + std::fmt::Display>(
+fn run_inner<P, F>(
     mut cli: Cli,
     complexity: &dyn ComplexityPort,
-    coverage: &dyn CoveragePort<Diagnostic = P>,
+    coverage_factory: F,
     tool_version: &str,
-) -> Result<bool> {
+) -> Result<bool>
+where
+    P: ParseDiagnostic + std::fmt::Display + 'static,
+    F: FnOnce(&Path) -> Box<dyn CoveragePort<Diagnostic = P>>,
+{
     if let Some(Command::Completions { shell }) = cli.command {
         emit_completions(shell, &current_bin_name());
         return Ok(true);
     }
 
-    let prep = prepare_pipeline(&mut cli, complexity, coverage)?;
+    let prep = prepare_pipeline(&mut cli, complexity, coverage_factory)?;
 
     // Build the spec, then shape the result through the View pipeline.
     // V1b: `--only-failing` flows through `Filters::only_failing` here.
@@ -870,11 +901,20 @@ fn apply_diagnostics<P: ParseDiagnostic + std::fmt::Display>(
 /// Validates inputs, merges effective config, runs the analyzer, and
 /// resolves the optional baseline delta. The bulk of `run_inner`'s
 /// pre-render work lives here so `run_inner` itself stays a flat dispatch.
-fn prepare_pipeline<P: ParseDiagnostic + std::fmt::Display>(
+///
+/// Constructs the coverage adapter via `coverage_factory` *after*
+/// `merge_effective_inputs` resolves the final source root, so the
+/// LCOV parser strips the correct prefix from `SF:` records even when
+/// `src` comes from `crap4rs.toml` rather than the CLI (#150).
+fn prepare_pipeline<P, F>(
     cli: &mut Cli,
     complexity: &dyn ComplexityPort,
-    coverage: &dyn CoveragePort<Diagnostic = P>,
-) -> Result<PipelinePrep<P>> {
+    coverage_factory: F,
+) -> Result<PipelinePrep<P>>
+where
+    P: ParseDiagnostic + std::fmt::Display + 'static,
+    F: FnOnce(&Path) -> Box<dyn CoveragePort<Diagnostic = P>>,
+{
     validate_display_flags(cli)?;
     apply_color(cli.display.color);
 
@@ -890,9 +930,22 @@ fn prepare_pipeline<P: ParseDiagnostic + std::fmt::Display>(
 
     let inputs = merge_effective_inputs(cli, &file_config);
     let coverage_path = validate_runtime_inputs(cli, &inputs)?;
+
+    // Canonicalize the effective `src` (post-config-merge) and hand
+    // it to the adapter's factory closure. Falls back to the raw path
+    // when the directory does not exist on disk — `validate_runtime_inputs`
+    // already gated on existence, but the closure is invoked unconditionally
+    // because some adapters (Istanbul) do not strip a prefix and consume the
+    // raw path. Mirrors `core::canonicalize_src`.
+    let src_canonical = inputs
+        .src
+        .canonicalize()
+        .unwrap_or_else(|_| inputs.src.clone());
+    let coverage = coverage_factory(&src_canonical);
+
     let options = build_analyze_options(cli, &inputs, coverage_path);
 
-    let analysis = crate::core::analyze(&options, complexity, coverage)?;
+    let analysis = crate::core::analyze(&options, complexity, &*coverage)?;
     apply_diagnostics(cli, &analysis.diagnostics);
 
     // Resolve --baseline (issue #81): load a previously-emitted JSON

--- a/crates/crap-core/src/cli/mod.rs
+++ b/crates/crap-core/src/cli/mod.rs
@@ -932,15 +932,12 @@ where
     let coverage_path = validate_runtime_inputs(cli, &inputs)?;
 
     // Canonicalize the effective `src` (post-config-merge) and hand
-    // it to the adapter's factory closure. Falls back to the raw path
-    // when the directory does not exist on disk — `validate_runtime_inputs`
-    // already gated on existence, but the closure is invoked unconditionally
-    // because some adapters (Istanbul) do not strip a prefix and consume the
-    // raw path. Mirrors `core::canonicalize_src`.
-    let src_canonical = inputs
-        .src
-        .canonicalize()
-        .unwrap_or_else(|_| inputs.src.clone());
+    // it to the adapter's factory closure. `validate_runtime_inputs`
+    // already gated on existence; `canonicalize_src`'s fallback path
+    // is purely defensive against TOCTOU between the two `metadata`
+    // calls and emits a warning on the error arm so the regression is
+    // observable instead of silent.
+    let src_canonical = crate::core::canonicalize_src(&inputs.src);
     let coverage = coverage_factory(&src_canonical);
 
     let options = build_analyze_options(cli, &inputs, coverage_path);

--- a/crates/crap-core/src/core/mod.rs
+++ b/crates/crap-core/src/core/mod.rs
@@ -341,8 +341,27 @@ impl<'a, P: ParseDiagnostic> AnalysisContext<'a, P> {
     }
 }
 
-fn canonicalize_src(src: &Path) -> PathBuf {
-    src.canonicalize().unwrap_or_else(|_| src.to_path_buf())
+/// Canonicalize the effective source root.
+///
+/// Falls back to the raw path on failure (e.g., the directory was
+/// validated to exist by `validate_runtime_inputs` but vanished in a
+/// TOCTOU window before this call). The fallback is observable via
+/// stderr — silent regression would re-introduce a `#150`-flavored
+/// path-strip mismatch for adapters that depend on the canonical
+/// root.
+///
+/// `pub(crate)` so `cli::prepare_pipeline` can late-bind coverage
+/// adapter construction against the same path that
+/// `AnalysisContext::new` uses internally — single source of truth
+/// for canonicalization semantics.
+pub(crate) fn canonicalize_src(src: &Path) -> PathBuf {
+    src.canonicalize().unwrap_or_else(|e| {
+        eprintln!(
+            "warning: failed to canonicalize {}: {e}; coverage path-strip may misalign",
+            src.display()
+        );
+        src.to_path_buf()
+    })
 }
 
 fn ensure_source_files_found(source_files: &[PathBuf], src: &Path) -> Result<()> {

--- a/crates/crap-core/tests/snapshots/wire_envelope_snapshot__envelope.snap
+++ b/crates/crap-core/tests/snapshots/wire_envelope_snapshot__envelope.snap
@@ -5232,9 +5232,9 @@ expression: pretty
             "qualified_name": "main",
             "span": {
               "end_column": 1,
-              "end_line": 20,
+              "end_line": 23,
               "start_column": 1,
-              "start_line": 10
+              "start_line": 14
             }
           }
         },
@@ -10645,9 +10645,9 @@ expression: pretty
             "qualified_name": "main",
             "span": {
               "end_column": 1,
-              "end_line": 20,
+              "end_line": 23,
               "start_column": 1,
-              "start_line": 10
+              "start_line": 14
             }
           }
         },

--- a/crates/crap4rs/src/main.rs
+++ b/crates/crap4rs/src/main.rs
@@ -1,7 +1,11 @@
 //! Thin Rust adapter binary — wires `crap_core::cli::run<P>` with the
 //! LCOV/`syn` ports and the version metadata baked in by `build.rs`.
+//!
+//! The coverage adapter is supplied as a factory closure so
+//! `crap_core::cli::run` can construct the LCOV parser *after*
+//! CLI/config-file merging resolves the effective source root —
+//! pre-construction was the silent path-strip mismatch fixed in #150.
 
-use std::path::PathBuf;
 use std::process::ExitCode;
 
 use crap4rs::adapters::complexity::SynComplexityAdapter;
@@ -9,12 +13,11 @@ use crap4rs::adapters::coverage::LcovParser;
 
 fn main() -> ExitCode {
     let cli = crap_core::cli::parse_args(env!("CARGO_PKG_VERSION"), env!("CRAP4RS_LONG_VERSION"));
-    let src = cli
-        .input
-        .src
-        .clone()
-        .unwrap_or_else(|| PathBuf::from("src"));
-    let coverage = LcovParser::new(src.canonicalize().unwrap_or(src));
     let complexity = SynComplexityAdapter::new();
-    crap_core::cli::run(cli, &complexity, &coverage, env!("CARGO_PKG_VERSION"))
+    crap_core::cli::run(
+        cli,
+        &complexity,
+        |src| Box::new(LcovParser::new(src.to_path_buf())),
+        env!("CARGO_PKG_VERSION"),
+    )
 }

--- a/crates/crap4rs/tests/config_src_path_strip.rs
+++ b/crates/crap4rs/tests/config_src_path_strip.rs
@@ -46,10 +46,11 @@ fn setup_dir(dir: &Path) -> std::path::PathBuf {
     let src_canonical = src.canonicalize().expect("canonicalize custom src dir");
     let lib_rs_absolute = src_canonical.join("lib.rs");
 
-    let lcov = format!(
-        "SF:{}\nDA:1,1\nDA:2,1\nDA:3,1\nend_of_record\n",
-        lib_rs_absolute.display()
-    );
+    // `cargo-llvm-cov` emits forward-slash `SF:` paths even on
+    // Windows; normalize here so the fixture stays portable if
+    // Windows joins the CI matrix later.
+    let lib_rs_sf = lib_rs_absolute.to_string_lossy().replace('\\', "/");
+    let lcov = format!("SF:{lib_rs_sf}\nDA:1,1\nDA:2,1\nDA:3,1\nend_of_record\n");
     std::fs::write(dir.join("lcov.info"), lcov).expect("write lcov.info fixture");
 
     let toml = format!("src = \"{CUSTOM_SRC_DIR}\"\n");

--- a/crates/crap4rs/tests/config_src_path_strip.rs
+++ b/crates/crap4rs/tests/config_src_path_strip.rs
@@ -1,0 +1,140 @@
+//! Integration tests for issue #150 — LcovParser path-strip must honor
+//! the effective source root *after* CLI/config-file merge.
+//!
+//! The bug fixture sets `src` only in `crap4rs.toml` (not on the CLI).
+//! Pre-fix, `crates/crap4rs/src/main.rs` constructed `LcovParser::new`
+//! from `cli.input.src` *before* config merging, so the parser stripped
+//! the default `src/` prefix from absolute `SF:` records emitted by
+//! `cargo llvm-cov`. That left coverage-map keys as absolute paths, the
+//! walker emitted src-relative keys, and `match_functions` found no
+//! overlap → coverage silently dropped to 0.
+//!
+//! Absolute `SF:` paths are mandatory here. Relative-path LCOV fixtures
+//! short-circuit `strip_prefix(...).unwrap_or(p)` and look like they
+//! "work" regardless of which root the parser uses — they don't surface
+//! the strip-prefix-mismatch bug.
+
+use std::path::Path;
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_crap4rs");
+
+const FIXTURE_SRC: &str = "\
+pub fn passing_a() -> i32 { 1 }
+pub fn passing_b() -> i32 { 2 }
+pub fn passing_c() -> i32 { 3 }
+";
+
+/// Custom source-directory name. NOT `src` — using a non-default name
+/// is what forces `cli.input.src` to be `None` and the effective `src`
+/// to come exclusively from `crap4rs.toml`.
+const CUSTOM_SRC_DIR: &str = "myproject_source";
+
+/// Set up the fixture in `dir`:
+///   - Create `<CUSTOM_SRC_DIR>/lib.rs` with `FIXTURE_SRC`.
+///   - Write `crap4rs.toml` with `src = "<CUSTOM_SRC_DIR>"`.
+///   - Write `lcov.info` with **absolute** `SF:` paths pointing into
+///     the canonicalized custom source dir — this is what
+///     `cargo llvm-cov` emits in CI.
+///
+/// Returns the canonicalized custom source dir for assertions.
+fn setup_dir(dir: &Path) -> std::path::PathBuf {
+    let src = dir.join(CUSTOM_SRC_DIR);
+    std::fs::create_dir_all(&src).expect("create custom src dir");
+    std::fs::write(src.join("lib.rs"), FIXTURE_SRC).expect("write lib.rs fixture");
+
+    let src_canonical = src.canonicalize().expect("canonicalize custom src dir");
+    let lib_rs_absolute = src_canonical.join("lib.rs");
+
+    let lcov = format!(
+        "SF:{}\nDA:1,1\nDA:2,1\nDA:3,1\nend_of_record\n",
+        lib_rs_absolute.display()
+    );
+    std::fs::write(dir.join("lcov.info"), lcov).expect("write lcov.info fixture");
+
+    let toml = format!("src = \"{CUSTOM_SRC_DIR}\"\n");
+    std::fs::write(dir.join("crap4rs.toml"), toml).expect("write crap4rs.toml fixture");
+
+    src_canonical
+}
+
+fn run_without_src_flag(dir: &Path) -> std::process::Output {
+    Command::new(BINARY)
+        .current_dir(dir)
+        // Deliberately omit `--src` so the effective source root comes
+        // from `crap4rs.toml` alone (the path that triggered #150).
+        .args([
+            "--coverage",
+            "lcov.info",
+            "--no-gitignore",
+            "--threshold",
+            "5",
+            "--no-fail",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("failed to run crap4rs binary")
+}
+
+#[test]
+fn config_only_src_strips_lcov_path_prefix() {
+    // #150 acceptance criterion 2:
+    //   "Add a config-file integration test where `[src] = ".../foo"`
+    //    only appears in `crap4rs.toml`; assert the LCOV parser strips
+    //    that prefix."
+    //
+    // After the fix, the parser strips the canonical custom-src prefix
+    // from the absolute `SF:` path, leaving `lib.rs` as the coverage
+    // key. That matches the walker's `lib.rs` and the scored result
+    // contains a function with non-zero coverage.
+    let dir = tempfile::tempdir().expect("create tempdir");
+    let _src_canonical = setup_dir(dir.path());
+
+    let output = run_without_src_flag(dir.path());
+
+    assert!(
+        output.status.success(),
+        "binary exited non-zero (stderr=\n{}\n stdout=\n{})",
+        String::from_utf8_lossy(&output.stderr),
+        String::from_utf8_lossy(&output.stdout),
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("stdout was not valid JSON: {e}\nraw stdout:\n{stdout}"));
+
+    let functions = json["result"]["functions"]
+        .as_array()
+        .expect("envelope must carry a result.functions array");
+
+    assert!(
+        !functions.is_empty(),
+        "expected at least one scored function; envelope = {json:#?}"
+    );
+
+    // The walker emits src-relative file_path = `lib.rs`. Pre-fix, the
+    // parser kept the absolute `SF:` path in its coverage map, so the
+    // `lib.rs` complexity entries had no matching coverage row and the
+    // scored `coverage_percent` was 0.0 across the board. After the fix
+    // the parser strips the canonical custom-src prefix and the
+    // coverage rows align with the walker keys.
+    //
+    // The fixture's LCOV marks lines 1–3 as fully hit (`DA:N,1`) and
+    // the three functions each occupy a single line, so every function
+    // must score exactly 100.0. Asserting on `> 0.0` alone would
+    // tolerate a partial-strip regression (some keys matched, others
+    // mis-keyed), which the per-function check catches.
+    let coverage_percents: Vec<f64> = functions
+        .iter()
+        .map(|f| f["scored"]["coverage_percent"].as_f64().unwrap_or(-1.0))
+        .collect();
+
+    assert_eq!(
+        coverage_percents,
+        vec![100.0, 100.0, 100.0],
+        "every function should score 100.0% with the fixture's full \
+         line hits; LCOV path-strip likely did not honor the \
+         config-file `src` (see #150). functions = {functions:#?}"
+    );
+}

--- a/crates/crap4ts/src/main.rs
+++ b/crates/crap4ts/src/main.rs
@@ -5,8 +5,12 @@
 //! sees one shape. ALPHA: invoking the real analysis path runtime-
 //! panics inside the walker / coverage parser stubs. `--help` and
 //! `--version` work because clap dispatch lives in `crap_core::cli`.
+//!
+//! The coverage adapter is supplied as a factory closure so
+//! `crap_core::cli::run` can construct the Istanbul parser *after*
+//! CLI/config-file merging resolves the effective source root —
+//! pre-construction was the silent path-strip mismatch fixed in #150.
 
-use std::path::PathBuf;
 use std::process::ExitCode;
 
 use crap4ts::adapters::coverage::IstanbulCoverage;
@@ -14,12 +18,11 @@ use crap4ts::adapters::walker::OxcWalker;
 
 fn main() -> ExitCode {
     let cli = crap_core::cli::parse_args(env!("CARGO_PKG_VERSION"), env!("CRAP4TS_LONG_VERSION"));
-    let src = cli
-        .input
-        .src
-        .clone()
-        .unwrap_or_else(|| PathBuf::from("src"));
-    let coverage = IstanbulCoverage::new(src.canonicalize().unwrap_or(src));
     let complexity = OxcWalker::new();
-    crap_core::cli::run(cli, &complexity, &coverage, env!("CARGO_PKG_VERSION"))
+    crap_core::cli::run(
+        cli,
+        &complexity,
+        |src| Box::new(IstanbulCoverage::new(src.to_path_buf())),
+        env!("CARGO_PKG_VERSION"),
+    )
 }


### PR DESCRIPTION
## Summary

Fixes the silent path-strip mismatch when `src` is set only in
`crap4rs.toml` (not on the CLI).

**The bug**: `crates/crap4rs/src/main.rs` constructed `LcovParser::new`
from `cli.input.src` *before* `crap_core::cli::run` merged the config
file. With `src = "<dir>"` only in `crap4rs.toml`, the parser
canonicalized the default `"src"` path, stripped that wrong prefix from
absolute `SF:` records emitted by `cargo llvm-cov`, and silently
produced zero coverage across every matched function.

**The fix**: `crap_core::cli::run` now takes a `coverage_factory: F`
closure (`F: FnOnce(&Path) -> Box<dyn CoveragePort<Diagnostic = P>>`)
instead of `coverage: &dyn CoveragePort<...>`. The factory is invoked
once inside `prepare_pipeline`, after `merge_effective_inputs` resolves
the final `src` and the orchestrator canonicalizes it. Adapter
factories stay dumb; the canonicalize concern lives at the layer that
owns config merging.

## What changed

- `crap_core::cli::run<P, F>` — new signature; takes factory closure.
- `crap_core::cli::run_inner` + `prepare_pipeline` — thread the factory
  through; canonicalize once after merge and invoke the factory with the
  canonical path.
- `crates/crap4rs/src/main.rs` — passes `|src| Box::new(LcovParser::new(src.to_path_buf()))`.
- `crates/crap4ts/src/main.rs` — same factory shape so the alpha shell
  stays in parity.
- Doc comments at the `parse_args` / `run` split rewritten — the prior
  text claimed `cli.input.src` was "config-aware" at parse_args time,
  which was the design intent that didn't match the code.
- New integration test
  `crates/crap4rs/tests/config_src_path_strip.rs` — tempdir with
  `crap4rs.toml` setting `src` to a non-default directory name and
  absolute \`SF:\` paths matching the canonical dir; asserts every function
  scores 100.0%. Catches partial-strip regressions, not just total
  failure.

## Why factory closure (not default-no-op `set_source_root`)

The factory shape fits ADR D9 (mixed-dispatch — generics on data
structures, trait objects on orchestration), keeps \`LcovParser\` immutable
by construction, and pushes the canonicalize concern to the orchestrator.
Approved as v1.0 prep (breaking OK) — bundles cleanly with PRs C and D
which also touch the v1.0 surface.

## BREAKING change scope

\`crap_core::cli::run\` signature change. External library consumers using
\`crap_core::cli::run\` directly must update to pass a coverage factory
closure. The adapter binary shape (\`crates/crap4rs/src/main.rs\`,
\`crates/crap4ts/src/main.rs\`) is the canonical reference for the migration.

## Wire-envelope canary

Snapshot updated. Drift is span-only on the \`main\` function
(\`start_line: 10→14\`, \`end_line: 20→23\`) because this PR's \`main.rs\`
added doc-comment lines and the factory closure body. **No JSON keys
added, removed, or retyped** — span values are source-content drift, not
envelope-shape drift. The canary's purpose (catch shape changes) is
preserved.

## Test plan

- [x] New integration test catches the bug pre-fix (RED) and passes
      post-fix (GREEN) with all three functions at 100.0% coverage
- [x] All 915 workspace tests pass (\`cargo nextest run --workspace --all-targets\`)
- [x] Wire-envelope canary passes (span-only drift accepted)
- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo +1.93 check --workspace --all-targets\` clean (MSRV)
- [x] \`RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps\` clean
- [x] \`cargo deny check\` clean
- [x] AST-purity grep on \`crates/crap-core/src/\` zero matches
- [ ] CI matrix green (build, test, clippy, fmt, MSRV 1.93, deny, doc,
      AST-purity, all 3 platforms, crap4ts-build)

## Closes

Closes #150

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed source path resolution in configuration files to ensure LCOV file paths are correctly processed according to the configured source root.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/breezy-bays-labs/crap-rs/pull/158)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->