### PR TITLE
test(reporters) + ci(ast-purity): #141 #142 #143 #145 — snapshots + hardened grep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,12 +364,22 @@ jobs:
     # false-positive on serde_derive's proc-macro chain or require a
     # fragile, ever-growing wrapper list — see deny.toml's "AST-library
     # policy" comment for the full rationale.
+    #
+    # Hardened in #145 with two additional checks:
+    #   - Grouped-import multi-line regex (catches `use { syn::Foo };`
+    #     and the multi-line `use {\n    syn::Item,\n};` form that the
+    #     original leading-token regex misses).
+    #   - Direct-dependency `cargo metadata --no-deps` check (catches
+    #     `syn = "2.0"` being added to crates/crap-core/Cargo.toml).
+    #
+    # No untrusted input is interpolated into any `run:` block; every
+    # regex / jq expression is a literal static string.
     name: crap-core AST-library purity
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
-      - name: Reject AST-library imports in crap-core
+      - name: Reject AST-library imports in crap-core (leading-token form)
         # Scope: crap-core ONLY. oxc/swc imports are legitimate in
         # crates/crap4ts/ once that lands; crap4rs uses syn. Do NOT
         # widen the path below to `crates/*/src/` — that would reject
@@ -386,11 +396,51 @@ jobs:
         #     positives like `use syntactic_analysis::X`.
         run: |
           set -euo pipefail
-          if grep -rE '^[[:space:]]*(use|extern[[:space:]]+crate)[[:space:]]+(::)?(syn|quote|proc_macro2?|tree_sitter|swc|oxc)([_:; ]|$)' crates/crap-core/src/; then
-            echo "::error::crap-core must not import AST libraries — see CLAUDE.md and shaping.md"
+          if grep -rnE '^[[:space:]]*(use|extern[[:space:]]+crate)[[:space:]]+(::)?(syn|quote|proc_macro2?|tree_sitter|swc|oxc)([_:; ]|$)' crates/crap-core/src/; then
+            echo "::error::crap-core must not import AST libraries (leading-token form, e.g. \`use syn::Foo;\`) — see CLAUDE.md and shaping.md"
             exit 1
           fi
-          echo "crap-core is AST-library-pure"
+          echo "crap-core leading-token imports: clean"
+      - name: Reject AST-library imports in crap-core (grouped-import form)
+        # Catches `use { syn::Foo };` and the multi-line variant
+        # `use {\n    syn::Item,\n};` which the leading-token regex
+        # above misses (since the first token after `use` is `{`, not
+        # the banned crate). Uses ripgrep's multiline mode (-U) +
+        # PCRE2 for `\b` word boundaries. ripgrep ships on
+        # ubuntu-latest's default toolchain.
+        #
+        # The pattern bounds the match to a single `use { … }` block
+        # via `[^}]*`, so nested braces inside a different scope
+        # cannot drag a false-positive across statements.
+        run: |
+          set -euo pipefail
+          if rg -nU --pcre2 'use\s*\{[^}]*\b(syn|quote|proc_macro2?|tree_sitter|swc|oxc)\b' crates/crap-core/src/; then
+            echo "::error::crap-core must not import AST libraries (grouped-import form, e.g. \`use { syn::Foo };\`) — see CLAUDE.md and shaping.md"
+            exit 1
+          fi
+          echo "crap-core grouped imports: clean"
+      - name: Reject AST-library direct dependencies in crap-core/Cargo.toml
+        # `cargo metadata --no-deps` lists workspace packages with
+        # their declared dependencies but does NOT resolve the
+        # transitive graph — so serde_derive's transitive `syn` does
+        # not false-positive (the documented reason cargo-deny
+        # transitive bans were rejected; see shaping.md "Patterns
+        # NOT copied" #3). Caught case: someone adds
+        # `syn = "2.0"` directly to crates/crap-core/Cargo.toml.
+        run: |
+          set -euo pipefail
+          banned=$(cargo metadata --format-version 1 --no-deps |
+            jq -r '
+              .packages[] |
+              select(.name == "crap-core") |
+              .dependencies[] |
+              select(.name | test("^(syn|quote|proc-macro2|tree-sitter|swc|oxc)$")) |
+              .name')
+          if [ -n "$banned" ]; then
+            echo "::error::crap-core declares banned direct dependency: $banned (see CLAUDE.md and shaping.md)"
+            exit 1
+          fi
+          echo "crap-core direct dependencies: clean"
 
   docs:
     name: cargo doc (warnings as errors)

--- a/crates/crap-core/src/adapters/reporters/advice_summary.rs
+++ b/crates/crap-core/src/adapters/reporters/advice_summary.rs
@@ -83,8 +83,8 @@ mod tests {
         Applicability, Diagnostic, LineRange, ProposedSplit, RootCause, SplitKind, SuggestedAction,
     };
     use crate::domain::types::{
-        AnalysisResult, AnalysisSummary, ComplexityMetric, CrapScore, FunctionIdentity, RiskLevel,
-        ScoredFunction, SourceSpan,
+        AnalysisResult, AnalysisSummary, ComplexityMetric, ContributorKind, CrapScore,
+        FunctionIdentity, RiskLevel, ScoredFunction, SourceSpan,
     };
     use crate::domain::view::{self, ViewSpec};
 
@@ -200,5 +200,74 @@ mod tests {
         assert_eq!(lines.len(), 2);
         assert!(lines[0].contains("b_second"));
         assert!(lines[1].contains("a_first"));
+    }
+
+    /// Byte-level snapshot lock for the advice_summary reporter
+    /// (#142). The format is plain text with no ANSI / no
+    /// terminal-width dependency, so the snapshot is fully
+    /// deterministic by construction.
+    ///
+    /// Covers all four `SuggestedAction` variants (the entire
+    /// `action_kind_label` match) plus the `[actions: none]` branch
+    /// (empty suggested_actions vec) so any future variant
+    /// addition that misses an arm or relabels surfaces here.
+    /// CRAP values are distinct and spread across `RiskLevel`s so
+    /// the default-sort ordering is also pinned by the snapshot.
+    #[test]
+    fn advice_summary_snapshot() {
+        let mut high = make_verdict("complex_handler", "src/cli/mod.rs", 600, 720);
+        high.scored.crap.value = 45.20;
+        high.scored.crap.risk_level = RiskLevel::High;
+        high.diagnostic = Some(Box::new(Diagnostic {
+            coverage_gaps: vec![LineRange::new(605, 612), LineRange::new(640, 660)],
+            complexity_drivers: vec![],
+            suggested_actions: vec![
+                SuggestedAction::AddTestsForLines {
+                    lines: vec![LineRange::new(605, 612)],
+                    applicability: Applicability::default(),
+                },
+                SuggestedAction::ExtractFunction {
+                    candidates: vec![ProposedSplit {
+                        line_range: LineRange::new(640, 700),
+                        complexity_contribution: 12,
+                        branch_path: "match-arms".to_string(),
+                        kind: SplitKind::DeepestNesting,
+                        recommended: true,
+                    }],
+                    applicability: Applicability::default(),
+                },
+            ],
+            root_cause: RootCause::Both,
+        }));
+
+        let mut moderate = make_verdict("parse_record", "src/adapters/coverage/mod.rs", 80, 145);
+        moderate.scored.crap.value = 15.00;
+        moderate.scored.crap.risk_level = RiskLevel::Moderate;
+        moderate.diagnostic = Some(Box::new(Diagnostic {
+            coverage_gaps: vec![],
+            complexity_drivers: vec![],
+            suggested_actions: vec![
+                SuggestedAction::SimplifyBranching {
+                    drivers: vec![ContributorKind::Match, ContributorKind::MatchArm],
+                    applicability: Applicability::default(),
+                },
+                SuggestedAction::AcceptInherentComplexity {
+                    applicability: Applicability::default(),
+                },
+            ],
+            root_cause: RootCause::HighComplexity,
+        }));
+
+        let mut bare = make_verdict("opaque_helper", "src/util.rs", 30, 42);
+        bare.scored.crap.value = 8.50;
+        bare.scored.crap.risk_level = RiskLevel::Acceptable;
+        // No diagnostic populated — exercises the `none` sentinel branch.
+
+        let result = make_result(vec![high, moderate, bare]);
+        let view = view::apply(&result, ViewSpec::default());
+        let mut sink = Vec::new();
+        render_summary(&view, &mut sink).unwrap();
+        let out = String::from_utf8(sink).unwrap();
+        insta::assert_snapshot!(out);
     }
 }

--- a/crates/crap-core/src/adapters/reporters/advice_summary.rs
+++ b/crates/crap-core/src/adapters/reporters/advice_summary.rs
@@ -215,7 +215,16 @@ mod tests {
     /// the default-sort ordering is also pinned by the snapshot.
     #[test]
     fn advice_summary_snapshot() {
+        // Pin threshold to 8.0 across all verdicts to match the
+        // `make_multi_function_result` convention used by sibling
+        // reporter tests. The value does not appear in
+        // advice_summary's output (`format_line` only includes
+        // `crap`, `file`, `lines`, `name`, `actions`), so the
+        // snapshot is unaffected — but pinning here keeps future
+        // test edits honest (e.g., a future passing-score case
+        // would otherwise quietly exceed the default 5.0).
         let mut high = make_verdict("complex_handler", "src/cli/mod.rs", 600, 720);
+        high.threshold = 8.0;
         high.scored.crap.value = 45.20;
         high.scored.crap.risk_level = RiskLevel::High;
         high.diagnostic = Some(Box::new(Diagnostic {
@@ -241,6 +250,7 @@ mod tests {
         }));
 
         let mut moderate = make_verdict("parse_record", "src/adapters/coverage/mod.rs", 80, 145);
+        moderate.threshold = 8.0;
         moderate.scored.crap.value = 15.00;
         moderate.scored.crap.risk_level = RiskLevel::Moderate;
         moderate.diagnostic = Some(Box::new(Diagnostic {
@@ -259,6 +269,7 @@ mod tests {
         }));
 
         let mut bare = make_verdict("opaque_helper", "src/util.rs", 30, 42);
+        bare.threshold = 8.0;
         bare.scored.crap.value = 8.50;
         bare.scored.crap.risk_level = RiskLevel::Acceptable;
         // No diagnostic populated — exercises the `none` sentinel branch.

--- a/crates/crap-core/src/adapters/reporters/html.rs
+++ b/crates/crap-core/src/adapters/reporters/html.rs
@@ -636,4 +636,29 @@ mod tests {
         assert!(!html.contains("src/lib.rs"));
         assert!(!html.contains("src/adapters/coverage/mod.rs"));
     }
+
+    /// Byte-level snapshot lock for the HTML reporter (#141).
+    ///
+    /// Complements the existing structural asserts (`PASS`/`FAIL`
+    /// badge, risk-class strings, self-contained markup) with a
+    /// full-document anchor so future format edits are reviewable
+    /// rather than silent. Mirrors the per-reporter pattern from
+    /// `json`, `markdown`, `sarif`, `csv`, `table`.
+    ///
+    /// Uses `make_multi_function_result` (3 functions spanning
+    /// Low/Moderate/High risk + a failing summary) and the default
+    /// view spec — the same fixture every other reporter snapshot
+    /// pins so cross-reporter diffs stay readable.
+    ///
+    /// Tool version pinned to "0.4.0" to match the surrounding
+    /// suite; the value is interpolated into the document header so
+    /// any unpinned ad-hoc version would churn the snapshot on every
+    /// crate-version bump.
+    #[test]
+    fn full_html_snapshot() {
+        let result = make_multi_function_result();
+        let view = make_view_default(&result);
+        let html = format_html(&view, 8.0, "0.4.0");
+        insta::assert_snapshot!(html);
+    }
 }

--- a/crates/crap-core/src/adapters/reporters/scorecard_row.rs
+++ b/crates/crap-core/src/adapters/reporters/scorecard_row.rs
@@ -174,4 +174,36 @@ mod tests {
         let out2 = format_scorecard_row(&red_data());
         assert_eq!(out1, out2, "format is deterministic");
     }
+
+    // ── Byte-level snapshot locks (#143) ───────────────────────────────
+    //
+    // Complement the existing `scorecard_row_integration.rs` schema
+    // validation (which gates the shape against mokumo's
+    // `Row::CrapDelta` JSON Schema) with insta snapshots that pin the
+    // exact serialization — pretty-printer settings, field ordering,
+    // failure-detail rendering. Schema + insta together = belt +
+    // suspenders.
+    //
+    // One snapshot per `CrapDeltaStatus` because each carries a
+    // structurally distinct payload (green/yellow omit
+    // `failure_detail_md`; red includes it). Without/with-delta is
+    // covered by the green vs red split (delta_count 0 vs 2).
+
+    #[test]
+    fn green_scorecard_row_snapshot() {
+        let out = format_scorecard_row(&green_data());
+        insta::assert_snapshot!(out);
+    }
+
+    #[test]
+    fn yellow_scorecard_row_snapshot() {
+        let out = format_scorecard_row(&yellow_data());
+        insta::assert_snapshot!(out);
+    }
+
+    #[test]
+    fn red_scorecard_row_snapshot() {
+        let out = format_scorecard_row(&red_data());
+        insta::assert_snapshot!(out);
+    }
 }

--- a/crates/crap-core/src/adapters/reporters/snapshots/crap_core__adapters__reporters__advice_summary__tests__advice_summary_snapshot.snap
+++ b/crates/crap-core/src/adapters/reporters/snapshots/crap_core__adapters__reporters__advice_summary__tests__advice_summary_snapshot.snap
@@ -1,0 +1,8 @@
+---
+source: crates/crap-core/src/adapters/reporters/advice_summary.rs
+assertion_line: 271
+expression: out
+---
+[crap=45.20] src/cli/mod.rs:600-720 complex_handler [actions: add_tests_for_lines,extract_function]
+[crap=15.00] src/adapters/coverage/mod.rs:80-145 parse_record [actions: simplify_branching,accept_inherent_complexity]
+[crap=8.50] src/util.rs:30-42 opaque_helper [actions: none]

--- a/crates/crap-core/src/adapters/reporters/snapshots/crap_core__adapters__reporters__html__tests__full_html_snapshot.snap
+++ b/crates/crap-core/src/adapters/reporters/snapshots/crap_core__adapters__reporters__html__tests__full_html_snapshot.snap
@@ -1,0 +1,222 @@
+---
+source: crates/crap-core/src/adapters/reporters/html.rs
+assertion_line: 662
+expression: html
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>crap4rs v0.4.0 — CRAP Score Analysis</title>
+<style>
+
+:root {
+  --bg: #ffffff;
+  --fg: #1f2328;
+  --muted: #57606a;
+  --border: #d0d7de;
+  --row-alt: #f6f8fa;
+  --risk-low: #16a34a;
+  --risk-acceptable: #ca8a04;
+  --risk-moderate: #ea580c;
+  --risk-high: #dc2626;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0d1117;
+    --fg: #e6edf3;
+    --muted: #8b949e;
+    --border: #30363d;
+    --row-alt: #161b22;
+  }
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  color: var(--fg);
+  background: var(--bg);
+  line-height: 1.45;
+  padding: 1.5rem;
+  max-width: 1200px;
+  margin-inline: auto;
+}
+header h1 { margin: 0 0 0.25rem 0; font-size: 1.5rem; }
+header .threshold { color: var(--muted); font-size: 0.9rem; }
+.badge {
+  display: inline-block;
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #fff;
+}
+.badge-pass { background: var(--risk-low); }
+.badge-fail { background: var(--risk-high); }
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.75rem;
+  margin: 1rem 0;
+}
+.stat {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.75rem;
+}
+.stat .label { color: var(--muted); font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.05em; }
+.stat .value { font-size: 1.4rem; font-weight: 600; margin-top: 0.25rem; }
+.distribution {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 0.75rem 0 1.5rem 0;
+}
+.dist-pill {
+  padding: 0.3rem 0.7rem;
+  border-radius: 4px;
+  color: #fff;
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+.dist-low { background: var(--risk-low); }
+.dist-acceptable { background: var(--risk-acceptable); }
+.dist-moderate { background: var(--risk-moderate); }
+.dist-high { background: var(--risk-high); }
+details.file {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  margin-bottom: 0.75rem;
+  background: var(--bg);
+}
+details.file > summary {
+  cursor: pointer;
+  padding: 0.6rem 0.85rem;
+  font-weight: 500;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.6rem;
+  user-select: none;
+}
+details.file > summary::before {
+  content: "▶";
+  font-size: 0.7rem;
+  color: var(--muted);
+  transition: transform 0.15s ease;
+}
+details.file[open] > summary::before { transform: rotate(90deg); }
+details.file > summary .file-path { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+details.file > summary .file-meta { color: var(--muted); font-size: 0.85rem; margin-left: auto; }
+table.functions {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+table.functions th, table.functions td {
+  text-align: left;
+  padding: 0.45rem 0.65rem;
+  border-bottom: 1px solid var(--border);
+  vertical-align: top;
+}
+table.functions th {
+  font-weight: 600;
+  color: var(--muted);
+  background: var(--row-alt);
+}
+table.functions td.numeric { text-align: right; font-variant-numeric: tabular-nums; }
+table.functions td.fn-name { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+.risk {
+  display: inline-block;
+  padding: 0.1rem 0.5rem;
+  border-radius: 4px;
+  color: #fff;
+  font-size: 0.78rem;
+  font-weight: 500;
+}
+.risk-low { background: var(--risk-low); }
+.risk-acceptable { background: var(--risk-acceptable); }
+.risk-moderate { background: var(--risk-moderate); }
+.risk-high { background: var(--risk-high); }
+.exceeds { color: var(--risk-high); font-weight: 600; }
+details.contributors {
+  margin-top: 0.4rem;
+  padding-left: 0.6rem;
+  border-left: 2px solid var(--border);
+}
+details.contributors > summary {
+  cursor: pointer;
+  font-size: 0.82rem;
+  color: var(--muted);
+  user-select: none;
+}
+details.contributors ul {
+  margin: 0.4rem 0 0.2rem 0;
+  padding-left: 1.2rem;
+  font-size: 0.82rem;
+}
+.empty { color: var(--muted); font-style: italic; }
+@media (max-width: 640px) {
+  body { padding: 1rem; }
+  table.functions th:nth-child(2),
+  table.functions td:nth-child(2) { display: none; }
+}
+
+</style>
+</head>
+<body>
+<header>
+<h1>crap4rs v0.4.0 — CRAP Score Analysis</h1>
+<p class="threshold">Threshold: <strong>8.00</strong></p>
+</header>
+<section class="summary">
+<h2>Summary <span class="badge badge-fail">FAIL</span></h2>
+<div class="summary-grid">
+<div class="stat"><div class="label">Functions</div><div class="value">3</div></div>
+<div class="stat"><div class="label">Files</div><div class="value">3</div></div>
+<div class="stat"><div class="label">Exceeding threshold</div><div class="value">2</div></div>
+<div class="stat"><div class="label">Average CRAP</div><div class="value">21.07</div></div>
+<div class="stat"><div class="label">Median CRAP</div><div class="value">15.00</div></div>
+<div class="stat"><div class="label">Max CRAP</div><div class="value">45.20</div></div>
+</div>
+<div class="distribution" aria-label="Risk distribution">
+<span class="dist-pill dist-low">low: 1</span>
+<span class="dist-pill dist-acceptable">acceptable: 0</span>
+<span class="dist-pill dist-moderate">moderate: 1</span>
+<span class="dist-pill dist-high">high: 1</span>
+</div>
+</section>
+<section class="files">
+<h2>Functions by file</h2>
+<details class="file" open>
+<summary><span class="file-path">src/adapters/coverage/mod.rs</span><span class="file-meta">1 fn · max CRAP 15.00 · 1 over</span></summary>
+<table class="functions">
+<thead><tr><th>Function</th><th>Lines</th><th class="numeric">CC</th><th class="numeric">Cov %</th><th class="numeric">CRAP</th><th>Risk</th></tr></thead>
+<tbody>
+<tr><td class="fn-name">parse_record</td><td>1–10</td><td class="numeric">6</td><td class="numeric">72.5</td><td class="numeric exceeds">15.00</td><td><span class="risk risk-moderate">moderate</span></td></tr>
+</tbody>
+</table>
+</details>
+<details class="file" open>
+<summary><span class="file-path">src/domain/crap.rs</span><span class="file-meta">1 fn · max CRAP 45.20 · 1 over</span></summary>
+<table class="functions">
+<thead><tr><th>Function</th><th>Lines</th><th class="numeric">CC</th><th class="numeric">Cov %</th><th class="numeric">CRAP</th><th>Risk</th></tr></thead>
+<tbody>
+<tr><td class="fn-name">complex_fn</td><td>1–10</td><td class="numeric">20</td><td class="numeric">30.0</td><td class="numeric exceeds">45.20</td><td><span class="risk risk-high">high</span></td></tr>
+</tbody>
+</table>
+</details>
+<details class="file">
+<summary><span class="file-path">src/lib.rs</span><span class="file-meta">1 fn · max CRAP 3.00 · 0 over</span></summary>
+<table class="functions">
+<thead><tr><th>Function</th><th>Lines</th><th class="numeric">CC</th><th class="numeric">Cov %</th><th class="numeric">CRAP</th><th>Risk</th></tr></thead>
+<tbody>
+<tr><td class="fn-name">simple_fn</td><td>1–10</td><td class="numeric">2</td><td class="numeric">95.0</td><td class="numeric">3.00</td><td><span class="risk risk-low">low</span></td></tr>
+</tbody>
+</table>
+</details>
+</section>
+</body>
+</html>

--- a/crates/crap-core/src/adapters/reporters/snapshots/crap_core__adapters__reporters__scorecard_row__tests__green_scorecard_row_snapshot.snap
+++ b/crates/crap-core/src/adapters/reporters/snapshots/crap_core__adapters__reporters__scorecard_row__tests__green_scorecard_row_snapshot.snap
@@ -1,0 +1,15 @@
+---
+source: crates/crap-core/src/adapters/reporters/scorecard_row.rs
+assertion_line: 195
+expression: out
+---
+{
+  "type": "CrapDelta",
+  "id": "crap_delta",
+  "label": "CRAP Δ",
+  "anchor": "crap-delta",
+  "status": "Green",
+  "threshold": 15,
+  "delta_count": 0,
+  "delta_text": "5 → 5"
+}

--- a/crates/crap-core/src/adapters/reporters/snapshots/crap_core__adapters__reporters__scorecard_row__tests__red_scorecard_row_snapshot.snap
+++ b/crates/crap-core/src/adapters/reporters/snapshots/crap_core__adapters__reporters__scorecard_row__tests__red_scorecard_row_snapshot.snap
@@ -1,0 +1,16 @@
+---
+source: crates/crap-core/src/adapters/reporters/scorecard_row.rs
+assertion_line: 207
+expression: out
+---
+{
+  "type": "CrapDelta",
+  "id": "crap_delta",
+  "label": "CRAP Δ",
+  "anchor": "crap-delta",
+  "status": "Red",
+  "threshold": 15,
+  "delta_count": 2,
+  "delta_text": "5 → 7 (+2)",
+  "failure_detail_md": "**New CRAP threshold violations (>15):**\n- `foo` — `a.rs:1` — CRAP 22.0 (newly added)\n"
+}

--- a/crates/crap-core/src/adapters/reporters/snapshots/crap_core__adapters__reporters__scorecard_row__tests__yellow_scorecard_row_snapshot.snap
+++ b/crates/crap-core/src/adapters/reporters/snapshots/crap_core__adapters__reporters__scorecard_row__tests__yellow_scorecard_row_snapshot.snap
@@ -1,0 +1,15 @@
+---
+source: crates/crap-core/src/adapters/reporters/scorecard_row.rs
+assertion_line: 201
+expression: out
+---
+{
+  "type": "CrapDelta",
+  "id": "crap_delta",
+  "label": "CRAP Δ",
+  "anchor": "crap-delta",
+  "status": "Yellow",
+  "threshold": 15,
+  "delta_count": 0,
+  "delta_text": "5 → 5 (regressions on existing functions)"
+}


### PR DESCRIPTION
## Summary

PR B in the Lane 2 cleanup — bundles the four "tighten safety net" tasks
so the next batch of v1.0 surface changes (PRs C and D) has a working
snapshot net to catch unintended drift.

## Reporter snapshots

Three reporters previously lacked byte-level insta locks, leaving them
out of the cross-reporter snapshot net that already covers json /
markdown / sarif / csv / table.

- **#141 html** — `full_html_snapshot` (222-line document, DOCTYPE, embedded
  CSS, badges, risk classes, details blocks).
- **#142 advice_summary** — one snapshot exercising all four
  \`SuggestedAction\` variants (\`add_tests_for_lines\`,
  \`extract_function\`, \`simplify_branching\`,
  \`accept_inherent_complexity\`) plus the \`none\` sentinel branch. Plain
  text — no ANSI / no terminal-width dependency, fully deterministic.
- **#143 scorecard_row** — one snapshot per \`CrapDeltaStatus\` (Green /
  Yellow / Red); each carries a structurally distinct payload (Green
  and Yellow omit \`failure_detail_md\`; Red includes it). Complements
  existing \`scorecard_row_integration.rs\` schema validation.

All snapshots reuse existing test_fixtures (\`make_multi_function_result\`,
\`make_view_default\`) or file-local fixture builders already in the
reporter's \`#[cfg(test)] mod tests\`. No new fixture infrastructure.

## AST-purity hardening (#145)

The \`ast-purity\` CI job previously enforced one source-level grep that
catches \`use syn::Foo;\` but missed the two grouped-import forms Gemini
Code Assist flagged on PR #144:

- \`use { syn::Foo };\` (single-line)
- Multi-line \`use {\n    syn::Item,\n};\`

Two additional checks added to the job (the original leading-token grep
stays unchanged):

1. **Grouped-import multi-line regex** using \`rg -nU --pcre2\` (ripgrep
   ships on ubuntu-latest). Pattern bounds the match to a single
   \`use { … }\` block via \`[^}]*\`.
2. **Direct-dependency check** using \`cargo metadata --no-deps | jq\`.
   \`--no-deps\` does not resolve the transitive graph, so
   \`serde_derive\`'s transitive \`syn\` does not false-positive (the
   documented reason cargo-deny transitive bans were rejected in
   shaping.md "Patterns NOT copied" #3). Catches the
   \`syn = "2.0"\` direct-declaration case the source grep cannot see.

Failure messages include the form (leading-token / grouped-import /
direct-dep) + the banned crate name, satisfying #145's acceptance
criterion. Line numbers come from \`grep -n\` and \`rg -n\`.

False-positive baseline verified locally — all three checks return zero
matches against current \`crates/crap-core/src/\` and Cargo.toml.

## Test plan

- [x] 920 workspace tests green (was 915 before; +5 new snapshot tests)
- [x] Wire-envelope canary byte-identical
- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo +1.93 check --workspace --all-targets\` clean (MSRV)
- [x] \`RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps\` clean
- [x] \`cargo deny check\` clean
- [x] AST-purity baseline (all three checks) returns zero matches
- [ ] CI matrix green (build, test, clippy, fmt, MSRV 1.93, deny, doc,
      hardened AST-purity, all 3 platforms, crap4ts-build)

## Closes

Closes #141
Closes #142
Closes #143
Closes #145