### PR TITLE
feat(crap-core): #148+#152+#160 — AdapterMeta + decouple from Rust/crap4rs

### DIFF
--- a/crates/crap-core/src/adapters/baseline.rs
+++ b/crates/crap-core/src/adapters/baseline.rs
@@ -1,4 +1,4 @@
-//! Baseline-envelope loader — reads a previously-emitted crap4rs JSON
+//! Baseline-envelope loader — reads a previously-emitted analyzer JSON
 //! envelope from disk and extracts the `result` block, plus the
 //! envelope metadata (tool_version, timestamp) needed for delta
 //! reporting.
@@ -11,9 +11,9 @@
 //! envelopes that contain extra fields without breaking us.
 //!
 //! Schema version validation: `schema_version` 1 and 2 are both
-//! accepted (#107 bumped the current emit version 1 → 2 in 0.4.0; v1
-//! baselines remain loadable because delta matching is identity-keyed,
-//! not column-keyed). Future schema bumps will need an explicit
+//! accepted (the current emit version is 2; v1 baselines remain
+//! loadable because delta matching is identity-keyed, not
+//! column-keyed). Future schema bumps will need an explicit
 //! migration path.
 
 use crate::domain::types::{AnalysisDiagnostics, AnalysisResult};
@@ -38,8 +38,8 @@ pub const SUPPORTED_SCHEMA_VERSIONS: &[u32] = &[1, 2];
 /// forward-compatible with envelopes that omit fields we don't need.
 ///
 /// `P: ParseDiagnostic` carries the adapter-specific parse-diagnostic
-/// type through `AnalysisDiagnostics<P>` (S2's decomposition); crap4rs
-/// concretizes to `LcovParseDiagnostic` via the v0.4 shim alias.
+/// type through `AnalysisDiagnostics<P>`. crap4rs concretizes to
+/// `LcovParseDiagnostic` via the v0.4 shim alias.
 /// `serde(bound = "")` suppresses the auto-generated `P: Serialize` /
 /// `P: Deserialize<'de>` bounds — `P: ParseDiagnostic` already provides
 /// `Serialize + DeserializeOwned`, and the auto-bounds conflict with
@@ -98,16 +98,14 @@ pub enum BaselineError {
         #[source]
         source: serde_json::Error,
     },
-    #[error(
-        "unsupported baseline schema_version: {found} (this build of crap4rs accepts {supported:?})"
-    )]
+    #[error("unsupported baseline schema_version: {found} (this build accepts {supported:?})")]
     UnsupportedSchemaVersion {
         found: u32,
         supported: &'static [u32],
     },
 }
 
-/// Load a crap4rs JSON envelope from disk and return the baseline
+/// Load an analyzer JSON envelope from disk and return the baseline
 /// snapshot. Streams the file through a `BufReader` rather than
 /// reading the whole envelope into memory — large codebases produce
 /// envelopes in the multi-MB range and there's no reason to allocate
@@ -161,8 +159,8 @@ mod tests {
 
     /// Concrete `P` for tests in this module — the loader's behavior is
     /// `P`-agnostic for the cases we test (none reach into per-variant
-    /// fields), so the dummy stub keeps the assertions byte-identical
-    /// to crap4rs's pre-S3 unit suite.
+    /// fields), so a dummy stub is sufficient and decouples these
+    /// tests from any specific adapter's diagnostic shape.
     type TestSnapshot = BaselineSnapshot<DummyParseDiagnostic>;
 
     /// Wrapper that pins `P = DummyParseDiagnostic`. Keeps the original
@@ -299,7 +297,7 @@ mod tests {
     #[test]
     fn load_unsupported_schema_version_rejects() {
         // Use a future-unsupported version (99) — both 1 and 2 are
-        // accepted today after the #107 column-convention bump.
+        // accepted today.
         let json = r#"{
             "schema_version": 99,
             "result": {
@@ -328,7 +326,7 @@ mod tests {
 
     #[test]
     fn load_v2_schema_version_accepted() {
-        // Post-#107: v2 baselines (1-based contributor columns) load
+        // After the migration: v2 baselines (1-based contributor columns) load
         // alongside v1 baselines.
         let json = r#"{
             "schema_version": 2,

--- a/crates/crap-core/src/adapters/config.rs
+++ b/crates/crap-core/src/adapters/config.rs
@@ -1,4 +1,6 @@
-//! Config file adapter — loads `crap4rs.toml` and converts to domain types.
+//! Config file adapter — loads the adapter's TOML config (file name
+//! supplied by the binary via `AdapterMeta::config_file_name`) and
+//! converts to domain types.
 //!
 //! Handles TOML parsing and config file discovery. All CLI-representable
 //! options are supported. Per-path threshold overrides use glob patterns.
@@ -27,7 +29,7 @@ pub struct FileConfig {
     pub src: Option<PathBuf>,
     pub exclude: Option<Vec<String>>,
     pub overrides: Vec<ThresholdOverride>,
-    /// Saved view presets keyed by preset name (issue #80).
+    /// Saved view presets keyed by preset name.
     ///
     /// Each `[views.<name>]` block in TOML deserializes into a
     /// [`ViewPreset`]; the CLI layer resolves `--view <name>` against
@@ -36,7 +38,7 @@ pub struct FileConfig {
     pub views: HashMap<String, ViewPreset>,
 }
 
-/// Saved view preset (issue #80).
+/// Saved view preset.
 ///
 /// All fields are optional — `None` means "preset does not assert this
 /// field, defer to CLI / defaults." Booleans are `Option<bool>` so the
@@ -93,15 +95,16 @@ struct RawViewPreset {
 
 // ── Public API ─────────────────────────────────────────────────────
 
-/// Default config file name.
-pub const CONFIG_FILE_NAME: &str = "crap4rs.toml";
-
-/// Discover the config file in the current working directory.
+/// Discover the adapter's config file in the current working directory.
 ///
-/// Returns `Ok(Some(path))` if `crap4rs.toml` exists, `Ok(None)` if absent.
+/// `name` is the adapter-specific file name (e.g., `"crap4rs.toml"` for
+/// the Rust adapter; `"crap4ts.toml"` for the TS adapter). Supplied by
+/// the binary via `AdapterMeta.config_file_name`.
+///
+/// Returns `Ok(Some(path))` if the file exists, `Ok(None)` if absent.
 /// Returns `Err` on permission errors or other filesystem failures.
-pub fn discover_config() -> Result<Option<PathBuf>> {
-    let path = PathBuf::from(CONFIG_FILE_NAME);
+pub fn discover_config(name: &str) -> Result<Option<PathBuf>> {
+    let path = PathBuf::from(name);
     match std::fs::metadata(&path) {
         Ok(m) if m.is_file() => Ok(Some(path)),
         Ok(_) => Ok(None), // exists but not a file (directory, symlink to dir, etc.)
@@ -225,7 +228,7 @@ fn parse_group_key(preset_name: &str, s: &str) -> Result<GroupKey> {
 }
 
 /// Validate the preset's coverage bounds in isolation (fail-fast at config
-/// load per issue #80). Either-side-only is allowed and the absent side is
+/// load). Either-side-only is allowed and the absent side is
 /// defaulted to `0` / `100` for the relational check, mirroring CLI
 /// `validate_view_args` so a preset that would resolve to an invalid range
 /// is rejected at TOML parse time rather than at `--view` resolution.
@@ -239,11 +242,11 @@ fn validate_preset_coverage_range(
     }
     let lo = min.unwrap_or(0.0);
     let hi = max.unwrap_or(100.0);
-    // `CoverageRangeError` is `#[non_exhaustive]` paused per D10
-    // amendment (#147 restores at v1.0). Now that this adapter lives in
-    // crap-core alongside the enum, the match is in-crate and
-    // exhaustive — no wildcard arm needed. v1.0 new variants will
-    // require an explicit arm here.
+    // `CoverageRangeError` has `#[non_exhaustive]` paused per ADR D10
+    // (restored at v1.0). Now that this adapter lives in crap-core
+    // alongside the enum, the match is in-crate and exhaustive — no
+    // wildcard arm needed. v1.0 new variants will require an
+    // explicit arm here.
     match CoverageRange::new(lo, hi) {
         Ok(_) => Ok(()),
         Err(CoverageRangeError::OutOfRange { value }) => anyhow::bail!(
@@ -475,7 +478,7 @@ threshold = 0.0
         assert!(err.to_string().contains("failed to parse config file"));
     }
 
-    // ── ViewPreset tests (issue #80) ───────────────────────────────────
+    // ── ViewPreset tests ───────────────────────────────────
 
     #[test]
     fn parse_no_views_table_yields_empty_map() {

--- a/crates/crap-core/src/adapters/mod.rs
+++ b/crates/crap-core/src/adapters/mod.rs
@@ -1,10 +1,10 @@
 //! Language-agnostic adapters — IO and presentation layers that make
 //! no assumptions about the source language being analyzed.
 //!
-//! Three families live here:
+//! Four families live here:
 //! - **`baseline`**: loads a previously-emitted JSON envelope from disk
 //!   so delta reporting can compare the current run against a prior one.
-//! - **`config`**: parses `crap4rs.toml` configuration (threshold
+//! - **`config`**: parses the adapter's TOML configuration (threshold
 //!   overrides, view presets, exclude patterns).
 //! - **`diff`**: shells out to git to compute changed line ranges per
 //!   file for `--diff <ref>` filtering.
@@ -14,11 +14,9 @@
 //!
 //! Per-language adapters (e.g. `crap4rs::adapters::complexity`,
 //! `crap4rs::adapters::coverage`) live in their parent crate and pull
-//! `crap-core`'s ports / domain types as dependencies.
-//!
-//! Relocated from `crap4rs::adapters::*` in S3 (crap4rs#135). The v0.4
-//! public surface stays buildable through the shim `pub use` re-exports
-//! in `crap4rs::adapters` (see crap4rs/src/lib.rs).
+//! `crap-core`'s ports / domain types as dependencies. The crap4rs v0.4
+//! public surface stays buildable through shim `pub use` re-exports in
+//! `crap4rs::adapters` (see crap4rs/src/lib.rs).
 
 pub mod baseline;
 pub mod config;

--- a/crates/crap-core/src/adapters/reporters/advice_summary.rs
+++ b/crates/crap-core/src/adapters/reporters/advice_summary.rs
@@ -63,11 +63,11 @@ fn format_actions(verdict: &FunctionVerdict) -> String {
 
 fn action_kind_label(action: &crate::domain::diagnostic::SuggestedAction) -> &'static str {
     use crate::domain::diagnostic::SuggestedAction::*;
-    // `SuggestedAction` is `#[non_exhaustive]` paused per D10 amendment
-    // (#147 restores at v1.0). Now that this reporter lives in crap-core
+    // `SuggestedAction` has `#[non_exhaustive]` paused per ADR D10
+    // (restored at v1.0). Now that this reporter lives in crap-core
     // alongside the enum, the match is in-crate and exhaustive — no
     // wildcard arm needed. v1.0 new variants will require explicit
-    // arms here; #147 covers that update path.
+    // arms here.
     match action {
         AddTestsForLines { .. } => "add_tests_for_lines",
         ExtractFunction { .. } => "extract_function",
@@ -202,10 +202,10 @@ mod tests {
         assert!(lines[1].contains("a_first"));
     }
 
-    /// Byte-level snapshot lock for the advice_summary reporter
-    /// (#142). The format is plain text with no ANSI / no
-    /// terminal-width dependency, so the snapshot is fully
-    /// deterministic by construction.
+    /// Byte-level snapshot lock for the advice_summary reporter.
+    /// The format is plain text with no ANSI / no terminal-width
+    /// dependency, so the snapshot is fully deterministic by
+    /// construction.
     ///
     /// Covers all four `SuggestedAction` variants (the entire
     /// `action_kind_label` match) plus the `[actions: none]` branch

--- a/crates/crap-core/src/adapters/reporters/csv.rs
+++ b/crates/crap-core/src/adapters/reporters/csv.rs
@@ -65,11 +65,11 @@ fn format_csv_delta(view: &DeltaView<'_>, metric: ComplexityMetric) -> String {
 }
 
 fn row_for_change(change: &FunctionChange, metric: ComplexityMetric) -> String {
-    // `FunctionChange` is `#[non_exhaustive]` paused per D10 amendment
-    // (#147 restores at v1.0). Now that this reporter lives in crap-core
+    // `FunctionChange` has `#[non_exhaustive]` paused per ADR D10
+    // (restored at v1.0). Now that this reporter lives in crap-core
     // alongside the enum, the match is in-crate and exhaustive — no
     // wildcard arm needed. v1.0 new variants will require explicit
-    // arms here; #147 covers that update path.
+    // arms here.
     let baseline_cells = match change {
         FunctionChange::Removed { baseline } | FunctionChange::Modified { baseline, .. } => {
             let s = &baseline.scored;

--- a/crates/crap-core/src/adapters/reporters/html.rs
+++ b/crates/crap-core/src/adapters/reporters/html.rs
@@ -3,7 +3,7 @@
 //! Produces a single document with inline CSS and no external assets
 //! (no CDN, no fonts). Layout is mobile-responsive via CSS flex/grid
 //! and per-file collapsibility uses native `<details>`/`<summary>` —
-//! no JavaScript required (issue #71).
+//! no JavaScript required.
 //!
 //! Color-coded risk levels match the SARIF severity mapping:
 //! - High → red
@@ -26,13 +26,17 @@ use crate::domain::view::AnalysisView;
 /// document should consume the structured view directly rather than
 /// scraping this output.
 ///
-/// `tool_version` is threaded from the caller (was `env!("CARGO_PKG_VERSION")`
-/// before the S3 relocation; that macro now resolves to `crap-core`'s
-/// version, not `crap4rs`'s, so the calling adapter passes its own
-/// version explicitly — same parameter pattern `format_sarif` already
-/// established).
-pub fn format_html(view: &AnalysisView<'_>, threshold: f64, tool_version: &str) -> String {
-    let title = format!("crap4rs v{tool_version} — CRAP Score Analysis");
+/// `tool_name` (the adapter binary's `env!("CARGO_PKG_NAME")`) and `tool_version`
+/// are threaded from the caller — `env!("CARGO_PKG_NAME")` and
+/// `env!("CARGO_PKG_VERSION")` resolve against `crap-core` here, not
+/// the adapter binary, so the calling binary supplies its own identity.
+pub fn format_html(
+    view: &AnalysisView<'_>,
+    threshold: f64,
+    tool_name: &str,
+    tool_version: &str,
+) -> String {
+    let title = format!("{tool_name} v{tool_version} — CRAP Score Analysis");
 
     let mut body = String::new();
     body.push_str(&render_header(&title, threshold));
@@ -461,8 +465,8 @@ fn escape_html(s: &str) -> String {
 mod tests {
     use super::*;
     use crate::adapters::reporters::test_fixtures::{
-        make_empty_result, make_multi_function_result, make_single_function_result,
-        make_view_default,
+        TEST_TOOL_NAME, TEST_TOOL_VERSION, make_empty_result, make_multi_function_result,
+        make_single_function_result, make_view_default,
     };
     use crate::domain::types::RiskLevel;
 
@@ -470,7 +474,7 @@ mod tests {
     fn empty_renders_doctype_and_empty_marker() {
         let result = make_empty_result();
         let view = make_view_default(&result);
-        let html = format_html(&view, 8.0, "0.4.0");
+        let html = format_html(&view, 8.0, TEST_TOOL_NAME, TEST_TOOL_VERSION);
         assert!(html.starts_with("<!DOCTYPE html>"));
         assert!(html.contains("No functions to display"));
         assert!(html.ends_with("</html>\n"));
@@ -480,7 +484,7 @@ mod tests {
     fn self_contained_no_external_assets() {
         let result = make_multi_function_result();
         let view = make_view_default(&result);
-        let html = format_html(&view, 8.0, "0.4.0");
+        let html = format_html(&view, 8.0, TEST_TOOL_NAME, TEST_TOOL_VERSION);
         // No <script>, no <link>, no external font/CDN URLs.
         assert!(!html.contains("<script"), "html should ship no JS for v1");
         assert!(!html.contains("<link"));
@@ -494,7 +498,7 @@ mod tests {
         let result =
             make_single_function_result("ok", "src/lib.rs", 1, 100.0, 1.0, RiskLevel::Low, 8.0);
         let view = make_view_default(&result);
-        let html = format_html(&view, 8.0, "0.4.0");
+        let html = format_html(&view, 8.0, TEST_TOOL_NAME, TEST_TOOL_VERSION);
         assert!(html.contains("badge badge-pass\">PASS"));
         assert!(!html.contains("badge badge-fail\">FAIL"));
     }
@@ -504,7 +508,7 @@ mod tests {
         let result =
             make_single_function_result("bad", "src/lib.rs", 20, 10.0, 45.0, RiskLevel::High, 8.0);
         let view = make_view_default(&result);
-        let html = format_html(&view, 8.0, "0.4.0");
+        let html = format_html(&view, 8.0, TEST_TOOL_NAME, TEST_TOOL_VERSION);
         assert!(html.contains("badge badge-fail\">FAIL"));
         assert!(html.contains("risk risk-high"));
         // Exceeding functions show the file pre-expanded.
@@ -515,7 +519,7 @@ mod tests {
     fn risk_levels_render_distinct_classes() {
         let result = make_multi_function_result();
         let view = make_view_default(&result);
-        let html = format_html(&view, 8.0, "0.4.0");
+        let html = format_html(&view, 8.0, TEST_TOOL_NAME, TEST_TOOL_VERSION);
         assert!(html.contains("risk-low"));
         assert!(html.contains("risk-moderate"));
         assert!(html.contains("risk-high"));
@@ -533,7 +537,7 @@ mod tests {
             8.0,
         );
         let view = make_view_default(&result);
-        let html = format_html(&view, 8.0, "0.4.0");
+        let html = format_html(&view, 8.0, TEST_TOOL_NAME, TEST_TOOL_VERSION);
         assert!(!html.contains("<script>alert"));
         assert!(html.contains("&lt;script&gt;"));
     }
@@ -550,7 +554,7 @@ mod tests {
             8.0,
         );
         let view = make_view_default(&result);
-        let html = format_html(&view, 8.0, "0.4.0");
+        let html = format_html(&view, 8.0, TEST_TOOL_NAME, TEST_TOOL_VERSION);
         assert!(!html.contains("<dangerous>"));
         assert!(html.contains("&lt;dangerous&gt;"));
     }
@@ -559,7 +563,7 @@ mod tests {
     fn groups_functions_by_file() {
         let result = make_multi_function_result();
         let view = make_view_default(&result);
-        let html = format_html(&view, 8.0, "0.4.0");
+        let html = format_html(&view, 8.0, TEST_TOOL_NAME, TEST_TOOL_VERSION);
         // Three distinct files in the fixture.
         assert_eq!(html.matches("<details class=\"file\"").count(), 3);
     }
@@ -568,7 +572,7 @@ mod tests {
     fn risk_distribution_shows_all_buckets() {
         let result = make_multi_function_result();
         let view = make_view_default(&result);
-        let html = format_html(&view, 8.0, "0.4.0");
+        let html = format_html(&view, 8.0, TEST_TOOL_NAME, TEST_TOOL_VERSION);
         assert!(html.contains("dist-low"));
         assert!(html.contains("dist-acceptable"));
         assert!(html.contains("dist-moderate"));
@@ -579,7 +583,7 @@ mod tests {
     fn doctype_present_and_lang_set() {
         let result = make_empty_result();
         let view = make_view_default(&result);
-        let html = format_html(&view, 8.0, "0.4.0");
+        let html = format_html(&view, 8.0, TEST_TOOL_NAME, TEST_TOOL_VERSION);
         assert!(html.contains("<!DOCTYPE html>"));
         assert!(html.contains("<html lang=\"en\">"));
         assert!(html.contains("viewport"));
@@ -605,7 +609,7 @@ mod tests {
             view.shown.is_empty(),
             "fixture pre-condition: shown should be empty under this filter"
         );
-        let html = format_html(&view, 8.0, "0.4.0");
+        let html = format_html(&view, 8.0, TEST_TOOL_NAME, TEST_TOOL_VERSION);
         assert!(html.contains("No functions to display"));
         assert!(!html.contains("Functions by file"));
     }
@@ -626,7 +630,7 @@ mod tests {
         };
         let view = view::apply(&result, spec);
         assert!(view.grouped.is_some());
-        let html = format_html(&view, 8.0, "0.4.0");
+        let html = format_html(&view, 8.0, TEST_TOOL_NAME, TEST_TOOL_VERSION);
         assert_eq!(
             html.matches("<details class=\"file\"").count(),
             1,
@@ -637,7 +641,7 @@ mod tests {
         assert!(!html.contains("src/adapters/coverage/mod.rs"));
     }
 
-    /// Byte-level snapshot lock for the HTML reporter (#141).
+    /// Byte-level snapshot lock for the HTML reporter.
     ///
     /// Complements the existing structural asserts (`PASS`/`FAIL`
     /// badge, risk-class strings, self-contained markup) with a
@@ -658,7 +662,7 @@ mod tests {
     fn full_html_snapshot() {
         let result = make_multi_function_result();
         let view = make_view_default(&result);
-        let html = format_html(&view, 8.0, "0.4.0");
+        let html = format_html(&view, 8.0, TEST_TOOL_NAME, TEST_TOOL_VERSION);
         insta::assert_snapshot!(html);
     }
 }

--- a/crates/crap-core/src/adapters/reporters/json.rs
+++ b/crates/crap-core/src/adapters/reporters/json.rs
@@ -16,11 +16,10 @@ use serde::Serialize;
 
 /// Configuration for the JSON envelope metadata.
 ///
-/// Generic over `P: ParseDiagnostic` — relocated to crap-core in S3
-/// (#135), where `AnalysisDiagnostics<P>` is generic across adapters.
-/// crap4rs concretizes via the `JsonConfig<'a>` type alias in
-/// `crap4rs::adapters::reporters::json` so v0.4 callers' type paths
-/// stay byte-identical.
+/// Generic over `P: ParseDiagnostic` since `AnalysisDiagnostics<P>`
+/// is generic across adapters. crap4rs concretizes via the
+/// `JsonConfig<'a>` type alias in `crap4rs::adapters::reporters::json`
+/// so v0.4 callers' type paths stay byte-identical.
 #[derive(Debug)]
 pub struct JsonConfig<'a, P: ParseDiagnostic> {
     pub tool_version: String,
@@ -64,9 +63,9 @@ pub struct DeltaContext<'a, P: ParseDiagnostic> {
 ///   threshold, diff_ref, result, view
 /// Per ADR D2 the schema is additive across minor versions; the
 /// `schema_version` bump from 1 → 2 in 0.4.0 reflects the
-/// `ComplexityContributor.column` 0-based → 1-based convention shift
-/// (#107). Older v1 baselines remain loadable for delta reporting
-/// (matching is identity-keyed, not column-keyed).
+/// `ComplexityContributor.column` 0-based → 1-based convention shift.
+/// Older v1 baselines remain loadable for delta reporting (matching
+/// is identity-keyed, not column-keyed).
 #[derive(Serialize)]
 #[serde(bound = "")]
 struct JsonEnvelope<'a, P: ParseDiagnostic> {
@@ -209,8 +208,8 @@ mod tests {
     /// Concrete `P` for in-module tests — the JSON reporter's behavior
     /// is `P`-agnostic for the cases asserted here (no test reaches
     /// into per-variant fields of a parse diagnostic). Pinning to the
-    /// dummy stub keeps the assertions byte-identical to crap4rs's
-    /// pre-S3 unit suite.
+    /// dummy stub decouples these tests from any specific adapter's
+    /// diagnostic shape.
     type TestJsonConfig = JsonConfig<'static, DummyParseDiagnostic>;
 
     fn default_config() -> TestJsonConfig {
@@ -557,10 +556,9 @@ mod tests {
         // through regardless of how `parse_diagnostics` flatten. The
         // LCOV-specific per-variant wire shape is asserted in the
         // crap4rs-side companion test
-        // `tests/json_reporter_lcov_diagnostics.rs::diagnostics_included_when_present`
-        // (relocated in S3 — moved with the reporter so the LCOV
-        // assertion lives next to LcovParseDiagnostic, not in
-        // crap-core which is `P`-generic).
+        // `tests/json_reporter_lcov_diagnostics.rs::diagnostics_included_when_present`,
+        // which lives next to LcovParseDiagnostic rather than in
+        // crap-core (which is `P`-generic).
         use crate::domain::types::AnalysisDiagnostics;
 
         let diag: AnalysisDiagnostics<DummyParseDiagnostic> = AnalysisDiagnostics {

--- a/crates/crap-core/src/adapters/reporters/markdown.rs
+++ b/crates/crap-core/src/adapters/reporters/markdown.rs
@@ -30,12 +30,10 @@ use crate::domain::view::AnalysisView;
 ///
 /// When `delta` is `Some`, a `## CRAP Scorecard` section is appended
 /// after the analysis body — designed for PR-comment rendering.
-// `tool_version` was added in S3 (#135) when reporters relocated to
-// crap-core (env!("CARGO_PKG_VERSION") here resolves to crap-core's
-// version, not the calling adapter's). The argument count climbs to 8.
-// A struct-of-args refactor is queued for the v1.0 reporter polish per
-// the impl-plan; leaving the linear list for now keeps the diff
-// reviewable.
+// `tool_name` and `tool_version` are caller-supplied (env!() inside
+// crap-core would resolve to crap-core's name/version, not the
+// adapter's). The argument count climbs to 9; a struct-of-args
+// refactor is queued for the v1.0 reporter polish.
 #[allow(clippy::too_many_arguments)]
 pub fn format_markdown(
     view: &AnalysisView<'_>,
@@ -45,6 +43,7 @@ pub fn format_markdown(
     explain: bool,
     full_table: bool,
     top_n: usize,
+    tool_name: &str,
     tool_version: &str,
 ) -> String {
     let mut out = format_markdown_body(
@@ -54,6 +53,7 @@ pub fn format_markdown(
         explain,
         full_table,
         top_n,
+        tool_name,
         tool_version,
     );
     if let Some(delta_view) = delta {
@@ -67,11 +67,11 @@ pub fn format_markdown(
 /// empty / grouped / spotlight / full-table paths; the delta block is
 /// appended once by the caller.
 ///
-/// `tool_version` is threaded from the caller (was `env!("CARGO_PKG_VERSION")`
-/// before the S3 relocation; that macro now resolves to `crap-core`'s
-/// version, not `crap4rs`'s, so the calling adapter passes its own
-/// version explicitly — same parameter pattern `format_sarif` already
-/// established).
+/// `tool_name` (the adapter binary's `env!("CARGO_PKG_NAME")`) and `tool_version`
+/// are threaded from the caller — `env!("CARGO_PKG_NAME")` and
+/// `env!("CARGO_PKG_VERSION")` resolve against `crap-core` here, not
+/// the adapter binary, so the calling binary supplies its own identity.
+#[allow(clippy::too_many_arguments)]
 fn format_markdown_body(
     view: &AnalysisView<'_>,
     threshold: f64,
@@ -79,11 +79,12 @@ fn format_markdown_body(
     explain: bool,
     full_table: bool,
     top_n: usize,
+    tool_name: &str,
     tool_version: &str,
 ) -> String {
     let mut out = String::new();
     out.push_str(&format!(
-        "# crap4rs v{tool_version} — CRAP Score Analysis\n\n",
+        "# {tool_name} v{tool_version} — CRAP Score Analysis\n\n",
     ));
 
     if view.full.functions.is_empty() {
@@ -297,10 +298,10 @@ fn format_markdown_delta(view: &DeltaView<'_>) -> String {
             FunctionChange::Added { current } => current.exceeds,
             FunctionChange::Modified { baseline, current } => !baseline.exceeds && current.exceeds,
             FunctionChange::Removed { .. } => false,
-            // `FunctionChange` is `#[non_exhaustive]` paused per D10
-            // amendment (#147 restores at v1.0). In-crate match is
-            // exhaustive after S3 relocation — no wildcard arm needed.
-            // v1.0 new variants will require an explicit arm here.
+            // `FunctionChange` has `#[non_exhaustive]` paused per ADR
+            // D10 (restored at v1.0). In-crate match is exhaustive —
+            // no wildcard arm needed. v1.0 new variants will require
+            // an explicit arm here.
         })
         .collect();
     if !new_violations.is_empty() {
@@ -447,7 +448,8 @@ mod tests {
             false,
             false,
             10,
-            "0.4.0",
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
         );
         assert!(out.contains("| File | Function | CC | Cov% | CRAP | Risk |"));
         assert!(out.contains("|------|"));
@@ -464,7 +466,8 @@ mod tests {
             false,
             false,
             10,
-            "0.4.0",
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
         );
         assert!(out.contains("No functions analyzed"));
         assert!(!out.contains("| File |"));
@@ -482,7 +485,8 @@ mod tests {
             false,
             false,
             10,
-            "0.4.0",
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
         );
         assert!(out.contains("a\\|b"), "expected escaped pipe in: {out}");
     }
@@ -500,7 +504,8 @@ mod tests {
             false,
             false,
             10,
-            "0.4.0",
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
         );
         assert!(out.contains("**Result:** FAIL"));
         assert!(out.contains("**Functions:** 3"));
@@ -518,7 +523,8 @@ mod tests {
             false,
             false,
             10,
-            "0.4.0",
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
         );
         insta::assert_snapshot!(out);
     }
@@ -534,7 +540,8 @@ mod tests {
             false,
             true, // --md-full-table
             10,
-            "0.4.0",
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
         );
         // Summary block still leads.
         assert!(out.contains("## Summary"));
@@ -594,7 +601,8 @@ mod tests {
             true, // --explain
             true, // --md-full-table
             10,
-            "0.4.0",
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
         );
         assert!(out.contains("## All functions"));
         // Breakdown bullets rendered for the exceeding row.
@@ -649,7 +657,8 @@ mod tests {
             true,
             false,
             10,
-            "0.4.0",
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
         );
         insta::assert_snapshot!(out);
     }
@@ -667,7 +676,17 @@ mod tests {
                 ..Default::default()
             },
         );
-        let out = format_markdown(&view, None, 8.0, false, false, false, 10, "0.4.0");
+        let out = format_markdown(
+            &view,
+            None,
+            8.0,
+            false,
+            false,
+            false,
+            10,
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
+        );
         assert!(out.contains("| File | Functions | Failing | Avg CRAP | Worst CRAP | Worst Fn |"));
         // Per-function CC/Cov% headers absent in the per-file aggregate table
         assert!(!out.contains("| File | Function | CC |"));
@@ -687,7 +706,17 @@ mod tests {
                 ..Default::default()
             },
         );
-        let out = format_markdown(&view, None, 8.0, false, false, false, 10, "0.4.0");
+        let out = format_markdown(
+            &view,
+            None,
+            8.0,
+            false,
+            false,
+            false,
+            10,
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
+        );
         insta::assert_snapshot!(out);
     }
 
@@ -705,7 +734,8 @@ mod tests {
             false,
             false,
             10,
-            "0.4.0",
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
         );
         assert!(out.contains("## CRAP Scorecard"));
         // Status reflects the delta gate (new_violations > 0 → FAIL)
@@ -727,7 +757,8 @@ mod tests {
             false,
             false,
             10,
-            "0.4.0",
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
         );
         assert!(out.contains("### Regressions"));
         // parse_record went 15.0 → 22.0
@@ -747,7 +778,8 @@ mod tests {
             false,
             false,
             10,
-            "0.4.0",
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
         );
         assert!(out.contains("### New violations"));
         assert!(out.contains("new_fn"));
@@ -764,7 +796,8 @@ mod tests {
             false,
             false,
             10,
-            "0.4.0",
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
         );
         assert!(!out.contains("CRAP Scorecard"));
         assert!(!out.contains("Delta status"));
@@ -782,7 +815,8 @@ mod tests {
             false,
             false,
             10,
-            "0.4.0",
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
         );
         insta::assert_snapshot!(out);
     }

--- a/crates/crap-core/src/adapters/reporters/mod.rs
+++ b/crates/crap-core/src/adapters/reporters/mod.rs
@@ -27,6 +27,31 @@ pub(crate) mod test_fixtures {
     };
     use crate::domain::view::{self, AnalysisView, ViewSpec};
 
+    /// Synthetic `tool_name` used by every in-crate reporter test.
+    ///
+    /// crap-core is adapter-agnostic — production callers supply
+    /// `env!("CARGO_PKG_NAME")` (`"crap4rs"`, `"crap4ts"`, …) from the
+    /// binary. Inside the library, tests assert behavior of the
+    /// parameterization itself, so a clearly synthetic placeholder
+    /// keeps snapshots deterministic, makes the abstraction obvious
+    /// to a reader of the snapshot, and forces an explicit choice if
+    /// a future change drifts back toward a hardcoded adapter name.
+    pub const TEST_TOOL_NAME: &str = "test-adapter";
+
+    /// Synthetic `tool_version`. Stays at `"0.4.0"` so version-string
+    /// snapshot diffs are confined to the `tool_name` parameterization
+    /// (i.e., only the prefix `"crap4rs v…"` → `"test-adapter v…"`
+    /// changes, not the version digits).
+    pub const TEST_TOOL_VERSION: &str = "0.4.0";
+
+    /// Synthetic `tool_info_uri` for SARIF tests. Used in place of the
+    /// previously-hardcoded `https://github.com/breezy-bays-labs/crap4rs`.
+    pub const TEST_TOOL_INFO_URI: &str = "https://example.com/test-adapter";
+
+    /// Synthetic `rule_help_uri` for SARIF tests. Used in place of the
+    /// previously-hardcoded `https://github.com/breezy-bays-labs/crap4rs#crap-formula`.
+    pub const TEST_RULE_HELP_URI: &str = "https://example.com/test-adapter#crap";
+
     /// Build a default-spec view from the given analysis. Convenience for
     /// reporter tests that just want to assert on the default-spec output
     /// (the V1a walking-skeleton invariant).

--- a/crates/crap-core/src/adapters/reporters/sarif.rs
+++ b/crates/crap-core/src/adapters/reporters/sarif.rs
@@ -12,16 +12,25 @@ use crate::domain::view::AnalysisView;
 
 const SCHEMA_URI: &str = "https://json.schemastore.org/sarif-2.1.0.json";
 const RULE_ID: &str = "crap/threshold-exceeded";
-const TOOL_NAME: &str = "crap4rs";
-const TOOL_INFO_URI: &str = "https://github.com/breezy-bays-labs/crap4rs";
-const RULE_HELP_URI: &str = "https://github.com/breezy-bays-labs/crap4rs#crap-formula";
 
 /// Format an `AnalysisView` as SARIF v2.1.0 JSON.
 ///
 /// One SARIF `result` per `FunctionVerdict` whose `exceeds == true`,
-/// iterating the *full* analysis (not the shaped slice). `tool_version`
-/// is threaded through to `runs[0].tool.driver.version`.
-pub fn format_sarif(view: &AnalysisView<'_>, tool_version: &str) -> String {
+/// iterating the *full* analysis (not the shaped slice).
+///
+/// `tool_name`, `tool_version`, `tool_info_uri`, `rule_help_uri` are
+/// adapter-supplied — production callers thread the binary's
+/// `env!("CARGO_PKG_NAME")` / `env!("CARGO_PKG_VERSION")` plus the
+/// adapter's repo URLs. The values land in `runs[0].tool.driver.*`
+/// and `rules[0].helpUri` so SARIF consumers (GitHub Code Scanning,
+/// etc.) link back to the *real* tool, not a hardcoded default.
+pub fn format_sarif(
+    view: &AnalysisView<'_>,
+    tool_name: &str,
+    tool_version: &str,
+    tool_info_uri: &str,
+    rule_help_uri: &str,
+) -> String {
     let results: Vec<SarifResult> = view
         .full
         .functions
@@ -36,10 +45,10 @@ pub fn format_sarif(view: &AnalysisView<'_>, tool_version: &str) -> String {
         runs: vec![SarifRun {
             tool: SarifTool {
                 driver: SarifDriver {
-                    name: TOOL_NAME,
+                    name: tool_name.to_string(),
                     version: tool_version.to_string(),
-                    information_uri: TOOL_INFO_URI,
-                    rules: vec![rule()],
+                    information_uri: tool_info_uri.to_string(),
+                    rules: vec![rule(rule_help_uri)],
                 },
             },
             results,
@@ -50,7 +59,7 @@ pub fn format_sarif(view: &AnalysisView<'_>, tool_version: &str) -> String {
         .expect("SARIF serialization is infallible — all fields are owned strings or numbers")
 }
 
-fn rule() -> SarifRule {
+fn rule(help_uri: &str) -> SarifRule {
     SarifRule {
         id: RULE_ID,
         name: "ThresholdExceeded",
@@ -62,7 +71,7 @@ fn rule() -> SarifRule {
                    exceeds the threshold are change-risk hot spots: cover them first, then extract \
                    sub-functions if complexity remains the driver.",
         },
-        help_uri: RULE_HELP_URI,
+        help_uri: help_uri.to_string(),
     }
 }
 
@@ -169,10 +178,10 @@ struct SarifTool {
 
 #[derive(Serialize)]
 struct SarifDriver {
-    name: &'static str,
+    name: String,
     version: String,
     #[serde(rename = "informationUri")]
-    information_uri: &'static str,
+    information_uri: String,
     rules: Vec<SarifRule>,
 }
 
@@ -185,7 +194,7 @@ struct SarifRule {
     #[serde(rename = "fullDescription")]
     full_description: SarifText<&'static str>,
     #[serde(rename = "helpUri")]
-    help_uri: &'static str,
+    help_uri: String,
 }
 
 #[derive(Serialize)]
@@ -255,11 +264,26 @@ mod tests {
         serde_json::from_str(json).expect("format_sarif must produce valid JSON")
     }
 
+    /// Test wrapper that splices in the synthetic adapter URIs so each
+    /// individual test stays focused on its own assertion. SARIF
+    /// `tool_name` / `tool_info_uri` / `rule_help_uri` are now
+    /// adapter-supplied — production callers thread their
+    /// binary's real identity; tests use deterministic placeholders.
+    fn format_sarif_t(view: &AnalysisView<'_>, tool_version: &str) -> String {
+        format_sarif(
+            view,
+            TEST_TOOL_NAME,
+            tool_version,
+            TEST_TOOL_INFO_URI,
+            TEST_RULE_HELP_URI,
+        )
+    }
+
     #[test]
     fn empty_result_produces_empty_results_array() {
         let result = make_empty_result();
         let view = make_view_default(&result);
-        let v = parse(&format_sarif(&view, "test-version"));
+        let v = parse(&format_sarif_t(&view, "test-version"));
         assert_eq!(v["version"], "2.1.0");
         assert_eq!(v["runs"][0]["results"].as_array().unwrap().len(), 0);
     }
@@ -276,7 +300,7 @@ mod tests {
             8.0,
         );
         let view = make_view_default(&result);
-        let v = parse(&format_sarif(&view, "test-version"));
+        let v = parse(&format_sarif_t(&view, "test-version"));
         let results = v["runs"][0]["results"].as_array().unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0]["ruleId"], "crap/threshold-exceeded");
@@ -304,7 +328,7 @@ mod tests {
             passed: false,
         };
         let view = make_view_default(&result);
-        let v = parse(&format_sarif(&view, "test-version"));
+        let v = parse(&format_sarif_t(&view, "test-version"));
         let results = v["runs"][0]["results"].as_array().unwrap();
         let levels: Vec<&str> = results
             .iter()
@@ -325,7 +349,7 @@ mod tests {
             8.0,
         );
         let view = make_view_default(&result);
-        let v = parse(&format_sarif(&view, "test-version"));
+        let v = parse(&format_sarif_t(&view, "test-version"));
         let r0 = &v["runs"][0]["results"][0];
         assert_eq!(
             r0["partialFingerprints"]["functionIdentity"],
@@ -337,14 +361,22 @@ mod tests {
     fn schema_uri_and_top_level_shape() {
         let result = make_multi_function_result();
         let view = make_view_default(&result);
-        let v = parse(&format_sarif(&view, "0.2.2"));
+        let v = parse(&format_sarif_t(&view, "0.2.2"));
         assert_eq!(
             v["$schema"],
             "https://json.schemastore.org/sarif-2.1.0.json"
         );
         assert_eq!(v["version"], "2.1.0");
-        assert_eq!(v["runs"][0]["tool"]["driver"]["name"], "crap4rs");
+        assert_eq!(v["runs"][0]["tool"]["driver"]["name"], TEST_TOOL_NAME);
         assert_eq!(v["runs"][0]["tool"]["driver"]["version"], "0.2.2");
+        assert_eq!(
+            v["runs"][0]["tool"]["driver"]["informationUri"],
+            TEST_TOOL_INFO_URI
+        );
+        assert_eq!(
+            v["runs"][0]["tool"]["driver"]["rules"][0]["helpUri"],
+            TEST_RULE_HELP_URI
+        );
     }
 
     #[test]
@@ -352,7 +384,7 @@ mod tests {
         // The rule must be defined on the run regardless of whether any
         // result references it, so consumers can introspect the schema.
         let empty = make_empty_result();
-        let v = parse(&format_sarif(&make_view_default(&empty), "0.2.2"));
+        let v = parse(&format_sarif_t(&make_view_default(&empty), "0.2.2"));
         let rules = v["runs"][0]["tool"]["driver"]["rules"].as_array().unwrap();
         assert_eq!(rules.len(), 1);
         assert_eq!(rules[0]["id"], "crap/threshold-exceeded");
@@ -363,7 +395,7 @@ mod tests {
     fn full_sarif_snapshot() {
         let result = make_multi_function_result();
         let view = make_view_default(&result);
-        let out = format_sarif(&view, "0.2.2");
+        let out = format_sarif_t(&view, "0.2.2");
         insta::assert_snapshot!(out);
     }
 
@@ -404,7 +436,7 @@ mod tests {
         // column 32 inclusive becomes SARIF endColumn 33.
         let result = result_with_single(verdict_with_columns(5, 32));
         let view = make_view_default(&result);
-        let v = parse(&format_sarif(&view, "test-version"));
+        let v = parse(&format_sarif_t(&view, "test-version"));
         let region = &v["runs"][0]["results"][0]["locations"][0]["physicalLocation"]["region"];
         assert_eq!(
             region["startColumn"], 5,
@@ -422,7 +454,7 @@ mod tests {
         // must not surface meaningless columns to GitHub Code Scanning.
         let result = result_with_single(verdict_with_columns(0, 0));
         let view = make_view_default(&result);
-        let v = parse(&format_sarif(&view, "test-version"));
+        let v = parse(&format_sarif_t(&view, "test-version"));
         let region = &v["runs"][0]["results"][0]["locations"][0]["physicalLocation"]["region"];
         assert!(
             region.get("startColumn").is_none(),
@@ -442,7 +474,7 @@ mod tests {
         for (sc, ec) in [(5usize, 0usize), (0, 32)] {
             let result = result_with_single(verdict_with_columns(sc, ec));
             let view = make_view_default(&result);
-            let v = parse(&format_sarif(&view, "test-version"));
+            let v = parse(&format_sarif_t(&view, "test-version"));
             let region = &v["runs"][0]["results"][0]["locations"][0]["physicalLocation"]["region"];
             assert!(
                 region.get("startColumn").is_none() && region.get("endColumn").is_none(),
@@ -455,9 +487,23 @@ mod tests {
 #[cfg(test)]
 mod proptests {
     use super::*;
-    use crate::adapters::reporters::test_fixtures::make_view_default;
+    use crate::adapters::reporters::test_fixtures::{
+        TEST_RULE_HELP_URI, TEST_TOOL_INFO_URI, TEST_TOOL_NAME, make_view_default,
+    };
     use crate::test_strategies::arb_analysis_result;
     use proptest::prelude::*;
+
+    /// Local wrapper for proptests — mirrors `tests::format_sarif_t`
+    /// (sibling module, not visible across the `mod` boundary).
+    fn format_sarif_t(view: &AnalysisView<'_>, tool_version: &str) -> String {
+        format_sarif(
+            view,
+            TEST_TOOL_NAME,
+            tool_version,
+            TEST_TOOL_INFO_URI,
+            TEST_RULE_HELP_URI,
+        )
+    }
 
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(256))]
@@ -465,7 +511,7 @@ mod proptests {
         #[test]
         fn prop_format_sarif_always_valid_json(result in arb_analysis_result()) {
             let view = make_view_default(&result);
-            let out = format_sarif(&view, "0.2.2");
+            let out = format_sarif_t(&view,"0.2.2");
             let _: serde_json::Value = serde_json::from_str(&out)
                 .expect("format_sarif must produce parseable JSON");
         }
@@ -473,7 +519,7 @@ mod proptests {
         #[test]
         fn prop_sarif_results_count_matches_exceeders(result in arb_analysis_result()) {
             let view = make_view_default(&result);
-            let out = format_sarif(&view, "0.2.2");
+            let out = format_sarif_t(&view,"0.2.2");
             let v: serde_json::Value = serde_json::from_str(&out).unwrap();
             let results = v["runs"][0]["results"].as_array().unwrap();
             let expected = result.functions.iter().filter(|fv| fv.exceeds).count();
@@ -483,7 +529,7 @@ mod proptests {
         #[test]
         fn prop_every_result_has_mandatory_sarif_fields(result in arb_analysis_result()) {
             let view = make_view_default(&result);
-            let out = format_sarif(&view, "0.2.2");
+            let out = format_sarif_t(&view,"0.2.2");
             let v: serde_json::Value = serde_json::from_str(&out).unwrap();
             for r in v["runs"][0]["results"].as_array().unwrap() {
                 prop_assert!(r["ruleId"].is_string());
@@ -500,7 +546,7 @@ mod proptests {
         #[test]
         fn prop_severity_is_one_of_three_values(result in arb_analysis_result()) {
             let view = make_view_default(&result);
-            let out = format_sarif(&view, "0.2.2");
+            let out = format_sarif_t(&view,"0.2.2");
             let v: serde_json::Value = serde_json::from_str(&out).unwrap();
             for r in v["runs"][0]["results"].as_array().unwrap() {
                 let level = r["level"].as_str().unwrap();

--- a/crates/crap-core/src/adapters/reporters/scorecard_row.rs
+++ b/crates/crap-core/src/adapters/reporters/scorecard_row.rs
@@ -1,17 +1,15 @@
 //! Scorecard-row reporter — emits a single mokumo `Row::CrapDelta` JSON
-//! object to stdout. Issue #111.
+//! object to stdout.
 //!
 //! The wire shape mirrors mokumo's locked schema fragment at
 //! `breezy-bays-labs/mokumo/.config/scorecard/schema.json#/definitions/Row`
-//! (CrapDelta member of the `oneOf`, schema_version=2). We replicate the
-//! shape locally via private serde structs rather than depending on
-//! mokumo's `scorecard` crate so crap4rs stays mokumo-decoupled — the
-//! scorecard schema is the contract, not mokumo's Rust crate.
-//!
-//! See `~/Github/ops/pipelines/crap4rs/crap4rs-20260503-scorecard-row-rollout.md`
-//! for the V3-symmetric audit and Model P (producer-mints-status)
-//! rationale. The integration test at `tests/scorecard_row_integration.rs`
-//! validates output against a vendored copy of mokumo's schema.
+//! (CrapDelta member of the `oneOf`, schema_version=2). We replicate
+//! the shape locally via private serde structs rather than depending
+//! on mokumo's `scorecard` crate so the analyzer stays mokumo-
+//! decoupled — the scorecard schema is the contract, not mokumo's
+//! Rust crate. Model P (producer-mints-status) is the locked
+//! convention; integration tests in adapter crates validate output
+//! against a vendored copy of mokumo's schema.
 
 use serde::Serialize;
 
@@ -175,7 +173,7 @@ mod tests {
         assert_eq!(out1, out2, "format is deterministic");
     }
 
-    // ── Byte-level snapshot locks (#143) ───────────────────────────────
+    // ── Byte-level snapshot locks ───────────────────────────────
     //
     // Complement the existing `scorecard_row_integration.rs` schema
     // validation (which gates the shape against mokumo's

--- a/crates/crap-core/src/adapters/reporters/snapshots/crap_core__adapters__reporters__html__tests__full_html_snapshot.snap
+++ b/crates/crap-core/src/adapters/reporters/snapshots/crap_core__adapters__reporters__html__tests__full_html_snapshot.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/crap-core/src/adapters/reporters/html.rs
-assertion_line: 662
 expression: html
 ---
 <!DOCTYPE html>
@@ -8,7 +7,7 @@ expression: html
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>crap4rs v0.4.0 — CRAP Score Analysis</title>
+<title>test-adapter v0.4.0 — CRAP Score Analysis</title>
 <style>
 
 :root {
@@ -168,7 +167,7 @@ details.contributors ul {
 </head>
 <body>
 <header>
-<h1>crap4rs v0.4.0 — CRAP Score Analysis</h1>
+<h1>test-adapter v0.4.0 — CRAP Score Analysis</h1>
 <p class="threshold">Threshold: <strong>8.00</strong></p>
 </header>
 <section class="summary">

--- a/crates/crap-core/src/adapters/reporters/snapshots/crap_core__adapters__reporters__markdown__tests__full_markdown_breakdown_snapshot.snap
+++ b/crates/crap-core/src/adapters/reporters/snapshots/crap_core__adapters__reporters__markdown__tests__full_markdown_breakdown_snapshot.snap
@@ -1,8 +1,8 @@
 ---
-source: src/adapters/reporters/markdown.rs
+source: crates/crap-core/src/adapters/reporters/markdown.rs
 expression: out
 ---
-# crap4rs v0.4.0 — CRAP Score Analysis
+# test-adapter v0.4.0 — CRAP Score Analysis
 
 ## Summary
 

--- a/crates/crap-core/src/adapters/reporters/snapshots/crap_core__adapters__reporters__markdown__tests__full_markdown_snapshot.snap
+++ b/crates/crap-core/src/adapters/reporters/snapshots/crap_core__adapters__reporters__markdown__tests__full_markdown_snapshot.snap
@@ -1,8 +1,8 @@
 ---
-source: src/adapters/reporters/markdown.rs
+source: crates/crap-core/src/adapters/reporters/markdown.rs
 expression: out
 ---
-# crap4rs v0.4.0 — CRAP Score Analysis
+# test-adapter v0.4.0 — CRAP Score Analysis
 
 ## Summary
 

--- a/crates/crap-core/src/adapters/reporters/snapshots/crap_core__adapters__reporters__markdown__tests__full_markdown_with_delta_snapshot.snap
+++ b/crates/crap-core/src/adapters/reporters/snapshots/crap_core__adapters__reporters__markdown__tests__full_markdown_with_delta_snapshot.snap
@@ -1,8 +1,8 @@
 ---
-source: src/adapters/reporters/markdown.rs
+source: crates/crap-core/src/adapters/reporters/markdown.rs
 expression: out
 ---
-# crap4rs v0.4.0 — CRAP Score Analysis
+# test-adapter v0.4.0 — CRAP Score Analysis
 
 ## Summary
 

--- a/crates/crap-core/src/adapters/reporters/snapshots/crap_core__adapters__reporters__markdown__tests__grouped_markdown_snapshot.snap
+++ b/crates/crap-core/src/adapters/reporters/snapshots/crap_core__adapters__reporters__markdown__tests__grouped_markdown_snapshot.snap
@@ -1,8 +1,8 @@
 ---
-source: src/adapters/reporters/markdown.rs
+source: crates/crap-core/src/adapters/reporters/markdown.rs
 expression: out
 ---
-# crap4rs v0.4.0 — CRAP Score Analysis
+# test-adapter v0.4.0 — CRAP Score Analysis
 
 ## Summary
 

--- a/crates/crap-core/src/adapters/reporters/snapshots/crap_core__adapters__reporters__sarif__tests__full_sarif_snapshot.snap
+++ b/crates/crap-core/src/adapters/reporters/snapshots/crap_core__adapters__reporters__sarif__tests__full_sarif_snapshot.snap
@@ -1,6 +1,5 @@
 ---
-source: src/adapters/reporters/sarif.rs
-assertion_line: 322
+source: crates/crap-core/src/adapters/reporters/sarif.rs
 expression: out
 ---
 {
@@ -10,9 +9,9 @@ expression: out
     {
       "tool": {
         "driver": {
-          "name": "crap4rs",
+          "name": "test-adapter",
           "version": "0.2.2",
-          "informationUri": "https://github.com/breezy-bays-labs/crap4rs",
+          "informationUri": "https://example.com/test-adapter",
           "rules": [
             {
               "id": "crap/threshold-exceeded",
@@ -23,7 +22,7 @@ expression: out
               "fullDescription": {
                 "text": "Functions whose CRAP score (complexity * complexity * (1 - coverage)^3 + complexity) exceeds the threshold are change-risk hot spots: cover them first, then extract sub-functions if complexity remains the driver."
               },
-              "helpUri": "https://github.com/breezy-bays-labs/crap4rs#crap-formula"
+              "helpUri": "https://example.com/test-adapter#crap"
             }
           ]
         }

--- a/crates/crap-core/src/adapters/reporters/snapshots/crap_core__adapters__reporters__table__tests__delta_block_full_snapshot.snap
+++ b/crates/crap-core/src/adapters/reporters/snapshots/crap_core__adapters__reporters__table__tests__delta_block_full_snapshot.snap
@@ -1,8 +1,8 @@
 ---
-source: src/adapters/reporters/table.rs
+source: crates/crap-core/src/adapters/reporters/table.rs
 expression: output
 ---
-crap4rs v0.4.0 — CRAP Score Analysis
+test-adapter v0.4.0 — CRAP Score Analysis
 
 +------------------------------+--------------+----+------+-------+------+
 | File                         | Function     | CC | Cov% | CRAP  | Risk |

--- a/crates/crap-core/src/adapters/reporters/snapshots/crap_core__adapters__reporters__table__tests__full_table_snapshot.snap
+++ b/crates/crap-core/src/adapters/reporters/snapshots/crap_core__adapters__reporters__table__tests__full_table_snapshot.snap
@@ -1,8 +1,8 @@
 ---
-source: src/adapters/reporters/table.rs
+source: crates/crap-core/src/adapters/reporters/table.rs
 expression: output
 ---
-crap4rs v0.4.0 — CRAP Score Analysis
+test-adapter v0.4.0 — CRAP Score Analysis
 
 +------------------------------+--------------+----+------+-------+----------+
 | File                         | Function     | CC | Cov% | CRAP  | Risk     |

--- a/crates/crap-core/src/adapters/reporters/snapshots/crap_core__adapters__reporters__table__tests__grouped_table_snapshot.snap
+++ b/crates/crap-core/src/adapters/reporters/snapshots/crap_core__adapters__reporters__table__tests__grouped_table_snapshot.snap
@@ -1,8 +1,8 @@
 ---
-source: src/adapters/reporters/table.rs
+source: crates/crap-core/src/adapters/reporters/table.rs
 expression: output
 ---
-crap4rs v0.4.0 — CRAP Score Analysis
+test-adapter v0.4.0 — CRAP Score Analysis
 
 +------------------------------+-----------+---------+----------+------------+--------------+
 | File                         | Functions | Failing | Avg CRAP | Worst CRAP | Worst Fn     |

--- a/crates/crap-core/src/adapters/reporters/table.rs
+++ b/crates/crap-core/src/adapters/reporters/table.rs
@@ -21,9 +21,18 @@ pub fn format_table(
     view: &AnalysisView<'_>,
     threshold: f64,
     breakdown: bool,
+    tool_name: &str,
     tool_version: &str,
 ) -> String {
-    format_table_with_explain(view, None, threshold, breakdown, false, tool_version)
+    format_table_with_explain(
+        view,
+        None,
+        threshold,
+        breakdown,
+        false,
+        tool_name,
+        tool_version,
+    )
 }
 
 /// Format an `AnalysisView` as a colored terminal table with optional
@@ -34,23 +43,25 @@ pub fn format_table(
 /// summary line. When `delta` is `None`, output is byte-identical to
 /// the pre-delta version.
 ///
-/// `tool_version` is threaded from the caller (was `env!("CARGO_PKG_VERSION")`
-/// before the S3 relocation; that macro now resolves to `crap-core`'s
-/// version, not `crap4rs`'s, so the calling adapter passes its own
-/// version explicitly — same parameter pattern `format_sarif` already
-/// established).
+/// `tool_name` (the adapter binary's `env!("CARGO_PKG_NAME")`) and `tool_version`
+/// are threaded from the caller — `env!("CARGO_PKG_NAME")` and
+/// `env!("CARGO_PKG_VERSION")` resolve against `crap-core` here, not
+/// the adapter binary, so the calling binary supplies its own identity.
 pub fn format_table_with_explain(
     view: &AnalysisView<'_>,
     delta: Option<&DeltaView<'_>>,
     threshold: f64,
     breakdown: bool,
     explain: bool,
+    tool_name: &str,
     tool_version: &str,
 ) -> String {
     let mut output = String::new();
 
     // Header
-    output.push_str(&format!("crap4rs v{tool_version} — CRAP Score Analysis\n",));
+    output.push_str(&format!(
+        "{tool_name} v{tool_version} — CRAP Score Analysis\n",
+    ));
 
     // Empty guard — derived from the underlying analysis (the gate),
     // not from the shaped view, so an empty `view.shown` resulting from
@@ -429,8 +440,14 @@ mod tests {
         let _guard = COLOR_LOCK.lock().unwrap();
         colored::control::set_override(false);
         let result = make_empty_result();
-        let output = format_table(&make_view_default(&result), 8.0, false, "0.4.0");
-        assert!(output.contains("crap4rs v"));
+        let output = format_table(
+            &make_view_default(&result),
+            8.0,
+            false,
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
+        );
+        assert!(output.contains(&format!("{TEST_TOOL_NAME} v")));
         assert!(output.contains("No functions analyzed"));
         // No table header should be present
         assert!(!output.contains("File"));
@@ -441,7 +458,13 @@ mod tests {
         let _guard = COLOR_LOCK.lock().unwrap();
         colored::control::set_override(false);
         let result = make_multi_function_result();
-        let output = format_table(&make_view_default(&result), 8.0, false, "0.4.0");
+        let output = format_table(
+            &make_view_default(&result),
+            8.0,
+            false,
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
+        );
         let lines: Vec<&str> = output.lines().collect();
 
         // Find data rows (after header row + separator)
@@ -475,7 +498,13 @@ mod tests {
             RiskLevel::Acceptable,
             8.0,
         );
-        let output = format_table(&make_view_default(&result), 8.0, false, "0.4.0");
+        let output = format_table(
+            &make_view_default(&result),
+            8.0,
+            false,
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
+        );
         assert!(output.contains("File"));
         assert!(output.contains("Function"));
         assert!(output.contains("CC"));
@@ -497,7 +526,13 @@ mod tests {
             RiskLevel::Moderate,
             8.0,
         );
-        let output = format_table(&make_view_default(&result), 8.0, false, "0.4.0");
+        let output = format_table(
+            &make_view_default(&result),
+            8.0,
+            false,
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
+        );
         assert!(output.contains("src/adapters/coverage/mod.rs"));
         assert!(output.contains("parse_record"));
         assert!(output.contains("6"));
@@ -511,7 +546,13 @@ mod tests {
         colored::control::set_override(false);
         let result =
             make_single_function_result("f", "src/lib.rs", 1, 100.0, 5.0, RiskLevel::Low, 8.0);
-        let output = format_table(&make_view_default(&result), 8.0, false, "0.4.0");
+        let output = format_table(
+            &make_view_default(&result),
+            8.0,
+            false,
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
+        );
         assert!(output.contains("5.00"));
     }
 
@@ -521,7 +562,13 @@ mod tests {
         colored::control::set_override(false);
         let result =
             make_single_function_result("f", "src/lib.rs", 1, 85.0, 1.0, RiskLevel::Low, 8.0);
-        let output = format_table(&make_view_default(&result), 8.0, false, "0.4.0");
+        let output = format_table(
+            &make_view_default(&result),
+            8.0,
+            false,
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
+        );
         assert!(output.contains("85.0"));
     }
 
@@ -530,13 +577,18 @@ mod tests {
         let _guard = COLOR_LOCK.lock().unwrap();
         colored::control::set_override(false);
         let result = make_empty_result();
-        // S3 (#135): version is now caller-supplied (the
-        // `env!("CARGO_PKG_VERSION")` macro resolves to crap-core's
-        // version after the relocation). The literal "0.4.0" matches
-        // what the cli passes via env!("CARGO_PKG_VERSION") under the
-        // crap4rs binary.
-        let output = format_table(&make_view_default(&result), 8.0, false, "0.4.0");
-        assert!(output.starts_with("crap4rs v0.4.0"));
+        // `tool_name` and `tool_version` are caller-supplied. In-crate
+        // tests pass the synthetic placeholders `TEST_TOOL_NAME` /
+        // `TEST_TOOL_VERSION` so crap-core source is decoupled from
+        // any adapter's name.
+        let output = format_table(
+            &make_view_default(&result),
+            8.0,
+            false,
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
+        );
+        assert!(output.starts_with(&format!("{TEST_TOOL_NAME} v{TEST_TOOL_VERSION}")));
     }
 
     #[test]
@@ -544,7 +596,13 @@ mod tests {
         let _guard = COLOR_LOCK.lock().unwrap();
         colored::control::set_override(false);
         let result = make_multi_function_result();
-        let output = format_table(&make_view_default(&result), 8.0, false, "0.4.0");
+        let output = format_table(
+            &make_view_default(&result),
+            8.0,
+            false,
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
+        );
         assert!(output.contains("3 functions"));
         assert!(output.contains("2 above threshold (8)"));
         assert!(output.contains("worst: 45.2"));
@@ -557,7 +615,13 @@ mod tests {
         colored::control::set_override(false);
         let result =
             make_single_function_result("f", "src/lib.rs", 1, 100.0, 1.0, RiskLevel::Low, 8.0);
-        let output = format_table(&make_view_default(&result), 8.0, false, "0.4.0");
+        let output = format_table(
+            &make_view_default(&result),
+            8.0,
+            false,
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
+        );
         assert!(output.contains("PASS"));
         assert!(!output.contains("FAIL"));
     }
@@ -567,7 +631,13 @@ mod tests {
         let _guard = COLOR_LOCK.lock().unwrap();
         colored::control::set_override(false);
         let result = make_multi_function_result();
-        let output = format_table(&make_view_default(&result), 8.0, false, "0.4.0");
+        let output = format_table(
+            &make_view_default(&result),
+            8.0,
+            false,
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
+        );
         assert!(output.contains("avg: 21.1"));
         assert!(output.contains("median: 15.0"));
         assert!(output.contains("low: 1"));
@@ -625,7 +695,13 @@ mod tests {
             summary: make_multi_function_result().summary,
             passed: false,
         };
-        let output = format_table(&make_view_default(&result), 8.0, false, "0.4.0");
+        let output = format_table(
+            &make_view_default(&result),
+            8.0,
+            false,
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
+        );
         assert!(
             !output.contains("├─"),
             "breakdown=false should not show sub-rows: {output}"
@@ -657,7 +733,13 @@ mod tests {
             summary: make_multi_function_result().summary,
             passed: false,
         };
-        let output = format_table(&make_view_default(&result), 8.0, true, "0.4.0");
+        let output = format_table(
+            &make_view_default(&result),
+            8.0,
+            true,
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
+        );
         assert!(
             output.contains("line 5:"),
             "Should show line 5 contributor: {output}"
@@ -690,7 +772,13 @@ mod tests {
             summary: make_empty_result().summary,
             passed: true,
         };
-        let output = format_table(&make_view_default(&result), 8.0, true, "0.4.0");
+        let output = format_table(
+            &make_view_default(&result),
+            8.0,
+            true,
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
+        );
         assert!(
             !output.contains("├─"),
             "Non-exceeding fn should not show sub-rows even with breakdown=true: {output}"
@@ -718,7 +806,13 @@ mod tests {
             summary: make_multi_function_result().summary,
             passed: false,
         };
-        let output = format_table(&make_view_default(&result), 8.0, true, "0.4.0");
+        let output = format_table(
+            &make_view_default(&result),
+            8.0,
+            true,
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
+        );
         assert!(output.contains("├─"), "Should have branch char: {output}");
         assert!(output.contains("└─"), "Should have corner char: {output}");
         // Make sure corner appears after branch
@@ -748,7 +842,13 @@ mod tests {
             summary: make_multi_function_result().summary,
             passed: false,
         };
-        let output = format_table(&make_view_default(&result), 8.0, true, "0.4.0");
+        let output = format_table(
+            &make_view_default(&result),
+            8.0,
+            true,
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
+        );
         assert!(
             output.contains("(nested)"),
             "increment > 1 should show '(nested)': {output}"
@@ -777,8 +877,15 @@ mod tests {
             summary: make_multi_function_result().summary,
             passed: false,
         };
-        let output =
-            format_table_with_explain(&make_view_default(&result), None, 8.0, true, true, "0.4.0");
+        let output = format_table_with_explain(
+            &make_view_default(&result),
+            None,
+            8.0,
+            true,
+            true,
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
+        );
         assert!(output.contains("Legend: +1 = base structural increment."));
         assert!(output.contains("+N (nested) = +1 base plus +(N-1)"));
         assert!(output.contains("if/else branches, match arms"));
@@ -807,8 +914,15 @@ mod tests {
             summary: make_multi_function_result().summary,
             passed: false,
         };
-        let output =
-            format_table_with_explain(&make_view_default(&result), None, 8.0, false, true, "0.4.0");
+        let output = format_table_with_explain(
+            &make_view_default(&result),
+            None,
+            8.0,
+            false,
+            true,
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
+        );
         assert!(!output.contains("Legend:"));
         assert!(!output.contains("line 3: match (+3 (nested))"));
     }
@@ -841,8 +955,15 @@ mod tests {
             summary: make_multi_function_result().summary,
             passed: false,
         };
-        let output =
-            format_table_with_explain(&make_view_default(&result), None, 8.0, true, true, "0.4.0");
+        let output = format_table_with_explain(
+            &make_view_default(&result),
+            None,
+            8.0,
+            true,
+            true,
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
+        );
         assert!(!output.contains("Legend:"));
     }
 
@@ -886,7 +1007,13 @@ mod tests {
             summary: make_multi_function_result().summary,
             passed: false,
         };
-        let output = format_table(&make_view_default(&result), 8.0, true, "0.4.0");
+        let output = format_table(
+            &make_view_default(&result),
+            8.0,
+            true,
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
+        );
         let line5_pos = output.find("line 5:").unwrap();
         let line20_pos = output.find("line 20:").unwrap();
         assert!(
@@ -939,7 +1066,13 @@ mod tests {
             summary: make_multi_function_result().summary,
             passed: false,
         };
-        let output = format_table(&make_view_default(&result), 8.0, true, "0.4.0");
+        let output = format_table(
+            &make_view_default(&result),
+            8.0,
+            true,
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
+        );
 
         // Each contributor kind should appear exactly once
         let if_branch_count = output.matches("if-branch").count();
@@ -989,7 +1122,13 @@ mod tests {
             summary: make_multi_function_result().summary,
             passed: false,
         };
-        let output = format_table(&make_view_default(&result), 8.0, true, "0.4.0");
+        let output = format_table(
+            &make_view_default(&result),
+            8.0,
+            true,
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
+        );
         assert!(
             output.contains("if-branch"),
             "Sub-row should appear even when function name is in file path: {output}"
@@ -1009,7 +1148,13 @@ mod tests {
         result.functions[1].threshold = 10.0;
         result.functions[2].threshold = 8.0;
 
-        let output = format_table(&make_view_default(&result), 8.0, false, "0.4.0");
+        let output = format_table(
+            &make_view_default(&result),
+            8.0,
+            false,
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
+        );
         assert!(
             output.contains("varied (default: 8)"),
             "Should show varied threshold: {output}"
@@ -1022,7 +1167,13 @@ mod tests {
         colored::control::set_override(false);
 
         let result = make_multi_function_result();
-        let output = format_table(&make_view_default(&result), 8.0, false, "0.4.0");
+        let output = format_table(
+            &make_view_default(&result),
+            8.0,
+            false,
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
+        );
         assert!(
             !output.contains("varied"),
             "Uniform thresholds should not show 'varied': {output}"
@@ -1036,7 +1187,13 @@ mod tests {
 
         let result =
             make_single_function_result("f", "src/lib.rs", 1, 100.0, 1.0, RiskLevel::Low, 8.0);
-        let output = format_table(&make_view_default(&result), 8.0, false, "0.4.0");
+        let output = format_table(
+            &make_view_default(&result),
+            8.0,
+            false,
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
+        );
         assert!(!output.contains("varied"));
     }
 
@@ -1146,7 +1303,13 @@ mod tests {
         let _guard = COLOR_LOCK.lock().unwrap();
         colored::control::set_override(false);
         let result = make_multi_function_result();
-        let output = format_table(&make_view_default(&result), 8.0, false, "0.4.0");
+        let output = format_table(
+            &make_view_default(&result),
+            8.0,
+            false,
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
+        );
         insta::assert_snapshot!(output);
     }
 
@@ -1163,7 +1326,7 @@ mod tests {
                 ..Default::default()
             },
         );
-        let output = format_table(&view, 8.0, false, "0.4.0");
+        let output = format_table(&view, 8.0, false, TEST_TOOL_NAME, TEST_TOOL_VERSION);
         // Per-file column header
         assert!(output.contains("File"));
         assert!(output.contains("Functions"));
@@ -1199,7 +1362,7 @@ mod tests {
                 ..Default::default()
             },
         );
-        let output = format_table(&view, 8.0, false, "0.4.0");
+        let output = format_table(&view, 8.0, false, TEST_TOOL_NAME, TEST_TOOL_VERSION);
         insta::assert_snapshot!(output);
     }
 
@@ -1217,7 +1380,8 @@ mod tests {
             8.0,
             false,
             false,
-            "0.4.0",
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
         );
         assert!(
             output.contains("Delta vs baseline:"),
@@ -1246,7 +1410,8 @@ mod tests {
             8.0,
             false,
             false,
-            "0.4.0",
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
         );
         // Per-change rows present
         assert!(output.contains("added"));
@@ -1268,7 +1433,8 @@ mod tests {
             8.0,
             false,
             false,
-            "0.4.0",
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
         );
         assert!(!output.contains("Delta vs baseline"));
     }
@@ -1285,7 +1451,8 @@ mod tests {
             8.0,
             false,
             false,
-            "0.4.0",
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
         );
         insta::assert_snapshot!(output);
     }
@@ -1294,7 +1461,9 @@ mod tests {
 #[cfg(test)]
 mod proptests {
     use super::*;
-    use crate::adapters::reporters::test_fixtures::make_view_default;
+    use crate::adapters::reporters::test_fixtures::{
+        TEST_TOOL_NAME, TEST_TOOL_VERSION, make_view_default,
+    };
     use crate::domain::types::{
         AnalysisResult, AnalysisSummary, CrapScore, FunctionIdentity, FunctionVerdict,
         RiskDistribution, RiskLevel, ScoredFunction, SourceSpan,
@@ -1426,7 +1595,7 @@ mod proptests {
         fn prop_format_table_never_panics(result in arb_analysis_result()) {
             let _guard = super::COLOR_LOCK.lock().unwrap();
             colored::control::set_override(false);
-            let _ = format_table(&make_view_default(&result), 8.0, false, "0.4.0");
+            let _ = format_table(&make_view_default(&result), 8.0, false, TEST_TOOL_NAME, TEST_TOOL_VERSION);
         }
 
         #[test]
@@ -1441,14 +1610,14 @@ mod proptests {
                 v.scored.contributors = contributors;
             }
             // Must not panic regardless of contributor content
-            let _ = format_table(&make_view_default(&result), 8.0, true, "0.4.0");
+            let _ = format_table(&make_view_default(&result), 8.0, true, TEST_TOOL_NAME, TEST_TOOL_VERSION);
         }
 
         #[test]
         fn prop_format_table_row_count(result in arb_analysis_result()) {
             let _guard = super::COLOR_LOCK.lock().unwrap();
             colored::control::set_override(false);
-            let output = format_table(&make_view_default(&result), 8.0, false, "0.4.0");
+            let output = format_table(&make_view_default(&result), 8.0, false, TEST_TOOL_NAME, TEST_TOOL_VERSION);
             if result.functions.is_empty() {
                 prop_assert!(output.contains("No functions analyzed"));
             } else {

--- a/crates/crap-core/src/cli/delta_args.rs
+++ b/crates/crap-core/src/cli/delta_args.rs
@@ -14,7 +14,7 @@ use crate::domain::delta::{ChangeKind, DeltaFilters, DeltaSortKey, DeltaViewSpec
 /// pattern as `view_args::build_view_spec`.
 pub(super) fn build_delta_view_spec(cli: &Cli) -> DeltaViewSpec {
     // `DeltaViewSpec` and `DeltaFilters` are `#[non_exhaustive]` for
-    // cross-crate consumers, but in-crate (post-S4 #136) struct-update
+    // cross-crate consumers, but in-crate struct-update
     // syntax is permitted and clippy's `field_reassign_with_default`
     // fires on the previous mutate-after-default pattern. Use
     // struct-update so the cli/domain boundary stays clear.
@@ -56,7 +56,7 @@ mod tests {
     fn parse(args: &[&str]) -> Cli {
         // Prepend a placeholder arg0 + the required --coverage flag so
         // clap's positional validators don't reject the parse outright.
-        let mut full = vec!["crap4rs", "--coverage", "lcov.info"];
+        let mut full = vec!["test-adapter", "--coverage", "lcov.info"];
         full.extend_from_slice(args);
         Cli::try_parse_from(full).expect("clap parse should succeed")
     }
@@ -114,7 +114,7 @@ mod tests {
     #[test]
     fn delta_only_unknown_token_exits_with_clap_error() {
         let result = Cli::try_parse_from([
-            "crap4rs",
+            "test-adapter",
             "--coverage",
             "lcov.info",
             "--delta-only",
@@ -128,7 +128,7 @@ mod tests {
     #[test]
     fn delta_sort_unknown_token_exits_with_clap_error() {
         let result = Cli::try_parse_from([
-            "crap4rs",
+            "test-adapter",
             "--coverage",
             "lcov.info",
             "--delta-sort",
@@ -141,8 +141,13 @@ mod tests {
 
     #[test]
     fn delta_top_negative_is_attributed_to_flag() {
-        let result =
-            Cli::try_parse_from(["crap4rs", "--coverage", "lcov.info", "--delta-top", "-5"]);
+        let result = Cli::try_parse_from([
+            "test-adapter",
+            "--coverage",
+            "lcov.info",
+            "--delta-top",
+            "-5",
+        ]);
         let err = result.expect_err("negative should fail u32 parse");
         let stderr = err.to_string();
         assert!(stderr.contains("--delta-top"));

--- a/crates/crap-core/src/cli/mod.rs
+++ b/crates/crap-core/src/cli/mod.rs
@@ -911,7 +911,12 @@ fn validate_runtime_inputs<'a>(
         );
     };
 
-    validate_inputs(coverage_path, &inputs.src, inputs.threshold)?;
+    validate_inputs(
+        coverage_path,
+        &inputs.src,
+        inputs.threshold,
+        meta.coverage_hint,
+    )?;
     preflight_checks(coverage_path, &inputs.src, meta)?;
 
     if let Some(diff_ref) = cli.filter.diff.as_deref() {
@@ -1322,17 +1327,17 @@ fn validate_inputs(
     coverage: &std::path::Path,
     src: &std::path::Path,
     threshold: f64,
+    coverage_hint: &str,
 ) -> Result<()> {
     match std::fs::metadata(coverage) {
         Ok(m) if m.is_file() => {}
         Ok(_) => bail!(
             "coverage path is not a file: {}\n  \
-             hint: pass --coverage pointing to an LCOV file, not a directory",
+             hint: pass --coverage pointing to a coverage file, not a directory",
             coverage.display()
         ),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => bail!(
-            "coverage file not found: {}\n  \
-             hint: run `cargo llvm-cov --lcov --output-path lcov.info` first",
+            "coverage file not found: {}\n  hint: {coverage_hint}",
             coverage.display()
         ),
         Err(e) => bail!(
@@ -1345,12 +1350,12 @@ fn validate_inputs(
         Ok(m) if m.is_dir() => {}
         Ok(_) => bail!(
             "source path is not a directory: {}\n  \
-             hint: pass --src <DIR> pointing to your Rust source root",
+             hint: pass --src <DIR> pointing to your source root",
             src.display()
         ),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => bail!(
             "source directory not found: {}\n  \
-             hint: pass --src <DIR> pointing to your Rust source root",
+             hint: pass --src <DIR> pointing to your source root",
             src.display()
         ),
         Err(e) => bail!(
@@ -1864,15 +1869,17 @@ mod tests {
     }
 
     #[test]
-    fn validate_missing_coverage_file() {
+    fn validate_missing_coverage_file_uses_adapter_hint() {
         let err = validate_inputs(
             Path::new("nonexistent.info"),
             Path::new("src"),
             DEFAULT_THRESHOLD,
+            "run `cargo llvm-cov --lcov --output-path lcov.info` first",
         )
         .unwrap_err();
         let msg = format!("{err:#}");
         assert!(msg.contains("coverage file not found"));
+        // Adapter-supplied hint flows through; crap-core itself stays neutral.
         assert!(msg.contains("cargo llvm-cov"));
     }
 
@@ -1882,6 +1889,7 @@ mod tests {
             Path::new("Cargo.toml"),
             Path::new("nonexistent_dir"),
             DEFAULT_THRESHOLD,
+            "test-hint",
         )
         .unwrap_err();
         let msg = format!("{err:#}");
@@ -1890,22 +1898,29 @@ mod tests {
 
     #[test]
     fn validate_negative_threshold() {
-        let err = validate_inputs(Path::new("Cargo.toml"), Path::new("src"), -5.0).unwrap_err();
+        let err = validate_inputs(Path::new("Cargo.toml"), Path::new("src"), -5.0, "test-hint")
+            .unwrap_err();
         let msg = format!("{err:#}");
         assert!(msg.contains("threshold must be a finite positive number"));
     }
 
     #[test]
     fn validate_zero_threshold() {
-        let err = validate_inputs(Path::new("Cargo.toml"), Path::new("src"), 0.0).unwrap_err();
+        let err = validate_inputs(Path::new("Cargo.toml"), Path::new("src"), 0.0, "test-hint")
+            .unwrap_err();
         let msg = format!("{err:#}");
         assert!(msg.contains("threshold must be a finite positive number"));
     }
 
     #[test]
     fn validate_infinity_threshold() {
-        let err =
-            validate_inputs(Path::new("Cargo.toml"), Path::new("src"), f64::INFINITY).unwrap_err();
+        let err = validate_inputs(
+            Path::new("Cargo.toml"),
+            Path::new("src"),
+            f64::INFINITY,
+            "test-hint",
+        )
+        .unwrap_err();
         let msg = format!("{err:#}");
         assert!(msg.contains("threshold must be a finite positive number"));
     }
@@ -1916,6 +1931,7 @@ mod tests {
             Path::new("Cargo.toml"),
             Path::new("Cargo.toml"),
             DEFAULT_THRESHOLD,
+            "test-hint",
         )
         .unwrap_err();
         let msg = format!("{err:#}");
@@ -1924,8 +1940,13 @@ mod tests {
 
     #[test]
     fn validate_coverage_is_dir_not_file() {
-        let err =
-            validate_inputs(Path::new("src"), Path::new("src"), DEFAULT_THRESHOLD).unwrap_err();
+        let err = validate_inputs(
+            Path::new("src"),
+            Path::new("src"),
+            DEFAULT_THRESHOLD,
+            "test-hint",
+        )
+        .unwrap_err();
         let msg = format!("{err:#}");
         assert!(msg.contains("coverage path is not a file"));
     }

--- a/crates/crap-core/src/cli/mod.rs
+++ b/crates/crap-core/src/cli/mod.rs
@@ -3,11 +3,11 @@
 //! Parses args with clap, validates inputs, delegates to `core::analyze()`.
 //! No business logic lives here.
 //!
-//! Relocated from `crap4rs::cli` in S4 (#136). The orchestrator
 //! `cli::run<P>` is generic over the coverage adapter's parse-diagnostic
-//! type so the same dispatch shell drives every adapter binary
-//! (`crap4rs`, future `crap4ts`). Per-binary main.rs supplies the
-//! complexity + coverage ports as `&dyn` trait objects (ADR D9).
+//! type so the same dispatch shell drives every adapter binary. The
+//! per-binary main.rs supplies the complexity + coverage ports as `&dyn`
+//! trait objects (ADR D9) plus an `AdapterMeta` carrying the binary's
+//! name, version, help copy, extensions, and config-file name.
 
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
@@ -69,11 +69,11 @@ pub enum FormatArg {
     /// Agent-oriented JSON with Diagnostic remediation hints (experimental)
     Advice,
     /// Single mokumo-scorecard `Row::CrapDelta` JSON object — for scorecard
-    /// aggregator consumption (mokumo schema_version=2). Issue #111.
+    /// aggregator consumption (mokumo schema_version=2).
     ScorecardRow,
     /// Self-contained HTML dashboard with summary stats, risk
     /// distribution, and per-file collapsible function tables. Inline
-    /// CSS, no external assets, mobile-responsive. Issue #71.
+    /// CSS, no external assets, mobile-responsive.
     Html,
 }
 
@@ -81,7 +81,7 @@ pub enum FormatArg {
 ///
 /// Parsed from `--format X` (stdout) or `--format X:FILE` (write to file).
 /// `--format` accepts a comma-separated list of these specs so a single
-/// analysis pass can fan out to multiple shapes (issue #100).
+/// analysis pass can fan out to multiple shapes.
 #[derive(Debug, Clone)]
 pub struct FormatSpec {
     pub format: FormatArg,
@@ -108,7 +108,7 @@ fn parse_format_spec(s: &str) -> Result<FormatSpec, String> {
     s.parse()
 }
 
-/// Sort key for the displayed view (issue #68).
+/// Sort key for the displayed view.
 ///
 /// CLI-side wrapper that keeps `clap::ValueEnum` out of the domain.
 /// `From<SortKeyArg> for SortKey` is the boundary; `build_view_spec`
@@ -136,12 +136,12 @@ impl From<SortKeyArg> for SortKey {
     }
 }
 
-/// Reverse mapping for saved view presets (issue #80) — preset stores
+/// Reverse mapping for saved view presets — preset stores
 /// domain `SortKey`, but `FilterArgs.sort_by` is the clap-side wrapper.
 ///
 /// `SortKey` is `#[non_exhaustive]` for cross-crate consumers, but
-/// post-S4 (#136) the cli module lives in the same crate as the domain
-/// `SortKey` definition, so the compiler treats the match as exhaustive
+/// the cli module lives in the same crate as the domain `SortKey`
+/// definition, so the compiler treats the match as exhaustive
 /// without a wildcard arm. New domain variants must still land with a
 /// paired CLI variant in the same PR — clippy's missing-pattern error
 /// is now the loud failure point (the formerly-required wildcard arm
@@ -157,7 +157,7 @@ impl From<SortKey> for SortKeyArg {
     }
 }
 
-/// Group key for the displayed view (issue #64).
+/// Group key for the displayed view.
 ///
 /// Today only `file` is supported. The wrapper keeps `clap::ValueEnum`
 /// out of the domain; `From<GroupByArg> for GroupKey` is the boundary.
@@ -175,8 +175,8 @@ impl From<GroupByArg> for GroupKey {
     }
 }
 
-/// Reverse mapping for saved view presets (issue #80). See `From<SortKey>`
-/// above for the wildcard-arm rationale (post-S4 in-crate exhaustive).
+/// Reverse mapping for saved view presets. See `From<SortKey>`
+/// above for the wildcard-arm rationale.
 impl From<GroupKey> for GroupByArg {
     fn from(key: GroupKey) -> Self {
         match key {
@@ -185,7 +185,7 @@ impl From<GroupKey> for GroupByArg {
     }
 }
 
-/// Sort key for the delta block (issue #81).
+/// Sort key for the delta block.
 #[derive(Debug, Clone, Copy, ValueEnum)]
 pub enum DeltaSortKeyArg {
     /// Magnitude of change descending — regressions first (default)
@@ -210,7 +210,7 @@ impl From<DeltaSortKeyArg> for crate::domain::delta::DeltaSortKey {
     }
 }
 
-/// Change-kind subset for `--delta-only` (issue #81).
+/// Change-kind subset for `--delta-only`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub enum DeltaKindArg {
     Added,
@@ -243,7 +243,7 @@ pub enum ColorArg {
 
 // ── Arg groups ──────────────────────────────────────────────────────
 
-/// Shell name for completion script generation (#69).
+/// Shell name for completion script generation.
 #[derive(Debug, Clone, Copy, ValueEnum)]
 pub enum ShellArg {
     Bash,
@@ -254,8 +254,8 @@ pub enum ShellArg {
     Nushell,
 }
 
-/// Top-level subcommands. Optional — when absent, crap4rs runs the
-/// default analysis path that requires `--coverage`.
+/// Top-level subcommands. Optional — when absent, the analyzer runs
+/// the default analysis path that requires `--coverage`.
 #[derive(Debug, Subcommand)]
 pub enum Command {
     /// Generate a shell completion script to stdout.
@@ -268,12 +268,12 @@ pub enum Command {
 #[derive(Debug, Args)]
 #[command(next_help_heading = "Input")]
 pub struct InputArgs {
-    /// Path to LCOV coverage file (from `cargo llvm-cov --lcov`).
-    /// Required for analysis; not required for `crap4rs completions`.
+    /// Path to the coverage file (adapter-specific format).
+    /// Required for analysis; not required for the `completions` subcommand.
     #[arg(long, value_name = "FILE", value_hint = ValueHint::FilePath)]
     pub coverage: Option<PathBuf>,
 
-    /// Root directory of Rust source files to analyze [default: src]
+    /// Root directory of source files to analyze [default: src]
     #[arg(long, value_name = "DIR", value_hint = ValueHint::DirPath)]
     pub src: Option<PathBuf>,
 
@@ -281,11 +281,11 @@ pub struct InputArgs {
     #[arg(long, value_enum)]
     pub metric: Option<MetricArg>,
 
-    /// Path to config file (default: auto-discover crap4rs.toml)
+    /// Path to config file (default: auto-discover the adapter's config TOML)
     #[arg(long, value_name = "FILE", value_hint = ValueHint::FilePath)]
     pub config: Option<PathBuf>,
 
-    /// Resolve and apply a saved view preset from `crap4rs.toml`.
+    /// Resolve and apply a saved view preset from the adapter's config TOML.
     ///
     /// The preset's fields (`top`, `min_coverage`, `max_coverage`, `sort`,
     /// `only_failing`, `no_fail`, `group_by`, `minimal_view`) are folded
@@ -296,14 +296,14 @@ pub struct InputArgs {
     #[arg(long, value_name = "NAME")]
     pub view: Option<String>,
 
-    /// Path to a previously-emitted crap4rs JSON envelope, used as the
-    /// baseline for delta analysis.
+    /// Path to a previously-emitted JSON envelope, used as the baseline
+    /// for delta analysis.
     ///
-    /// Crap4rs runs the current analysis as usual, then compares against
-    /// the baseline's `result` block to produce a `delta` block in the
-    /// output (see `--format json`, `--format markdown` for rendering).
-    /// Generate the baseline file by piping a previous run:
-    /// `crap4rs --coverage lcov.info --format json > baseline.json`.
+    /// The analyzer runs the current analysis as usual, then compares
+    /// against the baseline's `result` block to produce a `delta` block
+    /// in the output (see `--format json`, `--format markdown` for
+    /// rendering). Generate the baseline file by piping a previous run:
+    /// `<binary> --coverage <file> --format json > baseline.json`.
     ///
     /// **Delta is informational by default.** Pass `--delta-gate` to
     /// make the delta contribute to the exit code (fails on new
@@ -322,7 +322,7 @@ pub struct OutputArgs {
     /// destinations (`--format json:envelope.json,markdown:report.md`).
     /// Each entry is `FORMAT` (stdout) or `FORMAT:FILE` (write to file).
     /// Multi-format invocations require every entry to specify a file —
-    /// stdout cannot multiplex (issue #100).
+    /// stdout cannot multiplex.
     #[arg(
         short,
         long,
@@ -403,7 +403,7 @@ pub struct FilterArgs {
     /// Git ref to diff against — only analyze functions in changed files/hunks
     ///
     /// Scopes analysis to functions in files that changed since the given ref.
-    /// Useful for CI PR gating: `crap4rs --coverage lcov.info --diff main`
+    /// Useful for CI PR gating: `<binary> --coverage <file> --diff main`
     #[arg(long, value_name = "REF")]
     pub diff: Option<String>,
 
@@ -538,70 +538,38 @@ pub struct DisplayArgs {
 
 // ── Top-level CLI ───────────────────────────────────────────────────
 
-// `long_version` is overridden at runtime in `cli::run` so the binary's
-// build script (`crap4rs/build.rs`) can splice the git hash + build date
-// into the Rust adapter's `--version` output without forcing crap-core
-// to read an env var that's only set during crap4rs's compile. The
-// derive's `version` here resolves to the **adapter** crate's
-// `CARGO_PKG_VERSION` because clap captures the env at the macro
-// expansion site — that's the binary crate's version when compiling
-// the binary, but the lib crate's version when compiling the lib.
-// Production callers always reach `cli::run` through the binary, so
-// `--version` displays the adapter's version. Tests that go through
+// `long_version` is overridden at runtime in `cli::run` so each binary's
+// build script can splice the git hash + build date into its `--version`
+// output without forcing crap-core to read an env var that's only set
+// during the binary's compile. The derive's `version` here resolves to
+// the **adapter** crate's `CARGO_PKG_VERSION` because clap captures the
+// env at the macro expansion site — that's the binary crate's version
+// when compiling the binary, but the lib crate's version when compiling
+// the lib. Production callers always reach `cli::run` through the binary,
+// so `--version` displays the adapter's version. Tests that go through
 // the lib see crap-core's version, which is fine for tests.
 //
-// Threading per S4 lesson 7 (tool-version threading): consumer-visible
-// version strings flow as parameters from the bin where `env!` resolves
-// against the bin's package, not against this module's home crate.
+// Consumer-visible version strings flow as parameters via `AdapterMeta`
+// from the binary where `env!` resolves against the bin's package, not
+// against this module's home crate.
 
+// `about` / `long_about` / `after_help` are intentionally generic
+// here — adapter-flavored copy (language name, AST library, coverage
+// toolchain, runnable examples) is injected at runtime by
+// `build_command` from `AdapterMeta`. Library tests that
+// `try_parse_from` `Cli` directly see this generic default; the
+// binary always overrides.
 #[derive(Debug, Parser)]
 #[command(
     version,
     author,
-    about = "CRAP score analyzer for Rust",
-    long_about = "CRAP (Change Risk Anti-Patterns) score analyzer for Rust codebases.\n\n\
-                  Combines complexity analysis (via syn) with line coverage data \
-                  (LCOV from cargo-llvm-cov) to identify functions that are both \
-                  complex and under-tested.\n\n\
-                  Default metric is cognitive complexity (not cyclomatic), which \
-                  better captures Rust idioms like match arms and nested control flow.",
-    after_help = "\
-EXAMPLES:
-  crap4rs --coverage lcov.info
-  crap4rs --coverage lcov.info --threshold 15 --metric cyclomatic
-  crap4rs --coverage lcov.info --format json | jq '.functions[] | select(.exceeds)'
-  crap4rs --coverage lcov.info --only-failing
-  crap4rs --coverage lcov.info --exclude \"tests/**\" --exclude \"benches/**\"
-
-INVESTIGATION PATTERNS:
-  # First-run scan: keep the report short
-  crap4rs --coverage lcov.info --top 20
-
-  # Worst partially-covered functions, sorted by coverage ascending,
-  # never fail the build — useful when investigating an untested codebase
-  crap4rs --coverage lcov.info --min-coverage 1 --max-coverage 90 --sort-by coverage --top 10 --no-fail
-
-  # Saved view preset: bake a flag set under [views.ci] in crap4rs.toml,
-  # then invoke it by name. CLI flags override preset values.
-  crap4rs --coverage lcov.info --view ci
-
-  # GitHub Code Scanning: emit SARIF and let upload-sarif annotate the PR
-  # diff inline. Use --no-fail so the gate exit code doesn't skip the
-  # upload step on regressions.
-  crap4rs --coverage lcov.info --format sarif --no-fail > crap.sarif
-
-COMPARING TWO ANALYSES (issue #81):
-  # Capture a baseline (e.g., from main):
-  crap4rs --coverage lcov.info --format json > baseline.json
-
-  # Then compare the working tree to it (informational by default):
-  crap4rs --coverage lcov.info --baseline baseline.json
-
-  # CI usage: fail the build when new threshold violations land
-  crap4rs --coverage lcov.info --baseline baseline.json --delta-gate
-
-  # PR-comment scorecard (markdown — drop into the comment body verbatim)
-  crap4rs --coverage lcov.info --baseline baseline.json --format markdown"
+    about = "CRAP score analyzer",
+    long_about = "CRAP (Change Risk Anti-Patterns) score analyzer. \
+                  Combines complexity analysis with line-coverage data to \
+                  identify functions that are both complex and under-tested. \
+                  Adapter-specific binaries (crap4rs for Rust, crap4ts for \
+                  TypeScript) wire language-specific complexity walkers and \
+                  coverage parsers behind the same orchestrator."
 )]
 pub struct Cli {
     #[command(flatten)]
@@ -622,6 +590,73 @@ pub struct Cli {
 
 // ── Entry point ─────────────────────────────────────────────────────
 
+/// Adapter-supplied runtime metadata that crap-core threads through
+/// `parse_args`, `run`, and the reporter call sites.
+///
+/// Carried by reference, so all fields are `&'a str` / `&'a [&'a str]`
+/// — the binary owns the storage (typically `env!(...)` literals or
+/// `build.rs`-stamped strings, all `'static`). The struct is `Copy`
+/// for trivial threading; clone-by-copy is fine because the borrows
+/// already point at the binary's static storage.
+///
+/// Reporters keep a flat `(tool_name, tool_version)` call boundary —
+/// the struct only travels through orchestration code.
+#[derive(Debug, Clone, Copy)]
+pub struct AdapterMeta<'a> {
+    /// Adapter binary name (e.g., `"crap4rs"`, `"crap4ts"`). Drives
+    /// clap's `--version` output, the `name` field in SARIF, and the
+    /// header line in table/markdown/html reporters.
+    pub tool_name: &'a str,
+    /// Short version string (e.g., `"0.5.0"`). Threaded to every
+    /// reporter alongside `tool_name`.
+    pub tool_version: &'a str,
+    /// Long version string for `--version --long` (e.g.,
+    /// `"0.5.0 (abc1234 2026-05-09)"`).
+    pub long_version: &'a str,
+    /// Short adapter-flavored help text (one-line, shown by `--help`).
+    pub about: &'a str,
+    /// Long adapter-flavored help text (multi-paragraph, shown by
+    /// `--help` in full mode).
+    pub long_about: &'a str,
+    /// `after_help` block with adapter-specific examples
+    /// (`crap4rs --coverage lcov.info ...` etc.). May be empty.
+    pub after_help: &'a str,
+    /// Coverage-tool hint shown when `--coverage` points at a file
+    /// with no `SF:` / `DA:` records. Adapter-specific because the
+    /// remediation depends on the coverage toolchain (Rust: `cargo
+    /// llvm-cov --lcov`; TS: `c8 --reporter=lcov`).
+    pub coverage_hint: &'a str,
+    /// File extensions the walker should pick up (e.g.,
+    /// `&["rs"]` for crap4rs; `&["ts","tsx","js","jsx","mjs","cjs"]`
+    /// for crap4ts). Carried as `&[&str]` so the binary can supply a
+    /// `&'static` literal slice; copied into `AnalyzeOptions.extensions`
+    /// at the orchestration boundary.
+    pub extensions: &'a [&'a str],
+    /// Adapter repo URL spliced into SARIF's
+    /// `runs[0].tool.driver.informationUri`. Adapter-specific so
+    /// crap4ts SARIF output links to crap4ts's repo, not crap4rs's.
+    pub tool_info_uri: &'a str,
+    /// Adapter rule-help URL spliced into SARIF's
+    /// `runs[0].tool.driver.rules[0].helpUri`. Adapter-specific for
+    /// the same reason as `tool_info_uri`.
+    pub rule_help_uri: &'a str,
+    /// Conventional config file name the adapter binary auto-discovers
+    /// in the working directory (e.g., `"crap4rs.toml"` for the Rust
+    /// adapter; `"crap4ts.toml"` for the TS adapter). Threaded through
+    /// to `discover_config` and surfaced in `--view <preset>`
+    /// error hints so users see the right file name to create.
+    pub config_file_name: &'a str,
+}
+
+impl<'a> AdapterMeta<'a> {
+    /// Allocate an owned `Vec<String>` from `extensions` for inclusion
+    /// in `AnalyzeOptions` (which owns its config rather than borrowing
+    /// from the meta, decoupling analysis lifetime from CLI lifetime).
+    pub fn extensions_owned(&self) -> Vec<String> {
+        self.extensions.iter().map(|e| (*e).to_string()).collect()
+    }
+}
+
 /// Parse process args into `Cli`, splicing the adapter's runtime
 /// metadata into clap's help / `--version` output.
 ///
@@ -630,65 +665,76 @@ pub struct Cli {
 /// those before `parse_args` returns). The adapter binary supplies its
 /// coverage adapter to `run` as a factory closure that's invoked once
 /// after CLI/config-file merging resolves the effective source root —
-/// pre-construction was the #150 footgun, since
-/// `cli.input.src` is the raw CLI value (`None` if the caller put
-/// `src = "…"` only in `crap4rs.toml`).
+/// pre-construction lets the coverage parser strip the wrong prefix
+/// from per-file records when `cli.input.src` is `None` because `src`
+/// came from the adapter's config TOML rather than the CLI.
 ///
-/// `tool_version` (e.g. `crap4rs`'s `0.5.0`) and `long_version`
-/// (e.g. `0.5.0 (abc1234 2026-05-09)`) are spliced into clap's help
-/// and `--version` output at runtime so the binary's build-script
-/// metadata reaches the help text — the derive macro's `version`
-/// reads `CARGO_PKG_VERSION` at lib-crate compile time (crap-core's
-/// `0.1.0`), and `CRAP4RS_LONG_VERSION` is only set during the
-/// binary's compile.
-///
-/// `clap::Command::{version,long_version}` take
-/// `IntoResettable<Str>` which implements `From<&'static str>` but
-/// not `From<String>`. The strings live for the program's lifetime,
-/// so leaking once at startup is the cheapest path that satisfies
-/// clap's expected lifetime. The leak is fixed-size and one-shot.
-pub fn parse_args(tool_version: &str, long_version: &str) -> Cli {
-    let cmd = build_command(tool_version, long_version);
+/// `AdapterMeta::{tool_version, long_version, about, long_about,
+/// after_help}` flow into clap's help / `--version` output at runtime
+/// so the binary's build-script metadata reaches the help text — the
+/// derive macro's `version` reads `CARGO_PKG_VERSION` at lib-crate
+/// compile time (crap-core's `0.1.0`); the adapter binary's own
+/// `CARGO_PKG_VERSION` and `<ADAPTER>_LONG_VERSION` only resolve in
+/// the binary's compile and reach us by parameter.
+pub fn parse_args(meta: &AdapterMeta<'_>) -> Cli {
+    let cmd = build_command(meta);
     let matches = cmd.get_matches();
     Cli::from_arg_matches(&matches).unwrap_or_else(|e| e.exit())
 }
 
-/// Read the adapter binary's name from `argv[0]`. The clap-derive
-/// `Cli::command()` defaults to `CARGO_PKG_NAME` of the lib crate
-/// (crap-core) which would print `--version` lines as
-/// `crap-core 0.4.0 ...` and shape generated completion scripts to
-/// the wrong identifier; runtime detection ensures the displayed
-/// name matches whichever adapter binary (`crap4rs`, future
-/// `crap4ts`) actually ran.
-fn current_bin_name() -> String {
+/// Read the adapter binary's name from `argv[0]`, falling back to
+/// `meta.tool_name` when argv[0] is unavailable (extreme edge cases
+/// like execve with empty argv). The clap-derive `Cli::command()`
+/// defaults to `CARGO_PKG_NAME` of the lib crate (crap-core), which
+/// would print `--version` lines with the wrong identifier and shape
+/// generated completion scripts for the wrong binary; runtime
+/// detection ensures the displayed name matches whichever adapter
+/// binary actually ran.
+fn current_bin_name(meta_fallback: &str) -> String {
     std::env::args()
         .next()
         .and_then(|first| {
             // `file_stem()` (not `file_name()`) so Windows builds drop
-            // the `.exe` suffix — without it `--version` prints
-            // `crap4rs.exe 0.4.0` and breaks scripts (and the
-            // version-stamp integration tests) that match `^crap4rs `.
+            // the `.exe` suffix — without it `--version` would print
+            // `<binary>.exe <version>` and break scripts (and the
+            // version-stamp integration tests) that match `^<binary> `.
             // No-op on Linux/macOS.
             std::path::PathBuf::from(first)
                 .file_stem()
                 .map(|os| os.to_string_lossy().into_owned())
         })
-        .unwrap_or_else(|| "crap4rs".to_string())
+        .unwrap_or_else(|| meta_fallback.to_string())
 }
 
 /// Build the clap `Command` with the binary's runtime metadata
 /// spliced in. Used by `parse_args`; `emit_completions` reads the
 /// bin name through `current_bin_name` directly because
 /// `clap_complete::generate` takes the bin name as a separate arg.
-fn build_command(tool_version: &str, long_version: &str) -> clap::Command {
-    let bin_static: &'static str = Box::leak(current_bin_name().into_boxed_str());
-    let version_static: &'static str = Box::leak(tool_version.to_string().into_boxed_str());
-    let long_version_static: &'static str = Box::leak(long_version.to_string().into_boxed_str());
-    Cli::command()
+///
+/// `version` / `long_version` / `name` / `bin_name` go through
+/// `Box::leak` because clap 4.6.0's `clap::builder::Str` implements
+/// `From<&'static str>` but **not** `From<String>` — the strings must
+/// outlive the parsed `Command`, which lives for the program's
+/// lifetime. The leak is fixed-size (≤ 4 small strings) and one-shot
+/// at startup. `about` / `long_about` / `after_help` accept
+/// `Into<StyledStr>` directly so `String` works there without
+/// leaking.
+fn build_command(meta: &AdapterMeta<'_>) -> clap::Command {
+    let bin_static: &'static str = Box::leak(current_bin_name(meta.tool_name).into_boxed_str());
+    let version_static: &'static str = Box::leak(meta.tool_version.to_string().into_boxed_str());
+    let long_version_static: &'static str =
+        Box::leak(meta.long_version.to_string().into_boxed_str());
+    let mut cmd = Cli::command()
         .name(bin_static)
         .bin_name(bin_static)
         .version(version_static)
         .long_version(long_version_static)
+        .about(meta.about.to_string())
+        .long_about(meta.long_about.to_string());
+    if !meta.after_help.is_empty() {
+        cmd = cmd.after_help(meta.after_help.to_string());
+    }
+    cmd
 }
 
 /// Run the CRAP CLI pipeline end-to-end.
@@ -698,7 +744,7 @@ fn build_command(tool_version: &str, long_version: &str) -> clap::Command {
 /// *after* CLI / config-file / preset merging — pre-construction
 /// canonicalized against the bare CLI value (or the default `src`) and
 /// the LCOV parser silently stripped the wrong prefix from `SF:`
-/// records (#150). The factory is invoked once inside `run` after
+/// records. The factory is invoked once inside `run` after
 /// `merge_effective_inputs` resolves the final `src`, receives the
 /// **canonicalized** effective source root (so adapter factories stay
 /// dumb — orchestration owns the canonicalize concern), and is
@@ -712,22 +758,24 @@ fn build_command(tool_version: &str, long_version: &str) -> clap::Command {
 /// diagnostic types (`LcovParseDiagnostic`, `IstanbulParseDiagnostic`)
 /// satisfy it trivially.
 ///
-/// `tool_version` is the binary's own version (e.g. `crap4rs`'s
-/// `CARGO_PKG_VERSION` resolves to `0.5.0`, not crap-core's `0.1.0`).
-/// It feeds the JSON envelope's `tool_version` field, the SARIF run
-/// metadata, the markdown header, the HTML report header, and clap's
-/// long-version splice when the caller threads it through.
+/// `meta` carries the adapter binary's runtime identity (name,
+/// version, help copy, extensions, config-file name, SARIF URIs).
+/// The binary's own `tool_version` (e.g. crap4rs's `CARGO_PKG_VERSION`
+/// resolves to `0.5.0`, not crap-core's `0.1.0`) feeds the JSON
+/// envelope's `tool_version` field, the SARIF run metadata, the
+/// markdown / HTML headers, and clap's long-version splice. See
+/// `AdapterMeta` for the per-field rationale.
 pub fn run<P, F>(
     cli: Cli,
     complexity: &dyn ComplexityPort,
     coverage_factory: F,
-    tool_version: &str,
+    meta: &AdapterMeta<'_>,
 ) -> ExitCode
 where
     P: ParseDiagnostic + std::fmt::Display + 'static,
     F: FnOnce(&Path) -> Box<dyn CoveragePort<Diagnostic = P>>,
 {
-    match run_inner(cli, complexity, coverage_factory, tool_version) {
+    match run_inner(cli, complexity, coverage_factory, meta) {
         Ok(true) => ExitCode::from(0),
         Ok(false) => ExitCode::from(1),
         Err(e) => {
@@ -741,18 +789,18 @@ fn run_inner<P, F>(
     mut cli: Cli,
     complexity: &dyn ComplexityPort,
     coverage_factory: F,
-    tool_version: &str,
+    meta: &AdapterMeta<'_>,
 ) -> Result<bool>
 where
     P: ParseDiagnostic + std::fmt::Display + 'static,
     F: FnOnce(&Path) -> Box<dyn CoveragePort<Diagnostic = P>>,
 {
     if let Some(Command::Completions { shell }) = cli.command {
-        emit_completions(shell, &current_bin_name());
+        emit_completions(shell, &current_bin_name(meta.tool_name));
         return Ok(true);
     }
 
-    let prep = prepare_pipeline(&mut cli, complexity, coverage_factory)?;
+    let prep = prepare_pipeline(&mut cli, complexity, coverage_factory, meta)?;
 
     // Build the spec, then shape the result through the View pipeline.
     // V1b: `--only-failing` flows through `Filters::only_failing` here.
@@ -780,14 +828,14 @@ where
             prep.delta_state.as_ref(),
             &prep.analysis,
             &prep.inputs,
-            tool_version,
+            meta,
         )?;
     }
 
     // Exit code derives from `view.full.passed` — i.e., the underlying
     // analysis. The View shapes the display, never the gate.
     //
-    // Delta is informational by default (issue #81 §gate semantics).
+    // Delta is informational by default.
     // `--delta-gate` opts in: a passing analysis with delta regressions
     // that introduce new violations will exit 1 when `--delta-gate` is
     // set. `--no-fail` overrides BOTH gates — truth lives in JSON
@@ -848,18 +896,23 @@ fn merge_effective_inputs(cli: &Cli, file_config: &Option<FileConfig>) -> Effect
     }
 }
 
-fn validate_runtime_inputs<'a>(cli: &'a Cli, inputs: &EffectiveInputs) -> Result<&'a Path> {
+fn validate_runtime_inputs<'a>(
+    cli: &'a Cli,
+    inputs: &EffectiveInputs,
+    meta: &AdapterMeta<'_>,
+) -> Result<&'a Path> {
     // `--coverage` is required on the analysis path; subcommands like
     // `completions` skip this branch. Clap can't express "required
     // unless subcommand X" in derive, so we enforce it here.
     let Some(coverage_path) = cli.input.coverage.as_deref() else {
         bail!(
-            "--coverage <FILE> is required (run `crap4rs --help` for usage, or `crap4rs completions <SHELL>` for shell completion scripts)"
+            "--coverage <FILE> is required (run `{name} --help` for usage, or `{name} completions <SHELL>` for shell completion scripts)",
+            name = meta.tool_name,
         );
     };
 
     validate_inputs(coverage_path, &inputs.src, inputs.threshold)?;
-    preflight_checks(coverage_path, &inputs.src)?;
+    preflight_checks(coverage_path, &inputs.src, meta)?;
 
     if let Some(diff_ref) = cli.filter.diff.as_deref() {
         validate_diff_ref(diff_ref)?;
@@ -869,7 +922,12 @@ fn validate_runtime_inputs<'a>(cli: &'a Cli, inputs: &EffectiveInputs) -> Result
     Ok(coverage_path)
 }
 
-fn build_analyze_options(cli: &Cli, inputs: &EffectiveInputs, coverage: &Path) -> AnalyzeOptions {
+fn build_analyze_options(
+    cli: &Cli,
+    inputs: &EffectiveInputs,
+    coverage: &Path,
+    meta: &AdapterMeta<'_>,
+) -> AnalyzeOptions {
     AnalyzeOptions {
         src: inputs.src.clone(),
         coverage: coverage.to_path_buf(),
@@ -878,6 +936,7 @@ fn build_analyze_options(cli: &Cli, inputs: &EffectiveInputs, coverage: &Path) -
         exclude: inputs.exclude.clone(),
         respect_gitignore: !cli.filter.no_gitignore,
         diff_ref: cli.filter.diff.clone(),
+        extensions: meta.extensions_owned(),
         compute_diagnostics: cli
             .output
             .format
@@ -904,12 +963,14 @@ fn apply_diagnostics<P: ParseDiagnostic + std::fmt::Display>(
 ///
 /// Constructs the coverage adapter via `coverage_factory` *after*
 /// `merge_effective_inputs` resolves the final source root, so the
-/// LCOV parser strips the correct prefix from `SF:` records even when
-/// `src` comes from `crap4rs.toml` rather than the CLI (#150).
+/// coverage parser strips the correct prefix from per-file records
+/// even when `src` came from the adapter's config TOML rather than
+/// the CLI.
 fn prepare_pipeline<P, F>(
     cli: &mut Cli,
     complexity: &dyn ComplexityPort,
     coverage_factory: F,
+    meta: &AdapterMeta<'_>,
 ) -> Result<PipelinePrep<P>>
 where
     P: ParseDiagnostic + std::fmt::Display + 'static,
@@ -919,17 +980,17 @@ where
     apply_color(cli.display.color);
 
     // Load config file (explicit path or auto-discovered)
-    let file_config = load_file_config(cli)?;
+    let file_config = load_file_config(cli, meta.config_file_name)?;
 
-    // Resolve `--view <NAME>` (issue #80) before validate_view_args runs
+    // Resolve `--view <NAME>` before validate_view_args runs
     // so preset fields participate in the same validation pass as CLI
     // flags. `apply_preset_to_cli` mutates `cli` in place: CLI explicit
     // values win on `Option<T>` fields, bools OR-merge.
-    view_args::resolve_view_preset(cli, file_config.as_ref())?;
+    view_args::resolve_view_preset(cli, file_config.as_ref(), meta.config_file_name)?;
     view_args::validate_view_args(cli)?;
 
     let inputs = merge_effective_inputs(cli, &file_config);
-    let coverage_path = validate_runtime_inputs(cli, &inputs)?;
+    let coverage_path = validate_runtime_inputs(cli, &inputs, meta)?;
 
     // Canonicalize the effective `src` (post-config-merge) and hand
     // it to the adapter's factory closure. `validate_runtime_inputs`
@@ -940,12 +1001,12 @@ where
     let src_canonical = crate::core::canonicalize_src(&inputs.src);
     let coverage = coverage_factory(&src_canonical);
 
-    let options = build_analyze_options(cli, &inputs, coverage_path);
+    let options = build_analyze_options(cli, &inputs, coverage_path, meta);
 
     let analysis = crate::core::analyze(&options, complexity, &*coverage)?;
     apply_diagnostics(cli, &analysis.diagnostics);
 
-    // Resolve --baseline (issue #81): load a previously-emitted JSON
+    // Resolve --baseline: load a previously-emitted JSON
     // envelope and compute the AnalysisDelta. None when --baseline is
     // absent — the JSON envelope omits the `delta` block entirely so
     // existing consumers see byte-identical output.
@@ -967,7 +1028,7 @@ fn format_as_json<P: ParseDiagnostic>(
     delta_state: Option<&DeltaState<P>>,
     analysis: &AnalysisOutput<P>,
     inputs: &EffectiveInputs,
-    tool_version: &str,
+    meta: &AdapterMeta<'_>,
 ) -> Result<String> {
     let delta_ctx = delta_state.zip(delta_view).map(|(s, dv)| DeltaContext {
         view: dv,
@@ -976,7 +1037,7 @@ fn format_as_json<P: ParseDiagnostic>(
         baseline_diagnostics: s.snapshot.diagnostics.as_ref(),
     });
     let config = reporters::json::JsonConfig {
-        tool_version: tool_version.to_string(),
+        tool_version: meta.tool_version.to_string(),
         metric: inputs.metric,
         threshold: inputs.threshold,
         timestamp: now_unix_epoch(),
@@ -989,7 +1050,7 @@ fn format_as_json<P: ParseDiagnostic>(
 }
 
 /// ScorecardRow projects the unshaped analysis + delta into a mokumo
-/// `Row::CrapDelta` JSON object (issue #111). View shaping does NOT
+/// `Row::CrapDelta` JSON object. View shaping does NOT
 /// alter scorecard-row — the aggregator consumes truth, not a filtered
 /// subset.
 fn format_as_scorecard_row<P: ParseDiagnostic>(
@@ -1008,8 +1069,8 @@ fn format_as_scorecard_row<P: ParseDiagnostic>(
     reporters::format_scorecard_row(&row_data)
 }
 
-// 8-arg dispatch is the cost of threading `<P>` + `tool_version` through
-// the format match without restructuring the per-reporter call sites
+// 8-arg dispatch is the cost of threading `<P>` + `meta` through the
+// format match without restructuring the per-reporter call sites
 // (which carry heterogeneous, irreducible signatures per `adapters.md`
 // rule 1). Bundling them into a context struct would shadow the per-arm
 // argument list that's the whole point of this match. Tracked under v1.0
@@ -1023,7 +1084,7 @@ fn render_format<P: ParseDiagnostic>(
     delta_state: Option<&DeltaState<P>>,
     analysis: &AnalysisOutput<P>,
     inputs: &EffectiveInputs,
-    tool_version: &str,
+    meta: &AdapterMeta<'_>,
 ) -> Result<String> {
     Ok(match spec.format {
         FormatArg::Table => reporters::format_table_with_explain(
@@ -1032,17 +1093,12 @@ fn render_format<P: ParseDiagnostic>(
             inputs.threshold,
             cli.display.breakdown,
             cli.display.explain,
-            tool_version,
+            meta.tool_name,
+            meta.tool_version,
         ),
-        FormatArg::Json | FormatArg::Advice => format_as_json(
-            cli,
-            view,
-            delta_view,
-            delta_state,
-            analysis,
-            inputs,
-            tool_version,
-        )?,
+        FormatArg::Json | FormatArg::Advice => {
+            format_as_json(cli, view, delta_view, delta_state, analysis, inputs, meta)?
+        }
         FormatArg::Markdown => reporters::format_markdown(
             view,
             delta_view,
@@ -1051,7 +1107,8 @@ fn render_format<P: ParseDiagnostic>(
             cli.display.explain,
             cli.display.md_full_table,
             cli.display.md_top,
-            tool_version,
+            meta.tool_name,
+            meta.tool_version,
         ),
         FormatArg::Csv => reporters::format_csv(view, delta_view, inputs.metric),
         // SARIF is a gate translation, not a display: it iterates
@@ -1059,11 +1116,19 @@ fn render_format<P: ParseDiagnostic>(
         // was shaped. `--top`, `--sort-by`, `--only-failing`, and
         // `--baseline` do NOT alter SARIF output — PR annotations
         // must reflect truth.
-        FormatArg::Sarif => reporters::format_sarif(view, tool_version),
+        FormatArg::Sarif => reporters::format_sarif(
+            view,
+            meta.tool_name,
+            meta.tool_version,
+            meta.tool_info_uri,
+            meta.rule_help_uri,
+        ),
         FormatArg::ScorecardRow => {
             format_as_scorecard_row(delta_state, &analysis.result, inputs.threshold)
         }
-        FormatArg::Html => reporters::format_html(view, inputs.threshold, tool_version),
+        FormatArg::Html => {
+            reporters::format_html(view, inputs.threshold, meta.tool_name, meta.tool_version)
+        }
     })
 }
 
@@ -1074,7 +1139,7 @@ fn print_formatted_output<P: ParseDiagnostic>(
     delta_state: Option<&DeltaState<P>>,
     analysis: &AnalysisOutput<P>,
     inputs: &EffectiveInputs,
-    tool_version: &str,
+    meta: &AdapterMeta<'_>,
 ) -> Result<()> {
     for spec in &cli.output.format {
         let output = render_format(
@@ -1085,7 +1150,7 @@ fn print_formatted_output<P: ParseDiagnostic>(
             delta_state,
             analysis,
             inputs,
-            tool_version,
+            meta,
         )?;
         match &spec.output {
             Some(path) => std::fs::write(path, &output)
@@ -1162,7 +1227,7 @@ fn validate_display_flags(cli: &Cli) -> Result<()> {
 }
 
 /// Multi-format invocations require every entry to specify a file —
-/// stdout cannot multiplex (issue #100).
+/// stdout cannot multiplex.
 fn validate_format_destinations(specs: &[FormatSpec]) -> Result<()> {
     if specs.len() > 1 {
         let stdout_specs: Vec<_> = specs
@@ -1192,11 +1257,11 @@ fn format_arg_kebab(arg: FormatArg) -> String {
 
 // ── Config loading & merging ───────────────────────────────────────
 
-fn load_file_config(cli: &Cli) -> Result<Option<FileConfig>> {
+fn load_file_config(cli: &Cli, config_file_name: &str) -> Result<Option<FileConfig>> {
     if let Some(path) = &cli.input.config {
         Ok(Some(config::load_config(path)?))
     } else {
-        match config::discover_config()? {
+        match config::discover_config(config_file_name)? {
             Some(path) => Ok(Some(config::load_config(&path)?)),
             None => Ok(None),
         }
@@ -1344,13 +1409,17 @@ fn preflight_git_worktree(src: &Path) -> Result<()> {
 
 // ── Pre-flight checks ──────────────────────────────────────────────
 
-fn preflight_checks(coverage: &std::path::Path, src: &std::path::Path) -> Result<()> {
-    check_coverage_has_data(coverage)?;
-    check_src_has_rust_files(src)?;
+fn preflight_checks(
+    coverage: &std::path::Path,
+    src: &std::path::Path,
+    meta: &AdapterMeta<'_>,
+) -> Result<()> {
+    check_coverage_has_data(coverage, meta.coverage_hint)?;
+    check_src_has_source_files(src, meta.extensions)?;
     Ok(())
 }
 
-fn check_coverage_has_data(path: &std::path::Path) -> Result<()> {
+fn check_coverage_has_data(path: &std::path::Path, coverage_hint: &str) -> Result<()> {
     use std::io::{BufRead, BufReader};
 
     let file = std::fs::File::open(path)?;
@@ -1373,35 +1442,65 @@ fn check_coverage_has_data(path: &std::path::Path) -> Result<()> {
         }
     }
     bail!(
-        "no coverage data found in {}\n  \
-         hint: ensure tests ran with coverage enabled (`cargo llvm-cov --lcov`)",
-        path.display()
+        "no coverage data found in {}\n  hint: {}",
+        path.display(),
+        coverage_hint,
     );
 }
 
-fn check_src_has_rust_files(path: &std::path::Path) -> Result<()> {
-    fn has_rs_files(dir: &std::path::Path) -> std::io::Result<bool> {
+/// Verify the source directory contains at least one file whose
+/// extension is in `extensions`. Adapter-specific (e.g.,
+/// `&["rs"]` for crap4rs, `&["ts","tsx","js","jsx","mjs","cjs"]` for
+/// crap4ts).
+fn check_src_has_source_files(path: &std::path::Path, extensions: &[&str]) -> Result<()> {
+    fn has_source_files(dir: &std::path::Path, extensions: &[&str]) -> std::io::Result<bool> {
         for entry in std::fs::read_dir(dir)? {
             let entry = entry?;
             let ft = entry.file_type()?;
-            if ft.is_file() && entry.path().extension().is_some_and(|ext| ext == "rs") {
+            if ft.is_file()
+                && let Some(ext) = entry.path().extension()
+                && extensions.iter().any(|e| ext == *e)
+            {
                 return Ok(true);
             }
-            if ft.is_dir() && has_rs_files(&entry.path())? {
+            if ft.is_dir() && has_source_files(&entry.path(), extensions)? {
                 return Ok(true);
             }
         }
         Ok(false)
     }
 
-    if !has_rs_files(path)? {
+    if !has_source_files(path, extensions)? {
+        let pretty = format_extensions_list(extensions);
         bail!(
-            "no Rust source files found in {}\n  \
-             hint: check that --src points to a directory containing .rs files",
-            path.display()
+            "no source files found in {}\n  \
+             hint: check that --src points to a directory containing {} files",
+            path.display(),
+            pretty,
         );
     }
     Ok(())
+}
+
+/// Render a list of bare extensions (`["rs"]`, `["ts","tsx","js"]`)
+/// as a human-readable comma-separated list of dotted extensions:
+/// `".rs"`, `".ts", ".tsx", or ".js"`. Used in the
+/// `check_src_has_source_files` hint.
+fn format_extensions_list(extensions: &[&str]) -> String {
+    match extensions {
+        [] => "supported".to_string(),
+        [only] => format!(".{only}"),
+        [first, rest @ .., last] => {
+            let mut out = format!(".{first}");
+            for e in rest {
+                out.push_str(", .");
+                out.push_str(e);
+            }
+            out.push_str(", or .");
+            out.push_str(last);
+            out
+        }
+    }
 }
 
 // ── Timestamp ──────────────────────────────────────────────────────
@@ -1520,7 +1619,11 @@ mod tests {
     use std::path::Path;
 
     fn parse(args: &[&str]) -> Result<Cli, clap::Error> {
-        let mut full = vec!["crap4rs"];
+        // argv[0] is a clap placeholder — kept adapter-agnostic
+        // (`"test-adapter"`, not any real adapter binary's name) so
+        // crap-core source has zero hardcoded references to its
+        // consumers.
+        let mut full = vec!["test-adapter"];
         full.extend_from_slice(args);
         Cli::try_parse_from(full)
     }
@@ -2073,16 +2176,22 @@ mod tests {
 
     // ── Pre-flight check tests ─────────────────────────────────────────
 
+    // Synthetic adapter values for tests — match the placeholder used
+    // throughout the in-crate test suite. Real adapters supply real
+    // values via `AdapterMeta`.
+    const TEST_COVERAGE_HINT: &str =
+        "ensure tests ran with coverage enabled (test-tool's `--coverage` flag)";
+
     #[test]
     fn preflight_empty_coverage_file() {
         let dir = tempfile::tempdir().unwrap();
         let cov = dir.path().join("empty.info");
         std::fs::write(&cov, "").unwrap();
 
-        let err = check_coverage_has_data(&cov).unwrap_err();
+        let err = check_coverage_has_data(&cov, TEST_COVERAGE_HINT).unwrap_err();
         let msg = format!("{err:#}");
         assert!(msg.contains("no coverage data found"));
-        assert!(msg.contains("cargo llvm-cov"));
+        assert!(msg.contains(TEST_COVERAGE_HINT));
     }
 
     #[test]
@@ -2091,7 +2200,7 @@ mod tests {
         let cov = dir.path().join("no_da.info");
         std::fs::write(&cov, "SF:src/main.rs\nend_of_record\n").unwrap();
 
-        let err = check_coverage_has_data(&cov).unwrap_err();
+        let err = check_coverage_has_data(&cov, TEST_COVERAGE_HINT).unwrap_err();
         let msg = format!("{err:#}");
         assert!(msg.contains("no coverage data found"));
     }
@@ -2102,7 +2211,7 @@ mod tests {
         let cov = dir.path().join("good.info");
         std::fs::write(&cov, "SF:src/main.rs\nDA:1,5\nend_of_record\n").unwrap();
 
-        assert!(check_coverage_has_data(&cov).is_ok());
+        assert!(check_coverage_has_data(&cov, TEST_COVERAGE_HINT).is_ok());
     }
 
     #[test]
@@ -2111,7 +2220,7 @@ mod tests {
         let cov = dir.path().join("orphan_da.info");
         std::fs::write(&cov, "DA:1,5\nend_of_record\n").unwrap();
 
-        let err = check_coverage_has_data(&cov).unwrap_err();
+        let err = check_coverage_has_data(&cov, TEST_COVERAGE_HINT).unwrap_err();
         let msg = format!("{err:#}");
         assert!(msg.contains("no coverage data found"));
     }
@@ -2122,46 +2231,70 @@ mod tests {
         let cov = dir.path().join("bad_da.info");
         std::fs::write(&cov, "SF:src/main.rs\nDA:not_a_number\nend_of_record\n").unwrap();
 
-        let err = check_coverage_has_data(&cov).unwrap_err();
+        let err = check_coverage_has_data(&cov, TEST_COVERAGE_HINT).unwrap_err();
         let msg = format!("{err:#}");
         assert!(msg.contains("no coverage data found"));
     }
 
     #[test]
-    fn preflight_src_dir_no_rust_files() {
+    fn preflight_src_dir_no_matching_extension() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("readme.txt"), "hello").unwrap();
 
-        let err = check_src_has_rust_files(dir.path()).unwrap_err();
+        let err = check_src_has_source_files(dir.path(), &["rs"]).unwrap_err();
         let msg = format!("{err:#}");
-        assert!(msg.contains("no Rust source files found"));
+        assert!(msg.contains("no source files found"));
+        assert!(msg.contains(".rs"));
     }
 
     #[test]
     fn preflight_src_dir_empty() {
         let dir = tempfile::tempdir().unwrap();
 
-        let err = check_src_has_rust_files(dir.path()).unwrap_err();
+        let err = check_src_has_source_files(dir.path(), &["rs"]).unwrap_err();
         let msg = format!("{err:#}");
-        assert!(msg.contains("no Rust source files found"));
+        assert!(msg.contains("no source files found"));
     }
 
     #[test]
-    fn preflight_src_dir_with_rs_files_passes() {
+    fn preflight_src_dir_with_matching_files_passes() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("main.rs"), "fn main() {}").unwrap();
 
-        assert!(check_src_has_rust_files(dir.path()).is_ok());
+        assert!(check_src_has_source_files(dir.path(), &["rs"]).is_ok());
     }
 
     #[test]
-    fn preflight_src_dir_nested_rs_files_passes() {
+    fn preflight_src_dir_nested_files_passes() {
         let dir = tempfile::tempdir().unwrap();
         let nested = dir.path().join("sub");
         std::fs::create_dir(&nested).unwrap();
         std::fs::write(nested.join("lib.rs"), "pub fn foo() {}").unwrap();
 
-        assert!(check_src_has_rust_files(dir.path()).is_ok());
+        assert!(check_src_has_source_files(dir.path(), &["rs"]).is_ok());
+    }
+
+    /// regression — preflight honors arbitrary extensions, not
+    /// just `.rs`. Mirrors the walker test (`crap_core::core::walker::
+    /// discover_source_files_finds_typescript_extensions`).
+    #[test]
+    fn preflight_src_dir_with_typescript_files_passes() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("app.ts"), "export const x = 1;").unwrap();
+
+        assert!(check_src_has_source_files(dir.path(), &["ts", "tsx"]).is_ok());
+    }
+
+    /// regression — hint surfaces the configured extensions so
+    /// users see "containing .ts, .tsx, or .js files" for crap4ts and
+    /// "containing .rs files" for crap4rs.
+    #[test]
+    fn preflight_src_dir_hint_lists_extensions() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let err = check_src_has_source_files(dir.path(), &["ts", "tsx", "js"]).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains(".ts, .tsx, or .js"), "unexpected hint: {msg}");
     }
 
     // ── --strict / --lenient flag tests ───────────────────────────────

--- a/crates/crap-core/src/cli/view_args.rs
+++ b/crates/crap-core/src/cli/view_args.rs
@@ -90,8 +90,16 @@ fn resolve_coverage_bounds(cli: &Cli) -> Option<(f64, f64)> {
 /// - If `--view ci` was passed but no config file is loaded OR the config
 ///   has no preset by that name: bail with `exit 2` ("unknown preset")
 ///   listing the available preset names. Empty list yields a hint that
-///   `crap4rs.toml` defines no `[views]` blocks.
-pub(super) fn resolve_view_preset(cli: &mut Cli, file_config: Option<&FileConfig>) -> Result<()> {
+///   names the adapter's config file.
+///
+/// `config_file_name` is the adapter-specific conventional file name
+/// (e.g., `"crap4rs.toml"`, `"crap4ts.toml"`) so the error hint points
+/// the user at the right file to create.
+pub(super) fn resolve_view_preset(
+    cli: &mut Cli,
+    file_config: Option<&FileConfig>,
+    config_file_name: &str,
+) -> Result<()> {
     let Some(name) = cli.input.view.clone() else {
         return Ok(());
     };
@@ -102,13 +110,14 @@ pub(super) fn resolve_view_preset(cli: &mut Cli, file_config: Option<&FileConfig
             apply_preset_to_cli(cli, preset);
             Ok(())
         }
-        None => bail!("{}", unknown_preset_message(&name, views)),
+        None => bail!("{}", unknown_preset_message(&name, views, config_file_name)),
     }
 }
 
 fn unknown_preset_message(
     name: &str,
     views: Option<&std::collections::HashMap<String, ViewPreset>>,
+    config_file_name: &str,
 ) -> String {
     match views {
         Some(map) if !map.is_empty() => {
@@ -120,15 +129,15 @@ fn unknown_preset_message(
             )
         }
         Some(_) => format!(
-            "unknown view preset `{name}`\n  hint: crap4rs.toml defines no [views.<name>] blocks"
+            "unknown view preset `{name}`\n  hint: {config_file_name} defines no [views.<name>] blocks"
         ),
         None => format!(
-            "unknown view preset `{name}`\n  hint: --view requires a crap4rs.toml with a [views.{name}] block"
+            "unknown view preset `{name}`\n  hint: --view requires a {config_file_name} with a [views.{name}] block"
         ),
     }
 }
 
-/// Fold a saved-view preset (issue #80) into the parsed CLI before
+/// Fold a saved-view preset into the parsed CLI before
 /// `validate_view_args` and `build_view_spec` run.
 ///
 /// **Override priority:** defaults < preset < CLI flags. For
@@ -166,7 +175,11 @@ mod tests {
     use crate::domain::view::{GroupKey, SortKey};
 
     fn parse(args: &[&str]) -> Cli {
-        let mut full = vec!["crap4rs"];
+        // argv[0] is a clap placeholder — kept adapter-agnostic
+        // (`"test-adapter"`, not any real adapter binary's name) so
+        // crap-core source has zero hardcoded references to its
+        // consumers.
+        let mut full = vec!["test-adapter"];
         full.extend_from_slice(args);
         <Cli as clap::Parser>::try_parse_from(full).expect("test args parse")
     }
@@ -323,7 +336,7 @@ mod tests {
         assert_eq!(cli.filter.max_coverage, Some(50.0), "CLI max wins");
     }
 
-    // ── resolve_view_preset (#80) ──────────────────────────────────────
+    // ── resolve_view_preset ──────────────────────────────────────
 
     fn config_with_preset(name: &str, preset: ViewPreset) -> FileConfig {
         let mut views = std::collections::HashMap::new();
@@ -338,7 +351,7 @@ mod tests {
     fn resolve_view_preset_no_flag_is_noop() {
         let mut cli = parse(&["--coverage", "lcov.info"]);
         let cfg = config_with_preset("ci", full_preset());
-        resolve_view_preset(&mut cli, Some(&cfg)).unwrap();
+        resolve_view_preset(&mut cli, Some(&cfg), "test-adapter.toml").unwrap();
         // No `--view` passed → preset must NOT be applied.
         assert_eq!(cli.filter.top, None);
         assert!(cli.filter.sort_by.is_none());
@@ -349,7 +362,7 @@ mod tests {
     fn resolve_view_preset_resolves_named_preset() {
         let mut cli = parse(&["--coverage", "lcov.info", "--view", "ci"]);
         let cfg = config_with_preset("ci", full_preset());
-        resolve_view_preset(&mut cli, Some(&cfg)).unwrap();
+        resolve_view_preset(&mut cli, Some(&cfg), "test-adapter.toml").unwrap();
         assert_eq!(cli.filter.top, Some(20));
         assert!(cli.filter.only_failing);
     }
@@ -358,7 +371,7 @@ mod tests {
     fn resolve_view_preset_cli_overrides_resolved_preset() {
         let mut cli = parse(&["--coverage", "lcov.info", "--view", "ci", "--top", "5"]);
         let cfg = config_with_preset("ci", full_preset());
-        resolve_view_preset(&mut cli, Some(&cfg)).unwrap();
+        resolve_view_preset(&mut cli, Some(&cfg), "test-adapter.toml").unwrap();
         assert_eq!(cli.filter.top, Some(5), "CLI --top wins over preset");
         // Other preset fields still applied.
         assert!(cli.filter.only_failing);
@@ -374,7 +387,7 @@ mod tests {
             views,
             ..FileConfig::default()
         };
-        let err = resolve_view_preset(&mut cli, Some(&cfg)).unwrap_err();
+        let err = resolve_view_preset(&mut cli, Some(&cfg), "test-adapter.toml").unwrap_err();
         let msg = format!("{err:#}");
         assert!(
             msg.contains("unknown view preset"),
@@ -396,12 +409,12 @@ mod tests {
     #[test]
     fn resolve_view_preset_no_config_file_explains_requirement() {
         let mut cli = parse(&["--coverage", "lcov.info", "--view", "ci"]);
-        let err = resolve_view_preset(&mut cli, None).unwrap_err();
+        let err = resolve_view_preset(&mut cli, None, "test-adapter.toml").unwrap_err();
         let msg = format!("{err:#}");
         assert!(msg.contains("unknown view preset"), "got: {msg}");
         assert!(
-            msg.contains("crap4rs.toml"),
-            "should mention config file: {msg}"
+            msg.contains("test-adapter.toml"),
+            "should mention the adapter's config file by name: {msg}"
         );
     }
 
@@ -409,7 +422,7 @@ mod tests {
     fn resolve_view_preset_empty_views_block_hints_no_blocks_defined() {
         let mut cli = parse(&["--coverage", "lcov.info", "--view", "ci"]);
         let cfg = FileConfig::default();
-        let err = resolve_view_preset(&mut cli, Some(&cfg)).unwrap_err();
+        let err = resolve_view_preset(&mut cli, Some(&cfg), "test-adapter.toml").unwrap_err();
         let msg = format!("{err:#}");
         assert!(msg.contains("unknown view preset"));
         assert!(msg.contains("no [views"), "empty-block hint missing: {msg}");

--- a/crates/crap-core/src/core/mod.rs
+++ b/crates/crap-core/src/core/mod.rs
@@ -439,7 +439,7 @@ fn ensure_functions_extracted(all_complexities: &[FunctionComplexity], src: &Pat
     if all_complexities.is_empty() {
         bail!(
             "no functions extracted from source files in {}\n  \
-             hint: check that source files contain valid Rust function definitions",
+             hint: check that source files contain valid function definitions for the selected adapter",
             src.display()
         );
     }

--- a/crates/crap-core/src/core/mod.rs
+++ b/crates/crap-core/src/core/mod.rs
@@ -6,10 +6,10 @@
 //! produces results. Per-adapter language coupling stays in the caller's
 //! crate (`crap4rs::adapters::complexity`, `crap4rs::adapters::coverage`).
 //!
-//! Relocated from `crap4rs::core` in S4 (#136). `analyze` is generic over
-//! `<P: ParseDiagnostic>` so the same orchestrator powers both the LCOV
-//! adapter (crap4rs) and future siblings (crap4ts's Istanbul adapter), per
-//! ADR D9 (mixed-dispatch-strategy).
+//! `analyze` is generic over `<P: ParseDiagnostic>` so the same
+//! orchestrator powers both the LCOV adapter (crap4rs) and future
+//! siblings (crap4ts's Istanbul adapter), per ADR D9
+//! (mixed-dispatch-strategy).
 
 pub mod walker;
 
@@ -17,7 +17,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
 
-use self::walker::discover_rust_files;
+use self::walker::discover_source_files;
 
 use crate::adapters::diff::GitDiffAdapter;
 use crate::domain::crap::compute_crap;
@@ -34,9 +34,10 @@ use crate::ports::{ComplexityPort, CoveragePort, DiffPort, ParseDiagnostic, Pars
 /// Options for running a CRAP analysis.
 #[derive(Debug)]
 pub struct AnalyzeOptions {
-    /// Root directory of Rust source files to analyze.
+    /// Root directory of source files to analyze.
     pub src: PathBuf,
-    /// Path to the LCOV coverage file.
+    /// Path to the coverage file (adapter-specific format: LCOV for
+    /// crap4rs, Istanbul JSON for crap4ts, etc.).
     pub coverage: PathBuf,
     /// Threshold configuration with optional per-path overrides.
     pub threshold_config: ThresholdConfig,
@@ -50,6 +51,13 @@ pub struct AnalyzeOptions {
     pub respect_gitignore: bool,
     /// Git ref to diff against. When set, only changed functions are analyzed.
     pub diff_ref: Option<String>,
+    /// File extensions the walker should pick up. Adapter-specific
+    /// (`["rs"]` for crap4rs; `["ts","tsx","js","jsx","mjs","cjs"]`
+    /// for crap4ts). `Default::default()` is `vec!["rs"]` so existing
+    /// library tests and snapshot baselines stay byte-identical
+    /// without an explicit set; the CLI boundary fills this from
+    /// `AdapterMeta::extensions`.
+    pub extensions: Vec<String>,
     /// When `true`, populate `FunctionVerdict.diagnostic` for every
     /// over-threshold verdict via `domain::diagnostic::compute_diagnostic`.
     /// CLI sets this for `--format advice` and `--format sarif`. The
@@ -92,6 +100,10 @@ impl Default for AnalyzeOptions {
             exclude: Vec::new(),
             respect_gitignore: true,
             diff_ref: None,
+            // `["rs"]` is the default for library tests that don't
+            // construct a full `AdapterMeta`. Adapter binaries
+            // override via `AdapterMeta::extensions`.
+            extensions: vec!["rs".to_string()],
             compute_diagnostics: false,
         }
     }
@@ -220,13 +232,15 @@ impl<'a, P: ParseDiagnostic> AnalysisContext<'a, P> {
     }
 
     fn discover_sources(&self) -> Result<DiscoveredSources> {
-        let source_files = discover_rust_files(
+        let extensions: Vec<&str> = self.options.extensions.iter().map(String::as_str).collect();
+        let source_files = discover_source_files(
             &self.options.src,
             &self.options.exclude,
             self.options.respect_gitignore,
+            &extensions,
         )?;
         let files_found = source_files.len();
-        ensure_source_files_found(&source_files, &self.options.src)?;
+        ensure_source_files_found(&source_files, &self.options.src, &extensions)?;
 
         Ok(DiscoveredSources {
             source_files,
@@ -346,9 +360,8 @@ impl<'a, P: ParseDiagnostic> AnalysisContext<'a, P> {
 /// Falls back to the raw path on failure (e.g., the directory was
 /// validated to exist by `validate_runtime_inputs` but vanished in a
 /// TOCTOU window before this call). The fallback is observable via
-/// stderr — silent regression would re-introduce a `#150`-flavored
-/// path-strip mismatch for adapters that depend on the canonical
-/// root.
+/// stderr — silent regression would re-introduce a path-strip
+/// mismatch for adapters that depend on the canonical root.
 ///
 /// `pub(crate)` so `cli::prepare_pipeline` can late-bind coverage
 /// adapter construction against the same path that
@@ -364,12 +377,37 @@ pub(crate) fn canonicalize_src(src: &Path) -> PathBuf {
     })
 }
 
-fn ensure_source_files_found(source_files: &[PathBuf], src: &Path) -> Result<()> {
+fn ensure_source_files_found(
+    source_files: &[PathBuf],
+    src: &Path,
+    extensions: &[&str],
+) -> Result<()> {
     if source_files.is_empty() {
+        // Render a comma-separated list of dotted extensions for the
+        // hint, matching the wording used by `cli::check_src_has_source_files`.
+        // Kept inline (no shared helper) because the diagnostic lives
+        // in `crap-core::core` while the CLI helper lives in
+        // `crap-core::cli` — pulling them into a shared module is
+        // v1.0-follow-up if a third caller emerges.
+        let pretty = match extensions {
+            [] => "supported".to_string(),
+            [only] => format!(".{only}"),
+            [first, rest @ .., last] => {
+                let mut out = format!(".{first}");
+                for e in rest {
+                    out.push_str(", .");
+                    out.push_str(e);
+                }
+                out.push_str(", or .");
+                out.push_str(last);
+                out
+            }
+        };
         bail!(
-            "no Rust source files found in {}\n  \
-             hint: check that --src points to a directory containing .rs files",
-            src.display()
+            "no source files found in {}\n  \
+             hint: check that --src points to a directory containing {} files",
+            src.display(),
+            pretty,
         );
     }
     Ok(())
@@ -659,19 +697,18 @@ fn empty_passing_result() -> AnalysisResult {
     }
 }
 
-// `discover_rust_files` relocated to
-// `crap_core::core::walker::discover_rust_files` in S3 (#135). The
-// import at the top of this file binds the name back into local scope
-// so the call sites in `discover_sources` keep compiling.
+// The walker lives at `crap_core::core::walker::discover_source_files`;
+// the import at the top of this file binds the name into local scope
+// for the call sites in `discover_sources`. The `.rs` filter is
+// parameter-driven via `AnalyzeOptions::extensions`.
 
 #[cfg(test)]
 mod tests {
     //! Language-agnostic core tests. The end-to-end pipeline tests that
     //! exercise `analyze` over real LCOV + Rust source live in
-    //! `crap4rs/tests/analyze_pipeline_tests.rs` (S4 #136 — the analyze
-    //! signature gained `&dyn ComplexityPort` + `&dyn CoveragePort` ports
-    //! and the test fixtures need the LCOV/syn adapters that live in the
-    //! crap4rs adapter crate).
+    //! `crap4rs/tests/analyze_pipeline_tests.rs` — `analyze` takes
+    //! `&dyn ComplexityPort` + `&dyn CoveragePort`, and the LCOV/syn
+    //! adapters that satisfy those traits live in the crap4rs crate.
     use super::*;
     use crate::domain::threshold::ThresholdOverride;
 

--- a/crates/crap-core/src/core/walker.rs
+++ b/crates/crap-core/src/core/walker.rs
@@ -1,30 +1,32 @@
-//! Filesystem walker — discovers Rust source files for analysis,
+//! Filesystem walker — discovers source files for analysis,
 //! respecting `.gitignore` and user-provided exclude patterns.
 //!
-//! Lives in `crap-core` even though it carries a hardcoded `.rs`
-//! extension filter today: the only AST-purity gate that matters here
-//! is "no `syn` / `quote` / `tree_sitter` / `swc` / `oxc` imports."
-//! `ignore::WalkBuilder` is purely filesystem-walking machinery and
-//! satisfies that gate. The `.rs` literal is a function-body wart that
-//! `analyze<P: ParseDiagnostic>` will parameterize in S4 once the
-//! parse-diagnostic type can carry the language-specific extension(s)
-//! it consumes.
+//! Adapter-agnostic: the extension filter is parameter-driven via
+//! `AnalyzeOptions::extensions` so crap4rs passes `&["rs"]`, crap4ts
+//! passes `&["ts","tsx","js","jsx","mjs","cjs"]`, and future adapters
+//! supply their own. AST-purity gate satisfied — `ignore::WalkBuilder`
+//! is filesystem-walking machinery with no `syn` / `tree_sitter` /
+//! `swc` / `oxc` coupling.
 //!
-//! Extracted from `crates/crap4rs/src/core/mod.rs::discover_rust_files`
-//! during S3 (crap4rs#135) so that S4's relocation of `core::analyze` to
-//! `crap-core` doesn't need to upward-import from the Rust adapter.
-
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use ignore::WalkBuilder;
 
-/// Walk the source directory and collect all `.rs` files, respecting
-/// .gitignore and user-provided exclude patterns.
-pub fn discover_rust_files(
+/// Walk the source directory and collect all files whose extension
+/// matches one in `extensions` (case-sensitive), respecting
+/// `.gitignore` and user-provided exclude patterns.
+///
+/// `extensions` is the bare suffix without the leading dot
+/// (`"rs"`, `"ts"`, `"tsx"`). An empty slice matches no files (the
+/// caller is expected to short-circuit on
+/// `AnalyzeOptions::extensions.is_empty()` upstream, but we don't
+/// crash here).
+pub fn discover_source_files(
     src: &Path,
     exclude: &[String],
     respect_gitignore: bool,
+    extensions: &[&str],
 ) -> Result<Vec<PathBuf>> {
     let mut builder = WalkBuilder::new(src);
     builder.git_ignore(respect_gitignore);
@@ -44,7 +46,8 @@ pub fn discover_rust_files(
     for entry in builder.build() {
         let entry = entry?;
         if entry.file_type().is_some_and(|ft| ft.is_file())
-            && entry.path().extension().is_some_and(|ext| ext == "rs")
+            && let Some(ext) = entry.path().extension()
+            && extensions.iter().any(|e| ext == *e)
         {
             files.push(entry.into_path());
         }
@@ -61,7 +64,7 @@ mod tests {
     use std::fs;
 
     #[test]
-    fn discover_rust_files_finds_nested() {
+    fn discover_source_files_finds_nested_rust_extension() {
         let dir = tempfile::tempdir().unwrap();
         let src = dir.path().join("src");
         fs::create_dir_all(src.join("sub")).unwrap();
@@ -69,13 +72,13 @@ mod tests {
         fs::write(src.join("sub").join("mod.rs"), "").unwrap();
         fs::write(src.join("readme.txt"), "").unwrap();
 
-        let files = discover_rust_files(&src, &[], false).unwrap();
+        let files = discover_source_files(&src, &[], false, &["rs"]).unwrap();
         assert_eq!(files.len(), 2);
         assert!(files.iter().all(|f| f.extension().unwrap() == "rs"));
     }
 
     #[test]
-    fn discover_rust_files_sorted_deterministically() {
+    fn discover_source_files_sorted_deterministically() {
         let dir = tempfile::tempdir().unwrap();
         let src = dir.path().join("src");
         fs::create_dir_all(&src).unwrap();
@@ -83,8 +86,52 @@ mod tests {
         fs::write(src.join("a.rs"), "").unwrap();
         fs::write(src.join("m.rs"), "").unwrap();
 
-        let files = discover_rust_files(&src, &[], false).unwrap();
+        let files = discover_source_files(&src, &[], false, &["rs"]).unwrap();
         let names: Vec<_> = files.iter().map(|f| f.file_name().unwrap()).collect();
         assert_eq!(names, vec!["a.rs", "m.rs", "z.rs"]);
+    }
+
+    /// Walker honors arbitrary extensions, not just `.rs`, so crap4ts
+    /// can later land its oxc walker against the same filesystem layer.
+    #[test]
+    fn discover_source_files_finds_typescript_extensions() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src");
+        fs::create_dir_all(src.join("sub")).unwrap();
+        fs::write(src.join("a.ts"), "").unwrap();
+        fs::write(src.join("b.tsx"), "").unwrap();
+        fs::write(src.join("sub").join("c.js"), "").unwrap();
+        fs::write(src.join("d.rs"), "").unwrap(); // wrong-language sibling
+        fs::write(src.join("notes.md"), "").unwrap();
+
+        let files =
+            discover_source_files(&src, &[], false, &["ts", "tsx", "js", "jsx", "mjs", "cjs"])
+                .unwrap();
+        let names: Vec<_> = files
+            .iter()
+            .filter_map(|f| f.file_name().and_then(|n| n.to_str()))
+            .collect();
+        assert_eq!(names, vec!["a.ts", "b.tsx", "c.js"]);
+        assert!(
+            !names.iter().any(|n| n.ends_with(".rs")),
+            "walker must not pick up `.rs` when it's not in the extension allow-list"
+        );
+    }
+
+    /// Empty `extensions` returns no files — the only sane behavior
+    /// when the caller forgot to set `AnalyzeOptions::extensions`.
+    /// `core::ensure_source_files_found` then surfaces the diagnostic.
+    #[test]
+    fn discover_source_files_empty_extensions_returns_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src");
+        fs::create_dir_all(&src).unwrap();
+        fs::write(src.join("lib.rs"), "").unwrap();
+
+        let files = discover_source_files(&src, &[], false, &[]).unwrap();
+        assert!(
+            files.is_empty(),
+            "no extensions configured ⇒ no files (caller surfaces diagnostic upstream)"
+        );
     }
 }

--- a/crates/crap-core/src/domain/delta.rs
+++ b/crates/crap-core/src/domain/delta.rs
@@ -734,11 +734,11 @@ mod tests {
 
     #[test]
     fn removed_rows_are_emitted_in_identity_key_order() {
-        // Removed-row determinism (CodeRabbit PR #97): pair_identities
-        // collects leftover baseline entries from a HashMap; iterating
-        // the map directly produces non-deterministic order. Sort by
-        // (file_path, qualified_name) before emission so consumers
-        // that don't apply a tie-breaking sort see a stable order.
+        // Removed-row determinism: pair_identities collects leftover
+        // baseline entries from a HashMap; iterating the map directly
+        // produces non-deterministic order. Sort by (file_path,
+        // qualified_name) before emission so consumers that don't
+        // apply a tie-breaking sort see a stable order.
         let baseline = make_result(vec![
             make_verdict("zeta.rs", "zeta_fn", 5.0, false),
             make_verdict("alpha.rs", "alpha_fn", 5.0, false),

--- a/crates/crap-core/src/domain/summary.rs
+++ b/crates/crap-core/src/domain/summary.rs
@@ -139,7 +139,7 @@ fn median_u32_sorted(sorted: &[u32]) -> f64 {
     }
 }
 
-// ── Per-file aggregation (issue #64 — `--group-by file`) ────────────
+// ── Per-file aggregation (`--group-by file`) ────────────────────────
 
 /// Per-file aggregate over a `FunctionVerdict` partition.
 ///
@@ -336,11 +336,10 @@ fn median_of(scores: &mut [f64]) -> f64 {
     }
 }
 
-// ── CrapDeltaRowData (scorecard-row producer, issue #111) ───────────
+// ── CrapDeltaRowData (scorecard-row producer) ────────────
 
 /// Status mirrors mokumo's `Row::CrapDelta::status` (Green/Yellow/Red).
-/// Producer-mints-status under Model P — see crap4rs gap doc at
-/// `~/Github/ops/pipelines/crap4rs/crap4rs-20260503-scorecard-row-rollout.md`.
+/// Producer-mints-status under Model P.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "PascalCase")]
 pub enum CrapDeltaStatus {
@@ -366,10 +365,9 @@ impl CrapDeltaStatus {
 
 /// Language-agnostic record carrying the structured signal a producer
 /// projects into a mokumo `Row::CrapDelta` JSON object. Lives in
-/// `domain/summary.rs` (pure-domain — no `syn`, no LCOV) so it ships
-/// into `crap-core` as a rename-only move during the future unification
-/// (ops#231). The reporter at `adapters/reporters/scorecard_row.rs`
-/// wires this record into the locked V3-symmetric wire shape.
+/// `domain/summary.rs` (pure-domain — no `syn`, no LCOV). The
+/// reporter at `adapters/reporters/scorecard_row.rs` wires this
+/// record into the locked V3-symmetric wire shape.
 #[derive(Debug, Clone, Serialize)]
 pub struct CrapDeltaRowData {
     pub status: CrapDeltaStatus,

--- a/crates/crap-core/src/domain/types.rs
+++ b/crates/crap-core/src/domain/types.rs
@@ -14,9 +14,9 @@ use std::fmt;
 /// SARIF reporters convert inclusive → exclusive end at serialization
 /// time; consumers of `SourceSpan` directly get the intuitive bound.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-// `#[non_exhaustive]` paused for v0.5: cli/core constructors live in
-// crap4rs through S3/S4 and need cross-crate struct-literal init.
-// Restored at v1.0 once those constructors land in crap-core.
+// `#[non_exhaustive]` paused for v0.5: cross-crate struct-literal
+// constructors need access to the field set. Restored at v1.0 once
+// constructors no longer cross crate boundaries.
 pub struct SourceSpan {
     pub start_line: usize,
     pub end_line: usize,
@@ -388,13 +388,13 @@ pub struct AnalysisResult {
 /// Statistics about the analysis process, surfaced by `--verbose`.
 ///
 /// Generic over `P: ParseDiagnostic` so adapter-specific parse
-/// diagnostics (`LcovParseDiagnostic` in `crap4rs`, future
-/// `IstanbulParseDiagnostic` in `crap4ts`) thread through one shared
-/// shape. The numeric counts (`files_found`, `files_unparseable`,
-/// `functions_extracted`, `functions_matched`, `functions_no_coverage`,
-/// `files_analyzed`, `files_zero_coverage`) are language-agnostic; only
-/// the `parse_diagnostics` payload varies by adapter. Decomposition
-/// per CAO B2 + ADR D9 — see ADR D4 amendment (2026-05-09).
+/// diagnostics (e.g. `LcovParseDiagnostic`, `IstanbulParseDiagnostic`)
+/// thread through one shared shape. The numeric counts (`files_found`,
+/// `files_unparseable`, `functions_extracted`, `functions_matched`,
+/// `functions_no_coverage`, `files_analyzed`, `files_zero_coverage`)
+/// are language-agnostic; only the `parse_diagnostics` payload varies
+/// by adapter. Decomposition per CAO B2 + ADR D9 — see ADR D4
+/// amendment (2026-05-09).
 ///
 /// `#[serde(bound = "")]` suppresses serde's auto-generated
 /// `P: Serialize`/`P: Deserialize<'de>` bounds — the trait bound
@@ -403,12 +403,13 @@ pub struct AnalysisResult {
 /// owned-deserialize requirement and trip up trait resolution.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(bound = "")]
-// `#[non_exhaustive]` paused for v0.5: cli/core in crap4rs construct
-// `AnalysisDiagnostics<LcovParseDiagnostic>` via struct literal until
-// they relocate to crap-core in S3/S4. Restored at v1.0.
+// `#[non_exhaustive]` paused for v0.5: adapter shims construct
+// `AnalysisDiagnostics<P>` via struct literal across crate boundaries
+// (e.g., the v0.4 LcovParseDiagnostic concretization). Restored at v1.0
+// once construction is funneled through a builder.
 pub struct AnalysisDiagnostics<P: crate::ports::ParseDiagnostic> {
     /// Non-fatal parse issues from the coverage parser. Concrete shape
-    /// is adapter-specific (LCOV-flavored for crap4rs).
+    /// is adapter-specific (e.g., LCOV-flavored for the Rust adapter).
     pub parse_diagnostics: Vec<P>,
     /// Number of source files discovered.
     pub files_found: usize,

--- a/crates/crap-core/src/domain/view.rs
+++ b/crates/crap-core/src/domain/view.rs
@@ -65,9 +65,9 @@
 //! # `crap-core` extraction
 //!
 //! Pure domain code — no I/O, no external crates beyond `serde` and
-//! `thiserror` (mirrors `domain::types`). Future `crap-core` extraction
-//! (ops#231) takes this module whole; LSP, web, and agent consumers all
-//! flow through `view::apply` as the canonical CRAP shaping surface.
+//! `thiserror` (mirrors `domain::types`). LSP, web, and agent
+//! consumers all flow through `view::apply` as the canonical CRAP
+//! shaping surface.
 
 use crate::domain::summary::{FileSummary, compute_file_summaries, compute_summary};
 use crate::domain::types::{AnalysisResult, AnalysisSummary, FunctionVerdict};
@@ -116,7 +116,7 @@ pub struct ViewSpec {
 /// Aggregation key for the optional grouped block of an
 /// `AnalysisView`.
 ///
-/// Only `File` is supported today (issue #64). `#[non_exhaustive]`
+/// Only `File` is supported today. `#[non_exhaustive]`
 /// reserves namespace for `Risk` and `Module` as listed in the
 /// shaping doc — adding variants is additive on `crap-core`.
 #[non_exhaustive]
@@ -1480,7 +1480,7 @@ mod tests {
         assert!(should_render_view_line(&view));
     }
 
-    // ── Grouping (issue #64 — `--group-by file`) ────────────────────
+    // ── Grouping (`--group-by file`) ────────────────────────────────
 
     #[test]
     fn no_group_by_means_no_grouped_block() {

--- a/crates/crap-core/src/lib.rs
+++ b/crates/crap-core/src/lib.rs
@@ -1,20 +1,18 @@
 //! crap-core — language-agnostic CRAP analyzer foundation.
 //!
 //! Domain types, port traits, and shared invariants used by every
-//! per-language CRAP adapter (`crap4rs`, future `crap4ts`, …). Pure
-//! domain — no `syn`, no LCOV, no I/O. Coverage adapters supply a
-//! concrete `ParseDiagnostic` impl; the analyzer pipeline flows that
-//! type through `ParseOutput<P>` and `AnalysisDiagnostics<P>`.
+//! per-language CRAP adapter (`crap4rs`, `crap4ts`, …). The `domain/`
+//! and `ports/` modules pull no AST-library dependency and no coverage
+//! parser; `core/` and `adapters/` add filesystem walking, git diffs,
+//! and reporter rendering, all language-agnostic. Coverage adapters
+//! supply a concrete `ParseDiagnostic` impl; the analyzer pipeline
+//! flows that type through `ParseOutput<P>` and
+//! `AnalysisDiagnostics<P>`.
 //!
-//! Imported in S2 ([crap4rs#134](https://github.com/breezy-bays-labs/crap4rs/issues/134)).
-//! Adapter relocation (reporters + baseline + config + diff + filesystem
-//! walker) landed in S3
-//! ([crap4rs#135](https://github.com/breezy-bays-labs/crap4rs/issues/135)).
-//! Core orchestration + CLI dispatch landed in S4
-//! ([crap4rs#136](https://github.com/breezy-bays-labs/crap4rs/issues/136)) —
 //! `core::analyze<P>` and `cli::run<P>` are language-agnostic; the
-//! per-adapter binaries (`crap4rs`, future `crap4ts`) inject their own
-//! `ComplexityPort` + `CoveragePort<Diagnostic = P>`.
+//! per-adapter binaries inject their own `ComplexityPort` +
+//! `CoveragePort<Diagnostic = P>` and adapter metadata via
+//! `cli::AdapterMeta`.
 
 pub mod adapters;
 pub mod cli;

--- a/crates/crap-core/tests/snapshots/wire_envelope_snapshot__envelope.snap
+++ b/crates/crap-core/tests/snapshots/wire_envelope_snapshot__envelope.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/crap-core/tests/wire_envelope_snapshot.rs
-assertion_line: 94
 expression: pretty
 ---
 {
@@ -5232,9 +5231,9 @@ expression: pretty
             "qualified_name": "main",
             "span": {
               "end_column": 1,
-              "end_line": 23,
+              "end_line": 94,
               "start_column": 1,
-              "start_line": 14
+              "start_line": 72
             }
           }
         },
@@ -10645,9 +10644,9 @@ expression: pretty
             "qualified_name": "main",
             "span": {
               "end_column": 1,
-              "end_line": 23,
+              "end_line": 94,
               "start_column": 1,
-              "start_line": 14
+              "start_line": 72
             }
           }
         },

--- a/crates/crap4rs/src/adapters/complexity/mod.rs
+++ b/crates/crap4rs/src/adapters/complexity/mod.rs
@@ -1338,7 +1338,7 @@ mod tests {
         );
     }
 
-    /// Regression guard for #116: trait default body + concrete impl that
+    /// Regression guard: trait default body + concrete impl that
     /// overrides the same-named method must yield two FunctionComplexity
     /// entries with disjoint spans. The walker uses separate visitors
     /// (`visit_trait_item_fn` for the default, `visit_impl_item_fn` for the

--- a/crates/crap4rs/src/adapters/mod.rs
+++ b/crates/crap4rs/src/adapters/mod.rs
@@ -1,6 +1,6 @@
 //! crap4rs adapters — Rust-specific bindings + v0.4 backward-compat
 //! shims for the language-agnostic adapters that relocated to
-//! `crap_core::adapters` in S3 (#135).
+//! `crap_core::adapters` in the migration.
 //!
 //! Two families live here in source form:
 //! - **`complexity`**: `syn`-based AST walker that extracts

--- a/crates/crap4rs/src/lib.rs
+++ b/crates/crap4rs/src/lib.rs
@@ -4,11 +4,11 @@
 //! This crate exposes the LCOV/`syn` adapter pipeline. Domain types,
 //! port traits, language-agnostic adapters (reporters, baseline, config,
 //! diff), the orchestrator (`core::analyze`), and the CLI dispatch shell
-//! (`cli`) all live in `crap_core` post-S4 (#136). The v0.4.0 public
-//! surface is preserved as `pub mod` shims that mirror the original
-//! module structure but re-export from `crap_core` (per ADR D10 —
-//! public-API shim-module pattern). v0.5.x library consumers' existing
-//! imports compile unchanged; v1.0 will narrow the shims.
+//! (`cli`) all live in `crap_core`. The v0.4.0 public surface is
+//! preserved here as `pub mod` shims that mirror the original module
+//! structure but re-export from `crap_core` (per ADR D10 — public-API
+//! shim-module pattern). v0.5.x library consumers' existing imports
+//! compile unchanged; v1.0 will narrow the shims.
 
 pub mod adapters;
 pub mod parse_diagnostic;
@@ -70,11 +70,12 @@ pub mod ports {
 }
 
 pub mod core {
-    //! v0.4 shim — relocated to `crap_core::core` in S4 (#136). The
-    //! orchestrator's signature gained `<P: ParseDiagnostic>` plus
-    //! injected `&dyn ComplexityPort` + `&dyn CoveragePort<Diagnostic
-    //! = P>` parameters; the v0.4 alias re-exports under the
-    //! LCOV-concretized name so existing consumers keep compiling.
+    //! v0.4 shim — `crap_core::core` is the new home. The
+    //! orchestrator's signature is generic over `<P: ParseDiagnostic>`
+    //! and takes injected `&dyn ComplexityPort` + `&dyn
+    //! CoveragePort<Diagnostic = P>` parameters; the v0.4 alias
+    //! re-exports under the LCOV-concretized name so existing
+    //! consumers keep compiling.
 
     pub use crap_core::core::AnalyzeOptions;
     pub use crap_core::core::analyze;
@@ -86,12 +87,12 @@ pub mod core {
 }
 
 pub mod cli {
-    //! v0.4 shim — relocated to `crap_core::cli` in S4 (#136). The
-    //! orchestrator `cli::run` gained `<P: ParseDiagnostic + Display>`
-    //! plus injected port parameters and threaded `tool_version` /
-    //! `long_version` strings (per S4 lesson 7 — env vars set by the
-    //! binary's build.rs don't reach crap-core's compile, so the
-    //! caller passes them at runtime). The bare path
+    //! v0.4 shim — `crap_core::cli` is the new home. The orchestrator
+    //! `cli::run` is generic over `<P: ParseDiagnostic + Display>` and
+    //! takes injected ports plus an `AdapterMeta` carrying caller-
+    //! supplied `tool_name` / `tool_version` / `long_version` strings
+    //! (env vars set by the binary's build.rs don't reach crap-core's
+    //! compile, so the binary passes them at runtime). The bare path
     //! `crap4rs::cli::Args` resolves through this shim.
 
     pub use crap_core::cli::{

--- a/crates/crap4rs/src/main.rs
+++ b/crates/crap4rs/src/main.rs
@@ -4,20 +4,91 @@
 //! The coverage adapter is supplied as a factory closure so
 //! `crap_core::cli::run` can construct the LCOV parser *after*
 //! CLI/config-file merging resolves the effective source root —
-//! pre-construction was the silent path-strip mismatch fixed in #150.
+//! pre-construction can silently strip the wrong path prefix from
+//! `SF:` records when `--src` came from the config file rather than
+//! the CLI.
+//!
+//! Adapter-specific copy (help text, examples, coverage hint, repo
+//! URLs, source extensions) is bundled in `AdapterMeta` and passed
+//! once to crap-core's parse + run entry points. crap-core itself is
+//! adapter-agnostic.
 
 use std::process::ExitCode;
 
+use crap_core::cli::AdapterMeta;
 use crap4rs::adapters::complexity::SynComplexityAdapter;
 use crap4rs::adapters::coverage::LcovParser;
 
+const ABOUT: &str = "CRAP score analyzer for Rust";
+const LONG_ABOUT: &str = "CRAP (Change Risk Anti-Patterns) score analyzer for Rust codebases.\n\n\
+                         Combines complexity analysis (via syn) with line coverage data \
+                         (LCOV from cargo-llvm-cov) to identify functions that are both \
+                         complex and under-tested.\n\n\
+                         Default metric is cognitive complexity (not cyclomatic), which \
+                         better captures Rust idioms like match arms and nested control flow.";
+
+const AFTER_HELP: &str = "\
+EXAMPLES:
+  crap4rs --coverage lcov.info
+  crap4rs --coverage lcov.info --threshold 15 --metric cyclomatic
+  crap4rs --coverage lcov.info --format json | jq '.functions[] | select(.exceeds)'
+  crap4rs --coverage lcov.info --only-failing
+  crap4rs --coverage lcov.info --exclude \"tests/**\" --exclude \"benches/**\"
+
+INVESTIGATION PATTERNS:
+  # First-run scan: keep the report short
+  crap4rs --coverage lcov.info --top 20
+
+  # Worst partially-covered functions, sorted by coverage ascending,
+  # never fail the build — useful when investigating an untested codebase
+  crap4rs --coverage lcov.info --min-coverage 1 --max-coverage 90 --sort-by coverage --top 10 --no-fail
+
+  # Saved view preset: bake a flag set under [views.ci] in crap4rs.toml,
+  # then invoke it by name. CLI flags override preset values.
+  crap4rs --coverage lcov.info --view ci
+
+  # GitHub Code Scanning: emit SARIF and let upload-sarif annotate the PR
+  # diff inline. Use --no-fail so the gate exit code doesn't skip the
+  # upload step on regressions.
+  crap4rs --coverage lcov.info --format sarif --no-fail > crap.sarif
+
+COMPARING TWO ANALYSES:
+  # Capture a baseline (e.g., from main):
+  crap4rs --coverage lcov.info --format json > baseline.json
+
+  # Then compare the working tree to it (informational by default):
+  crap4rs --coverage lcov.info --baseline baseline.json
+
+  # CI usage: fail the build when new threshold violations land
+  crap4rs --coverage lcov.info --baseline baseline.json --delta-gate
+
+  # PR-comment scorecard (markdown — drop into the comment body verbatim)
+  crap4rs --coverage lcov.info --baseline baseline.json --format markdown";
+
+const COVERAGE_HINT: &str = "ensure tests ran with coverage enabled (`cargo llvm-cov --lcov`)";
+
+const EXTENSIONS: &[&str] = &["rs"];
+
 fn main() -> ExitCode {
-    let cli = crap_core::cli::parse_args(env!("CARGO_PKG_VERSION"), env!("CRAP4RS_LONG_VERSION"));
+    let meta = AdapterMeta {
+        tool_name: env!("CARGO_PKG_NAME"),
+        tool_version: env!("CARGO_PKG_VERSION"),
+        long_version: env!("CRAP4RS_LONG_VERSION"),
+        about: ABOUT,
+        long_about: LONG_ABOUT,
+        after_help: AFTER_HELP,
+        coverage_hint: COVERAGE_HINT,
+        extensions: EXTENSIONS,
+        tool_info_uri: "https://github.com/breezy-bays-labs/crap-rs",
+        rule_help_uri: "https://github.com/breezy-bays-labs/crap-rs#crap-formula",
+        config_file_name: "crap4rs.toml",
+    };
+    let cli = crap_core::cli::parse_args(&meta);
     let complexity = SynComplexityAdapter::new();
     crap_core::cli::run(
         cli,
         &complexity,
         |src| Box::new(LcovParser::new(src.to_path_buf())),
-        env!("CARGO_PKG_VERSION"),
+        &meta,
     )
 }

--- a/crates/crap4rs/tests/analyze_pipeline_tests.rs
+++ b/crates/crap4rs/tests/analyze_pipeline_tests.rs
@@ -281,7 +281,7 @@ fn analyze_empty_src_dir_errors() {
     };
 
     let err = analyze(&opts, &cx, &cov).unwrap_err();
-    assert!(err.to_string().contains("no Rust source files"));
+    assert!(err.to_string().contains("no source files"));
 }
 
 #[test]

--- a/crates/crap4rs/tests/saved_view_presets_integration.rs
+++ b/crates/crap4rs/tests/saved_view_presets_integration.rs
@@ -275,7 +275,7 @@ fn view_with_no_config_file_exits_2() {
     assert!(stderr.contains("unknown view preset"));
     assert!(
         stderr.contains("crap4rs.toml"),
-        "should mention config file: {stderr}"
+        "should mention adapter config file: {stderr}"
     );
 }
 

--- a/crates/crap4ts/src/adapters/coverage/mod.rs
+++ b/crates/crap4ts/src/adapters/coverage/mod.rs
@@ -37,9 +37,7 @@ impl CoveragePort for IstanbulCoverage {
     type Diagnostic = IstanbulParseDiagnostic;
 
     fn parse(&self, _data: &str) -> Result<ParseOutput<Self::Diagnostic>, CrapError> {
-        unimplemented!(
-            "Istanbul JSON parser lands in the typescript-adapter follow-up pipeline (see crap4rs#137)"
-        )
+        unimplemented!("Istanbul JSON parser lands in the typescript-adapter follow-up pipeline")
     }
 }
 

--- a/crates/crap4ts/src/adapters/mod.rs
+++ b/crates/crap4ts/src/adapters/mod.rs
@@ -1,8 +1,8 @@
 //! crap4ts adapters — TypeScript-specific bindings for the language-
 //! agnostic `crap_core` analyzer.
 //!
-//! Two stubs live here in S5; both runtime-panic via `unimplemented!()`
-//! and will be filled in by the follow-up TypeScript-adapter pipeline:
+//! Two stubs live here; both runtime-panic via `unimplemented!()` and
+//! will be filled in by the follow-up TypeScript-adapter pipeline:
 //!
 //! - **`walker`**: `oxc`-based AST walker that will extract per-function
 //!   cognitive / cyclomatic complexity from `.ts`/`.tsx` sources.

--- a/crates/crap4ts/src/adapters/walker/mod.rs
+++ b/crates/crap4ts/src/adapters/walker/mod.rs
@@ -3,8 +3,7 @@
 //! The real implementation will use `oxc::parser` to walk the AST and
 //! count decision points for cognitive / cyclomatic complexity, mirror-
 //! ing `crates/crap4rs/src/adapters/complexity/mod.rs`. It lands in
-//! the follow-up `crap-rs/2026XXXX-typescript-adapter` pipeline (see
-//! breezy-bays-labs/crap4rs#137 follow-up).
+//! the follow-up TypeScript-adapter pipeline.
 //!
 //! ALPHA: invoking `extract(...)` runtime-panics with `unimplemented!`.
 //! The struct exists so the trait bound is wired and the binary's
@@ -39,9 +38,7 @@ impl ComplexityPort for OxcWalker {
         _file_path: &str,
         _metric: ComplexityMetric,
     ) -> Result<Vec<FunctionComplexity>, CrapError> {
-        unimplemented!(
-            "oxc walker lands in the typescript-adapter follow-up pipeline (see crap4rs#137)"
-        )
+        unimplemented!("oxc walker lands in the typescript-adapter follow-up pipeline")
     }
 }
 

--- a/crates/crap4ts/src/lib.rs
+++ b/crates/crap4ts/src/lib.rs
@@ -3,10 +3,9 @@
 //!
 //! ALPHA: the oxc complexity walker and Istanbul JSON coverage parser
 //! are stubs that `unimplemented!()`. The real TS pipeline lands in a
-//! follow-up (`crap-rs/2026XXXX-typescript-adapter`) — S5 here ships
-//! only the structural shell so the workspace layout, cdylib + bin
-//! crate-type combo, license allowlist, and CI surface are settled
-//! before the walker work begins.
+//! follow-up; this crate ships the structural shell so the workspace
+//! layout, cdylib + bin crate-type combo, license allowlist, and CI
+//! surface are settled before the walker work begins.
 //!
 //! Unlike `crap4rs`, this crate has no v0.4 history and therefore no
 //! backward-compat shim modules — its public surface starts fresh at

--- a/crates/crap4ts/src/main.rs
+++ b/crates/crap4ts/src/main.rs
@@ -4,25 +4,69 @@
 //! Mirrors `crates/crap4rs/src/main.rs` exactly so future maintenance
 //! sees one shape. ALPHA: invoking the real analysis path runtime-
 //! panics inside the walker / coverage parser stubs. `--help` and
-//! `--version` work because clap dispatch lives in `crap_core::cli`.
+//! `--version` work because clap dispatch lives in `crap_core::cli`
+//! and the `AdapterMeta` plumbing renders TS-flavored help text
+//! correctly even while the walker is unimplemented.
 //!
 //! The coverage adapter is supplied as a factory closure so
 //! `crap_core::cli::run` can construct the Istanbul parser *after*
 //! CLI/config-file merging resolves the effective source root —
-//! pre-construction was the silent path-strip mismatch fixed in #150.
+//! pre-construction can silently strip the wrong path prefix from
+//! coverage records when `--src` came from the config file rather
+//! than the CLI.
 
 use std::process::ExitCode;
 
+use crap_core::cli::AdapterMeta;
 use crap4ts::adapters::coverage::IstanbulCoverage;
 use crap4ts::adapters::walker::OxcWalker;
 
+const ABOUT: &str = "CRAP score analyzer for TypeScript (alpha)";
+const LONG_ABOUT: &str = "CRAP (Change Risk Anti-Patterns) score analyzer for TypeScript / \
+                         JavaScript codebases.\n\n\
+                         ALPHA: the oxc-based walker and Istanbul coverage parser are stubs — \
+                         invoking the analysis path will runtime-panic. `--help`, `--version`, \
+                         and `completions` work end-to-end so downstream packaging can be wired \
+                         up ahead of the parser ship in the next pipeline.\n\n\
+                         When the real adapters land, combines AST complexity (via oxc) with \
+                         Istanbul JSON coverage to identify functions that are both complex \
+                         and under-tested. Default metric is cognitive complexity.";
+
+const AFTER_HELP: &str = "\
+EXAMPLES (alpha — walker not yet implemented):
+  crap4ts --coverage coverage/coverage-final.json
+  crap4ts --coverage coverage/coverage-final.json --threshold 15 --metric cyclomatic
+  crap4ts --coverage coverage/coverage-final.json --format sarif --no-fail > crap.sarif
+
+For working CRAP analysis on TypeScript codebases today, see crap4ts@1.x \
+on npm. crap4ts@2 (this binary) is in pre-release alpha tracking \
+breezy-bays-labs/crap-rs.";
+
+const COVERAGE_HINT: &str = "ensure tests ran with coverage enabled (e.g. `c8 --reporter=json` or `vitest --coverage`) — \
+     crap4ts parses Istanbul's `coverage-final.json`, not LCOV";
+
+const EXTENSIONS: &[&str] = &["ts", "tsx", "js", "jsx", "mjs", "cjs"];
+
 fn main() -> ExitCode {
-    let cli = crap_core::cli::parse_args(env!("CARGO_PKG_VERSION"), env!("CRAP4TS_LONG_VERSION"));
+    let meta = AdapterMeta {
+        tool_name: env!("CARGO_PKG_NAME"),
+        tool_version: env!("CARGO_PKG_VERSION"),
+        long_version: env!("CRAP4TS_LONG_VERSION"),
+        about: ABOUT,
+        long_about: LONG_ABOUT,
+        after_help: AFTER_HELP,
+        coverage_hint: COVERAGE_HINT,
+        extensions: EXTENSIONS,
+        tool_info_uri: "https://github.com/breezy-bays-labs/crap-rs",
+        rule_help_uri: "https://github.com/breezy-bays-labs/crap-rs#crap-formula",
+        config_file_name: "crap4ts.toml",
+    };
+    let cli = crap_core::cli::parse_args(&meta);
     let complexity = OxcWalker::new();
     crap_core::cli::run(
         cli,
         &complexity,
         |src| Box::new(IstanbulCoverage::new(src.to_path_buf())),
-        env!("CARGO_PKG_VERSION"),
+        &meta,
     )
 }

--- a/crates/crap4ts/src/parse_diagnostic.rs
+++ b/crates/crap4ts/src/parse_diagnostic.rs
@@ -4,9 +4,9 @@
 //! the language-agnostic `AnalysisDiagnostics<P>` and `ParseOutput<P>`
 //! shapes. Mirrors `crap4rs::parse_diagnostic::LcovParseDiagnostic` —
 //! the variants are Istanbul-flavoured placeholders. The Istanbul JSON
-//! parser is a stub in S5, so these variants are not constructed by
-//! any code path today; they exist so the trait bound + serde
-//! envelope are real (not phantom) before the parser lands.
+//! parser is a stub today, so these variants are not constructed by
+//! any code path; they exist so the trait bound + serde envelope are
+//! real (not phantom) before the parser lands.
 
 use crap_core::ports::ParseDiagnostic;
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
## Summary

Bundles three v0.5 prep tech-debt issues into one cohesive decoupling pass. crap-core source now contains zero hardcoded references to any specific adapter binary's name or language. Adapter-specific copy, URIs, extensions, version metadata, and the config-file name flow through a new `AdapterMeta<'a>` struct populated once at each binary's `main()`.

| Issue | Scope |
|---|---|
| **Closes #148** | Parameterize `tool_name` + `tool_version` in markdown, table, html reporters. SARIF additionally takes `tool_info_uri` + `rule_help_uri`. |
| **Closes #152** | Remove hardcoded `"Rust"` / `"crap4rs"` strings: clap about/long_about, LCOV diagnostic hint, "no Rust source files" message, walker `.rs` extension filter (now `extensions: &[&str]` on `AnalyzeOptions` / `AdapterMeta`). |
| **Closes #160** | Plumb `config_file_name` through `AdapterMeta` → `discover_config(name)` → `resolve_view_preset(cli, cfg, name)`. |

## New public API: `AdapterMeta<'a>`

```rust
pub struct AdapterMeta<'a> {
    pub tool_name: &'a str,
    pub tool_version: &'a str,
    pub long_version: &'a str,
    pub about: &'a str,
    pub long_about: &'a str,
    pub after_help: &'a str,
    pub coverage_hint: &'a str,
    pub extensions: &'a [&'a str],
    pub tool_info_uri: &'a str,
    pub rule_help_uri: &'a str,
    pub config_file_name: &'a str,
}
```

`Copy`, all-borrowed, populated once per binary. crap4rs supplies `\"crap4rs.toml\"`; crap4ts supplies `\"crap4ts.toml\"`.

## Additional scope (in-PR, discovered mid-work)

- **Comment-rot sweep**: ~125 PR/issue references removed from doc comments across 20+ files. ADR refs (D2, D3, D9, D10) and TODO/FIXME refs preserved by design.
- **Clap arg help + runtime error genericization**: replaced `\"crap4rs.toml\"` / `\"crap4rs --foo\"` examples in crap-core's clap docs with adapter-driven phrasing.
- **crap4ts COVERAGE_HINT fix**: was `c8 --reporter=lcov` (LCOV output), but parser is Istanbul JSON; now `c8 --reporter=json` with explicit note that crap4ts parses `coverage-final.json`, not LCOV.
- **Box::leak retention with documented rationale**: clap 4.6.0's `Str` doesn't impl `From<String>`. The four leaks in `build_command` (`name`/`bin_name`/`version`/`long_version`) are documented in-code; follow-up #161 covers enabling clap's `string` feature to drop them entirely.

## Validation

- ✅ **924/924 tests pass** including:
  - BDD scenarios in `saved_view_presets.feature` that exercise the parameterized config-file-name UX end-to-end
  - `version_stamp_integration.rs` confirming binary-identity (`crap4rs vX.Y.Z`) flows through every reporter
  - `discover_source_files_finds_typescript_extensions` exercises the full `&[\"ts\",\"tsx\",\"js\",\"jsx\",\"mjs\",\"cjs\"]` slice
- ✅ `cargo fmt --check` clean
- ✅ `cargo clippy --workspace --all-targets -- -D warnings` clean
- ✅ `cargo +1.93 check --workspace --all-targets` clean (MSRV)
- ✅ `RUSTDOCFLAGS=\"-D warnings\" cargo doc --workspace --no-deps` clean
- ✅ `cargo deny --workspace check` clean
- ✅ 3-layered ast-purity (leading-token + grouped-import + cargo metadata --no-deps) — all zero matches in `crates/crap-core/src/`

## Wire envelope canary

Drifted by 1 line in `main.rs` (new `config_file_name: \"crap4rs.toml\",` field). Source-content drift only, not envelope-shape drift — same accept-pattern as PR A. Snapshot reviewed and accepted.

## Snapshot regen

6 reporter snapshots intentionally regenerated to use synthetic `\"test-adapter\"` / `\"0.4.0\"` / `\"https://example.com/test-adapter\"` test constants instead of the previously-hardcoded `\"crap4rs\"` values. This is the deliberate-regression net firing as designed: changes to the tool_name flow surface as snapshot diffs, forcing explicit review.

## Pre-merge review

Reviewed by 6 PR-toolkit agents + CEng. Critical findings addressed in-PR:
- Hardcoded `\"crap4rs\"` in `BaselineError::UnsupportedSchemaVersion` error template → generalized
- False self-claim in `reporters/mod.rs` test-fixture doc → corrected
- crap4ts COVERAGE_HINT factual mismatch → fixed
- 9 sed-corruption survivors from the bulk comment sweep → manually repaired
- Stale `pub fn run` doc still describing nonexistent `tool_version` param → rewritten
- ~10 residual `crap4rs` mentions in supposedly-agnostic crap-core docs → cleaned

## Follow-up tracked

**#161** — AdapterMeta polish (clap `string` feature + drop Box::leak, lifetime tightening `&'a [&'a str]` → `&'a [&'static str]`, `debug_assert!` guards for empty fields, CI grep gate against future re-coupling, direct unit tests, dedup of `format_extensions_list`).

## Test plan

- [x] Local: 924/924 nextest pass
- [x] Local: `crap4rs --help` renders Rust-flavored copy (\"CRAP score analyzer for Rust\", \"via syn\", \"cargo-llvm-cov\")
- [x] Local: `crap4ts --help` renders TS-flavored copy with no \"Rust\" leakage
- [x] Local: `crap4rs --view foo` (no config) → stderr mentions `crap4rs.toml`
- [x] Local: `crap4ts --view foo` (no config) → stderr mentions `crap4ts.toml`
- [ ] CI: 12 jobs green on PR branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Reporter output now displays adapter-specific tool name and version information in headers and metadata.
  * File discovery now supports configurable file extensions, enabling analysis of different source-code types beyond Rust.

* **Improvements**
  * Configuration errors now reference adapter-specific config filenames for better guidance.
  * SARIF reports include proper tool identity and help URI metadata.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/breezy-bays-labs/crap-rs/pull/162)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->