### PR TITLE
fix: #163 — adapter-aware coverage preflight + walker reconciliation + config-path hint

### DIFF
--- a/crates/crap-core/src/cli/mod.rs
+++ b/crates/crap-core/src/cli/mod.rs
@@ -917,7 +917,6 @@ fn validate_runtime_inputs<'a>(
         inputs.threshold,
         meta.coverage_hint,
     )?;
-    preflight_checks(coverage_path, &inputs.src, meta)?;
 
     if let Some(diff_ref) = cli.filter.diff.as_deref() {
         validate_diff_ref(diff_ref)?;
@@ -1005,6 +1004,12 @@ where
     // observable instead of silent.
     let src_canonical = crate::core::canonicalize_src(&inputs.src);
     let coverage = coverage_factory(&src_canonical);
+
+    // Adapter-aware pre-flight runs after construction so
+    // `CoveragePort::validate` can apply its own structural check
+    // (LCOV: SF/DA records; future Istanbul: non-empty statementMap)
+    // before the full parse pass. See ADR D-coverage-validate.
+    preflight_checks(coverage_path, &*coverage, meta)?;
 
     let options = build_analyze_options(cli, &inputs, coverage_path, meta);
 
@@ -1414,98 +1419,38 @@ fn preflight_git_worktree(src: &Path) -> Result<()> {
 
 // ── Pre-flight checks ──────────────────────────────────────────────
 
-fn preflight_checks(
+/// Adapter-aware coverage pre-flight: read the coverage file once and
+/// delegate the structural check to `CoveragePort::validate`. The
+/// source-directory check is handled by `core::ensure_source_files_found`
+/// during the analyze pipeline — see ADR D-preflight-walker-reconcile.
+fn preflight_checks<P>(
     coverage: &std::path::Path,
-    src: &std::path::Path,
+    coverage_port: &dyn CoveragePort<Diagnostic = P>,
     meta: &AdapterMeta<'_>,
-) -> Result<()> {
-    check_coverage_has_data(coverage, meta.coverage_hint)?;
-    check_src_has_source_files(src, meta.extensions)?;
-    Ok(())
+) -> Result<()>
+where
+    P: ParseDiagnostic,
+{
+    check_coverage_has_data(coverage, coverage_port, meta.coverage_hint)
 }
 
-fn check_coverage_has_data(path: &std::path::Path, coverage_hint: &str) -> Result<()> {
-    use std::io::{BufRead, BufReader};
-
-    let file = std::fs::File::open(path)?;
-    let reader = BufReader::new(file);
-    let mut in_sf_block = false;
-
-    for line in reader.lines() {
-        let line = line?;
-        if line.starts_with("SF:") {
-            in_sf_block = true;
-            continue;
-        }
-        if in_sf_block
-            && let Some(rest) = line.strip_prefix("DA:")
-            && let Some((line_no, hits)) = rest.split_once(',')
-            && line_no.parse::<usize>().is_ok()
-            && hits.split(',').next().unwrap_or("").parse::<u64>().is_ok()
-        {
-            return Ok(());
-        }
-    }
-    bail!(
-        "no coverage data found in {}\n  hint: {}",
-        path.display(),
-        coverage_hint,
-    );
-}
-
-/// Verify the source directory contains at least one file whose
-/// extension is in `extensions`. Adapter-specific (e.g.,
-/// `&["rs"]` for crap4rs, `&["ts","tsx","js","jsx","mjs","cjs"]` for
-/// crap4ts).
-fn check_src_has_source_files(path: &std::path::Path, extensions: &[&str]) -> Result<()> {
-    fn has_source_files(dir: &std::path::Path, extensions: &[&str]) -> std::io::Result<bool> {
-        for entry in std::fs::read_dir(dir)? {
-            let entry = entry?;
-            let ft = entry.file_type()?;
-            if ft.is_file()
-                && let Some(ext) = entry.path().extension()
-                && extensions.iter().any(|e| ext == *e)
-            {
-                return Ok(true);
-            }
-            if ft.is_dir() && has_source_files(&entry.path(), extensions)? {
-                return Ok(true);
-            }
-        }
-        Ok(false)
-    }
-
-    if !has_source_files(path, extensions)? {
-        let pretty = format_extensions_list(extensions);
+fn check_coverage_has_data<P>(
+    path: &std::path::Path,
+    coverage_port: &dyn CoveragePort<Diagnostic = P>,
+    coverage_hint: &str,
+) -> Result<()>
+where
+    P: ParseDiagnostic,
+{
+    let data = std::fs::read_to_string(path)?;
+    if coverage_port.validate(&data).is_err() {
         bail!(
-            "no source files found in {}\n  \
-             hint: check that --src points to a directory containing {} files",
+            "no coverage data found in {}\n  hint: {}",
             path.display(),
-            pretty,
+            coverage_hint,
         );
     }
     Ok(())
-}
-
-/// Render a list of bare extensions (`["rs"]`, `["ts","tsx","js"]`)
-/// as a human-readable comma-separated list of dotted extensions:
-/// `".rs"`, `".ts", ".tsx", or ".js"`. Used in the
-/// `check_src_has_source_files` hint.
-fn format_extensions_list(extensions: &[&str]) -> String {
-    match extensions {
-        [] => "supported".to_string(),
-        [only] => format!(".{only}"),
-        [first, rest @ .., last] => {
-            let mut out = format!(".{first}");
-            for e in rest {
-                out.push_str(", .");
-                out.push_str(e);
-            }
-            out.push_str(", or .");
-            out.push_str(last);
-            out
-        }
-    }
 }
 
 // ── Timestamp ──────────────────────────────────────────────────────
@@ -2203,119 +2148,82 @@ mod tests {
     const TEST_COVERAGE_HINT: &str =
         "ensure tests ran with coverage enabled (test-tool's `--coverage` flag)";
 
+    /// Stub `CoveragePort` whose `validate` returns whatever the caller
+    /// configured. `parse` panics — these tests exercise the CLI-layer
+    /// preflight wrapper, not the adapter's parsing path.
+    struct StubCoveragePort {
+        validate_result: Result<(), String>,
+    }
+
+    impl CoveragePort for StubCoveragePort {
+        type Diagnostic = crate::test_strategies::DummyParseDiagnostic;
+
+        fn parse(
+            &self,
+            _data: &str,
+        ) -> Result<crate::ports::ParseOutput<Self::Diagnostic>, crate::domain::types::CrapError>
+        {
+            unreachable!("preflight tests never invoke parse")
+        }
+
+        fn validate(&self, _data: &str) -> Result<(), String> {
+            self.validate_result.clone()
+        }
+    }
+
+    fn stub_ok() -> StubCoveragePort {
+        StubCoveragePort {
+            validate_result: Ok(()),
+        }
+    }
+
+    fn stub_err(reason: &str) -> StubCoveragePort {
+        StubCoveragePort {
+            validate_result: Err(reason.to_string()),
+        }
+    }
+
     #[test]
-    fn preflight_empty_coverage_file() {
+    fn preflight_surfaces_hint_when_adapter_reports_no_data() {
         let dir = tempfile::tempdir().unwrap();
         let cov = dir.path().join("empty.info");
         std::fs::write(&cov, "").unwrap();
 
-        let err = check_coverage_has_data(&cov, TEST_COVERAGE_HINT).unwrap_err();
+        let err =
+            check_coverage_has_data(&cov, &stub_err("no records"), TEST_COVERAGE_HINT).unwrap_err();
         let msg = format!("{err:#}");
         assert!(msg.contains("no coverage data found"));
         assert!(msg.contains(TEST_COVERAGE_HINT));
     }
 
     #[test]
-    fn preflight_coverage_no_da_lines() {
+    fn preflight_passes_when_adapter_accepts_data() {
         let dir = tempfile::tempdir().unwrap();
-        let cov = dir.path().join("no_da.info");
-        std::fs::write(&cov, "SF:src/main.rs\nend_of_record\n").unwrap();
+        let cov = dir.path().join("ok.info");
+        std::fs::write(&cov, "any contents — adapter decides").unwrap();
 
-        let err = check_coverage_has_data(&cov, TEST_COVERAGE_HINT).unwrap_err();
-        let msg = format!("{err:#}");
-        assert!(msg.contains("no coverage data found"));
+        assert!(check_coverage_has_data(&cov, &stub_ok(), TEST_COVERAGE_HINT).is_ok());
     }
 
     #[test]
-    fn preflight_coverage_with_da_lines_passes() {
+    fn preflight_propagates_io_errors_for_missing_files() {
         let dir = tempfile::tempdir().unwrap();
-        let cov = dir.path().join("good.info");
-        std::fs::write(&cov, "SF:src/main.rs\nDA:1,5\nend_of_record\n").unwrap();
+        let missing = dir.path().join("does_not_exist.info");
 
-        assert!(check_coverage_has_data(&cov, TEST_COVERAGE_HINT).is_ok());
-    }
-
-    #[test]
-    fn preflight_coverage_da_outside_sf_block_rejected() {
-        let dir = tempfile::tempdir().unwrap();
-        let cov = dir.path().join("orphan_da.info");
-        std::fs::write(&cov, "DA:1,5\nend_of_record\n").unwrap();
-
-        let err = check_coverage_has_data(&cov, TEST_COVERAGE_HINT).unwrap_err();
-        let msg = format!("{err:#}");
-        assert!(msg.contains("no coverage data found"));
-    }
-
-    #[test]
-    fn preflight_coverage_malformed_da_rejected() {
-        let dir = tempfile::tempdir().unwrap();
-        let cov = dir.path().join("bad_da.info");
-        std::fs::write(&cov, "SF:src/main.rs\nDA:not_a_number\nend_of_record\n").unwrap();
-
-        let err = check_coverage_has_data(&cov, TEST_COVERAGE_HINT).unwrap_err();
-        let msg = format!("{err:#}");
-        assert!(msg.contains("no coverage data found"));
-    }
-
-    #[test]
-    fn preflight_src_dir_no_matching_extension() {
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("readme.txt"), "hello").unwrap();
-
-        let err = check_src_has_source_files(dir.path(), &["rs"]).unwrap_err();
-        let msg = format!("{err:#}");
-        assert!(msg.contains("no source files found"));
-        assert!(msg.contains(".rs"));
-    }
-
-    #[test]
-    fn preflight_src_dir_empty() {
-        let dir = tempfile::tempdir().unwrap();
-
-        let err = check_src_has_source_files(dir.path(), &["rs"]).unwrap_err();
-        let msg = format!("{err:#}");
-        assert!(msg.contains("no source files found"));
-    }
-
-    #[test]
-    fn preflight_src_dir_with_matching_files_passes() {
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("main.rs"), "fn main() {}").unwrap();
-
-        assert!(check_src_has_source_files(dir.path(), &["rs"]).is_ok());
-    }
-
-    #[test]
-    fn preflight_src_dir_nested_files_passes() {
-        let dir = tempfile::tempdir().unwrap();
-        let nested = dir.path().join("sub");
-        std::fs::create_dir(&nested).unwrap();
-        std::fs::write(nested.join("lib.rs"), "pub fn foo() {}").unwrap();
-
-        assert!(check_src_has_source_files(dir.path(), &["rs"]).is_ok());
-    }
-
-    /// regression — preflight honors arbitrary extensions, not
-    /// just `.rs`. Mirrors the walker test (`crap_core::core::walker::
-    /// discover_source_files_finds_typescript_extensions`).
-    #[test]
-    fn preflight_src_dir_with_typescript_files_passes() {
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("app.ts"), "export const x = 1;").unwrap();
-
-        assert!(check_src_has_source_files(dir.path(), &["ts", "tsx"]).is_ok());
-    }
-
-    /// regression — hint surfaces the configured extensions so
-    /// users see "containing .ts, .tsx, or .js files" for crap4ts and
-    /// "containing .rs files" for crap4rs.
-    #[test]
-    fn preflight_src_dir_hint_lists_extensions() {
-        let dir = tempfile::tempdir().unwrap();
-
-        let err = check_src_has_source_files(dir.path(), &["ts", "tsx", "js"]).unwrap_err();
-        let msg = format!("{err:#}");
-        assert!(msg.contains(".ts, .tsx, or .js"), "unexpected hint: {msg}");
+        let err =
+            check_coverage_has_data(&missing, &stub_ok(), TEST_COVERAGE_HINT).unwrap_err();
+        // I/O error surfaces as a `CrapError::Io` (via `?` on `read_to_string`);
+        // the user-facing wrapper from `validate_inputs` covers the
+        // "coverage file not found" hint path. This test guards the
+        // boundary: an unreadable file must NOT silently pass preflight.
+        let kind = err
+            .downcast_ref::<std::io::Error>()
+            .map(|e| e.kind())
+            .or_else(|| {
+                err.chain()
+                    .find_map(|e| e.downcast_ref::<std::io::Error>().map(|e| e.kind()))
+            });
+        assert_eq!(kind, Some(std::io::ErrorKind::NotFound));
     }
 
     // ── --strict / --lenient flag tests ───────────────────────────────

--- a/crates/crap-core/src/cli/mod.rs
+++ b/crates/crap-core/src/cli/mod.rs
@@ -1462,10 +1462,18 @@ fn check_coverage_has_data<P>(
 where
     P: ParseDiagnostic,
 {
-    let data = std::fs::read_to_string(path)?;
-    if coverage_port.validate(&data).is_err() {
+    // The adapter's `validate` streams the file itself (LCOV) or
+    // slurps (Istanbul, post-implementation) — whichever is cheaper
+    // for that format. We do NOT pre-read here: `core::analyze` will
+    // read the file again for the full parse pass, and slurping twice
+    // for large workspaces (100 MB+ LCOV) is a memory regression.
+    //
+    // The validation reason (e.g. `"no SF/DA records"`) is surfaced
+    // alongside the path so the user knows whether the file was
+    // syntactically empty, malformed, or just missing data points.
+    if let Err(reason) = coverage_port.validate(path) {
         bail!(
-            "no coverage data found in {}\n  hint: {}",
+            "no coverage data found in {} ({reason})\n  hint: {}",
             path.display(),
             coverage_hint,
         );
@@ -2186,7 +2194,7 @@ mod tests {
             unreachable!("preflight tests never invoke parse")
         }
 
-        fn validate(&self, _data: &str) -> Result<(), String> {
+        fn validate(&self, _path: &std::path::Path) -> Result<(), String> {
             self.validate_result.clone()
         }
     }
@@ -2213,6 +2221,10 @@ mod tests {
             check_coverage_has_data(&cov, &stub_err("no records"), TEST_COVERAGE_HINT).unwrap_err();
         let msg = format!("{err:#}");
         assert!(msg.contains("no coverage data found"));
+        // The adapter's structural reason is surfaced alongside the
+        // path so the user knows whether the file was empty,
+        // malformed, or just missing data points.
+        assert!(msg.contains("no records"), "expected reason in msg: {msg}");
         assert!(msg.contains(TEST_COVERAGE_HINT));
     }
 
@@ -2223,26 +2235,6 @@ mod tests {
         std::fs::write(&cov, "any contents — adapter decides").unwrap();
 
         assert!(check_coverage_has_data(&cov, &stub_ok(), TEST_COVERAGE_HINT).is_ok());
-    }
-
-    #[test]
-    fn preflight_propagates_io_errors_for_missing_files() {
-        let dir = tempfile::tempdir().unwrap();
-        let missing = dir.path().join("does_not_exist.info");
-
-        let err = check_coverage_has_data(&missing, &stub_ok(), TEST_COVERAGE_HINT).unwrap_err();
-        // I/O error surfaces as a `CrapError::Io` (via `?` on `read_to_string`);
-        // the user-facing wrapper from `validate_inputs` covers the
-        // "coverage file not found" hint path. This test guards the
-        // boundary: an unreadable file must NOT silently pass preflight.
-        let kind = err
-            .downcast_ref::<std::io::Error>()
-            .map(|e| e.kind())
-            .or_else(|| {
-                err.chain()
-                    .find_map(|e| e.downcast_ref::<std::io::Error>().map(|e| e.kind()))
-            });
-        assert_eq!(kind, Some(std::io::ErrorKind::NotFound));
     }
 
     // ── --strict / --lenient flag tests ───────────────────────────────

--- a/crates/crap-core/src/cli/mod.rs
+++ b/crates/crap-core/src/cli/mod.rs
@@ -983,14 +983,22 @@ where
     validate_display_flags(cli)?;
     apply_color(cli.display.color);
 
-    // Load config file (explicit path or auto-discovered)
-    let file_config = load_file_config(cli, meta.config_file_name)?;
+    // Load config file (explicit path or auto-discovered). Path is
+    // kept alongside the loaded config so downstream diagnostics
+    // (e.g., unknown `--view` preset) can point the user at the
+    // exact file to edit.
+    let (file_config, config_path) = load_file_config(cli, meta.config_file_name)?.unzip();
 
     // Resolve `--view <NAME>` before validate_view_args runs
     // so preset fields participate in the same validation pass as CLI
     // flags. `apply_preset_to_cli` mutates `cli` in place: CLI explicit
     // values win on `Option<T>` fields, bools OR-merge.
-    view_args::resolve_view_preset(cli, file_config.as_ref(), meta.config_file_name)?;
+    view_args::resolve_view_preset(
+        cli,
+        file_config.as_ref(),
+        config_path.as_deref(),
+        meta.config_file_name,
+    )?;
     view_args::validate_view_args(cli)?;
 
     let inputs = merge_effective_inputs(cli, &file_config);
@@ -1267,12 +1275,24 @@ fn format_arg_kebab(arg: FormatArg) -> String {
 
 // ── Config loading & merging ───────────────────────────────────────
 
-fn load_file_config(cli: &Cli, config_file_name: &str) -> Result<Option<FileConfig>> {
+/// Load the on-disk config file (explicit `--config` path or
+/// auto-discovered by adapter convention) and return it paired with
+/// the path it came from. The path is threaded into downstream error
+/// hints (e.g., the `--view` unknown-preset diagnostic) so the user
+/// sees the exact file to edit — not just the conventional name.
+fn load_file_config(
+    cli: &Cli,
+    config_file_name: &str,
+) -> Result<Option<(FileConfig, std::path::PathBuf)>> {
     if let Some(path) = &cli.input.config {
-        Ok(Some(config::load_config(path)?))
+        let cfg = config::load_config(path)?;
+        Ok(Some((cfg, path.clone())))
     } else {
         match config::discover_config(config_file_name)? {
-            Some(path) => Ok(Some(config::load_config(&path)?)),
+            Some(path) => {
+                let cfg = config::load_config(&path)?;
+                Ok(Some((cfg, path)))
+            }
             None => Ok(None),
         }
     }
@@ -2210,8 +2230,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let missing = dir.path().join("does_not_exist.info");
 
-        let err =
-            check_coverage_has_data(&missing, &stub_ok(), TEST_COVERAGE_HINT).unwrap_err();
+        let err = check_coverage_has_data(&missing, &stub_ok(), TEST_COVERAGE_HINT).unwrap_err();
         // I/O error surfaces as a `CrapError::Io` (via `?` on `read_to_string`);
         // the user-facing wrapper from `validate_inputs` covers the
         // "coverage file not found" hint path. This test guards the

--- a/crates/crap-core/src/cli/view_args.rs
+++ b/crates/crap-core/src/cli/view_args.rs
@@ -92,12 +92,15 @@ fn resolve_coverage_bounds(cli: &Cli) -> Option<(f64, f64)> {
 ///   listing the available preset names. Empty list yields a hint that
 ///   names the adapter's config file.
 ///
-/// `config_file_name` is the adapter-specific conventional file name
-/// (e.g., `"crap4rs.toml"`, `"crap4ts.toml"`) so the error hint points
-/// the user at the right file to create.
+/// `config_path` is the resolved on-disk location the config was loaded
+/// from (from `--config` or auto-discovery); when present, hints point
+/// the user at the exact file. `config_file_name` is the adapter
+/// convention (e.g., `"crap4rs.toml"`) used as the fallback when no
+/// config is loaded.
 pub(super) fn resolve_view_preset(
     cli: &mut Cli,
     file_config: Option<&FileConfig>,
+    config_path: Option<&std::path::Path>,
     config_file_name: &str,
 ) -> Result<()> {
     let Some(name) = cli.input.view.clone() else {
@@ -110,15 +113,25 @@ pub(super) fn resolve_view_preset(
             apply_preset_to_cli(cli, preset);
             Ok(())
         }
-        None => bail!("{}", unknown_preset_message(&name, views, config_file_name)),
+        None => bail!(
+            "{}",
+            unknown_preset_message(&name, views, config_path, config_file_name)
+        ),
     }
 }
 
 fn unknown_preset_message(
     name: &str,
     views: Option<&std::collections::HashMap<String, ViewPreset>>,
+    config_path: Option<&std::path::Path>,
     config_file_name: &str,
 ) -> String {
+    // Prefer the resolved on-disk path when available — points the user
+    // at the exact file to edit (matters when `--config` overrides
+    // auto-discovery or the discovered file lives several parents up).
+    let display = config_path
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|| config_file_name.to_string());
     match views {
         Some(map) if !map.is_empty() => {
             let mut names: Vec<&str> = map.keys().map(String::as_str).collect();
@@ -129,10 +142,10 @@ fn unknown_preset_message(
             )
         }
         Some(_) => format!(
-            "unknown view preset `{name}`\n  hint: {config_file_name} defines no [views.<name>] blocks"
+            "unknown view preset `{name}`\n  hint: {display} defines no [views.<name>] blocks"
         ),
         None => format!(
-            "unknown view preset `{name}`\n  hint: --view requires a {config_file_name} with a [views.{name}] block"
+            "unknown view preset `{name}`\n  hint: --view requires a {display} with a [views.{name}] block"
         ),
     }
 }
@@ -351,7 +364,7 @@ mod tests {
     fn resolve_view_preset_no_flag_is_noop() {
         let mut cli = parse(&["--coverage", "lcov.info"]);
         let cfg = config_with_preset("ci", full_preset());
-        resolve_view_preset(&mut cli, Some(&cfg), "test-adapter.toml").unwrap();
+        resolve_view_preset(&mut cli, Some(&cfg), None, "test-adapter.toml").unwrap();
         // No `--view` passed → preset must NOT be applied.
         assert_eq!(cli.filter.top, None);
         assert!(cli.filter.sort_by.is_none());
@@ -362,7 +375,7 @@ mod tests {
     fn resolve_view_preset_resolves_named_preset() {
         let mut cli = parse(&["--coverage", "lcov.info", "--view", "ci"]);
         let cfg = config_with_preset("ci", full_preset());
-        resolve_view_preset(&mut cli, Some(&cfg), "test-adapter.toml").unwrap();
+        resolve_view_preset(&mut cli, Some(&cfg), None, "test-adapter.toml").unwrap();
         assert_eq!(cli.filter.top, Some(20));
         assert!(cli.filter.only_failing);
     }
@@ -371,7 +384,7 @@ mod tests {
     fn resolve_view_preset_cli_overrides_resolved_preset() {
         let mut cli = parse(&["--coverage", "lcov.info", "--view", "ci", "--top", "5"]);
         let cfg = config_with_preset("ci", full_preset());
-        resolve_view_preset(&mut cli, Some(&cfg), "test-adapter.toml").unwrap();
+        resolve_view_preset(&mut cli, Some(&cfg), None, "test-adapter.toml").unwrap();
         assert_eq!(cli.filter.top, Some(5), "CLI --top wins over preset");
         // Other preset fields still applied.
         assert!(cli.filter.only_failing);
@@ -387,7 +400,7 @@ mod tests {
             views,
             ..FileConfig::default()
         };
-        let err = resolve_view_preset(&mut cli, Some(&cfg), "test-adapter.toml").unwrap_err();
+        let err = resolve_view_preset(&mut cli, Some(&cfg), None, "test-adapter.toml").unwrap_err();
         let msg = format!("{err:#}");
         assert!(
             msg.contains("unknown view preset"),
@@ -409,7 +422,7 @@ mod tests {
     #[test]
     fn resolve_view_preset_no_config_file_explains_requirement() {
         let mut cli = parse(&["--coverage", "lcov.info", "--view", "ci"]);
-        let err = resolve_view_preset(&mut cli, None, "test-adapter.toml").unwrap_err();
+        let err = resolve_view_preset(&mut cli, None, None, "test-adapter.toml").unwrap_err();
         let msg = format!("{err:#}");
         assert!(msg.contains("unknown view preset"), "got: {msg}");
         assert!(
@@ -422,9 +435,48 @@ mod tests {
     fn resolve_view_preset_empty_views_block_hints_no_blocks_defined() {
         let mut cli = parse(&["--coverage", "lcov.info", "--view", "ci"]);
         let cfg = FileConfig::default();
-        let err = resolve_view_preset(&mut cli, Some(&cfg), "test-adapter.toml").unwrap_err();
+        let err = resolve_view_preset(&mut cli, Some(&cfg), None, "test-adapter.toml").unwrap_err();
         let msg = format!("{err:#}");
         assert!(msg.contains("unknown view preset"));
         assert!(msg.contains("no [views"), "empty-block hint missing: {msg}");
+    }
+
+    /// Regression — when the config was loaded from a specific on-disk
+    /// location, the empty-block hint must surface that path so the
+    /// user can `$EDITOR` directly to the right file. Falls back to
+    /// the adapter convention only when no path was resolved.
+    #[test]
+    fn resolve_view_preset_empty_views_block_surfaces_loaded_path() {
+        let mut cli = parse(&["--coverage", "lcov.info", "--view", "ci"]);
+        let cfg = FileConfig::default();
+        let loaded = std::path::PathBuf::from("/home/me/project/test-adapter.toml");
+        let err = resolve_view_preset(
+            &mut cli,
+            Some(&cfg),
+            Some(loaded.as_path()),
+            "test-adapter.toml",
+        )
+        .unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("/home/me/project/test-adapter.toml"),
+            "hint must include the resolved on-disk path: {msg}"
+        );
+        // The full path replaces — does not append to — the convention
+        // name (no duplication).
+        assert_eq!(msg.matches("test-adapter.toml").count(), 1);
+    }
+
+    #[test]
+    fn resolve_view_preset_no_config_falls_back_to_convention_name() {
+        // No on-disk path resolved → hint uses the adapter convention.
+        // This guards the regression: `display` only swaps in the path
+        // when one was actually loaded.
+        let mut cli = parse(&["--coverage", "lcov.info", "--view", "ci"]);
+        let err = resolve_view_preset(&mut cli, None, None, "test-adapter.toml").unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("test-adapter.toml"), "got: {msg}");
+        // No bogus absolute path crept in.
+        assert!(!msg.contains('/'), "no resolved path should appear: {msg}");
     }
 }

--- a/crates/crap-core/src/core/mod.rs
+++ b/crates/crap-core/src/core/mod.rs
@@ -384,11 +384,9 @@ fn ensure_source_files_found(
 ) -> Result<()> {
     if source_files.is_empty() {
         // Render a comma-separated list of dotted extensions for the
-        // hint, matching the wording used by `cli::check_src_has_source_files`.
-        // Kept inline (no shared helper) because the diagnostic lives
-        // in `crap-core::core` while the CLI helper lives in
-        // `crap-core::cli` — pulling them into a shared module is
-        // v1.0-follow-up if a third caller emerges.
+        // hint. Single source of truth — `cli/mod.rs` previously had a
+        // duplicate pre-flight walk that emitted identical wording; that
+        // duplicate was retired once both paths agreed (issue #163).
         let pretty = match extensions {
             [] => "supported".to_string(),
             [only] => format!(".{only}"),

--- a/crates/crap-core/src/ports/mod.rs
+++ b/crates/crap-core/src/ports/mod.rs
@@ -58,10 +58,19 @@ pub trait CoveragePort {
     type Diagnostic: ParseDiagnostic;
     fn parse(&self, data: &str) -> Result<ParseOutput<Self::Diagnostic>, CrapError>;
 
-    /// Adapter-aware pre-flight check: does `data` contain at least one
-    /// usable coverage record? Runs before the analyzer dispatches to
-    /// `parse`, so the CLI can surface a helpful "your coverage file
-    /// has no data points" diagnostic before a full parse pass.
+    /// Adapter-aware pre-flight check: does the file at `path` contain
+    /// at least one usable coverage record? Runs before the analyzer
+    /// dispatches to `parse`, so the CLI can surface a helpful "your
+    /// coverage file has no data points" diagnostic before the full
+    /// parse pass.
+    ///
+    /// Takes `&Path` (not `&str`) so adapters can stream the file
+    /// line-by-line and short-circuit on the first valid record — the
+    /// LCOV format easily exceeds 100 MB on large workspaces and
+    /// loading the whole file into memory twice (once here, once in
+    /// `parse`) would double peak RSS for no semantic gain. Adapters
+    /// that need random access (Istanbul JSON, post-implementation)
+    /// can still slurp via `read_to_string` internally.
     ///
     /// Default implementation returns `Ok(())` (skip validation) —
     /// adapters with a cheap structural signature override. The LCOV
@@ -72,7 +81,7 @@ pub trait CoveragePort {
     /// (e.g., `"no SF/DA records"`); the CLI layer pairs it with the
     /// coverage path and adapter-specific generation hint
     /// (`AdapterMeta::coverage_hint`) before surfacing to the user.
-    fn validate(&self, _data: &str) -> Result<(), String> {
+    fn validate(&self, _path: &Path) -> Result<(), String> {
         Ok(())
     }
 }

--- a/crates/crap-core/src/ports/mod.rs
+++ b/crates/crap-core/src/ports/mod.rs
@@ -57,6 +57,24 @@ pub struct ParseOutput<P: ParseDiagnostic> {
 pub trait CoveragePort {
     type Diagnostic: ParseDiagnostic;
     fn parse(&self, data: &str) -> Result<ParseOutput<Self::Diagnostic>, CrapError>;
+
+    /// Adapter-aware pre-flight check: does `data` contain at least one
+    /// usable coverage record? Runs before the analyzer dispatches to
+    /// `parse`, so the CLI can surface a helpful "your coverage file
+    /// has no data points" diagnostic before a full parse pass.
+    ///
+    /// Default implementation returns `Ok(())` (skip validation) —
+    /// adapters with a cheap structural signature override. The LCOV
+    /// adapter checks for `SF:` + `DA:` records; the Istanbul adapter
+    /// will check for non-empty `statementMap` once implemented.
+    ///
+    /// The returned `Err(String)` is the structural reason
+    /// (e.g., `"no SF/DA records"`); the CLI layer pairs it with the
+    /// coverage path and adapter-specific generation hint
+    /// (`AdapterMeta::coverage_hint`) before surfacing to the user.
+    fn validate(&self, _data: &str) -> Result<(), String> {
+        Ok(())
+    }
 }
 
 /// Port for computing which files/regions changed relative to a git ref.

--- a/crates/crap-core/tests/snapshots/wire_envelope_snapshot__envelope.snap
+++ b/crates/crap-core/tests/snapshots/wire_envelope_snapshot__envelope.snap
@@ -4460,7 +4460,7 @@ expression: pretty
             "qualified_name": "validate_first_da_in_second_block_passes",
             "span": {
               "end_column": 5,
-              "end_line": 377,
+              "end_line": 375,
               "start_column": 5,
               "start_line": 366
             }
@@ -4484,9 +4484,9 @@ expression: pretty
             "qualified_name": "single_file_single_da",
             "span": {
               "end_column": 5,
-              "end_line": 387,
+              "end_line": 385,
               "start_column": 5,
-              "start_line": 379
+              "start_line": 377
             }
           }
         },
@@ -4508,9 +4508,9 @@ expression: pretty
             "qualified_name": "multiple_da_lines",
             "span": {
               "end_column": 5,
-              "end_line": 397,
+              "end_line": 395,
               "start_column": 5,
-              "start_line": 389
+              "start_line": 387
             }
           }
         },
@@ -4532,9 +4532,9 @@ expression: pretty
             "qualified_name": "multiple_source_files",
             "span": {
               "end_column": 5,
-              "end_line": 406,
+              "end_line": 404,
               "start_column": 5,
-              "start_line": 399
+              "start_line": 397
             }
           }
         },
@@ -4556,9 +4556,9 @@ expression: pretty
             "qualified_name": "hit_count_preservation",
             "span": {
               "end_column": 5,
-              "end_line": 414,
+              "end_line": 412,
               "start_column": 5,
-              "start_line": 408
+              "start_line": 406
             }
           }
         },
@@ -4580,9 +4580,9 @@ expression: pretty
             "qualified_name": "path_normalization_strips_prefix",
             "span": {
               "end_column": 5,
-              "end_line": 420,
+              "end_line": 418,
               "start_column": 5,
-              "start_line": 416
+              "start_line": 414
             }
           }
         },
@@ -4604,9 +4604,9 @@ expression: pretty
             "qualified_name": "non_matching_path_passes_through",
             "span": {
               "end_column": 5,
-              "end_line": 426,
+              "end_line": 424,
               "start_column": 5,
-              "start_line": 422
+              "start_line": 420
             }
           }
         },
@@ -4628,9 +4628,9 @@ expression: pretty
             "qualified_name": "backslash_normalized_to_forward_slash",
             "span": {
               "end_column": 5,
-              "end_line": 433,
+              "end_line": 431,
               "start_column": 5,
-              "start_line": 428
+              "start_line": 426
             }
           }
         },
@@ -4652,9 +4652,9 @@ expression: pretty
             "qualified_name": "path_boundary_not_confused_by_prefix_substring",
             "span": {
               "end_column": 5,
-              "end_line": 439,
+              "end_line": 437,
               "start_column": 5,
-              "start_line": 435
+              "start_line": 433
             }
           }
         },
@@ -4676,9 +4676,9 @@ expression: pretty
             "qualified_name": "repeated_sf_blocks_merge_coverage",
             "span": {
               "end_column": 5,
-              "end_line": 453,
+              "end_line": 451,
               "start_column": 5,
-              "start_line": 441
+              "start_line": 439
             }
           }
         },
@@ -4700,9 +4700,9 @@ expression: pretty
             "qualified_name": "duplicate_da_lines_sum_hits",
             "span": {
               "end_column": 5,
-              "end_line": 462,
+              "end_line": 460,
               "start_column": 5,
-              "start_line": 455
+              "start_line": 453
             }
           }
         },
@@ -4724,9 +4724,9 @@ expression: pretty
             "qualified_name": "duplicate_da_multiple_lines_sum_correctly",
             "span": {
               "end_column": 5,
-              "end_line": 474,
+              "end_line": 472,
               "start_column": 5,
-              "start_line": 464
+              "start_line": 462
             }
           }
         },
@@ -4740,10 +4740,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 490,
+              "end_line": 488,
               "increment": 1,
               "kind": "match",
-              "line": 481,
+              "line": 479,
               "nesting_depth": 0
             }
           ],
@@ -4757,9 +4757,9 @@ expression: pretty
             "qualified_name": "malformed_da_produces_diagnostic",
             "span": {
               "end_column": 5,
-              "end_line": 491,
+              "end_line": 489,
               "start_column": 5,
-              "start_line": 476
+              "start_line": 474
             }
           }
         },
@@ -4781,9 +4781,9 @@ expression: pretty
             "qualified_name": "malformed_da_does_not_stop_parsing",
             "span": {
               "end_column": 5,
-              "end_line": 499,
+              "end_line": 497,
               "start_column": 5,
-              "start_line": 493
+              "start_line": 491
             }
           }
         },
@@ -4805,9 +4805,9 @@ expression: pretty
             "qualified_name": "da_missing_hit_count_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 509,
+              "end_line": 507,
               "start_column": 5,
-              "start_line": 501
+              "start_line": 499
             }
           }
         },
@@ -4829,9 +4829,9 @@ expression: pretty
             "qualified_name": "da_negative_hit_count_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 519,
+              "end_line": 517,
               "start_column": 5,
-              "start_line": 511
+              "start_line": 509
             }
           }
         },
@@ -4845,10 +4845,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 534,
+              "end_line": 532,
               "increment": 1,
               "kind": "match",
-              "line": 525,
+              "line": 523,
               "nesting_depth": 0
             }
           ],
@@ -4862,9 +4862,9 @@ expression: pretty
             "qualified_name": "da_line_zero_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 535,
+              "end_line": 533,
               "start_column": 5,
-              "start_line": 521
+              "start_line": 519
             }
           }
         },
@@ -4886,9 +4886,9 @@ expression: pretty
             "qualified_name": "end_of_record_is_ignored",
             "span": {
               "end_column": 5,
-              "end_line": 546,
+              "end_line": 544,
               "start_column": 5,
-              "start_line": 537
+              "start_line": 535
             }
           }
         },
@@ -4910,9 +4910,9 @@ expression: pretty
             "qualified_name": "unterminated_final_block_emits_data",
             "span": {
               "end_column": 5,
-              "end_line": 553,
+              "end_line": 551,
               "start_column": 5,
-              "start_line": 548
+              "start_line": 546
             }
           }
         },
@@ -4934,9 +4934,9 @@ expression: pretty
             "qualified_name": "empty_sf_path_emits_diagnostic",
             "span": {
               "end_column": 5,
-              "end_line": 564,
+              "end_line": 562,
               "start_column": 5,
-              "start_line": 555
+              "start_line": 553
             }
           }
         },
@@ -4958,9 +4958,9 @@ expression: pretty
             "qualified_name": "da_with_checksum_field_is_accepted",
             "span": {
               "end_column": 5,
-              "end_line": 573,
+              "end_line": 571,
               "start_column": 5,
-              "start_line": 566
+              "start_line": 564
             }
           }
         },
@@ -4982,9 +4982,9 @@ expression: pretty
             "qualified_name": "non_coverage_records_are_ignored",
             "span": {
               "end_column": 5,
-              "end_line": 587,
+              "end_line": 585,
               "start_column": 5,
-              "start_line": 575
+              "start_line": 573
             }
           }
         },
@@ -5006,9 +5006,9 @@ expression: pretty
             "qualified_name": "brda_and_da_records_parsed",
             "span": {
               "end_column": 5,
-              "end_line": 599,
+              "end_line": 597,
               "start_column": 5,
-              "start_line": 591
+              "start_line": 589
             }
           }
         },
@@ -5030,9 +5030,9 @@ expression: pretty
             "qualified_name": "brda_dash_maps_to_none",
             "span": {
               "end_column": 5,
-              "end_line": 606,
+              "end_line": 604,
               "start_column": 5,
-              "start_line": 601
+              "start_line": 599
             }
           }
         },
@@ -5054,9 +5054,9 @@ expression: pretty
             "qualified_name": "brda_numeric_maps_to_some",
             "span": {
               "end_column": 5,
-              "end_line": 613,
+              "end_line": 611,
               "start_column": 5,
-              "start_line": 608
+              "start_line": 606
             }
           }
         },
@@ -5078,9 +5078,9 @@ expression: pretty
             "qualified_name": "brda_zero_maps_to_some_zero",
             "span": {
               "end_column": 5,
-              "end_line": 620,
+              "end_line": 618,
               "start_column": 5,
-              "start_line": 615
+              "start_line": 613
             }
           }
         },
@@ -5102,9 +5102,9 @@ expression: pretty
             "qualified_name": "duplicate_brda_sum_taken",
             "span": {
               "end_column": 5,
-              "end_line": 630,
+              "end_line": 628,
               "start_column": 5,
-              "start_line": 622
+              "start_line": 620
             }
           }
         },
@@ -5126,9 +5126,9 @@ expression: pretty
             "qualified_name": "brda_dash_and_numeric_merge",
             "span": {
               "end_column": 5,
-              "end_line": 638,
+              "end_line": 636,
               "start_column": 5,
-              "start_line": 632
+              "start_line": 630
             }
           }
         },
@@ -5142,10 +5142,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 653,
+              "end_line": 651,
               "increment": 1,
               "kind": "match",
-              "line": 644,
+              "line": 642,
               "nesting_depth": 0
             }
           ],
@@ -5159,9 +5159,9 @@ expression: pretty
             "qualified_name": "malformed_brda_produces_diagnostic",
             "span": {
               "end_column": 5,
-              "end_line": 654,
+              "end_line": 652,
               "start_column": 5,
-              "start_line": 640
+              "start_line": 638
             }
           }
         },
@@ -5183,9 +5183,9 @@ expression: pretty
             "qualified_name": "brda_missing_fields_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 665,
+              "end_line": 663,
               "start_column": 5,
-              "start_line": 656
+              "start_line": 654
             }
           }
         },
@@ -5207,9 +5207,9 @@ expression: pretty
             "qualified_name": "brda_missing_taken_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 676,
+              "end_line": 674,
               "start_column": 5,
-              "start_line": 667
+              "start_line": 665
             }
           }
         },
@@ -5223,10 +5223,10 @@ expression: pretty
           "contributors": [
             {
               "column": 13,
-              "end_line": 695,
+              "end_line": 693,
               "increment": 1,
               "kind": "for-loop",
-              "line": 693,
+              "line": 691,
               "nesting_depth": 0
             }
           ],
@@ -5240,9 +5240,9 @@ expression: pretty
             "qualified_name": "repeated_sf_blocks_merge_branch_coverage",
             "span": {
               "end_column": 5,
-              "end_line": 705,
+              "end_line": 703,
               "start_column": 5,
-              "start_line": 678
+              "start_line": 676
             }
           }
         },
@@ -5264,9 +5264,9 @@ expression: pretty
             "qualified_name": "brda_line_zero_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 715,
+              "end_line": 713,
               "start_column": 5,
-              "start_line": 707
+              "start_line": 705
             }
           }
         },
@@ -5288,9 +5288,9 @@ expression: pretty
             "qualified_name": "no_brda_produces_none_branches",
             "span": {
               "end_column": 5,
-              "end_line": 721,
+              "end_line": 719,
               "start_column": 5,
-              "start_line": 717
+              "start_line": 715
             }
           }
         },
@@ -5312,9 +5312,9 @@ expression: pretty
             "qualified_name": "arb_da_line",
             "span": {
               "end_column": 5,
-              "end_line": 731,
+              "end_line": 729,
               "start_column": 5,
-              "start_line": 729
+              "start_line": 727
             }
           }
         },
@@ -5328,10 +5328,10 @@ expression: pretty
           "contributors": [
             {
               "column": 13,
-              "end_line": 739,
+              "end_line": 737,
               "increment": 2,
               "kind": "for-loop",
-              "line": 736,
+              "line": 734,
               "nesting_depth": 1
             }
           ],
@@ -5345,9 +5345,9 @@ expression: pretty
             "qualified_name": "arb_lcov_block",
             "span": {
               "end_column": 5,
-              "end_line": 743,
+              "end_line": 741,
               "start_column": 5,
-              "start_line": 733
+              "start_line": 731
             }
           }
         },
@@ -5369,9 +5369,9 @@ expression: pretty
             "qualified_name": "arb_lcov_input",
             "span": {
               "end_column": 5,
-              "end_line": 747,
+              "end_line": 745,
               "start_column": 5,
-              "start_line": 745
+              "start_line": 743
             }
           }
         },
@@ -6537,10 +6537,10 @@ expression: pretty
           "contributors": [
             {
               "column": 13,
-              "end_line": 739,
+              "end_line": 737,
               "increment": 2,
               "kind": "for-loop",
-              "line": 736,
+              "line": 734,
               "nesting_depth": 1
             }
           ],
@@ -6554,9 +6554,9 @@ expression: pretty
             "qualified_name": "arb_lcov_block",
             "span": {
               "end_column": 5,
-              "end_line": 743,
+              "end_line": 741,
               "start_column": 5,
-              "start_line": 733
+              "start_line": 731
             }
           }
         },
@@ -7362,10 +7362,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 490,
+              "end_line": 488,
               "increment": 1,
               "kind": "match",
-              "line": 481,
+              "line": 479,
               "nesting_depth": 0
             }
           ],
@@ -7379,9 +7379,9 @@ expression: pretty
             "qualified_name": "malformed_da_produces_diagnostic",
             "span": {
               "end_column": 5,
-              "end_line": 491,
+              "end_line": 489,
               "start_column": 5,
-              "start_line": 476
+              "start_line": 474
             }
           }
         },
@@ -7395,10 +7395,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 534,
+              "end_line": 532,
               "increment": 1,
               "kind": "match",
-              "line": 525,
+              "line": 523,
               "nesting_depth": 0
             }
           ],
@@ -7412,9 +7412,9 @@ expression: pretty
             "qualified_name": "da_line_zero_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 535,
+              "end_line": 533,
               "start_column": 5,
-              "start_line": 521
+              "start_line": 519
             }
           }
         },
@@ -7428,10 +7428,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 653,
+              "end_line": 651,
               "increment": 1,
               "kind": "match",
-              "line": 644,
+              "line": 642,
               "nesting_depth": 0
             }
           ],
@@ -7445,9 +7445,9 @@ expression: pretty
             "qualified_name": "malformed_brda_produces_diagnostic",
             "span": {
               "end_column": 5,
-              "end_line": 654,
+              "end_line": 652,
               "start_column": 5,
-              "start_line": 640
+              "start_line": 638
             }
           }
         },
@@ -7461,10 +7461,10 @@ expression: pretty
           "contributors": [
             {
               "column": 13,
-              "end_line": 695,
+              "end_line": 693,
               "increment": 1,
               "kind": "for-loop",
-              "line": 693,
+              "line": 691,
               "nesting_depth": 0
             }
           ],
@@ -7478,9 +7478,9 @@ expression: pretty
             "qualified_name": "repeated_sf_blocks_merge_branch_coverage",
             "span": {
               "end_column": 5,
-              "end_line": 705,
+              "end_line": 703,
               "start_column": 5,
-              "start_line": 678
+              "start_line": 676
             }
           }
         },
@@ -10247,7 +10247,7 @@ expression: pretty
             "qualified_name": "validate_first_da_in_second_block_passes",
             "span": {
               "end_column": 5,
-              "end_line": 377,
+              "end_line": 375,
               "start_column": 5,
               "start_line": 366
             }
@@ -10271,9 +10271,9 @@ expression: pretty
             "qualified_name": "single_file_single_da",
             "span": {
               "end_column": 5,
-              "end_line": 387,
+              "end_line": 385,
               "start_column": 5,
-              "start_line": 379
+              "start_line": 377
             }
           }
         },
@@ -10295,9 +10295,9 @@ expression: pretty
             "qualified_name": "multiple_da_lines",
             "span": {
               "end_column": 5,
-              "end_line": 397,
+              "end_line": 395,
               "start_column": 5,
-              "start_line": 389
+              "start_line": 387
             }
           }
         },
@@ -10319,9 +10319,9 @@ expression: pretty
             "qualified_name": "multiple_source_files",
             "span": {
               "end_column": 5,
-              "end_line": 406,
+              "end_line": 404,
               "start_column": 5,
-              "start_line": 399
+              "start_line": 397
             }
           }
         },
@@ -10343,9 +10343,9 @@ expression: pretty
             "qualified_name": "hit_count_preservation",
             "span": {
               "end_column": 5,
-              "end_line": 414,
+              "end_line": 412,
               "start_column": 5,
-              "start_line": 408
+              "start_line": 406
             }
           }
         },
@@ -10367,9 +10367,9 @@ expression: pretty
             "qualified_name": "path_normalization_strips_prefix",
             "span": {
               "end_column": 5,
-              "end_line": 420,
+              "end_line": 418,
               "start_column": 5,
-              "start_line": 416
+              "start_line": 414
             }
           }
         },
@@ -10391,9 +10391,9 @@ expression: pretty
             "qualified_name": "non_matching_path_passes_through",
             "span": {
               "end_column": 5,
-              "end_line": 426,
+              "end_line": 424,
               "start_column": 5,
-              "start_line": 422
+              "start_line": 420
             }
           }
         },
@@ -10415,9 +10415,9 @@ expression: pretty
             "qualified_name": "backslash_normalized_to_forward_slash",
             "span": {
               "end_column": 5,
-              "end_line": 433,
+              "end_line": 431,
               "start_column": 5,
-              "start_line": 428
+              "start_line": 426
             }
           }
         },
@@ -10439,9 +10439,9 @@ expression: pretty
             "qualified_name": "path_boundary_not_confused_by_prefix_substring",
             "span": {
               "end_column": 5,
-              "end_line": 439,
+              "end_line": 437,
               "start_column": 5,
-              "start_line": 435
+              "start_line": 433
             }
           }
         },
@@ -10463,9 +10463,9 @@ expression: pretty
             "qualified_name": "repeated_sf_blocks_merge_coverage",
             "span": {
               "end_column": 5,
-              "end_line": 453,
+              "end_line": 451,
               "start_column": 5,
-              "start_line": 441
+              "start_line": 439
             }
           }
         },
@@ -10487,9 +10487,9 @@ expression: pretty
             "qualified_name": "duplicate_da_lines_sum_hits",
             "span": {
               "end_column": 5,
-              "end_line": 462,
+              "end_line": 460,
               "start_column": 5,
-              "start_line": 455
+              "start_line": 453
             }
           }
         },
@@ -10511,9 +10511,9 @@ expression: pretty
             "qualified_name": "duplicate_da_multiple_lines_sum_correctly",
             "span": {
               "end_column": 5,
-              "end_line": 474,
+              "end_line": 472,
               "start_column": 5,
-              "start_line": 464
+              "start_line": 462
             }
           }
         },
@@ -10535,9 +10535,9 @@ expression: pretty
             "qualified_name": "malformed_da_does_not_stop_parsing",
             "span": {
               "end_column": 5,
-              "end_line": 499,
+              "end_line": 497,
               "start_column": 5,
-              "start_line": 493
+              "start_line": 491
             }
           }
         },
@@ -10559,9 +10559,9 @@ expression: pretty
             "qualified_name": "da_missing_hit_count_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 509,
+              "end_line": 507,
               "start_column": 5,
-              "start_line": 501
+              "start_line": 499
             }
           }
         },
@@ -10583,9 +10583,9 @@ expression: pretty
             "qualified_name": "da_negative_hit_count_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 519,
+              "end_line": 517,
               "start_column": 5,
-              "start_line": 511
+              "start_line": 509
             }
           }
         },
@@ -10607,9 +10607,9 @@ expression: pretty
             "qualified_name": "end_of_record_is_ignored",
             "span": {
               "end_column": 5,
-              "end_line": 546,
+              "end_line": 544,
               "start_column": 5,
-              "start_line": 537
+              "start_line": 535
             }
           }
         },
@@ -10631,9 +10631,9 @@ expression: pretty
             "qualified_name": "unterminated_final_block_emits_data",
             "span": {
               "end_column": 5,
-              "end_line": 553,
+              "end_line": 551,
               "start_column": 5,
-              "start_line": 548
+              "start_line": 546
             }
           }
         },
@@ -10655,9 +10655,9 @@ expression: pretty
             "qualified_name": "empty_sf_path_emits_diagnostic",
             "span": {
               "end_column": 5,
-              "end_line": 564,
+              "end_line": 562,
               "start_column": 5,
-              "start_line": 555
+              "start_line": 553
             }
           }
         },
@@ -10679,9 +10679,9 @@ expression: pretty
             "qualified_name": "da_with_checksum_field_is_accepted",
             "span": {
               "end_column": 5,
-              "end_line": 573,
+              "end_line": 571,
               "start_column": 5,
-              "start_line": 566
+              "start_line": 564
             }
           }
         },
@@ -10703,9 +10703,9 @@ expression: pretty
             "qualified_name": "non_coverage_records_are_ignored",
             "span": {
               "end_column": 5,
-              "end_line": 587,
+              "end_line": 585,
               "start_column": 5,
-              "start_line": 575
+              "start_line": 573
             }
           }
         },
@@ -10727,9 +10727,9 @@ expression: pretty
             "qualified_name": "brda_and_da_records_parsed",
             "span": {
               "end_column": 5,
-              "end_line": 599,
+              "end_line": 597,
               "start_column": 5,
-              "start_line": 591
+              "start_line": 589
             }
           }
         },
@@ -10751,9 +10751,9 @@ expression: pretty
             "qualified_name": "brda_dash_maps_to_none",
             "span": {
               "end_column": 5,
-              "end_line": 606,
+              "end_line": 604,
               "start_column": 5,
-              "start_line": 601
+              "start_line": 599
             }
           }
         },
@@ -10775,9 +10775,9 @@ expression: pretty
             "qualified_name": "brda_numeric_maps_to_some",
             "span": {
               "end_column": 5,
-              "end_line": 613,
+              "end_line": 611,
               "start_column": 5,
-              "start_line": 608
+              "start_line": 606
             }
           }
         },
@@ -10799,9 +10799,9 @@ expression: pretty
             "qualified_name": "brda_zero_maps_to_some_zero",
             "span": {
               "end_column": 5,
-              "end_line": 620,
+              "end_line": 618,
               "start_column": 5,
-              "start_line": 615
+              "start_line": 613
             }
           }
         },
@@ -10823,9 +10823,9 @@ expression: pretty
             "qualified_name": "duplicate_brda_sum_taken",
             "span": {
               "end_column": 5,
-              "end_line": 630,
+              "end_line": 628,
               "start_column": 5,
-              "start_line": 622
+              "start_line": 620
             }
           }
         },
@@ -10847,9 +10847,9 @@ expression: pretty
             "qualified_name": "brda_dash_and_numeric_merge",
             "span": {
               "end_column": 5,
-              "end_line": 638,
+              "end_line": 636,
               "start_column": 5,
-              "start_line": 632
+              "start_line": 630
             }
           }
         },
@@ -10871,9 +10871,9 @@ expression: pretty
             "qualified_name": "brda_missing_fields_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 665,
+              "end_line": 663,
               "start_column": 5,
-              "start_line": 656
+              "start_line": 654
             }
           }
         },
@@ -10895,9 +10895,9 @@ expression: pretty
             "qualified_name": "brda_missing_taken_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 676,
+              "end_line": 674,
               "start_column": 5,
-              "start_line": 667
+              "start_line": 665
             }
           }
         },
@@ -10919,9 +10919,9 @@ expression: pretty
             "qualified_name": "brda_line_zero_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 715,
+              "end_line": 713,
               "start_column": 5,
-              "start_line": 707
+              "start_line": 705
             }
           }
         },
@@ -10943,9 +10943,9 @@ expression: pretty
             "qualified_name": "no_brda_produces_none_branches",
             "span": {
               "end_column": 5,
-              "end_line": 721,
+              "end_line": 719,
               "start_column": 5,
-              "start_line": 717
+              "start_line": 715
             }
           }
         },
@@ -10967,9 +10967,9 @@ expression: pretty
             "qualified_name": "arb_da_line",
             "span": {
               "end_column": 5,
-              "end_line": 731,
+              "end_line": 729,
               "start_column": 5,
-              "start_line": 729
+              "start_line": 727
             }
           }
         },
@@ -10991,9 +10991,9 @@ expression: pretty
             "qualified_name": "arb_lcov_input",
             "span": {
               "end_column": 5,
-              "end_line": 747,
+              "end_line": 745,
               "start_column": 5,
-              "start_line": 745
+              "start_line": 743
             }
           }
         },

--- a/crates/crap-core/tests/snapshots/wire_envelope_snapshot__envelope.snap
+++ b/crates/crap-core/tests/snapshots/wire_envelope_snapshot__envelope.snap
@@ -3564,61 +3564,77 @@ expression: pretty
       {
         "exceeds": true,
         "scored": {
-          "complexity": 8,
+          "complexity": 10,
           "complexity_metric": "cognitive",
           "contributors": [
             {
-              "column": 9,
-              "end_line": 93,
+              "column": 73,
+              "end_line": 84,
               "increment": 1,
-              "kind": "for-loop",
-              "line": 80,
+              "kind": "try",
+              "line": 84,
               "nesting_depth": 0
             },
             {
-              "column": 13,
-              "end_line": 84,
-              "increment": 2,
-              "kind": "if-branch",
-              "line": 81,
-              "nesting_depth": 1
+              "column": 9,
+              "end_line": 101,
+              "increment": 1,
+              "kind": "for-loop",
+              "line": 87,
+              "nesting_depth": 0
             },
             {
-              "column": 17,
-              "end_line": 83,
+              "column": 68,
+              "end_line": 88,
               "increment": 1,
-              "kind": "continue",
-              "line": 83,
-              "nesting_depth": 2
+              "kind": "try",
+              "line": 88,
+              "nesting_depth": 1
             },
             {
               "column": 13,
               "end_line": 92,
               "increment": 2,
               "kind": "if-branch",
-              "line": 85,
+              "line": 89,
               "nesting_depth": 1
             },
             {
               "column": 17,
-              "end_line": 86,
+              "end_line": 91,
+              "increment": 1,
+              "kind": "continue",
+              "line": 91,
+              "nesting_depth": 2
+            },
+            {
+              "column": 13,
+              "end_line": 100,
+              "increment": 2,
+              "kind": "if-branch",
+              "line": 93,
+              "nesting_depth": 1
+            },
+            {
+              "column": 17,
+              "end_line": 94,
               "increment": 1,
               "kind": "logical-operator",
-              "line": 86,
+              "line": 94,
               "nesting_depth": 1
             }
           ],
           "coverage_percent": 0.0,
           "crap": {
             "risk_level": "high",
-            "value": 72.0
+            "value": 110.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
             "qualified_name": "LcovParser::validate",
             "span": {
               "end_column": 5,
-              "end_line": 95,
+              "end_line": 103,
               "start_column": 5,
               "start_line": 71
             }
@@ -3634,26 +3650,26 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 102,
+              "end_line": 110,
               "increment": 1,
               "kind": "if-branch",
-              "line": 99,
+              "line": 107,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 107,
+              "end_line": 115,
               "increment": 1,
               "kind": "if-branch",
-              "line": 104,
+              "line": 112,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 111,
+              "end_line": 119,
               "increment": 1,
               "kind": "if-branch",
-              "line": 109,
+              "line": 117,
               "nesting_depth": 0
             }
           ],
@@ -3667,9 +3683,9 @@ expression: pretty
             "qualified_name": "handle_parse_line",
             "span": {
               "end_column": 1,
-              "end_line": 112,
+              "end_line": 120,
               "start_column": 1,
-              "start_line": 98
+              "start_line": 106
             }
           }
         },
@@ -3683,10 +3699,10 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 124,
+              "end_line": 132,
               "increment": 1,
               "kind": "if-branch",
-              "line": 117,
+              "line": 125,
               "nesting_depth": 0
             }
           ],
@@ -3700,9 +3716,9 @@ expression: pretty
             "qualified_name": "start_source_file",
             "span": {
               "end_column": 1,
-              "end_line": 125,
+              "end_line": 133,
               "start_column": 1,
-              "start_line": 114
+              "start_line": 122
             }
           }
         },
@@ -3716,18 +3732,18 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 130,
+              "end_line": 138,
               "increment": 1,
               "kind": "if-branch",
-              "line": 128,
+              "line": 136,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 135,
+              "end_line": 143,
               "increment": 1,
               "kind": "match",
-              "line": 132,
+              "line": 140,
               "nesting_depth": 0
             }
           ],
@@ -3741,9 +3757,9 @@ expression: pretty
             "qualified_name": "record_da",
             "span": {
               "end_column": 1,
-              "end_line": 136,
+              "end_line": 144,
               "start_column": 1,
-              "start_line": 127
+              "start_line": 135
             }
           }
         },
@@ -3757,18 +3773,18 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 141,
+              "end_line": 149,
               "increment": 1,
               "kind": "if-branch",
-              "line": 139,
+              "line": 147,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 148,
+              "end_line": 156,
               "increment": 1,
               "kind": "match",
-              "line": 143,
+              "line": 151,
               "nesting_depth": 0
             }
           ],
@@ -3782,9 +3798,9 @@ expression: pretty
             "qualified_name": "record_brda",
             "span": {
               "end_column": 1,
-              "end_line": 149,
+              "end_line": 157,
               "start_column": 1,
-              "start_line": 138
+              "start_line": 146
             }
           }
         },
@@ -3806,9 +3822,9 @@ expression: pretty
             "qualified_name": "push_malformed_record",
             "span": {
               "end_column": 1,
-              "end_line": 158,
+              "end_line": 166,
               "start_column": 1,
-              "start_line": 151
+              "start_line": 159
             }
           }
         },
@@ -3822,42 +3838,42 @@ expression: pretty
           "contributors": [
             {
               "column": 56,
-              "end_line": 163,
+              "end_line": 171,
               "increment": 1,
               "kind": "try",
-              "line": 163,
+              "line": 171,
               "nesting_depth": 0
             },
             {
               "column": 52,
-              "end_line": 165,
+              "end_line": 173,
               "increment": 1,
               "kind": "try",
-              "line": 165,
+              "line": 173,
               "nesting_depth": 0
             },
             {
               "column": 58,
-              "end_line": 166,
+              "end_line": 174,
               "increment": 1,
               "kind": "try",
-              "line": 166,
+              "line": 174,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 169,
+              "end_line": 177,
               "increment": 1,
               "kind": "if-branch",
-              "line": 167,
+              "line": 175,
               "nesting_depth": 0
             },
             {
               "column": 53,
-              "end_line": 170,
+              "end_line": 178,
               "increment": 1,
               "kind": "try",
-              "line": 170,
+              "line": 178,
               "nesting_depth": 0
             }
           ],
@@ -3871,9 +3887,9 @@ expression: pretty
             "qualified_name": "parse_da",
             "span": {
               "end_column": 1,
-              "end_line": 172,
+              "end_line": 180,
               "start_column": 1,
-              "start_line": 160
+              "start_line": 168
             }
           }
         },
@@ -3887,54 +3903,14 @@ expression: pretty
           "contributors": [
             {
               "column": 42,
-              "end_line": 179,
-              "increment": 1,
-              "kind": "try",
-              "line": 179,
-              "nesting_depth": 0
-            },
-            {
-              "column": 43,
-              "end_line": 180,
-              "increment": 1,
-              "kind": "try",
-              "line": 180,
-              "nesting_depth": 0
-            },
-            {
-              "column": 44,
-              "end_line": 181,
-              "increment": 1,
-              "kind": "try",
-              "line": 181,
-              "nesting_depth": 0
-            },
-            {
-              "column": 43,
-              "end_line": 182,
-              "increment": 1,
-              "kind": "try",
-              "line": 182,
-              "nesting_depth": 0
-            },
-            {
-              "column": 58,
-              "end_line": 184,
-              "increment": 1,
-              "kind": "try",
-              "line": 184,
-              "nesting_depth": 0
-            },
-            {
-              "column": 5,
               "end_line": 187,
               "increment": 1,
-              "kind": "if-branch",
-              "line": 185,
+              "kind": "try",
+              "line": 187,
               "nesting_depth": 0
             },
             {
-              "column": 55,
+              "column": 43,
               "end_line": 188,
               "increment": 1,
               "kind": "try",
@@ -3942,7 +3918,7 @@ expression: pretty
               "nesting_depth": 0
             },
             {
-              "column": 57,
+              "column": 44,
               "end_line": 189,
               "increment": 1,
               "kind": "try",
@@ -3950,19 +3926,59 @@ expression: pretty
               "nesting_depth": 0
             },
             {
-              "column": 17,
-              "end_line": 194,
+              "column": 43,
+              "end_line": 190,
               "increment": 1,
-              "kind": "if-branch",
+              "kind": "try",
               "line": 190,
               "nesting_depth": 0
             },
             {
-              "column": 54,
-              "end_line": 193,
+              "column": 58,
+              "end_line": 192,
               "increment": 1,
               "kind": "try",
+              "line": 192,
+              "nesting_depth": 0
+            },
+            {
+              "column": 5,
+              "end_line": 195,
+              "increment": 1,
+              "kind": "if-branch",
               "line": 193,
+              "nesting_depth": 0
+            },
+            {
+              "column": 55,
+              "end_line": 196,
+              "increment": 1,
+              "kind": "try",
+              "line": 196,
+              "nesting_depth": 0
+            },
+            {
+              "column": 57,
+              "end_line": 197,
+              "increment": 1,
+              "kind": "try",
+              "line": 197,
+              "nesting_depth": 0
+            },
+            {
+              "column": 17,
+              "end_line": 202,
+              "increment": 1,
+              "kind": "if-branch",
+              "line": 198,
+              "nesting_depth": 0
+            },
+            {
+              "column": 54,
+              "end_line": 201,
+              "increment": 1,
+              "kind": "try",
+              "line": 201,
               "nesting_depth": 1
             }
           ],
@@ -3976,9 +3992,9 @@ expression: pretty
             "qualified_name": "parse_brda",
             "span": {
               "end_column": 1,
-              "end_line": 197,
+              "end_line": 205,
               "start_column": 1,
-              "start_line": 174
+              "start_line": 182
             }
           }
         },
@@ -3992,10 +4008,10 @@ expression: pretty
           "contributors": [
             {
               "column": 52,
-              "end_line": 203,
+              "end_line": 211,
               "increment": 1,
               "kind": "let-else",
-              "line": 200,
+              "line": 208,
               "nesting_depth": 0
             }
           ],
@@ -4009,9 +4025,9 @@ expression: pretty
             "qualified_name": "flush_block",
             "span": {
               "end_column": 1,
-              "end_line": 208,
+              "end_line": 216,
               "start_column": 1,
-              "start_line": 199
+              "start_line": 207
             }
           }
         },
@@ -4025,18 +4041,18 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 217,
+              "end_line": 225,
               "increment": 1,
               "kind": "if-branch",
-              "line": 215,
+              "line": 223,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 222,
+              "end_line": 230,
               "increment": 1,
               "kind": "for-loop",
-              "line": 220,
+              "line": 228,
               "nesting_depth": 0
             }
           ],
@@ -4050,9 +4066,9 @@ expression: pretty
             "qualified_name": "merge_line_block",
             "span": {
               "end_column": 1,
-              "end_line": 223,
+              "end_line": 231,
               "start_column": 1,
-              "start_line": 210
+              "start_line": 218
             }
           }
         },
@@ -4066,18 +4082,18 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 232,
+              "end_line": 240,
               "increment": 1,
               "kind": "if-branch",
-              "line": 230,
+              "line": 238,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 237,
+              "end_line": 245,
               "increment": 1,
               "kind": "for-loop",
-              "line": 235,
+              "line": 243,
               "nesting_depth": 0
             }
           ],
@@ -4091,9 +4107,9 @@ expression: pretty
             "qualified_name": "merge_branch_block",
             "span": {
               "end_column": 1,
-              "end_line": 238,
+              "end_line": 246,
               "start_column": 1,
-              "start_line": 225
+              "start_line": 233
             }
           }
         },
@@ -4115,9 +4131,9 @@ expression: pretty
             "qualified_name": "merge_hits",
             "span": {
               "end_column": 1,
-              "end_line": 245,
+              "end_line": 253,
               "start_column": 1,
-              "start_line": 240
+              "start_line": 248
             }
           }
         },
@@ -4139,9 +4155,9 @@ expression: pretty
             "qualified_name": "merge_branch_value",
             "span": {
               "end_column": 1,
-              "end_line": 256,
+              "end_line": 264,
               "start_column": 1,
-              "start_line": 247
+              "start_line": 255
             }
           }
         },
@@ -4155,10 +4171,10 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 264,
+              "end_line": 272,
               "increment": 1,
               "kind": "match",
-              "line": 259,
+              "line": 267,
               "nesting_depth": 0
             }
           ],
@@ -4172,9 +4188,9 @@ expression: pretty
             "qualified_name": "merge_taken",
             "span": {
               "end_column": 1,
-              "end_line": 265,
+              "end_line": 273,
               "start_column": 1,
-              "start_line": 258
+              "start_line": 266
             }
           }
         },
@@ -4196,9 +4212,9 @@ expression: pretty
             "qualified_name": "clear_current_block",
             "span": {
               "end_column": 1,
-              "end_line": 270,
+              "end_line": 278,
               "start_column": 1,
-              "start_line": 267
+              "start_line": 275
             }
           }
         },
@@ -4220,9 +4236,9 @@ expression: pretty
             "qualified_name": "build_parse_output",
             "span": {
               "end_column": 1,
-              "end_line": 298,
+              "end_line": 306,
               "start_column": 1,
-              "start_line": 272
+              "start_line": 280
             }
           }
         },
@@ -4244,9 +4260,9 @@ expression: pretty
             "qualified_name": "to_line_coverage",
             "span": {
               "end_column": 1,
-              "end_line": 305,
+              "end_line": 313,
               "start_column": 1,
-              "start_line": 300
+              "start_line": 308
             }
           }
         },
@@ -4268,9 +4284,9 @@ expression: pretty
             "qualified_name": "parser",
             "span": {
               "end_column": 5,
-              "end_line": 314,
+              "end_line": 322,
               "start_column": 5,
-              "start_line": 312
+              "start_line": 320
             }
           }
         },
@@ -4292,9 +4308,9 @@ expression: pretty
             "qualified_name": "parse",
             "span": {
               "end_column": 5,
-              "end_line": 318,
+              "end_line": 326,
               "start_column": 5,
-              "start_line": 316
+              "start_line": 324
             }
           }
         },
@@ -4316,9 +4332,33 @@ expression: pretty
             "qualified_name": "empty_input_returns_empty_output",
             "span": {
               "end_column": 5,
-              "end_line": 325,
+              "end_line": 333,
               "start_column": 5,
-              "start_line": 320
+              "start_line": 328
+            }
+          }
+        },
+        "threshold": 25.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 0.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "validate_str",
+            "span": {
+              "end_column": 5,
+              "end_line": 347,
+              "start_column": 5,
+              "start_line": 337
             }
           }
         },
@@ -4340,9 +4380,9 @@ expression: pretty
             "qualified_name": "validate_empty_input_rejected",
             "span": {
               "end_column": 5,
-              "end_line": 332,
+              "end_line": 352,
               "start_column": 5,
-              "start_line": 329
+              "start_line": 349
             }
           }
         },
@@ -4364,9 +4404,9 @@ expression: pretty
             "qualified_name": "validate_no_da_lines_rejected",
             "span": {
               "end_column": 5,
-              "end_line": 341,
+              "end_line": 357,
               "start_column": 5,
-              "start_line": 334
+              "start_line": 354
             }
           }
         },
@@ -4388,9 +4428,9 @@ expression: pretty
             "qualified_name": "validate_da_outside_sf_block_rejected",
             "span": {
               "end_column": 5,
-              "end_line": 346,
+              "end_line": 362,
               "start_column": 5,
-              "start_line": 343
+              "start_line": 359
             }
           }
         },
@@ -4412,9 +4452,9 @@ expression: pretty
             "qualified_name": "validate_malformed_da_rejected",
             "span": {
               "end_column": 5,
-              "end_line": 355,
+              "end_line": 367,
               "start_column": 5,
-              "start_line": 348
+              "start_line": 364
             }
           }
         },
@@ -4436,9 +4476,9 @@ expression: pretty
             "qualified_name": "validate_single_da_inside_sf_block_passes",
             "span": {
               "end_column": 5,
-              "end_line": 364,
+              "end_line": 372,
               "start_column": 5,
-              "start_line": 357
+              "start_line": 369
             }
           }
         },
@@ -4460,9 +4500,33 @@ expression: pretty
             "qualified_name": "validate_first_da_in_second_block_passes",
             "span": {
               "end_column": 5,
-              "end_line": 375,
+              "end_line": 382,
               "start_column": 5,
-              "start_line": 366
+              "start_line": 374
+            }
+          }
+        },
+        "threshold": 25.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 0.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "validate_missing_path_returns_open_error",
+            "span": {
+              "end_column": 5,
+              "end_line": 394,
+              "start_column": 5,
+              "start_line": 384
             }
           }
         },
@@ -4484,9 +4548,9 @@ expression: pretty
             "qualified_name": "single_file_single_da",
             "span": {
               "end_column": 5,
-              "end_line": 385,
+              "end_line": 404,
               "start_column": 5,
-              "start_line": 377
+              "start_line": 396
             }
           }
         },
@@ -4508,9 +4572,9 @@ expression: pretty
             "qualified_name": "multiple_da_lines",
             "span": {
               "end_column": 5,
-              "end_line": 395,
+              "end_line": 414,
               "start_column": 5,
-              "start_line": 387
+              "start_line": 406
             }
           }
         },
@@ -4532,9 +4596,9 @@ expression: pretty
             "qualified_name": "multiple_source_files",
             "span": {
               "end_column": 5,
-              "end_line": 404,
+              "end_line": 423,
               "start_column": 5,
-              "start_line": 397
+              "start_line": 416
             }
           }
         },
@@ -4556,9 +4620,9 @@ expression: pretty
             "qualified_name": "hit_count_preservation",
             "span": {
               "end_column": 5,
-              "end_line": 412,
+              "end_line": 431,
               "start_column": 5,
-              "start_line": 406
+              "start_line": 425
             }
           }
         },
@@ -4578,78 +4642,6 @@ expression: pretty
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
             "qualified_name": "path_normalization_strips_prefix",
-            "span": {
-              "end_column": 5,
-              "end_line": 418,
-              "start_column": 5,
-              "start_line": 414
-            }
-          }
-        },
-        "threshold": 25.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "non_matching_path_passes_through",
-            "span": {
-              "end_column": 5,
-              "end_line": 424,
-              "start_column": 5,
-              "start_line": 420
-            }
-          }
-        },
-        "threshold": 25.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "backslash_normalized_to_forward_slash",
-            "span": {
-              "end_column": 5,
-              "end_line": 431,
-              "start_column": 5,
-              "start_line": 426
-            }
-          }
-        },
-        "threshold": 25.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "path_boundary_not_confused_by_prefix_substring",
             "span": {
               "end_column": 5,
               "end_line": 437,
@@ -4673,12 +4665,84 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "non_matching_path_passes_through",
+            "span": {
+              "end_column": 5,
+              "end_line": 443,
+              "start_column": 5,
+              "start_line": 439
+            }
+          }
+        },
+        "threshold": 25.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 0.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "backslash_normalized_to_forward_slash",
+            "span": {
+              "end_column": 5,
+              "end_line": 450,
+              "start_column": 5,
+              "start_line": 445
+            }
+          }
+        },
+        "threshold": 25.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 0.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "path_boundary_not_confused_by_prefix_substring",
+            "span": {
+              "end_column": 5,
+              "end_line": 456,
+              "start_column": 5,
+              "start_line": 452
+            }
+          }
+        },
+        "threshold": 25.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 0.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
             "qualified_name": "repeated_sf_blocks_merge_coverage",
             "span": {
               "end_column": 5,
-              "end_line": 451,
+              "end_line": 470,
               "start_column": 5,
-              "start_line": 439
+              "start_line": 458
             }
           }
         },
@@ -4700,9 +4764,9 @@ expression: pretty
             "qualified_name": "duplicate_da_lines_sum_hits",
             "span": {
               "end_column": 5,
-              "end_line": 460,
+              "end_line": 479,
               "start_column": 5,
-              "start_line": 453
+              "start_line": 472
             }
           }
         },
@@ -4724,9 +4788,9 @@ expression: pretty
             "qualified_name": "duplicate_da_multiple_lines_sum_correctly",
             "span": {
               "end_column": 5,
-              "end_line": 472,
+              "end_line": 491,
               "start_column": 5,
-              "start_line": 462
+              "start_line": 481
             }
           }
         },
@@ -4740,10 +4804,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 488,
+              "end_line": 507,
               "increment": 1,
               "kind": "match",
-              "line": 479,
+              "line": 498,
               "nesting_depth": 0
             }
           ],
@@ -4757,9 +4821,9 @@ expression: pretty
             "qualified_name": "malformed_da_produces_diagnostic",
             "span": {
               "end_column": 5,
-              "end_line": 489,
+              "end_line": 508,
               "start_column": 5,
-              "start_line": 474
+              "start_line": 493
             }
           }
         },
@@ -4781,9 +4845,9 @@ expression: pretty
             "qualified_name": "malformed_da_does_not_stop_parsing",
             "span": {
               "end_column": 5,
-              "end_line": 497,
+              "end_line": 516,
               "start_column": 5,
-              "start_line": 491
+              "start_line": 510
             }
           }
         },
@@ -4805,9 +4869,9 @@ expression: pretty
             "qualified_name": "da_missing_hit_count_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 507,
+              "end_line": 526,
               "start_column": 5,
-              "start_line": 499
+              "start_line": 518
             }
           }
         },
@@ -4829,9 +4893,9 @@ expression: pretty
             "qualified_name": "da_negative_hit_count_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 517,
+              "end_line": 536,
               "start_column": 5,
-              "start_line": 509
+              "start_line": 528
             }
           }
         },
@@ -4845,10 +4909,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 532,
+              "end_line": 551,
               "increment": 1,
               "kind": "match",
-              "line": 523,
+              "line": 542,
               "nesting_depth": 0
             }
           ],
@@ -4862,9 +4926,9 @@ expression: pretty
             "qualified_name": "da_line_zero_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 533,
+              "end_line": 552,
               "start_column": 5,
-              "start_line": 519
+              "start_line": 538
             }
           }
         },
@@ -4886,9 +4950,9 @@ expression: pretty
             "qualified_name": "end_of_record_is_ignored",
             "span": {
               "end_column": 5,
-              "end_line": 544,
+              "end_line": 563,
               "start_column": 5,
-              "start_line": 535
+              "start_line": 554
             }
           }
         },
@@ -4910,9 +4974,9 @@ expression: pretty
             "qualified_name": "unterminated_final_block_emits_data",
             "span": {
               "end_column": 5,
-              "end_line": 551,
+              "end_line": 570,
               "start_column": 5,
-              "start_line": 546
+              "start_line": 565
             }
           }
         },
@@ -4934,9 +4998,9 @@ expression: pretty
             "qualified_name": "empty_sf_path_emits_diagnostic",
             "span": {
               "end_column": 5,
-              "end_line": 562,
+              "end_line": 581,
               "start_column": 5,
-              "start_line": 553
+              "start_line": 572
             }
           }
         },
@@ -4958,9 +5022,9 @@ expression: pretty
             "qualified_name": "da_with_checksum_field_is_accepted",
             "span": {
               "end_column": 5,
-              "end_line": 571,
+              "end_line": 590,
               "start_column": 5,
-              "start_line": 564
+              "start_line": 583
             }
           }
         },
@@ -4982,9 +5046,9 @@ expression: pretty
             "qualified_name": "non_coverage_records_are_ignored",
             "span": {
               "end_column": 5,
-              "end_line": 585,
+              "end_line": 604,
               "start_column": 5,
-              "start_line": 573
+              "start_line": 592
             }
           }
         },
@@ -5006,9 +5070,9 @@ expression: pretty
             "qualified_name": "brda_and_da_records_parsed",
             "span": {
               "end_column": 5,
-              "end_line": 597,
+              "end_line": 616,
               "start_column": 5,
-              "start_line": 589
+              "start_line": 608
             }
           }
         },
@@ -5030,9 +5094,9 @@ expression: pretty
             "qualified_name": "brda_dash_maps_to_none",
             "span": {
               "end_column": 5,
-              "end_line": 604,
+              "end_line": 623,
               "start_column": 5,
-              "start_line": 599
+              "start_line": 618
             }
           }
         },
@@ -5054,9 +5118,9 @@ expression: pretty
             "qualified_name": "brda_numeric_maps_to_some",
             "span": {
               "end_column": 5,
-              "end_line": 611,
+              "end_line": 630,
               "start_column": 5,
-              "start_line": 606
+              "start_line": 625
             }
           }
         },
@@ -5078,9 +5142,9 @@ expression: pretty
             "qualified_name": "brda_zero_maps_to_some_zero",
             "span": {
               "end_column": 5,
-              "end_line": 618,
+              "end_line": 637,
               "start_column": 5,
-              "start_line": 613
+              "start_line": 632
             }
           }
         },
@@ -5102,9 +5166,9 @@ expression: pretty
             "qualified_name": "duplicate_brda_sum_taken",
             "span": {
               "end_column": 5,
-              "end_line": 628,
+              "end_line": 647,
               "start_column": 5,
-              "start_line": 620
+              "start_line": 639
             }
           }
         },
@@ -5126,9 +5190,9 @@ expression: pretty
             "qualified_name": "brda_dash_and_numeric_merge",
             "span": {
               "end_column": 5,
-              "end_line": 636,
+              "end_line": 655,
               "start_column": 5,
-              "start_line": 630
+              "start_line": 649
             }
           }
         },
@@ -5142,10 +5206,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 651,
+              "end_line": 670,
               "increment": 1,
               "kind": "match",
-              "line": 642,
+              "line": 661,
               "nesting_depth": 0
             }
           ],
@@ -5159,9 +5223,9 @@ expression: pretty
             "qualified_name": "malformed_brda_produces_diagnostic",
             "span": {
               "end_column": 5,
-              "end_line": 652,
+              "end_line": 671,
               "start_column": 5,
-              "start_line": 638
+              "start_line": 657
             }
           }
         },
@@ -5183,9 +5247,9 @@ expression: pretty
             "qualified_name": "brda_missing_fields_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 663,
+              "end_line": 682,
               "start_column": 5,
-              "start_line": 654
+              "start_line": 673
             }
           }
         },
@@ -5207,9 +5271,9 @@ expression: pretty
             "qualified_name": "brda_missing_taken_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 674,
+              "end_line": 693,
               "start_column": 5,
-              "start_line": 665
+              "start_line": 684
             }
           }
         },
@@ -5223,10 +5287,10 @@ expression: pretty
           "contributors": [
             {
               "column": 13,
-              "end_line": 693,
+              "end_line": 712,
               "increment": 1,
               "kind": "for-loop",
-              "line": 691,
+              "line": 710,
               "nesting_depth": 0
             }
           ],
@@ -5240,9 +5304,9 @@ expression: pretty
             "qualified_name": "repeated_sf_blocks_merge_branch_coverage",
             "span": {
               "end_column": 5,
-              "end_line": 703,
+              "end_line": 722,
               "start_column": 5,
-              "start_line": 676
+              "start_line": 695
             }
           }
         },
@@ -5264,9 +5328,9 @@ expression: pretty
             "qualified_name": "brda_line_zero_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 713,
+              "end_line": 732,
               "start_column": 5,
-              "start_line": 705
+              "start_line": 724
             }
           }
         },
@@ -5288,9 +5352,9 @@ expression: pretty
             "qualified_name": "no_brda_produces_none_branches",
             "span": {
               "end_column": 5,
-              "end_line": 719,
+              "end_line": 738,
               "start_column": 5,
-              "start_line": 715
+              "start_line": 734
             }
           }
         },
@@ -5312,9 +5376,9 @@ expression: pretty
             "qualified_name": "arb_da_line",
             "span": {
               "end_column": 5,
-              "end_line": 729,
+              "end_line": 748,
               "start_column": 5,
-              "start_line": 727
+              "start_line": 746
             }
           }
         },
@@ -5328,10 +5392,10 @@ expression: pretty
           "contributors": [
             {
               "column": 13,
-              "end_line": 737,
+              "end_line": 756,
               "increment": 2,
               "kind": "for-loop",
-              "line": 734,
+              "line": 753,
               "nesting_depth": 1
             }
           ],
@@ -5345,9 +5409,9 @@ expression: pretty
             "qualified_name": "arb_lcov_block",
             "span": {
               "end_column": 5,
-              "end_line": 741,
+              "end_line": 760,
               "start_column": 5,
-              "start_line": 731
+              "start_line": 750
             }
           }
         },
@@ -5369,9 +5433,9 @@ expression: pretty
             "qualified_name": "arb_lcov_input",
             "span": {
               "end_column": 5,
-              "end_line": 745,
+              "end_line": 764,
               "start_column": 5,
-              "start_line": 743
+              "start_line": 762
             }
           }
         },
@@ -5557,13 +5621,13 @@ expression: pretty
     ],
     "passed": false,
     "summary": {
-      "average_complexity": 1.515,
+      "average_complexity": 1.5198019801980198,
       "average_coverage": 0.0,
-      "average_crap": 5.57,
+      "average_crap": 5.7227722772277225,
       "distribution": {
         "acceptable": 29,
         "high": 6,
-        "low": 151,
+        "low": 153,
         "moderate": 14
       },
       "exceeding_threshold": 6,
@@ -5577,15 +5641,15 @@ expression: pretty
       "median_crap": 2.0,
       "min_coverage": 0.0,
       "total_files": 5,
-      "total_functions": 200,
+      "total_functions": 202,
       "worst_function": {
         "file_path": "adapters/coverage/mod.rs",
         "qualified_name": "parse_brda",
         "span": {
           "end_column": 1,
-          "end_line": 197,
+          "end_line": 205,
           "start_column": 1,
-          "start_line": 174
+          "start_line": 182
         }
       }
     }
@@ -5595,7 +5659,7 @@ expression: pretty
   "timestamp": "[STRIPPED:timestamp]",
   "tool_version": "[STRIPPED:tool_version]",
   "view": {
-    "eligible_count": 200,
+    "eligible_count": 202,
     "grouped": null,
     "shown": [
       {
@@ -5606,54 +5670,14 @@ expression: pretty
           "contributors": [
             {
               "column": 42,
-              "end_line": 179,
-              "increment": 1,
-              "kind": "try",
-              "line": 179,
-              "nesting_depth": 0
-            },
-            {
-              "column": 43,
-              "end_line": 180,
-              "increment": 1,
-              "kind": "try",
-              "line": 180,
-              "nesting_depth": 0
-            },
-            {
-              "column": 44,
-              "end_line": 181,
-              "increment": 1,
-              "kind": "try",
-              "line": 181,
-              "nesting_depth": 0
-            },
-            {
-              "column": 43,
-              "end_line": 182,
-              "increment": 1,
-              "kind": "try",
-              "line": 182,
-              "nesting_depth": 0
-            },
-            {
-              "column": 58,
-              "end_line": 184,
-              "increment": 1,
-              "kind": "try",
-              "line": 184,
-              "nesting_depth": 0
-            },
-            {
-              "column": 5,
               "end_line": 187,
               "increment": 1,
-              "kind": "if-branch",
-              "line": 185,
+              "kind": "try",
+              "line": 187,
               "nesting_depth": 0
             },
             {
-              "column": 55,
+              "column": 43,
               "end_line": 188,
               "increment": 1,
               "kind": "try",
@@ -5661,7 +5685,7 @@ expression: pretty
               "nesting_depth": 0
             },
             {
-              "column": 57,
+              "column": 44,
               "end_line": 189,
               "increment": 1,
               "kind": "try",
@@ -5669,19 +5693,59 @@ expression: pretty
               "nesting_depth": 0
             },
             {
-              "column": 17,
-              "end_line": 194,
+              "column": 43,
+              "end_line": 190,
               "increment": 1,
-              "kind": "if-branch",
+              "kind": "try",
               "line": 190,
               "nesting_depth": 0
             },
             {
-              "column": 54,
-              "end_line": 193,
+              "column": 58,
+              "end_line": 192,
               "increment": 1,
               "kind": "try",
+              "line": 192,
+              "nesting_depth": 0
+            },
+            {
+              "column": 5,
+              "end_line": 195,
+              "increment": 1,
+              "kind": "if-branch",
               "line": 193,
+              "nesting_depth": 0
+            },
+            {
+              "column": 55,
+              "end_line": 196,
+              "increment": 1,
+              "kind": "try",
+              "line": 196,
+              "nesting_depth": 0
+            },
+            {
+              "column": 57,
+              "end_line": 197,
+              "increment": 1,
+              "kind": "try",
+              "line": 197,
+              "nesting_depth": 0
+            },
+            {
+              "column": 17,
+              "end_line": 202,
+              "increment": 1,
+              "kind": "if-branch",
+              "line": 198,
+              "nesting_depth": 0
+            },
+            {
+              "column": 54,
+              "end_line": 201,
+              "increment": 1,
+              "kind": "try",
+              "line": 201,
               "nesting_depth": 1
             }
           ],
@@ -5695,9 +5759,90 @@ expression: pretty
             "qualified_name": "parse_brda",
             "span": {
               "end_column": 1,
-              "end_line": 197,
+              "end_line": 205,
               "start_column": 1,
-              "start_line": 174
+              "start_line": 182
+            }
+          }
+        },
+        "threshold": 25.0
+      },
+      {
+        "exceeds": true,
+        "scored": {
+          "complexity": 10,
+          "complexity_metric": "cognitive",
+          "contributors": [
+            {
+              "column": 73,
+              "end_line": 84,
+              "increment": 1,
+              "kind": "try",
+              "line": 84,
+              "nesting_depth": 0
+            },
+            {
+              "column": 9,
+              "end_line": 101,
+              "increment": 1,
+              "kind": "for-loop",
+              "line": 87,
+              "nesting_depth": 0
+            },
+            {
+              "column": 68,
+              "end_line": 88,
+              "increment": 1,
+              "kind": "try",
+              "line": 88,
+              "nesting_depth": 1
+            },
+            {
+              "column": 13,
+              "end_line": 92,
+              "increment": 2,
+              "kind": "if-branch",
+              "line": 89,
+              "nesting_depth": 1
+            },
+            {
+              "column": 17,
+              "end_line": 91,
+              "increment": 1,
+              "kind": "continue",
+              "line": 91,
+              "nesting_depth": 2
+            },
+            {
+              "column": 13,
+              "end_line": 100,
+              "increment": 2,
+              "kind": "if-branch",
+              "line": 93,
+              "nesting_depth": 1
+            },
+            {
+              "column": 17,
+              "end_line": 94,
+              "increment": 1,
+              "kind": "logical-operator",
+              "line": 94,
+              "nesting_depth": 1
+            }
+          ],
+          "coverage_percent": 0.0,
+          "crap": {
+            "risk_level": "high",
+            "value": 110.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "LcovParser::validate",
+            "span": {
+              "end_column": 5,
+              "end_line": 103,
+              "start_column": 5,
+              "start_line": 71
             }
           }
         },
@@ -5755,71 +5900,6 @@ expression: pretty
               "end_line": 629,
               "start_column": 1,
               "start_line": 591
-            }
-          }
-        },
-        "threshold": 25.0
-      },
-      {
-        "exceeds": true,
-        "scored": {
-          "complexity": 8,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 9,
-              "end_line": 93,
-              "increment": 1,
-              "kind": "for-loop",
-              "line": 80,
-              "nesting_depth": 0
-            },
-            {
-              "column": 13,
-              "end_line": 84,
-              "increment": 2,
-              "kind": "if-branch",
-              "line": 81,
-              "nesting_depth": 1
-            },
-            {
-              "column": 17,
-              "end_line": 83,
-              "increment": 1,
-              "kind": "continue",
-              "line": 83,
-              "nesting_depth": 2
-            },
-            {
-              "column": 13,
-              "end_line": 92,
-              "increment": 2,
-              "kind": "if-branch",
-              "line": 85,
-              "nesting_depth": 1
-            },
-            {
-              "column": 17,
-              "end_line": 86,
-              "increment": 1,
-              "kind": "logical-operator",
-              "line": 86,
-              "nesting_depth": 1
-            }
-          ],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "high",
-            "value": 72.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "LcovParser::validate",
-            "span": {
-              "end_column": 5,
-              "end_line": 95,
-              "start_column": 5,
-              "start_line": 71
             }
           }
         },
@@ -5931,42 +6011,42 @@ expression: pretty
           "contributors": [
             {
               "column": 56,
-              "end_line": 163,
+              "end_line": 171,
               "increment": 1,
               "kind": "try",
-              "line": 163,
+              "line": 171,
               "nesting_depth": 0
             },
             {
               "column": 52,
-              "end_line": 165,
+              "end_line": 173,
               "increment": 1,
               "kind": "try",
-              "line": 165,
+              "line": 173,
               "nesting_depth": 0
             },
             {
               "column": 58,
-              "end_line": 166,
+              "end_line": 174,
               "increment": 1,
               "kind": "try",
-              "line": 166,
+              "line": 174,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 169,
+              "end_line": 177,
               "increment": 1,
               "kind": "if-branch",
-              "line": 167,
+              "line": 175,
               "nesting_depth": 0
             },
             {
               "column": 53,
-              "end_line": 170,
+              "end_line": 178,
               "increment": 1,
               "kind": "try",
-              "line": 170,
+              "line": 178,
               "nesting_depth": 0
             }
           ],
@@ -5980,9 +6060,9 @@ expression: pretty
             "qualified_name": "parse_da",
             "span": {
               "end_column": 1,
-              "end_line": 172,
+              "end_line": 180,
               "start_column": 1,
-              "start_line": 160
+              "start_line": 168
             }
           }
         },
@@ -6160,26 +6240,26 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 102,
+              "end_line": 110,
               "increment": 1,
               "kind": "if-branch",
-              "line": 99,
+              "line": 107,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 107,
+              "end_line": 115,
               "increment": 1,
               "kind": "if-branch",
-              "line": 104,
+              "line": 112,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 111,
+              "end_line": 119,
               "increment": 1,
               "kind": "if-branch",
-              "line": 109,
+              "line": 117,
               "nesting_depth": 0
             }
           ],
@@ -6193,9 +6273,9 @@ expression: pretty
             "qualified_name": "handle_parse_line",
             "span": {
               "end_column": 1,
-              "end_line": 112,
+              "end_line": 120,
               "start_column": 1,
-              "start_line": 98
+              "start_line": 106
             }
           }
         },
@@ -6373,18 +6453,18 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 130,
+              "end_line": 138,
               "increment": 1,
               "kind": "if-branch",
-              "line": 128,
+              "line": 136,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 135,
+              "end_line": 143,
               "increment": 1,
               "kind": "match",
-              "line": 132,
+              "line": 140,
               "nesting_depth": 0
             }
           ],
@@ -6398,9 +6478,9 @@ expression: pretty
             "qualified_name": "record_da",
             "span": {
               "end_column": 1,
-              "end_line": 136,
+              "end_line": 144,
               "start_column": 1,
-              "start_line": 127
+              "start_line": 135
             }
           }
         },
@@ -6414,18 +6494,18 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 141,
+              "end_line": 149,
               "increment": 1,
               "kind": "if-branch",
-              "line": 139,
+              "line": 147,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 148,
+              "end_line": 156,
               "increment": 1,
               "kind": "match",
-              "line": 143,
+              "line": 151,
               "nesting_depth": 0
             }
           ],
@@ -6439,9 +6519,9 @@ expression: pretty
             "qualified_name": "record_brda",
             "span": {
               "end_column": 1,
-              "end_line": 149,
+              "end_line": 157,
               "start_column": 1,
-              "start_line": 138
+              "start_line": 146
             }
           }
         },
@@ -6455,18 +6535,18 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 217,
+              "end_line": 225,
               "increment": 1,
               "kind": "if-branch",
-              "line": 215,
+              "line": 223,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 222,
+              "end_line": 230,
               "increment": 1,
               "kind": "for-loop",
-              "line": 220,
+              "line": 228,
               "nesting_depth": 0
             }
           ],
@@ -6480,9 +6560,9 @@ expression: pretty
             "qualified_name": "merge_line_block",
             "span": {
               "end_column": 1,
-              "end_line": 223,
+              "end_line": 231,
               "start_column": 1,
-              "start_line": 210
+              "start_line": 218
             }
           }
         },
@@ -6496,18 +6576,18 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 232,
+              "end_line": 240,
               "increment": 1,
               "kind": "if-branch",
-              "line": 230,
+              "line": 238,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 237,
+              "end_line": 245,
               "increment": 1,
               "kind": "for-loop",
-              "line": 235,
+              "line": 243,
               "nesting_depth": 0
             }
           ],
@@ -6521,9 +6601,9 @@ expression: pretty
             "qualified_name": "merge_branch_block",
             "span": {
               "end_column": 1,
-              "end_line": 238,
+              "end_line": 246,
               "start_column": 1,
-              "start_line": 225
+              "start_line": 233
             }
           }
         },
@@ -6537,10 +6617,10 @@ expression: pretty
           "contributors": [
             {
               "column": 13,
-              "end_line": 737,
+              "end_line": 756,
               "increment": 2,
               "kind": "for-loop",
-              "line": 734,
+              "line": 753,
               "nesting_depth": 1
             }
           ],
@@ -6554,9 +6634,9 @@ expression: pretty
             "qualified_name": "arb_lcov_block",
             "span": {
               "end_column": 5,
-              "end_line": 741,
+              "end_line": 760,
               "start_column": 5,
-              "start_line": 731
+              "start_line": 750
             }
           }
         },
@@ -7263,10 +7343,10 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 124,
+              "end_line": 132,
               "increment": 1,
               "kind": "if-branch",
-              "line": 117,
+              "line": 125,
               "nesting_depth": 0
             }
           ],
@@ -7280,9 +7360,9 @@ expression: pretty
             "qualified_name": "start_source_file",
             "span": {
               "end_column": 1,
-              "end_line": 125,
+              "end_line": 133,
               "start_column": 1,
-              "start_line": 114
+              "start_line": 122
             }
           }
         },
@@ -7296,10 +7376,10 @@ expression: pretty
           "contributors": [
             {
               "column": 52,
-              "end_line": 203,
+              "end_line": 211,
               "increment": 1,
               "kind": "let-else",
-              "line": 200,
+              "line": 208,
               "nesting_depth": 0
             }
           ],
@@ -7313,9 +7393,9 @@ expression: pretty
             "qualified_name": "flush_block",
             "span": {
               "end_column": 1,
-              "end_line": 208,
+              "end_line": 216,
               "start_column": 1,
-              "start_line": 199
+              "start_line": 207
             }
           }
         },
@@ -7329,10 +7409,10 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 264,
+              "end_line": 272,
               "increment": 1,
               "kind": "match",
-              "line": 259,
+              "line": 267,
               "nesting_depth": 0
             }
           ],
@@ -7346,9 +7426,9 @@ expression: pretty
             "qualified_name": "merge_taken",
             "span": {
               "end_column": 1,
-              "end_line": 265,
+              "end_line": 273,
               "start_column": 1,
-              "start_line": 258
+              "start_line": 266
             }
           }
         },
@@ -7362,10 +7442,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 488,
+              "end_line": 507,
               "increment": 1,
               "kind": "match",
-              "line": 479,
+              "line": 498,
               "nesting_depth": 0
             }
           ],
@@ -7379,9 +7459,9 @@ expression: pretty
             "qualified_name": "malformed_da_produces_diagnostic",
             "span": {
               "end_column": 5,
-              "end_line": 489,
+              "end_line": 508,
               "start_column": 5,
-              "start_line": 474
+              "start_line": 493
             }
           }
         },
@@ -7395,10 +7475,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 532,
+              "end_line": 551,
               "increment": 1,
               "kind": "match",
-              "line": 523,
+              "line": 542,
               "nesting_depth": 0
             }
           ],
@@ -7412,9 +7492,9 @@ expression: pretty
             "qualified_name": "da_line_zero_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 533,
+              "end_line": 552,
               "start_column": 5,
-              "start_line": 519
+              "start_line": 538
             }
           }
         },
@@ -7428,10 +7508,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 651,
+              "end_line": 670,
               "increment": 1,
               "kind": "match",
-              "line": 642,
+              "line": 661,
               "nesting_depth": 0
             }
           ],
@@ -7445,9 +7525,9 @@ expression: pretty
             "qualified_name": "malformed_brda_produces_diagnostic",
             "span": {
               "end_column": 5,
-              "end_line": 652,
+              "end_line": 671,
               "start_column": 5,
-              "start_line": 638
+              "start_line": 657
             }
           }
         },
@@ -7461,10 +7541,10 @@ expression: pretty
           "contributors": [
             {
               "column": 13,
-              "end_line": 693,
+              "end_line": 712,
               "increment": 1,
               "kind": "for-loop",
-              "line": 691,
+              "line": 710,
               "nesting_depth": 0
             }
           ],
@@ -7478,9 +7558,9 @@ expression: pretty
             "qualified_name": "repeated_sf_blocks_merge_branch_coverage",
             "span": {
               "end_column": 5,
-              "end_line": 703,
+              "end_line": 722,
               "start_column": 5,
-              "start_line": 676
+              "start_line": 695
             }
           }
         },
@@ -9911,9 +9991,9 @@ expression: pretty
             "qualified_name": "push_malformed_record",
             "span": {
               "end_column": 1,
-              "end_line": 158,
+              "end_line": 166,
               "start_column": 1,
-              "start_line": 151
+              "start_line": 159
             }
           }
         },
@@ -9935,9 +10015,9 @@ expression: pretty
             "qualified_name": "merge_hits",
             "span": {
               "end_column": 1,
-              "end_line": 245,
+              "end_line": 253,
               "start_column": 1,
-              "start_line": 240
+              "start_line": 248
             }
           }
         },
@@ -9959,9 +10039,9 @@ expression: pretty
             "qualified_name": "merge_branch_value",
             "span": {
               "end_column": 1,
-              "end_line": 256,
+              "end_line": 264,
               "start_column": 1,
-              "start_line": 247
+              "start_line": 255
             }
           }
         },
@@ -9983,9 +10063,9 @@ expression: pretty
             "qualified_name": "clear_current_block",
             "span": {
               "end_column": 1,
-              "end_line": 270,
+              "end_line": 278,
               "start_column": 1,
-              "start_line": 267
+              "start_line": 275
             }
           }
         },
@@ -10007,9 +10087,9 @@ expression: pretty
             "qualified_name": "build_parse_output",
             "span": {
               "end_column": 1,
-              "end_line": 298,
+              "end_line": 306,
               "start_column": 1,
-              "start_line": 272
+              "start_line": 280
             }
           }
         },
@@ -10031,9 +10111,9 @@ expression: pretty
             "qualified_name": "to_line_coverage",
             "span": {
               "end_column": 1,
-              "end_line": 305,
+              "end_line": 313,
               "start_column": 1,
-              "start_line": 300
+              "start_line": 308
             }
           }
         },
@@ -10055,9 +10135,9 @@ expression: pretty
             "qualified_name": "parser",
             "span": {
               "end_column": 5,
-              "end_line": 314,
+              "end_line": 322,
               "start_column": 5,
-              "start_line": 312
+              "start_line": 320
             }
           }
         },
@@ -10079,9 +10159,9 @@ expression: pretty
             "qualified_name": "parse",
             "span": {
               "end_column": 5,
-              "end_line": 318,
+              "end_line": 326,
               "start_column": 5,
-              "start_line": 316
+              "start_line": 324
             }
           }
         },
@@ -10103,9 +10183,33 @@ expression: pretty
             "qualified_name": "empty_input_returns_empty_output",
             "span": {
               "end_column": 5,
-              "end_line": 325,
+              "end_line": 333,
               "start_column": 5,
-              "start_line": 320
+              "start_line": 328
+            }
+          }
+        },
+        "threshold": 25.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 0.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "validate_str",
+            "span": {
+              "end_column": 5,
+              "end_line": 347,
+              "start_column": 5,
+              "start_line": 337
             }
           }
         },
@@ -10127,9 +10231,9 @@ expression: pretty
             "qualified_name": "validate_empty_input_rejected",
             "span": {
               "end_column": 5,
-              "end_line": 332,
+              "end_line": 352,
               "start_column": 5,
-              "start_line": 329
+              "start_line": 349
             }
           }
         },
@@ -10151,9 +10255,9 @@ expression: pretty
             "qualified_name": "validate_no_da_lines_rejected",
             "span": {
               "end_column": 5,
-              "end_line": 341,
+              "end_line": 357,
               "start_column": 5,
-              "start_line": 334
+              "start_line": 354
             }
           }
         },
@@ -10175,9 +10279,9 @@ expression: pretty
             "qualified_name": "validate_da_outside_sf_block_rejected",
             "span": {
               "end_column": 5,
-              "end_line": 346,
+              "end_line": 362,
               "start_column": 5,
-              "start_line": 343
+              "start_line": 359
             }
           }
         },
@@ -10199,9 +10303,9 @@ expression: pretty
             "qualified_name": "validate_malformed_da_rejected",
             "span": {
               "end_column": 5,
-              "end_line": 355,
+              "end_line": 367,
               "start_column": 5,
-              "start_line": 348
+              "start_line": 364
             }
           }
         },
@@ -10223,9 +10327,9 @@ expression: pretty
             "qualified_name": "validate_single_da_inside_sf_block_passes",
             "span": {
               "end_column": 5,
-              "end_line": 364,
+              "end_line": 372,
               "start_column": 5,
-              "start_line": 357
+              "start_line": 369
             }
           }
         },
@@ -10247,9 +10351,33 @@ expression: pretty
             "qualified_name": "validate_first_da_in_second_block_passes",
             "span": {
               "end_column": 5,
-              "end_line": 375,
+              "end_line": 382,
               "start_column": 5,
-              "start_line": 366
+              "start_line": 374
+            }
+          }
+        },
+        "threshold": 25.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 0.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "validate_missing_path_returns_open_error",
+            "span": {
+              "end_column": 5,
+              "end_line": 394,
+              "start_column": 5,
+              "start_line": 384
             }
           }
         },
@@ -10271,9 +10399,9 @@ expression: pretty
             "qualified_name": "single_file_single_da",
             "span": {
               "end_column": 5,
-              "end_line": 385,
+              "end_line": 404,
               "start_column": 5,
-              "start_line": 377
+              "start_line": 396
             }
           }
         },
@@ -10295,9 +10423,9 @@ expression: pretty
             "qualified_name": "multiple_da_lines",
             "span": {
               "end_column": 5,
-              "end_line": 395,
+              "end_line": 414,
               "start_column": 5,
-              "start_line": 387
+              "start_line": 406
             }
           }
         },
@@ -10319,9 +10447,9 @@ expression: pretty
             "qualified_name": "multiple_source_files",
             "span": {
               "end_column": 5,
-              "end_line": 404,
+              "end_line": 423,
               "start_column": 5,
-              "start_line": 397
+              "start_line": 416
             }
           }
         },
@@ -10343,9 +10471,9 @@ expression: pretty
             "qualified_name": "hit_count_preservation",
             "span": {
               "end_column": 5,
-              "end_line": 412,
+              "end_line": 431,
               "start_column": 5,
-              "start_line": 406
+              "start_line": 425
             }
           }
         },
@@ -10365,78 +10493,6 @@ expression: pretty
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
             "qualified_name": "path_normalization_strips_prefix",
-            "span": {
-              "end_column": 5,
-              "end_line": 418,
-              "start_column": 5,
-              "start_line": 414
-            }
-          }
-        },
-        "threshold": 25.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "non_matching_path_passes_through",
-            "span": {
-              "end_column": 5,
-              "end_line": 424,
-              "start_column": 5,
-              "start_line": 420
-            }
-          }
-        },
-        "threshold": 25.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "backslash_normalized_to_forward_slash",
-            "span": {
-              "end_column": 5,
-              "end_line": 431,
-              "start_column": 5,
-              "start_line": 426
-            }
-          }
-        },
-        "threshold": 25.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "path_boundary_not_confused_by_prefix_substring",
             "span": {
               "end_column": 5,
               "end_line": 437,
@@ -10460,12 +10516,84 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "non_matching_path_passes_through",
+            "span": {
+              "end_column": 5,
+              "end_line": 443,
+              "start_column": 5,
+              "start_line": 439
+            }
+          }
+        },
+        "threshold": 25.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 0.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "backslash_normalized_to_forward_slash",
+            "span": {
+              "end_column": 5,
+              "end_line": 450,
+              "start_column": 5,
+              "start_line": 445
+            }
+          }
+        },
+        "threshold": 25.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 0.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "path_boundary_not_confused_by_prefix_substring",
+            "span": {
+              "end_column": 5,
+              "end_line": 456,
+              "start_column": 5,
+              "start_line": 452
+            }
+          }
+        },
+        "threshold": 25.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 0.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
             "qualified_name": "repeated_sf_blocks_merge_coverage",
             "span": {
               "end_column": 5,
-              "end_line": 451,
+              "end_line": 470,
               "start_column": 5,
-              "start_line": 439
+              "start_line": 458
             }
           }
         },
@@ -10487,9 +10615,9 @@ expression: pretty
             "qualified_name": "duplicate_da_lines_sum_hits",
             "span": {
               "end_column": 5,
-              "end_line": 460,
+              "end_line": 479,
               "start_column": 5,
-              "start_line": 453
+              "start_line": 472
             }
           }
         },
@@ -10511,9 +10639,9 @@ expression: pretty
             "qualified_name": "duplicate_da_multiple_lines_sum_correctly",
             "span": {
               "end_column": 5,
-              "end_line": 472,
+              "end_line": 491,
               "start_column": 5,
-              "start_line": 462
+              "start_line": 481
             }
           }
         },
@@ -10535,9 +10663,9 @@ expression: pretty
             "qualified_name": "malformed_da_does_not_stop_parsing",
             "span": {
               "end_column": 5,
-              "end_line": 497,
+              "end_line": 516,
               "start_column": 5,
-              "start_line": 491
+              "start_line": 510
             }
           }
         },
@@ -10559,9 +10687,9 @@ expression: pretty
             "qualified_name": "da_missing_hit_count_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 507,
+              "end_line": 526,
               "start_column": 5,
-              "start_line": 499
+              "start_line": 518
             }
           }
         },
@@ -10583,9 +10711,9 @@ expression: pretty
             "qualified_name": "da_negative_hit_count_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 517,
+              "end_line": 536,
               "start_column": 5,
-              "start_line": 509
+              "start_line": 528
             }
           }
         },
@@ -10607,9 +10735,9 @@ expression: pretty
             "qualified_name": "end_of_record_is_ignored",
             "span": {
               "end_column": 5,
-              "end_line": 544,
+              "end_line": 563,
               "start_column": 5,
-              "start_line": 535
+              "start_line": 554
             }
           }
         },
@@ -10631,9 +10759,9 @@ expression: pretty
             "qualified_name": "unterminated_final_block_emits_data",
             "span": {
               "end_column": 5,
-              "end_line": 551,
+              "end_line": 570,
               "start_column": 5,
-              "start_line": 546
+              "start_line": 565
             }
           }
         },
@@ -10655,9 +10783,9 @@ expression: pretty
             "qualified_name": "empty_sf_path_emits_diagnostic",
             "span": {
               "end_column": 5,
-              "end_line": 562,
+              "end_line": 581,
               "start_column": 5,
-              "start_line": 553
+              "start_line": 572
             }
           }
         },
@@ -10679,9 +10807,9 @@ expression: pretty
             "qualified_name": "da_with_checksum_field_is_accepted",
             "span": {
               "end_column": 5,
-              "end_line": 571,
+              "end_line": 590,
               "start_column": 5,
-              "start_line": 564
+              "start_line": 583
             }
           }
         },
@@ -10703,9 +10831,9 @@ expression: pretty
             "qualified_name": "non_coverage_records_are_ignored",
             "span": {
               "end_column": 5,
-              "end_line": 585,
+              "end_line": 604,
               "start_column": 5,
-              "start_line": 573
+              "start_line": 592
             }
           }
         },
@@ -10727,9 +10855,9 @@ expression: pretty
             "qualified_name": "brda_and_da_records_parsed",
             "span": {
               "end_column": 5,
-              "end_line": 597,
+              "end_line": 616,
               "start_column": 5,
-              "start_line": 589
+              "start_line": 608
             }
           }
         },
@@ -10751,9 +10879,9 @@ expression: pretty
             "qualified_name": "brda_dash_maps_to_none",
             "span": {
               "end_column": 5,
-              "end_line": 604,
+              "end_line": 623,
               "start_column": 5,
-              "start_line": 599
+              "start_line": 618
             }
           }
         },
@@ -10775,9 +10903,9 @@ expression: pretty
             "qualified_name": "brda_numeric_maps_to_some",
             "span": {
               "end_column": 5,
-              "end_line": 611,
+              "end_line": 630,
               "start_column": 5,
-              "start_line": 606
+              "start_line": 625
             }
           }
         },
@@ -10799,9 +10927,9 @@ expression: pretty
             "qualified_name": "brda_zero_maps_to_some_zero",
             "span": {
               "end_column": 5,
-              "end_line": 618,
+              "end_line": 637,
               "start_column": 5,
-              "start_line": 613
+              "start_line": 632
             }
           }
         },
@@ -10823,9 +10951,9 @@ expression: pretty
             "qualified_name": "duplicate_brda_sum_taken",
             "span": {
               "end_column": 5,
-              "end_line": 628,
+              "end_line": 647,
               "start_column": 5,
-              "start_line": 620
+              "start_line": 639
             }
           }
         },
@@ -10847,9 +10975,9 @@ expression: pretty
             "qualified_name": "brda_dash_and_numeric_merge",
             "span": {
               "end_column": 5,
-              "end_line": 636,
+              "end_line": 655,
               "start_column": 5,
-              "start_line": 630
+              "start_line": 649
             }
           }
         },
@@ -10871,9 +10999,9 @@ expression: pretty
             "qualified_name": "brda_missing_fields_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 663,
+              "end_line": 682,
               "start_column": 5,
-              "start_line": 654
+              "start_line": 673
             }
           }
         },
@@ -10895,9 +11023,9 @@ expression: pretty
             "qualified_name": "brda_missing_taken_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 674,
+              "end_line": 693,
               "start_column": 5,
-              "start_line": 665
+              "start_line": 684
             }
           }
         },
@@ -10919,9 +11047,9 @@ expression: pretty
             "qualified_name": "brda_line_zero_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 713,
+              "end_line": 732,
               "start_column": 5,
-              "start_line": 705
+              "start_line": 724
             }
           }
         },
@@ -10943,9 +11071,9 @@ expression: pretty
             "qualified_name": "no_brda_produces_none_branches",
             "span": {
               "end_column": 5,
-              "end_line": 719,
+              "end_line": 738,
               "start_column": 5,
-              "start_line": 715
+              "start_line": 734
             }
           }
         },
@@ -10967,9 +11095,9 @@ expression: pretty
             "qualified_name": "arb_da_line",
             "span": {
               "end_column": 5,
-              "end_line": 729,
+              "end_line": 748,
               "start_column": 5,
-              "start_line": 727
+              "start_line": 746
             }
           }
         },
@@ -10991,9 +11119,9 @@ expression: pretty
             "qualified_name": "arb_lcov_input",
             "span": {
               "end_column": 5,
-              "end_line": 745,
+              "end_line": 764,
               "start_column": 5,
-              "start_line": 743
+              "start_line": 762
             }
           }
         },
@@ -11145,13 +11273,13 @@ expression: pretty
       }
     ],
     "shown_summary": {
-      "average_complexity": 1.515,
+      "average_complexity": 1.5198019801980198,
       "average_coverage": 0.0,
-      "average_crap": 5.57,
+      "average_crap": 5.7227722772277225,
       "distribution": {
         "acceptable": 29,
         "high": 6,
-        "low": 151,
+        "low": 153,
         "moderate": 14
       },
       "exceeding_threshold": 6,
@@ -11165,15 +11293,15 @@ expression: pretty
       "median_crap": 2.0,
       "min_coverage": 0.0,
       "total_files": 5,
-      "total_functions": 200,
+      "total_functions": 202,
       "worst_function": {
         "file_path": "adapters/coverage/mod.rs",
         "qualified_name": "parse_brda",
         "span": {
           "end_column": 1,
-          "end_line": 197,
+          "end_line": 205,
           "start_column": 1,
-          "start_line": 174
+          "start_line": 182
         }
       }
     },

--- a/crates/crap-core/tests/snapshots/wire_envelope_snapshot__envelope.snap
+++ b/crates/crap-core/tests/snapshots/wire_envelope_snapshot__envelope.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/crap-core/tests/wire_envelope_snapshot.rs
+assertion_line: 94
 expression: pretty
 ---
 {
@@ -3561,6 +3562,71 @@ expression: pretty
         "threshold": 25.0
       },
       {
+        "exceeds": true,
+        "scored": {
+          "complexity": 8,
+          "complexity_metric": "cognitive",
+          "contributors": [
+            {
+              "column": 9,
+              "end_line": 93,
+              "increment": 1,
+              "kind": "for-loop",
+              "line": 80,
+              "nesting_depth": 0
+            },
+            {
+              "column": 13,
+              "end_line": 84,
+              "increment": 2,
+              "kind": "if-branch",
+              "line": 81,
+              "nesting_depth": 1
+            },
+            {
+              "column": 17,
+              "end_line": 83,
+              "increment": 1,
+              "kind": "continue",
+              "line": 83,
+              "nesting_depth": 2
+            },
+            {
+              "column": 13,
+              "end_line": 92,
+              "increment": 2,
+              "kind": "if-branch",
+              "line": 85,
+              "nesting_depth": 1
+            },
+            {
+              "column": 17,
+              "end_line": 86,
+              "increment": 1,
+              "kind": "logical-operator",
+              "line": 86,
+              "nesting_depth": 1
+            }
+          ],
+          "coverage_percent": 0.0,
+          "crap": {
+            "risk_level": "high",
+            "value": 72.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "LcovParser::validate",
+            "span": {
+              "end_column": 5,
+              "end_line": 95,
+              "start_column": 5,
+              "start_line": 71
+            }
+          }
+        },
+        "threshold": 25.0
+      },
+      {
         "exceeds": false,
         "scored": {
           "complexity": 4,
@@ -3568,26 +3634,26 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 76,
+              "end_line": 102,
               "increment": 1,
               "kind": "if-branch",
-              "line": 73,
+              "line": 99,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 81,
+              "end_line": 107,
               "increment": 1,
               "kind": "if-branch",
-              "line": 78,
+              "line": 104,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 85,
+              "end_line": 111,
               "increment": 1,
               "kind": "if-branch",
-              "line": 83,
+              "line": 109,
               "nesting_depth": 0
             }
           ],
@@ -3601,9 +3667,9 @@ expression: pretty
             "qualified_name": "handle_parse_line",
             "span": {
               "end_column": 1,
-              "end_line": 86,
+              "end_line": 112,
               "start_column": 1,
-              "start_line": 72
+              "start_line": 98
             }
           }
         },
@@ -3617,10 +3683,10 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 98,
+              "end_line": 124,
               "increment": 1,
               "kind": "if-branch",
-              "line": 91,
+              "line": 117,
               "nesting_depth": 0
             }
           ],
@@ -3634,9 +3700,9 @@ expression: pretty
             "qualified_name": "start_source_file",
             "span": {
               "end_column": 1,
-              "end_line": 99,
+              "end_line": 125,
               "start_column": 1,
-              "start_line": 88
+              "start_line": 114
             }
           }
         },
@@ -3650,18 +3716,18 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 104,
+              "end_line": 130,
               "increment": 1,
               "kind": "if-branch",
-              "line": 102,
+              "line": 128,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 109,
+              "end_line": 135,
               "increment": 1,
               "kind": "match",
-              "line": 106,
+              "line": 132,
               "nesting_depth": 0
             }
           ],
@@ -3675,9 +3741,9 @@ expression: pretty
             "qualified_name": "record_da",
             "span": {
               "end_column": 1,
-              "end_line": 110,
+              "end_line": 136,
               "start_column": 1,
-              "start_line": 101
+              "start_line": 127
             }
           }
         },
@@ -3691,18 +3757,18 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 115,
+              "end_line": 141,
               "increment": 1,
               "kind": "if-branch",
-              "line": 113,
+              "line": 139,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 122,
+              "end_line": 148,
               "increment": 1,
               "kind": "match",
-              "line": 117,
+              "line": 143,
               "nesting_depth": 0
             }
           ],
@@ -3716,9 +3782,9 @@ expression: pretty
             "qualified_name": "record_brda",
             "span": {
               "end_column": 1,
-              "end_line": 123,
+              "end_line": 149,
               "start_column": 1,
-              "start_line": 112
+              "start_line": 138
             }
           }
         },
@@ -3740,9 +3806,9 @@ expression: pretty
             "qualified_name": "push_malformed_record",
             "span": {
               "end_column": 1,
-              "end_line": 132,
+              "end_line": 158,
               "start_column": 1,
-              "start_line": 125
+              "start_line": 151
             }
           }
         },
@@ -3756,42 +3822,42 @@ expression: pretty
           "contributors": [
             {
               "column": 56,
-              "end_line": 137,
+              "end_line": 163,
               "increment": 1,
               "kind": "try",
-              "line": 137,
+              "line": 163,
               "nesting_depth": 0
             },
             {
               "column": 52,
-              "end_line": 139,
+              "end_line": 165,
               "increment": 1,
               "kind": "try",
-              "line": 139,
+              "line": 165,
               "nesting_depth": 0
             },
             {
               "column": 58,
-              "end_line": 140,
+              "end_line": 166,
               "increment": 1,
               "kind": "try",
-              "line": 140,
+              "line": 166,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 143,
+              "end_line": 169,
               "increment": 1,
               "kind": "if-branch",
-              "line": 141,
+              "line": 167,
               "nesting_depth": 0
             },
             {
               "column": 53,
-              "end_line": 144,
+              "end_line": 170,
               "increment": 1,
               "kind": "try",
-              "line": 144,
+              "line": 170,
               "nesting_depth": 0
             }
           ],
@@ -3805,9 +3871,9 @@ expression: pretty
             "qualified_name": "parse_da",
             "span": {
               "end_column": 1,
-              "end_line": 146,
+              "end_line": 172,
               "start_column": 1,
-              "start_line": 134
+              "start_line": 160
             }
           }
         },
@@ -3821,82 +3887,82 @@ expression: pretty
           "contributors": [
             {
               "column": 42,
-              "end_line": 153,
+              "end_line": 179,
               "increment": 1,
               "kind": "try",
-              "line": 153,
+              "line": 179,
               "nesting_depth": 0
             },
             {
               "column": 43,
-              "end_line": 154,
+              "end_line": 180,
               "increment": 1,
               "kind": "try",
-              "line": 154,
+              "line": 180,
               "nesting_depth": 0
             },
             {
               "column": 44,
-              "end_line": 155,
+              "end_line": 181,
               "increment": 1,
               "kind": "try",
-              "line": 155,
+              "line": 181,
               "nesting_depth": 0
             },
             {
               "column": 43,
-              "end_line": 156,
+              "end_line": 182,
               "increment": 1,
               "kind": "try",
-              "line": 156,
+              "line": 182,
               "nesting_depth": 0
             },
             {
               "column": 58,
-              "end_line": 158,
+              "end_line": 184,
               "increment": 1,
               "kind": "try",
-              "line": 158,
+              "line": 184,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 161,
+              "end_line": 187,
               "increment": 1,
               "kind": "if-branch",
-              "line": 159,
+              "line": 185,
               "nesting_depth": 0
             },
             {
               "column": 55,
-              "end_line": 162,
+              "end_line": 188,
               "increment": 1,
               "kind": "try",
-              "line": 162,
+              "line": 188,
               "nesting_depth": 0
             },
             {
               "column": 57,
-              "end_line": 163,
+              "end_line": 189,
               "increment": 1,
               "kind": "try",
-              "line": 163,
+              "line": 189,
               "nesting_depth": 0
             },
             {
               "column": 17,
-              "end_line": 168,
+              "end_line": 194,
               "increment": 1,
               "kind": "if-branch",
-              "line": 164,
+              "line": 190,
               "nesting_depth": 0
             },
             {
               "column": 54,
-              "end_line": 167,
+              "end_line": 193,
               "increment": 1,
               "kind": "try",
-              "line": 167,
+              "line": 193,
               "nesting_depth": 1
             }
           ],
@@ -3910,9 +3976,9 @@ expression: pretty
             "qualified_name": "parse_brda",
             "span": {
               "end_column": 1,
-              "end_line": 171,
+              "end_line": 197,
               "start_column": 1,
-              "start_line": 148
+              "start_line": 174
             }
           }
         },
@@ -3926,10 +3992,10 @@ expression: pretty
           "contributors": [
             {
               "column": 52,
-              "end_line": 177,
+              "end_line": 203,
               "increment": 1,
               "kind": "let-else",
-              "line": 174,
+              "line": 200,
               "nesting_depth": 0
             }
           ],
@@ -3943,9 +4009,9 @@ expression: pretty
             "qualified_name": "flush_block",
             "span": {
               "end_column": 1,
-              "end_line": 182,
+              "end_line": 208,
               "start_column": 1,
-              "start_line": 173
+              "start_line": 199
             }
           }
         },
@@ -3959,18 +4025,18 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 191,
+              "end_line": 217,
               "increment": 1,
               "kind": "if-branch",
-              "line": 189,
+              "line": 215,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 196,
+              "end_line": 222,
               "increment": 1,
               "kind": "for-loop",
-              "line": 194,
+              "line": 220,
               "nesting_depth": 0
             }
           ],
@@ -3984,9 +4050,9 @@ expression: pretty
             "qualified_name": "merge_line_block",
             "span": {
               "end_column": 1,
-              "end_line": 197,
+              "end_line": 223,
               "start_column": 1,
-              "start_line": 184
+              "start_line": 210
             }
           }
         },
@@ -4000,18 +4066,18 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 206,
+              "end_line": 232,
               "increment": 1,
               "kind": "if-branch",
-              "line": 204,
+              "line": 230,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 211,
+              "end_line": 237,
               "increment": 1,
               "kind": "for-loop",
-              "line": 209,
+              "line": 235,
               "nesting_depth": 0
             }
           ],
@@ -4025,9 +4091,9 @@ expression: pretty
             "qualified_name": "merge_branch_block",
             "span": {
               "end_column": 1,
-              "end_line": 212,
+              "end_line": 238,
               "start_column": 1,
-              "start_line": 199
+              "start_line": 225
             }
           }
         },
@@ -4049,9 +4115,9 @@ expression: pretty
             "qualified_name": "merge_hits",
             "span": {
               "end_column": 1,
-              "end_line": 219,
+              "end_line": 245,
               "start_column": 1,
-              "start_line": 214
+              "start_line": 240
             }
           }
         },
@@ -4073,9 +4139,9 @@ expression: pretty
             "qualified_name": "merge_branch_value",
             "span": {
               "end_column": 1,
-              "end_line": 230,
+              "end_line": 256,
               "start_column": 1,
-              "start_line": 221
+              "start_line": 247
             }
           }
         },
@@ -4089,10 +4155,10 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 238,
+              "end_line": 264,
               "increment": 1,
               "kind": "match",
-              "line": 233,
+              "line": 259,
               "nesting_depth": 0
             }
           ],
@@ -4106,9 +4172,9 @@ expression: pretty
             "qualified_name": "merge_taken",
             "span": {
               "end_column": 1,
-              "end_line": 239,
+              "end_line": 265,
               "start_column": 1,
-              "start_line": 232
+              "start_line": 258
             }
           }
         },
@@ -4130,9 +4196,9 @@ expression: pretty
             "qualified_name": "clear_current_block",
             "span": {
               "end_column": 1,
-              "end_line": 244,
+              "end_line": 270,
               "start_column": 1,
-              "start_line": 241
+              "start_line": 267
             }
           }
         },
@@ -4154,9 +4220,9 @@ expression: pretty
             "qualified_name": "build_parse_output",
             "span": {
               "end_column": 1,
-              "end_line": 272,
+              "end_line": 298,
               "start_column": 1,
-              "start_line": 246
+              "start_line": 272
             }
           }
         },
@@ -4178,9 +4244,9 @@ expression: pretty
             "qualified_name": "to_line_coverage",
             "span": {
               "end_column": 1,
-              "end_line": 279,
+              "end_line": 305,
               "start_column": 1,
-              "start_line": 274
+              "start_line": 300
             }
           }
         },
@@ -4202,9 +4268,9 @@ expression: pretty
             "qualified_name": "parser",
             "span": {
               "end_column": 5,
-              "end_line": 288,
+              "end_line": 314,
               "start_column": 5,
-              "start_line": 286
+              "start_line": 312
             }
           }
         },
@@ -4226,9 +4292,9 @@ expression: pretty
             "qualified_name": "parse",
             "span": {
               "end_column": 5,
-              "end_line": 292,
+              "end_line": 318,
               "start_column": 5,
-              "start_line": 290
+              "start_line": 316
             }
           }
         },
@@ -4250,9 +4316,153 @@ expression: pretty
             "qualified_name": "empty_input_returns_empty_output",
             "span": {
               "end_column": 5,
-              "end_line": 299,
+              "end_line": 325,
               "start_column": 5,
-              "start_line": 294
+              "start_line": 320
+            }
+          }
+        },
+        "threshold": 25.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 0.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "validate_empty_input_rejected",
+            "span": {
+              "end_column": 5,
+              "end_line": 332,
+              "start_column": 5,
+              "start_line": 329
+            }
+          }
+        },
+        "threshold": 25.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 0.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "validate_no_da_lines_rejected",
+            "span": {
+              "end_column": 5,
+              "end_line": 341,
+              "start_column": 5,
+              "start_line": 334
+            }
+          }
+        },
+        "threshold": 25.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 0.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "validate_da_outside_sf_block_rejected",
+            "span": {
+              "end_column": 5,
+              "end_line": 346,
+              "start_column": 5,
+              "start_line": 343
+            }
+          }
+        },
+        "threshold": 25.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 0.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "validate_malformed_da_rejected",
+            "span": {
+              "end_column": 5,
+              "end_line": 355,
+              "start_column": 5,
+              "start_line": 348
+            }
+          }
+        },
+        "threshold": 25.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 0.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "validate_single_da_inside_sf_block_passes",
+            "span": {
+              "end_column": 5,
+              "end_line": 364,
+              "start_column": 5,
+              "start_line": 357
+            }
+          }
+        },
+        "threshold": 25.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 0.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "validate_first_da_in_second_block_passes",
+            "span": {
+              "end_column": 5,
+              "end_line": 377,
+              "start_column": 5,
+              "start_line": 366
             }
           }
         },
@@ -4274,9 +4484,9 @@ expression: pretty
             "qualified_name": "single_file_single_da",
             "span": {
               "end_column": 5,
-              "end_line": 309,
+              "end_line": 387,
               "start_column": 5,
-              "start_line": 301
+              "start_line": 379
             }
           }
         },
@@ -4298,9 +4508,9 @@ expression: pretty
             "qualified_name": "multiple_da_lines",
             "span": {
               "end_column": 5,
-              "end_line": 319,
+              "end_line": 397,
               "start_column": 5,
-              "start_line": 311
+              "start_line": 389
             }
           }
         },
@@ -4322,9 +4532,9 @@ expression: pretty
             "qualified_name": "multiple_source_files",
             "span": {
               "end_column": 5,
-              "end_line": 328,
+              "end_line": 406,
               "start_column": 5,
-              "start_line": 321
+              "start_line": 399
             }
           }
         },
@@ -4346,9 +4556,9 @@ expression: pretty
             "qualified_name": "hit_count_preservation",
             "span": {
               "end_column": 5,
-              "end_line": 336,
+              "end_line": 414,
               "start_column": 5,
-              "start_line": 330
+              "start_line": 408
             }
           }
         },
@@ -4370,9 +4580,9 @@ expression: pretty
             "qualified_name": "path_normalization_strips_prefix",
             "span": {
               "end_column": 5,
-              "end_line": 342,
+              "end_line": 420,
               "start_column": 5,
-              "start_line": 338
+              "start_line": 416
             }
           }
         },
@@ -4394,9 +4604,9 @@ expression: pretty
             "qualified_name": "non_matching_path_passes_through",
             "span": {
               "end_column": 5,
-              "end_line": 348,
+              "end_line": 426,
               "start_column": 5,
-              "start_line": 344
+              "start_line": 422
             }
           }
         },
@@ -4418,9 +4628,9 @@ expression: pretty
             "qualified_name": "backslash_normalized_to_forward_slash",
             "span": {
               "end_column": 5,
-              "end_line": 355,
+              "end_line": 433,
               "start_column": 5,
-              "start_line": 350
+              "start_line": 428
             }
           }
         },
@@ -4442,9 +4652,9 @@ expression: pretty
             "qualified_name": "path_boundary_not_confused_by_prefix_substring",
             "span": {
               "end_column": 5,
-              "end_line": 361,
+              "end_line": 439,
               "start_column": 5,
-              "start_line": 357
+              "start_line": 435
             }
           }
         },
@@ -4466,9 +4676,9 @@ expression: pretty
             "qualified_name": "repeated_sf_blocks_merge_coverage",
             "span": {
               "end_column": 5,
-              "end_line": 375,
+              "end_line": 453,
               "start_column": 5,
-              "start_line": 363
+              "start_line": 441
             }
           }
         },
@@ -4490,9 +4700,9 @@ expression: pretty
             "qualified_name": "duplicate_da_lines_sum_hits",
             "span": {
               "end_column": 5,
-              "end_line": 384,
+              "end_line": 462,
               "start_column": 5,
-              "start_line": 377
+              "start_line": 455
             }
           }
         },
@@ -4514,9 +4724,9 @@ expression: pretty
             "qualified_name": "duplicate_da_multiple_lines_sum_correctly",
             "span": {
               "end_column": 5,
-              "end_line": 396,
+              "end_line": 474,
               "start_column": 5,
-              "start_line": 386
+              "start_line": 464
             }
           }
         },
@@ -4530,10 +4740,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 412,
+              "end_line": 490,
               "increment": 1,
               "kind": "match",
-              "line": 403,
+              "line": 481,
               "nesting_depth": 0
             }
           ],
@@ -4547,9 +4757,9 @@ expression: pretty
             "qualified_name": "malformed_da_produces_diagnostic",
             "span": {
               "end_column": 5,
-              "end_line": 413,
+              "end_line": 491,
               "start_column": 5,
-              "start_line": 398
+              "start_line": 476
             }
           }
         },
@@ -4571,9 +4781,9 @@ expression: pretty
             "qualified_name": "malformed_da_does_not_stop_parsing",
             "span": {
               "end_column": 5,
-              "end_line": 421,
+              "end_line": 499,
               "start_column": 5,
-              "start_line": 415
+              "start_line": 493
             }
           }
         },
@@ -4595,9 +4805,9 @@ expression: pretty
             "qualified_name": "da_missing_hit_count_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 431,
+              "end_line": 509,
               "start_column": 5,
-              "start_line": 423
+              "start_line": 501
             }
           }
         },
@@ -4619,9 +4829,9 @@ expression: pretty
             "qualified_name": "da_negative_hit_count_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 441,
+              "end_line": 519,
               "start_column": 5,
-              "start_line": 433
+              "start_line": 511
             }
           }
         },
@@ -4635,10 +4845,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 456,
+              "end_line": 534,
               "increment": 1,
               "kind": "match",
-              "line": 447,
+              "line": 525,
               "nesting_depth": 0
             }
           ],
@@ -4652,9 +4862,9 @@ expression: pretty
             "qualified_name": "da_line_zero_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 457,
+              "end_line": 535,
               "start_column": 5,
-              "start_line": 443
+              "start_line": 521
             }
           }
         },
@@ -4676,9 +4886,9 @@ expression: pretty
             "qualified_name": "end_of_record_is_ignored",
             "span": {
               "end_column": 5,
-              "end_line": 468,
+              "end_line": 546,
               "start_column": 5,
-              "start_line": 459
+              "start_line": 537
             }
           }
         },
@@ -4700,9 +4910,9 @@ expression: pretty
             "qualified_name": "unterminated_final_block_emits_data",
             "span": {
               "end_column": 5,
-              "end_line": 475,
+              "end_line": 553,
               "start_column": 5,
-              "start_line": 470
+              "start_line": 548
             }
           }
         },
@@ -4724,9 +4934,9 @@ expression: pretty
             "qualified_name": "empty_sf_path_emits_diagnostic",
             "span": {
               "end_column": 5,
-              "end_line": 486,
+              "end_line": 564,
               "start_column": 5,
-              "start_line": 477
+              "start_line": 555
             }
           }
         },
@@ -4748,9 +4958,9 @@ expression: pretty
             "qualified_name": "da_with_checksum_field_is_accepted",
             "span": {
               "end_column": 5,
-              "end_line": 495,
+              "end_line": 573,
               "start_column": 5,
-              "start_line": 488
+              "start_line": 566
             }
           }
         },
@@ -4772,9 +4982,9 @@ expression: pretty
             "qualified_name": "non_coverage_records_are_ignored",
             "span": {
               "end_column": 5,
-              "end_line": 509,
+              "end_line": 587,
               "start_column": 5,
-              "start_line": 497
+              "start_line": 575
             }
           }
         },
@@ -4796,9 +5006,9 @@ expression: pretty
             "qualified_name": "brda_and_da_records_parsed",
             "span": {
               "end_column": 5,
-              "end_line": 521,
+              "end_line": 599,
               "start_column": 5,
-              "start_line": 513
+              "start_line": 591
             }
           }
         },
@@ -4820,9 +5030,9 @@ expression: pretty
             "qualified_name": "brda_dash_maps_to_none",
             "span": {
               "end_column": 5,
-              "end_line": 528,
+              "end_line": 606,
               "start_column": 5,
-              "start_line": 523
+              "start_line": 601
             }
           }
         },
@@ -4844,9 +5054,9 @@ expression: pretty
             "qualified_name": "brda_numeric_maps_to_some",
             "span": {
               "end_column": 5,
-              "end_line": 535,
+              "end_line": 613,
               "start_column": 5,
-              "start_line": 530
+              "start_line": 608
             }
           }
         },
@@ -4868,9 +5078,9 @@ expression: pretty
             "qualified_name": "brda_zero_maps_to_some_zero",
             "span": {
               "end_column": 5,
-              "end_line": 542,
+              "end_line": 620,
               "start_column": 5,
-              "start_line": 537
+              "start_line": 615
             }
           }
         },
@@ -4892,9 +5102,9 @@ expression: pretty
             "qualified_name": "duplicate_brda_sum_taken",
             "span": {
               "end_column": 5,
-              "end_line": 552,
+              "end_line": 630,
               "start_column": 5,
-              "start_line": 544
+              "start_line": 622
             }
           }
         },
@@ -4916,9 +5126,9 @@ expression: pretty
             "qualified_name": "brda_dash_and_numeric_merge",
             "span": {
               "end_column": 5,
-              "end_line": 560,
+              "end_line": 638,
               "start_column": 5,
-              "start_line": 554
+              "start_line": 632
             }
           }
         },
@@ -4932,10 +5142,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 575,
+              "end_line": 653,
               "increment": 1,
               "kind": "match",
-              "line": 566,
+              "line": 644,
               "nesting_depth": 0
             }
           ],
@@ -4949,9 +5159,9 @@ expression: pretty
             "qualified_name": "malformed_brda_produces_diagnostic",
             "span": {
               "end_column": 5,
-              "end_line": 576,
+              "end_line": 654,
               "start_column": 5,
-              "start_line": 562
+              "start_line": 640
             }
           }
         },
@@ -4973,9 +5183,9 @@ expression: pretty
             "qualified_name": "brda_missing_fields_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 587,
+              "end_line": 665,
               "start_column": 5,
-              "start_line": 578
+              "start_line": 656
             }
           }
         },
@@ -4997,9 +5207,9 @@ expression: pretty
             "qualified_name": "brda_missing_taken_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 598,
+              "end_line": 676,
               "start_column": 5,
-              "start_line": 589
+              "start_line": 667
             }
           }
         },
@@ -5013,10 +5223,10 @@ expression: pretty
           "contributors": [
             {
               "column": 13,
-              "end_line": 617,
+              "end_line": 695,
               "increment": 1,
               "kind": "for-loop",
-              "line": 615,
+              "line": 693,
               "nesting_depth": 0
             }
           ],
@@ -5030,9 +5240,9 @@ expression: pretty
             "qualified_name": "repeated_sf_blocks_merge_branch_coverage",
             "span": {
               "end_column": 5,
-              "end_line": 627,
+              "end_line": 705,
               "start_column": 5,
-              "start_line": 600
+              "start_line": 678
             }
           }
         },
@@ -5054,9 +5264,9 @@ expression: pretty
             "qualified_name": "brda_line_zero_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 637,
+              "end_line": 715,
               "start_column": 5,
-              "start_line": 629
+              "start_line": 707
             }
           }
         },
@@ -5078,9 +5288,9 @@ expression: pretty
             "qualified_name": "no_brda_produces_none_branches",
             "span": {
               "end_column": 5,
-              "end_line": 643,
+              "end_line": 721,
               "start_column": 5,
-              "start_line": 639
+              "start_line": 717
             }
           }
         },
@@ -5102,9 +5312,9 @@ expression: pretty
             "qualified_name": "arb_da_line",
             "span": {
               "end_column": 5,
-              "end_line": 653,
+              "end_line": 731,
               "start_column": 5,
-              "start_line": 651
+              "start_line": 729
             }
           }
         },
@@ -5118,10 +5328,10 @@ expression: pretty
           "contributors": [
             {
               "column": 13,
-              "end_line": 661,
+              "end_line": 739,
               "increment": 2,
               "kind": "for-loop",
-              "line": 658,
+              "line": 736,
               "nesting_depth": 1
             }
           ],
@@ -5135,9 +5345,9 @@ expression: pretty
             "qualified_name": "arb_lcov_block",
             "span": {
               "end_column": 5,
-              "end_line": 665,
+              "end_line": 743,
               "start_column": 5,
-              "start_line": 655
+              "start_line": 733
             }
           }
         },
@@ -5159,9 +5369,9 @@ expression: pretty
             "qualified_name": "arb_lcov_input",
             "span": {
               "end_column": 5,
-              "end_line": 669,
+              "end_line": 747,
               "start_column": 5,
-              "start_line": 667
+              "start_line": 745
             }
           }
         },
@@ -5347,16 +5557,16 @@ expression: pretty
     ],
     "passed": false,
     "summary": {
-      "average_complexity": 1.4974093264248705,
+      "average_complexity": 1.515,
       "average_coverage": 0.0,
-      "average_crap": 5.33678756476684,
+      "average_crap": 5.57,
       "distribution": {
         "acceptable": 29,
-        "high": 5,
-        "low": 145,
+        "high": 6,
+        "low": 151,
         "moderate": 14
       },
-      "exceeding_threshold": 5,
+      "exceeding_threshold": 6,
       "max_complexity": 11,
       "max_crap": {
         "risk_level": "high",
@@ -5367,15 +5577,15 @@ expression: pretty
       "median_crap": 2.0,
       "min_coverage": 0.0,
       "total_files": 5,
-      "total_functions": 193,
+      "total_functions": 200,
       "worst_function": {
         "file_path": "adapters/coverage/mod.rs",
         "qualified_name": "parse_brda",
         "span": {
           "end_column": 1,
-          "end_line": 171,
+          "end_line": 197,
           "start_column": 1,
-          "start_line": 148
+          "start_line": 174
         }
       }
     }
@@ -5385,7 +5595,7 @@ expression: pretty
   "timestamp": "[STRIPPED:timestamp]",
   "tool_version": "[STRIPPED:tool_version]",
   "view": {
-    "eligible_count": 193,
+    "eligible_count": 200,
     "grouped": null,
     "shown": [
       {
@@ -5396,82 +5606,82 @@ expression: pretty
           "contributors": [
             {
               "column": 42,
-              "end_line": 153,
+              "end_line": 179,
               "increment": 1,
               "kind": "try",
-              "line": 153,
+              "line": 179,
               "nesting_depth": 0
             },
             {
               "column": 43,
-              "end_line": 154,
+              "end_line": 180,
               "increment": 1,
               "kind": "try",
-              "line": 154,
+              "line": 180,
               "nesting_depth": 0
             },
             {
               "column": 44,
-              "end_line": 155,
+              "end_line": 181,
               "increment": 1,
               "kind": "try",
-              "line": 155,
+              "line": 181,
               "nesting_depth": 0
             },
             {
               "column": 43,
-              "end_line": 156,
+              "end_line": 182,
               "increment": 1,
               "kind": "try",
-              "line": 156,
+              "line": 182,
               "nesting_depth": 0
             },
             {
               "column": 58,
-              "end_line": 158,
+              "end_line": 184,
               "increment": 1,
               "kind": "try",
-              "line": 158,
+              "line": 184,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 161,
+              "end_line": 187,
               "increment": 1,
               "kind": "if-branch",
-              "line": 159,
+              "line": 185,
               "nesting_depth": 0
             },
             {
               "column": 55,
-              "end_line": 162,
+              "end_line": 188,
               "increment": 1,
               "kind": "try",
-              "line": 162,
+              "line": 188,
               "nesting_depth": 0
             },
             {
               "column": 57,
-              "end_line": 163,
+              "end_line": 189,
               "increment": 1,
               "kind": "try",
-              "line": 163,
+              "line": 189,
               "nesting_depth": 0
             },
             {
               "column": 17,
-              "end_line": 168,
+              "end_line": 194,
               "increment": 1,
               "kind": "if-branch",
-              "line": 164,
+              "line": 190,
               "nesting_depth": 0
             },
             {
               "column": 54,
-              "end_line": 167,
+              "end_line": 193,
               "increment": 1,
               "kind": "try",
-              "line": 167,
+              "line": 193,
               "nesting_depth": 1
             }
           ],
@@ -5485,9 +5695,9 @@ expression: pretty
             "qualified_name": "parse_brda",
             "span": {
               "end_column": 1,
-              "end_line": 171,
+              "end_line": 197,
               "start_column": 1,
-              "start_line": 148
+              "start_line": 174
             }
           }
         },
@@ -5545,6 +5755,71 @@ expression: pretty
               "end_line": 629,
               "start_column": 1,
               "start_line": 591
+            }
+          }
+        },
+        "threshold": 25.0
+      },
+      {
+        "exceeds": true,
+        "scored": {
+          "complexity": 8,
+          "complexity_metric": "cognitive",
+          "contributors": [
+            {
+              "column": 9,
+              "end_line": 93,
+              "increment": 1,
+              "kind": "for-loop",
+              "line": 80,
+              "nesting_depth": 0
+            },
+            {
+              "column": 13,
+              "end_line": 84,
+              "increment": 2,
+              "kind": "if-branch",
+              "line": 81,
+              "nesting_depth": 1
+            },
+            {
+              "column": 17,
+              "end_line": 83,
+              "increment": 1,
+              "kind": "continue",
+              "line": 83,
+              "nesting_depth": 2
+            },
+            {
+              "column": 13,
+              "end_line": 92,
+              "increment": 2,
+              "kind": "if-branch",
+              "line": 85,
+              "nesting_depth": 1
+            },
+            {
+              "column": 17,
+              "end_line": 86,
+              "increment": 1,
+              "kind": "logical-operator",
+              "line": 86,
+              "nesting_depth": 1
+            }
+          ],
+          "coverage_percent": 0.0,
+          "crap": {
+            "risk_level": "high",
+            "value": 72.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "LcovParser::validate",
+            "span": {
+              "end_column": 5,
+              "end_line": 95,
+              "start_column": 5,
+              "start_line": 71
             }
           }
         },
@@ -5656,42 +5931,42 @@ expression: pretty
           "contributors": [
             {
               "column": 56,
-              "end_line": 137,
+              "end_line": 163,
               "increment": 1,
               "kind": "try",
-              "line": 137,
+              "line": 163,
               "nesting_depth": 0
             },
             {
               "column": 52,
-              "end_line": 139,
+              "end_line": 165,
               "increment": 1,
               "kind": "try",
-              "line": 139,
+              "line": 165,
               "nesting_depth": 0
             },
             {
               "column": 58,
-              "end_line": 140,
+              "end_line": 166,
               "increment": 1,
               "kind": "try",
-              "line": 140,
+              "line": 166,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 143,
+              "end_line": 169,
               "increment": 1,
               "kind": "if-branch",
-              "line": 141,
+              "line": 167,
               "nesting_depth": 0
             },
             {
               "column": 53,
-              "end_line": 144,
+              "end_line": 170,
               "increment": 1,
               "kind": "try",
-              "line": 144,
+              "line": 170,
               "nesting_depth": 0
             }
           ],
@@ -5705,9 +5980,9 @@ expression: pretty
             "qualified_name": "parse_da",
             "span": {
               "end_column": 1,
-              "end_line": 146,
+              "end_line": 172,
               "start_column": 1,
-              "start_line": 134
+              "start_line": 160
             }
           }
         },
@@ -5885,26 +6160,26 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 76,
+              "end_line": 102,
               "increment": 1,
               "kind": "if-branch",
-              "line": 73,
+              "line": 99,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 81,
+              "end_line": 107,
               "increment": 1,
               "kind": "if-branch",
-              "line": 78,
+              "line": 104,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 85,
+              "end_line": 111,
               "increment": 1,
               "kind": "if-branch",
-              "line": 83,
+              "line": 109,
               "nesting_depth": 0
             }
           ],
@@ -5918,9 +6193,9 @@ expression: pretty
             "qualified_name": "handle_parse_line",
             "span": {
               "end_column": 1,
-              "end_line": 86,
+              "end_line": 112,
               "start_column": 1,
-              "start_line": 72
+              "start_line": 98
             }
           }
         },
@@ -6098,18 +6373,18 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 104,
+              "end_line": 130,
               "increment": 1,
               "kind": "if-branch",
-              "line": 102,
+              "line": 128,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 109,
+              "end_line": 135,
               "increment": 1,
               "kind": "match",
-              "line": 106,
+              "line": 132,
               "nesting_depth": 0
             }
           ],
@@ -6123,9 +6398,9 @@ expression: pretty
             "qualified_name": "record_da",
             "span": {
               "end_column": 1,
-              "end_line": 110,
+              "end_line": 136,
               "start_column": 1,
-              "start_line": 101
+              "start_line": 127
             }
           }
         },
@@ -6139,18 +6414,18 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 115,
+              "end_line": 141,
               "increment": 1,
               "kind": "if-branch",
-              "line": 113,
+              "line": 139,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 122,
+              "end_line": 148,
               "increment": 1,
               "kind": "match",
-              "line": 117,
+              "line": 143,
               "nesting_depth": 0
             }
           ],
@@ -6164,9 +6439,9 @@ expression: pretty
             "qualified_name": "record_brda",
             "span": {
               "end_column": 1,
-              "end_line": 123,
+              "end_line": 149,
               "start_column": 1,
-              "start_line": 112
+              "start_line": 138
             }
           }
         },
@@ -6180,18 +6455,18 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 191,
+              "end_line": 217,
               "increment": 1,
               "kind": "if-branch",
-              "line": 189,
+              "line": 215,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 196,
+              "end_line": 222,
               "increment": 1,
               "kind": "for-loop",
-              "line": 194,
+              "line": 220,
               "nesting_depth": 0
             }
           ],
@@ -6205,9 +6480,9 @@ expression: pretty
             "qualified_name": "merge_line_block",
             "span": {
               "end_column": 1,
-              "end_line": 197,
+              "end_line": 223,
               "start_column": 1,
-              "start_line": 184
+              "start_line": 210
             }
           }
         },
@@ -6221,18 +6496,18 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 206,
+              "end_line": 232,
               "increment": 1,
               "kind": "if-branch",
-              "line": 204,
+              "line": 230,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 211,
+              "end_line": 237,
               "increment": 1,
               "kind": "for-loop",
-              "line": 209,
+              "line": 235,
               "nesting_depth": 0
             }
           ],
@@ -6246,9 +6521,9 @@ expression: pretty
             "qualified_name": "merge_branch_block",
             "span": {
               "end_column": 1,
-              "end_line": 212,
+              "end_line": 238,
               "start_column": 1,
-              "start_line": 199
+              "start_line": 225
             }
           }
         },
@@ -6262,10 +6537,10 @@ expression: pretty
           "contributors": [
             {
               "column": 13,
-              "end_line": 661,
+              "end_line": 739,
               "increment": 2,
               "kind": "for-loop",
-              "line": 658,
+              "line": 736,
               "nesting_depth": 1
             }
           ],
@@ -6279,9 +6554,9 @@ expression: pretty
             "qualified_name": "arb_lcov_block",
             "span": {
               "end_column": 5,
-              "end_line": 665,
+              "end_line": 743,
               "start_column": 5,
-              "start_line": 655
+              "start_line": 733
             }
           }
         },
@@ -6988,10 +7263,10 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 98,
+              "end_line": 124,
               "increment": 1,
               "kind": "if-branch",
-              "line": 91,
+              "line": 117,
               "nesting_depth": 0
             }
           ],
@@ -7005,9 +7280,9 @@ expression: pretty
             "qualified_name": "start_source_file",
             "span": {
               "end_column": 1,
-              "end_line": 99,
+              "end_line": 125,
               "start_column": 1,
-              "start_line": 88
+              "start_line": 114
             }
           }
         },
@@ -7021,10 +7296,10 @@ expression: pretty
           "contributors": [
             {
               "column": 52,
-              "end_line": 177,
+              "end_line": 203,
               "increment": 1,
               "kind": "let-else",
-              "line": 174,
+              "line": 200,
               "nesting_depth": 0
             }
           ],
@@ -7038,9 +7313,9 @@ expression: pretty
             "qualified_name": "flush_block",
             "span": {
               "end_column": 1,
-              "end_line": 182,
+              "end_line": 208,
               "start_column": 1,
-              "start_line": 173
+              "start_line": 199
             }
           }
         },
@@ -7054,10 +7329,10 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 238,
+              "end_line": 264,
               "increment": 1,
               "kind": "match",
-              "line": 233,
+              "line": 259,
               "nesting_depth": 0
             }
           ],
@@ -7071,9 +7346,9 @@ expression: pretty
             "qualified_name": "merge_taken",
             "span": {
               "end_column": 1,
-              "end_line": 239,
+              "end_line": 265,
               "start_column": 1,
-              "start_line": 232
+              "start_line": 258
             }
           }
         },
@@ -7087,10 +7362,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 412,
+              "end_line": 490,
               "increment": 1,
               "kind": "match",
-              "line": 403,
+              "line": 481,
               "nesting_depth": 0
             }
           ],
@@ -7104,9 +7379,9 @@ expression: pretty
             "qualified_name": "malformed_da_produces_diagnostic",
             "span": {
               "end_column": 5,
-              "end_line": 413,
+              "end_line": 491,
               "start_column": 5,
-              "start_line": 398
+              "start_line": 476
             }
           }
         },
@@ -7120,10 +7395,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 456,
+              "end_line": 534,
               "increment": 1,
               "kind": "match",
-              "line": 447,
+              "line": 525,
               "nesting_depth": 0
             }
           ],
@@ -7137,9 +7412,9 @@ expression: pretty
             "qualified_name": "da_line_zero_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 457,
+              "end_line": 535,
               "start_column": 5,
-              "start_line": 443
+              "start_line": 521
             }
           }
         },
@@ -7153,10 +7428,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 575,
+              "end_line": 653,
               "increment": 1,
               "kind": "match",
-              "line": 566,
+              "line": 644,
               "nesting_depth": 0
             }
           ],
@@ -7170,9 +7445,9 @@ expression: pretty
             "qualified_name": "malformed_brda_produces_diagnostic",
             "span": {
               "end_column": 5,
-              "end_line": 576,
+              "end_line": 654,
               "start_column": 5,
-              "start_line": 562
+              "start_line": 640
             }
           }
         },
@@ -7186,10 +7461,10 @@ expression: pretty
           "contributors": [
             {
               "column": 13,
-              "end_line": 617,
+              "end_line": 695,
               "increment": 1,
               "kind": "for-loop",
-              "line": 615,
+              "line": 693,
               "nesting_depth": 0
             }
           ],
@@ -7203,9 +7478,9 @@ expression: pretty
             "qualified_name": "repeated_sf_blocks_merge_branch_coverage",
             "span": {
               "end_column": 5,
-              "end_line": 627,
+              "end_line": 705,
               "start_column": 5,
-              "start_line": 600
+              "start_line": 678
             }
           }
         },
@@ -9636,9 +9911,9 @@ expression: pretty
             "qualified_name": "push_malformed_record",
             "span": {
               "end_column": 1,
-              "end_line": 132,
+              "end_line": 158,
               "start_column": 1,
-              "start_line": 125
+              "start_line": 151
             }
           }
         },
@@ -9660,9 +9935,9 @@ expression: pretty
             "qualified_name": "merge_hits",
             "span": {
               "end_column": 1,
-              "end_line": 219,
+              "end_line": 245,
               "start_column": 1,
-              "start_line": 214
+              "start_line": 240
             }
           }
         },
@@ -9684,9 +9959,9 @@ expression: pretty
             "qualified_name": "merge_branch_value",
             "span": {
               "end_column": 1,
-              "end_line": 230,
+              "end_line": 256,
               "start_column": 1,
-              "start_line": 221
+              "start_line": 247
             }
           }
         },
@@ -9708,9 +9983,9 @@ expression: pretty
             "qualified_name": "clear_current_block",
             "span": {
               "end_column": 1,
-              "end_line": 244,
+              "end_line": 270,
               "start_column": 1,
-              "start_line": 241
+              "start_line": 267
             }
           }
         },
@@ -9732,9 +10007,9 @@ expression: pretty
             "qualified_name": "build_parse_output",
             "span": {
               "end_column": 1,
-              "end_line": 272,
+              "end_line": 298,
               "start_column": 1,
-              "start_line": 246
+              "start_line": 272
             }
           }
         },
@@ -9756,9 +10031,9 @@ expression: pretty
             "qualified_name": "to_line_coverage",
             "span": {
               "end_column": 1,
-              "end_line": 279,
+              "end_line": 305,
               "start_column": 1,
-              "start_line": 274
+              "start_line": 300
             }
           }
         },
@@ -9780,9 +10055,9 @@ expression: pretty
             "qualified_name": "parser",
             "span": {
               "end_column": 5,
-              "end_line": 288,
+              "end_line": 314,
               "start_column": 5,
-              "start_line": 286
+              "start_line": 312
             }
           }
         },
@@ -9804,9 +10079,9 @@ expression: pretty
             "qualified_name": "parse",
             "span": {
               "end_column": 5,
-              "end_line": 292,
+              "end_line": 318,
               "start_column": 5,
-              "start_line": 290
+              "start_line": 316
             }
           }
         },
@@ -9828,9 +10103,153 @@ expression: pretty
             "qualified_name": "empty_input_returns_empty_output",
             "span": {
               "end_column": 5,
-              "end_line": 299,
+              "end_line": 325,
               "start_column": 5,
-              "start_line": 294
+              "start_line": 320
+            }
+          }
+        },
+        "threshold": 25.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 0.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "validate_empty_input_rejected",
+            "span": {
+              "end_column": 5,
+              "end_line": 332,
+              "start_column": 5,
+              "start_line": 329
+            }
+          }
+        },
+        "threshold": 25.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 0.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "validate_no_da_lines_rejected",
+            "span": {
+              "end_column": 5,
+              "end_line": 341,
+              "start_column": 5,
+              "start_line": 334
+            }
+          }
+        },
+        "threshold": 25.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 0.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "validate_da_outside_sf_block_rejected",
+            "span": {
+              "end_column": 5,
+              "end_line": 346,
+              "start_column": 5,
+              "start_line": 343
+            }
+          }
+        },
+        "threshold": 25.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 0.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "validate_malformed_da_rejected",
+            "span": {
+              "end_column": 5,
+              "end_line": 355,
+              "start_column": 5,
+              "start_line": 348
+            }
+          }
+        },
+        "threshold": 25.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 0.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "validate_single_da_inside_sf_block_passes",
+            "span": {
+              "end_column": 5,
+              "end_line": 364,
+              "start_column": 5,
+              "start_line": 357
+            }
+          }
+        },
+        "threshold": 25.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 0.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "validate_first_da_in_second_block_passes",
+            "span": {
+              "end_column": 5,
+              "end_line": 377,
+              "start_column": 5,
+              "start_line": 366
             }
           }
         },
@@ -9852,9 +10271,9 @@ expression: pretty
             "qualified_name": "single_file_single_da",
             "span": {
               "end_column": 5,
-              "end_line": 309,
+              "end_line": 387,
               "start_column": 5,
-              "start_line": 301
+              "start_line": 379
             }
           }
         },
@@ -9876,9 +10295,9 @@ expression: pretty
             "qualified_name": "multiple_da_lines",
             "span": {
               "end_column": 5,
-              "end_line": 319,
+              "end_line": 397,
               "start_column": 5,
-              "start_line": 311
+              "start_line": 389
             }
           }
         },
@@ -9900,9 +10319,9 @@ expression: pretty
             "qualified_name": "multiple_source_files",
             "span": {
               "end_column": 5,
-              "end_line": 328,
+              "end_line": 406,
               "start_column": 5,
-              "start_line": 321
+              "start_line": 399
             }
           }
         },
@@ -9924,9 +10343,9 @@ expression: pretty
             "qualified_name": "hit_count_preservation",
             "span": {
               "end_column": 5,
-              "end_line": 336,
+              "end_line": 414,
               "start_column": 5,
-              "start_line": 330
+              "start_line": 408
             }
           }
         },
@@ -9948,9 +10367,9 @@ expression: pretty
             "qualified_name": "path_normalization_strips_prefix",
             "span": {
               "end_column": 5,
-              "end_line": 342,
+              "end_line": 420,
               "start_column": 5,
-              "start_line": 338
+              "start_line": 416
             }
           }
         },
@@ -9972,9 +10391,9 @@ expression: pretty
             "qualified_name": "non_matching_path_passes_through",
             "span": {
               "end_column": 5,
-              "end_line": 348,
+              "end_line": 426,
               "start_column": 5,
-              "start_line": 344
+              "start_line": 422
             }
           }
         },
@@ -9996,9 +10415,9 @@ expression: pretty
             "qualified_name": "backslash_normalized_to_forward_slash",
             "span": {
               "end_column": 5,
-              "end_line": 355,
+              "end_line": 433,
               "start_column": 5,
-              "start_line": 350
+              "start_line": 428
             }
           }
         },
@@ -10020,9 +10439,9 @@ expression: pretty
             "qualified_name": "path_boundary_not_confused_by_prefix_substring",
             "span": {
               "end_column": 5,
-              "end_line": 361,
+              "end_line": 439,
               "start_column": 5,
-              "start_line": 357
+              "start_line": 435
             }
           }
         },
@@ -10044,9 +10463,9 @@ expression: pretty
             "qualified_name": "repeated_sf_blocks_merge_coverage",
             "span": {
               "end_column": 5,
-              "end_line": 375,
+              "end_line": 453,
               "start_column": 5,
-              "start_line": 363
+              "start_line": 441
             }
           }
         },
@@ -10068,9 +10487,9 @@ expression: pretty
             "qualified_name": "duplicate_da_lines_sum_hits",
             "span": {
               "end_column": 5,
-              "end_line": 384,
+              "end_line": 462,
               "start_column": 5,
-              "start_line": 377
+              "start_line": 455
             }
           }
         },
@@ -10092,9 +10511,9 @@ expression: pretty
             "qualified_name": "duplicate_da_multiple_lines_sum_correctly",
             "span": {
               "end_column": 5,
-              "end_line": 396,
+              "end_line": 474,
               "start_column": 5,
-              "start_line": 386
+              "start_line": 464
             }
           }
         },
@@ -10116,9 +10535,9 @@ expression: pretty
             "qualified_name": "malformed_da_does_not_stop_parsing",
             "span": {
               "end_column": 5,
-              "end_line": 421,
+              "end_line": 499,
               "start_column": 5,
-              "start_line": 415
+              "start_line": 493
             }
           }
         },
@@ -10140,9 +10559,9 @@ expression: pretty
             "qualified_name": "da_missing_hit_count_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 431,
+              "end_line": 509,
               "start_column": 5,
-              "start_line": 423
+              "start_line": 501
             }
           }
         },
@@ -10164,9 +10583,9 @@ expression: pretty
             "qualified_name": "da_negative_hit_count_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 441,
+              "end_line": 519,
               "start_column": 5,
-              "start_line": 433
+              "start_line": 511
             }
           }
         },
@@ -10188,9 +10607,9 @@ expression: pretty
             "qualified_name": "end_of_record_is_ignored",
             "span": {
               "end_column": 5,
-              "end_line": 468,
+              "end_line": 546,
               "start_column": 5,
-              "start_line": 459
+              "start_line": 537
             }
           }
         },
@@ -10212,9 +10631,9 @@ expression: pretty
             "qualified_name": "unterminated_final_block_emits_data",
             "span": {
               "end_column": 5,
-              "end_line": 475,
+              "end_line": 553,
               "start_column": 5,
-              "start_line": 470
+              "start_line": 548
             }
           }
         },
@@ -10236,9 +10655,9 @@ expression: pretty
             "qualified_name": "empty_sf_path_emits_diagnostic",
             "span": {
               "end_column": 5,
-              "end_line": 486,
+              "end_line": 564,
               "start_column": 5,
-              "start_line": 477
+              "start_line": 555
             }
           }
         },
@@ -10260,9 +10679,9 @@ expression: pretty
             "qualified_name": "da_with_checksum_field_is_accepted",
             "span": {
               "end_column": 5,
-              "end_line": 495,
+              "end_line": 573,
               "start_column": 5,
-              "start_line": 488
+              "start_line": 566
             }
           }
         },
@@ -10284,9 +10703,9 @@ expression: pretty
             "qualified_name": "non_coverage_records_are_ignored",
             "span": {
               "end_column": 5,
-              "end_line": 509,
+              "end_line": 587,
               "start_column": 5,
-              "start_line": 497
+              "start_line": 575
             }
           }
         },
@@ -10308,9 +10727,9 @@ expression: pretty
             "qualified_name": "brda_and_da_records_parsed",
             "span": {
               "end_column": 5,
-              "end_line": 521,
+              "end_line": 599,
               "start_column": 5,
-              "start_line": 513
+              "start_line": 591
             }
           }
         },
@@ -10332,9 +10751,9 @@ expression: pretty
             "qualified_name": "brda_dash_maps_to_none",
             "span": {
               "end_column": 5,
-              "end_line": 528,
+              "end_line": 606,
               "start_column": 5,
-              "start_line": 523
+              "start_line": 601
             }
           }
         },
@@ -10356,9 +10775,9 @@ expression: pretty
             "qualified_name": "brda_numeric_maps_to_some",
             "span": {
               "end_column": 5,
-              "end_line": 535,
+              "end_line": 613,
               "start_column": 5,
-              "start_line": 530
+              "start_line": 608
             }
           }
         },
@@ -10380,9 +10799,9 @@ expression: pretty
             "qualified_name": "brda_zero_maps_to_some_zero",
             "span": {
               "end_column": 5,
-              "end_line": 542,
+              "end_line": 620,
               "start_column": 5,
-              "start_line": 537
+              "start_line": 615
             }
           }
         },
@@ -10404,9 +10823,9 @@ expression: pretty
             "qualified_name": "duplicate_brda_sum_taken",
             "span": {
               "end_column": 5,
-              "end_line": 552,
+              "end_line": 630,
               "start_column": 5,
-              "start_line": 544
+              "start_line": 622
             }
           }
         },
@@ -10428,9 +10847,9 @@ expression: pretty
             "qualified_name": "brda_dash_and_numeric_merge",
             "span": {
               "end_column": 5,
-              "end_line": 560,
+              "end_line": 638,
               "start_column": 5,
-              "start_line": 554
+              "start_line": 632
             }
           }
         },
@@ -10452,9 +10871,9 @@ expression: pretty
             "qualified_name": "brda_missing_fields_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 587,
+              "end_line": 665,
               "start_column": 5,
-              "start_line": 578
+              "start_line": 656
             }
           }
         },
@@ -10476,9 +10895,9 @@ expression: pretty
             "qualified_name": "brda_missing_taken_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 598,
+              "end_line": 676,
               "start_column": 5,
-              "start_line": 589
+              "start_line": 667
             }
           }
         },
@@ -10500,9 +10919,9 @@ expression: pretty
             "qualified_name": "brda_line_zero_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 637,
+              "end_line": 715,
               "start_column": 5,
-              "start_line": 629
+              "start_line": 707
             }
           }
         },
@@ -10524,9 +10943,9 @@ expression: pretty
             "qualified_name": "no_brda_produces_none_branches",
             "span": {
               "end_column": 5,
-              "end_line": 643,
+              "end_line": 721,
               "start_column": 5,
-              "start_line": 639
+              "start_line": 717
             }
           }
         },
@@ -10548,9 +10967,9 @@ expression: pretty
             "qualified_name": "arb_da_line",
             "span": {
               "end_column": 5,
-              "end_line": 653,
+              "end_line": 731,
               "start_column": 5,
-              "start_line": 651
+              "start_line": 729
             }
           }
         },
@@ -10572,9 +10991,9 @@ expression: pretty
             "qualified_name": "arb_lcov_input",
             "span": {
               "end_column": 5,
-              "end_line": 669,
+              "end_line": 747,
               "start_column": 5,
-              "start_line": 667
+              "start_line": 745
             }
           }
         },
@@ -10726,16 +11145,16 @@ expression: pretty
       }
     ],
     "shown_summary": {
-      "average_complexity": 1.4974093264248705,
+      "average_complexity": 1.515,
       "average_coverage": 0.0,
-      "average_crap": 5.33678756476684,
+      "average_crap": 5.57,
       "distribution": {
         "acceptable": 29,
-        "high": 5,
-        "low": 145,
+        "high": 6,
+        "low": 151,
         "moderate": 14
       },
-      "exceeding_threshold": 5,
+      "exceeding_threshold": 6,
       "max_complexity": 11,
       "max_crap": {
         "risk_level": "high",
@@ -10746,15 +11165,15 @@ expression: pretty
       "median_crap": 2.0,
       "min_coverage": 0.0,
       "total_files": 5,
-      "total_functions": 193,
+      "total_functions": 200,
       "worst_function": {
         "file_path": "adapters/coverage/mod.rs",
         "qualified_name": "parse_brda",
         "span": {
           "end_column": 1,
-          "end_line": 171,
+          "end_line": 197,
           "start_column": 1,
-          "start_line": 148
+          "start_line": 174
         }
       }
     },

--- a/crates/crap4rs/src/adapters/coverage/mod.rs
+++ b/crates/crap4rs/src/adapters/coverage/mod.rs
@@ -67,6 +67,32 @@ impl CoveragePort for LcovParser {
         flush_block(&mut state);
         Ok(build_parse_output(state))
     }
+
+    /// LCOV-flavoured pre-flight: scan for at least one well-formed
+    /// `DA:line,hits` line inside an `SF:` block. Mirrors the structural
+    /// shape that `parse` consumes; orphan `DA:` records outside an
+    /// `SF:` block and malformed line/hit pairs are rejected.
+    ///
+    /// Linear single-pass over `data` — cheap relative to the full
+    /// parse, which builds maps and emits per-record diagnostics.
+    fn validate(&self, data: &str) -> Result<(), String> {
+        let mut in_sf_block = false;
+        for line in data.lines() {
+            if line.starts_with("SF:") {
+                in_sf_block = true;
+                continue;
+            }
+            if in_sf_block
+                && let Some(rest) = line.strip_prefix("DA:")
+                && let Some((line_no, hits)) = rest.split_once(',')
+                && line_no.parse::<usize>().is_ok()
+                && hits.split(',').next().unwrap_or("").parse::<u64>().is_ok()
+            {
+                return Ok(());
+            }
+        }
+        Err("no SF/DA records".to_string())
+    }
 }
 
 fn handle_parse_line(parser: &LcovParser, state: &mut ParseState, line: &str, line_number: usize) {
@@ -296,6 +322,58 @@ mod tests {
         let output = parse("");
         assert!(output.coverage.is_empty());
         assert!(output.diagnostics.is_empty());
+    }
+
+    // ── validate (preflight) ──────────────────────────────────────────
+
+    #[test]
+    fn validate_empty_input_rejected() {
+        assert!(parser().validate("").is_err());
+    }
+
+    #[test]
+    fn validate_no_da_lines_rejected() {
+        assert!(
+            parser()
+                .validate("SF:src/main.rs\nend_of_record\n")
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn validate_da_outside_sf_block_rejected() {
+        assert!(parser().validate("DA:1,5\nend_of_record\n").is_err());
+    }
+
+    #[test]
+    fn validate_malformed_da_rejected() {
+        assert!(
+            parser()
+                .validate("SF:src/main.rs\nDA:not_a_number\nend_of_record\n")
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn validate_single_da_inside_sf_block_passes() {
+        assert!(
+            parser()
+                .validate("SF:src/main.rs\nDA:1,5\nend_of_record\n")
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn validate_first_da_in_second_block_passes() {
+        // First SF: has no DA — second SF: provides one. validate
+        // walks both blocks and accepts the first valid DA encountered.
+        assert!(
+            parser()
+                .validate(
+                    "SF:src/a.rs\nend_of_record\nSF:src/b.rs\nDA:1,1\nend_of_record\n"
+                )
+                .is_ok()
+        );
     }
 
     #[test]

--- a/crates/crap4rs/src/adapters/coverage/mod.rs
+++ b/crates/crap4rs/src/adapters/coverage/mod.rs
@@ -369,9 +369,7 @@ mod tests {
         // walks both blocks and accepts the first valid DA encountered.
         assert!(
             parser()
-                .validate(
-                    "SF:src/a.rs\nend_of_record\nSF:src/b.rs\nDA:1,1\nend_of_record\n"
-                )
+                .validate("SF:src/a.rs\nend_of_record\nSF:src/b.rs\nDA:1,1\nend_of_record\n")
                 .is_ok()
         );
     }

--- a/crates/crap4rs/src/adapters/coverage/mod.rs
+++ b/crates/crap4rs/src/adapters/coverage/mod.rs
@@ -68,16 +68,24 @@ impl CoveragePort for LcovParser {
         Ok(build_parse_output(state))
     }
 
-    /// LCOV-flavoured pre-flight: scan for at least one well-formed
-    /// `DA:line,hits` line inside an `SF:` block. Mirrors the structural
+    /// LCOV-flavoured pre-flight: stream the file line-by-line via
+    /// `BufReader` and short-circuit on the first well-formed
+    /// `DA:line,hits` inside an `SF:` block. Mirrors the structural
     /// shape that `parse` consumes; orphan `DA:` records outside an
     /// `SF:` block and malformed line/hit pairs are rejected.
     ///
-    /// Linear single-pass over `data` — cheap relative to the full
-    /// parse, which builds maps and emits per-record diagnostics.
-    fn validate(&self, data: &str) -> Result<(), String> {
+    /// Streams (rather than slurping) because LCOV files easily exceed
+    /// 100 MB on large workspaces and `parse` will read the file again
+    /// shortly after — doubling peak RSS would be a regression from the
+    /// pre-D5 single-pass preflight.
+    fn validate(&self, path: &Path) -> Result<(), String> {
+        use std::io::{BufRead, BufReader};
+        let file = std::fs::File::open(path)
+            .map_err(|e| format!("cannot open {}: {e}", path.display()))?;
+        let reader = BufReader::new(file);
         let mut in_sf_block = false;
-        for line in data.lines() {
+        for line in reader.lines() {
+            let line = line.map_err(|e| format!("read error: {e}"))?;
             if line.starts_with("SF:") {
                 in_sf_block = true;
                 continue;
@@ -326,41 +334,41 @@ mod tests {
 
     // ── validate (preflight) ──────────────────────────────────────────
 
+    /// Materialise `contents` into a tempfile and run `validate` against
+    /// its path. The adapter streams the file via `BufReader` so we
+    /// must hand it a real on-disk path; using `&str` directly would
+    /// skip the streaming behaviour Gemini flagged as the regression
+    /// trigger.
+    fn validate_str(contents: &str) -> Result<(), String> {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("preflight.info");
+        std::fs::write(&path, contents).unwrap();
+        parser().validate(&path)
+    }
+
     #[test]
     fn validate_empty_input_rejected() {
-        assert!(parser().validate("").is_err());
+        assert!(validate_str("").is_err());
     }
 
     #[test]
     fn validate_no_da_lines_rejected() {
-        assert!(
-            parser()
-                .validate("SF:src/main.rs\nend_of_record\n")
-                .is_err()
-        );
+        assert!(validate_str("SF:src/main.rs\nend_of_record\n").is_err());
     }
 
     #[test]
     fn validate_da_outside_sf_block_rejected() {
-        assert!(parser().validate("DA:1,5\nend_of_record\n").is_err());
+        assert!(validate_str("DA:1,5\nend_of_record\n").is_err());
     }
 
     #[test]
     fn validate_malformed_da_rejected() {
-        assert!(
-            parser()
-                .validate("SF:src/main.rs\nDA:not_a_number\nend_of_record\n")
-                .is_err()
-        );
+        assert!(validate_str("SF:src/main.rs\nDA:not_a_number\nend_of_record\n").is_err());
     }
 
     #[test]
     fn validate_single_da_inside_sf_block_passes() {
-        assert!(
-            parser()
-                .validate("SF:src/main.rs\nDA:1,5\nend_of_record\n")
-                .is_ok()
-        );
+        assert!(validate_str("SF:src/main.rs\nDA:1,5\nend_of_record\n").is_ok());
     }
 
     #[test]
@@ -368,10 +376,21 @@ mod tests {
         // First SF: has no DA — second SF: provides one. validate
         // walks both blocks and accepts the first valid DA encountered.
         assert!(
-            parser()
-                .validate("SF:src/a.rs\nend_of_record\nSF:src/b.rs\nDA:1,1\nend_of_record\n")
+            validate_str("SF:src/a.rs\nend_of_record\nSF:src/b.rs\nDA:1,1\nend_of_record\n")
                 .is_ok()
         );
+    }
+
+    #[test]
+    fn validate_missing_path_returns_open_error() {
+        // Adapter owns I/O — file-not-found surfaces as the structured
+        // `Err(String)` from `validate`, not as an `io::Error`
+        // propagated from a separate slurp step. Lets the CLI compose
+        // it with the hint via the same path as "no records".
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("nope.info");
+        let err = parser().validate(&missing).unwrap_err();
+        assert!(err.contains("cannot open"), "got: {err}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes the three sub-items deferred from PR #162's review (issue #163):

1. **Adapter-aware coverage validation.** `CoveragePort` gains a `validate(&str) -> Result<(), String>` default method (no-op). The LCOV adapter overrides with the SF/DA scan that previously lived in `cli::check_coverage_has_data`. crap-core no longer hardcodes LCOV record syntax; Istanbul inherits the no-op default and will override when the real parser ships.
2. **Walker reconciliation.** The CLI-layer `check_src_has_source_files` duplicated `core::ensure_source_files_found`'s "no source files" wording byte-for-byte. Deleted — WalkBuilder's `.gitignore`-aware walk is now the single source of truth, with tests migrated to the LCOV adapter side.
3. **Config-path threading.** `load_file_config` now returns `Option<(FileConfig, PathBuf)>`. When `--view <NAME>` references a missing preset, the hint surfaces the resolved on-disk path (`/home/me/proj/crap4rs.toml`) instead of just `crap4rs.toml` — matters when `--config` overrides auto-discovery or the discovered file lives several parents up.

## Wire envelope snapshot

Updated for source-content drift only (+7 functions from new `validate` impl + tests, then line shifts from a fmt pass). No structural change to the JSON envelope; semantic shape is byte-identical.

## Test plan

- [x] `cargo nextest run --workspace` — 924/924 pass (added 8 new tests: 6 LCOV `validate` structural cases, 2 view-preset path-hint regressions)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo +1.93 check --workspace --all-targets` (MSRV) clean
- [x] `cargo deny --workspace check` clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` clean
- [x] AST-purity grep on `crates/crap-core/src/` — zero matches
- [x] End-to-end smoke:
  - `crap4rs --view ci` (auto-discovered config, no preset): hint shows `crap4rs.toml`
  - `crap4rs --config /tmp/foo/crap4rs.toml --view ci`: hint shows full path
  - `crap4rs --view wat` (config has presets): hint lists alphabetised available names

## Officer review

CAO / CEng / CQO not pre-spawned for this PR — three tightly-scoped sub-items, all locally testable, no public-API additions beyond the optional `CoveragePort::validate` default method (which is backward-compatible — existing impls keep the no-op).

Closes #163.