### PR TITLE
chore(crap-core): #161 — AdapterMeta polish + ci(ast-purity) adapter-name gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -441,6 +441,44 @@ jobs:
             exit 1
           fi
           echo "crap-core direct dependencies: clean"
+      - name: Reject adapter-name string literals in crap-core
+        # Structural protection against silent re-coupling: if a future
+        # change re-introduces `"crap4rs"` or `"crap4ts"` as a string
+        # literal in crap-core source, that's a regression — adapter
+        # names belong in `AdapterMeta` supplied by the binary, never
+        # baked into the language-agnostic library (#161).
+        #
+        # Doc comments and code comments (`///`, `//!`, `//`, leading
+        # `*` in block comments) are allowed to mention the adapter
+        # names — those are legitimate references in the API surface
+        # docstrings. The awk filter strips rg's `path:lineno:` prefix
+        # and only fires on lines whose content (after optional
+        # whitespace) does NOT start with a comment marker.
+        #
+        # No untrusted-input interpolation: literals and patterns are
+        # static; `rg`/`awk` invocations contain no `${{ github.* }}`
+        # references.
+        run: |
+          set -euo pipefail
+          hits=$(rg -nF -e '"crap4rs"' -e '"crap4ts"' crates/crap-core/src 2>/dev/null || true)
+          if [ -z "$hits" ]; then
+            echo "crap-core adapter-name literals: clean"
+            exit 0
+          fi
+          non_comment_hits=$(echo "$hits" | awk -F: '
+            {
+              content = ""
+              for (i = 3; i <= NF; i++) content = content (i > 3 ? ":" : "") $i
+              gsub(/^[ \t]+/, "", content)
+              if (content !~ /^(\/\/|\*)/) print
+            }
+          ')
+          if [ -n "$non_comment_hits" ]; then
+            echo "::error::crap-core must not contain \"crap4rs\" / \"crap4ts\" string literals — adapter names belong in AdapterMeta from the binary (see #161)"
+            echo "$non_comment_hits"
+            exit 1
+          fi
+          echo "crap-core adapter-name literals: clean (comment-only references allowed)"
 
   docs:
     name: cargo doc (warnings as errors)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -448,12 +448,13 @@ jobs:
         # names belong in `AdapterMeta` supplied by the binary, never
         # baked into the language-agnostic library (#161).
         #
-        # Doc comments and code comments (`///`, `//!`, `//`, leading
-        # `*` in block comments) are allowed to mention the adapter
-        # names — those are legitimate references in the API surface
-        # docstrings. The awk filter strips rg's `path:lineno:` prefix
-        # and only fires on lines whose content (after optional
-        # whitespace) does NOT start with a comment marker.
+        # Doc comments and code comments (`///`, `//!`, `//`, `/*`
+        # block openers, leading `*` continuation lines) are allowed
+        # to mention the adapter names — those are legitimate
+        # references in the API surface docstrings. The awk filter
+        # strips rg's `path:lineno:` prefix and only fires on lines
+        # whose content (after optional whitespace) does NOT start
+        # with a comment marker.
         #
         # No untrusted-input interpolation: literals and patterns are
         # static; `rg`/`awk` invocations contain no `${{ github.* }}`
@@ -470,7 +471,7 @@ jobs:
               content = ""
               for (i = 3; i <= NF; i++) content = content (i > 3 ? ":" : "") $i
               gsub(/^[ \t]+/, "", content)
-              if (content !~ /^(\/\/|\*)/) print
+              if (content !~ /^(\/\/|\/\*|\*)/) print
             }
           ')
           if [ -n "$non_comment_hits" ]; then

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ authors = ["Christopher Bays <cmbays@breezybayslabs.com>"]
 crap-core = { path = "crates/crap-core", version = "0.1.0" }
 
 # ── CLI (crap4rs only today) ──
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "string"] }
 clap_complete = "4"
 clap_complete_nushell = "4"
 

--- a/crates/crap-core/src/adapters/config.rs
+++ b/crates/crap-core/src/adapters/config.rs
@@ -699,25 +699,27 @@ sort = "path"
         // regression would silently fall back to a hardcoded constant
         // (e.g., the v0.4 `crap4rs.toml` literal) and make the second
         // adapter (`crap4ts.toml`) invisible to discovery.
+        //
+        // `discover_config` interprets `name` as a path (it calls
+        // `PathBuf::from(name)` and feeds it to `std::fs::metadata`),
+        // so passing tempdir-qualified paths avoids any process-wide
+        // CWD mutation. This keeps the test safe under nextest's
+        // parallel execution model.
         let dir = tempfile::tempdir().unwrap();
-        let cwd = std::env::current_dir().unwrap();
-        std::env::set_current_dir(dir.path()).unwrap();
-
-        // Both adapters' conventional config names: only the one
-        // actually on disk should be returned, and the lookup must be
-        // param-driven (not constant).
         std::fs::write(dir.path().join("crap4ts.toml"), "threshold = 7.0\n").unwrap();
 
-        let rust_lookup = discover_config("crap4rs.toml").unwrap();
-        let ts_lookup = discover_config("crap4ts.toml").unwrap();
-        let alt_lookup = discover_config("custom-tool.toml").unwrap();
+        let rust_path = dir.path().join("crap4rs.toml");
+        let ts_path = dir.path().join("crap4ts.toml");
+        let alt_path = dir.path().join("custom-tool.toml");
 
-        std::env::set_current_dir(cwd).unwrap();
+        let rust_lookup = discover_config(rust_path.to_str().unwrap()).unwrap();
+        let ts_lookup = discover_config(ts_path.to_str().unwrap()).unwrap();
+        let alt_lookup = discover_config(alt_path.to_str().unwrap()).unwrap();
 
         assert_eq!(rust_lookup, None, "absent crap4rs.toml must return None");
         assert_eq!(
             ts_lookup,
-            Some(PathBuf::from("crap4ts.toml")),
+            Some(ts_path.clone()),
             "present crap4ts.toml must be discovered by name"
         );
         assert_eq!(alt_lookup, None, "absent custom name must return None");

--- a/crates/crap-core/src/adapters/config.rs
+++ b/crates/crap-core/src/adapters/config.rs
@@ -690,4 +690,36 @@ sort = "path"
         );
         assert_eq!(config.views["path_sort"].sort, Some(SortKey::Path));
     }
+
+    // ── discover_config parameterization (#161) ───────────────────
+
+    #[test]
+    fn discover_config_honors_caller_supplied_name() {
+        // Verifies the `name` parameter actually drives lookup — a
+        // regression would silently fall back to a hardcoded constant
+        // (e.g., the v0.4 `crap4rs.toml` literal) and make the second
+        // adapter (`crap4ts.toml`) invisible to discovery.
+        let dir = tempfile::tempdir().unwrap();
+        let cwd = std::env::current_dir().unwrap();
+        std::env::set_current_dir(dir.path()).unwrap();
+
+        // Both adapters' conventional config names: only the one
+        // actually on disk should be returned, and the lookup must be
+        // param-driven (not constant).
+        std::fs::write(dir.path().join("crap4ts.toml"), "threshold = 7.0\n").unwrap();
+
+        let rust_lookup = discover_config("crap4rs.toml").unwrap();
+        let ts_lookup = discover_config("crap4ts.toml").unwrap();
+        let alt_lookup = discover_config("custom-tool.toml").unwrap();
+
+        std::env::set_current_dir(cwd).unwrap();
+
+        assert_eq!(rust_lookup, None, "absent crap4rs.toml must return None");
+        assert_eq!(
+            ts_lookup,
+            Some(PathBuf::from("crap4ts.toml")),
+            "present crap4ts.toml must be discovered by name"
+        );
+        assert_eq!(alt_lookup, None, "absent custom name must return None");
+    }
 }

--- a/crates/crap-core/src/cli/mod.rs
+++ b/crates/crap-core/src/cli/mod.rs
@@ -759,22 +759,25 @@ fn current_bin_name(meta_fallback: &str) -> String {
 /// bin name through `current_bin_name` directly because
 /// `clap_complete::generate` takes the bin name as a separate arg.
 ///
-/// All metadata fields accept owned `String` directly thanks to clap's
-/// `string` feature, which adds `impl From<String> for clap::builder::Str`.
-/// Without the feature, `name` / `bin_name` / `version` / `long_version`
-/// require `&'static str` and the only way to satisfy that from a
-/// runtime-built `String` is `Box::leak` — see #161.
+/// `name` / `bin_name` need clap's `string` feature
+/// (`impl From<String> for clap::builder::Str`) because
+/// `current_bin_name` constructs the bin name at runtime from
+/// `argv[0]` and returns `String` — without the feature, the only way
+/// to satisfy `From<&'static str>` from a runtime `String` is
+/// `Box::leak` (the pre-#161 workaround). The remaining fields are
+/// `&'static str` on `AdapterMeta`, so they pass through clap's
+/// default `Into<Str>` impl with zero heap allocations.
 fn build_command(meta: &AdapterMeta) -> clap::Command {
     let bin_name = current_bin_name(meta.tool_name);
     let mut cmd = Cli::command()
         .name(bin_name.clone())
         .bin_name(bin_name)
-        .version(meta.tool_version.to_string())
-        .long_version(meta.long_version.to_string())
-        .about(meta.about.to_string())
-        .long_about(meta.long_about.to_string());
+        .version(meta.tool_version)
+        .long_version(meta.long_version)
+        .about(meta.about)
+        .long_about(meta.long_about);
     if !meta.after_help.is_empty() {
-        cmd = cmd.after_help(meta.after_help.to_string());
+        cmd = cmd.after_help(meta.after_help);
     }
     cmd
 }

--- a/crates/crap-core/src/cli/mod.rs
+++ b/crates/crap-core/src/cli/mod.rs
@@ -593,67 +593,114 @@ pub struct Cli {
 /// Adapter-supplied runtime metadata that crap-core threads through
 /// `parse_args`, `run`, and the reporter call sites.
 ///
-/// Carried by reference, so all fields are `&'a str` / `&'a [&'a str]`
-/// — the binary owns the storage (typically `env!(...)` literals or
-/// `build.rs`-stamped strings, all `'static`). The struct is `Copy`
-/// for trivial threading; clone-by-copy is fine because the borrows
-/// already point at the binary's static storage.
+/// All fields are `&'static` because every production caller supplies
+/// `env!(...)` / `build.rs`-stamped literals or `const &[&str]` slices.
+/// Tests construct from `&'static str` literals too. The lifetime
+/// parameter was dropped in #161 — no caller ever needed non-static
+/// metadata, and the `<'a>` ripple polluted 15 function signatures for
+/// no payoff. The struct stays `Copy` so threading is trivial.
 ///
 /// Reporters keep a flat `(tool_name, tool_version)` call boundary —
 /// the struct only travels through orchestration code.
 #[derive(Debug, Clone, Copy)]
-pub struct AdapterMeta<'a> {
+pub struct AdapterMeta {
     /// Adapter binary name (e.g., `"crap4rs"`, `"crap4ts"`). Drives
     /// clap's `--version` output, the `name` field in SARIF, and the
     /// header line in table/markdown/html reporters.
-    pub tool_name: &'a str,
+    pub tool_name: &'static str,
     /// Short version string (e.g., `"0.5.0"`). Threaded to every
     /// reporter alongside `tool_name`.
-    pub tool_version: &'a str,
+    pub tool_version: &'static str,
     /// Long version string for `--version --long` (e.g.,
     /// `"0.5.0 (abc1234 2026-05-09)"`).
-    pub long_version: &'a str,
+    pub long_version: &'static str,
     /// Short adapter-flavored help text (one-line, shown by `--help`).
-    pub about: &'a str,
+    pub about: &'static str,
     /// Long adapter-flavored help text (multi-paragraph, shown by
     /// `--help` in full mode).
-    pub long_about: &'a str,
+    pub long_about: &'static str,
     /// `after_help` block with adapter-specific examples
     /// (`crap4rs --coverage lcov.info ...` etc.). May be empty.
-    pub after_help: &'a str,
+    pub after_help: &'static str,
     /// Coverage-tool hint shown when `--coverage` points at a file
     /// with no `SF:` / `DA:` records. Adapter-specific because the
     /// remediation depends on the coverage toolchain (Rust: `cargo
     /// llvm-cov --lcov`; TS: `c8 --reporter=lcov`).
-    pub coverage_hint: &'a str,
+    pub coverage_hint: &'static str,
     /// File extensions the walker should pick up (e.g.,
     /// `&["rs"]` for crap4rs; `&["ts","tsx","js","jsx","mjs","cjs"]`
-    /// for crap4ts). Carried as `&[&str]` so the binary can supply a
-    /// `&'static` literal slice; copied into `AnalyzeOptions.extensions`
-    /// at the orchestration boundary.
-    pub extensions: &'a [&'a str],
+    /// for crap4ts). Adapter binaries supply a `const &[&str]`; copied
+    /// into `AnalyzeOptions.extensions` at the orchestration boundary.
+    pub extensions: &'static [&'static str],
     /// Adapter repo URL spliced into SARIF's
     /// `runs[0].tool.driver.informationUri`. Adapter-specific so
     /// crap4ts SARIF output links to crap4ts's repo, not crap4rs's.
-    pub tool_info_uri: &'a str,
+    pub tool_info_uri: &'static str,
     /// Adapter rule-help URL spliced into SARIF's
     /// `runs[0].tool.driver.rules[0].helpUri`. Adapter-specific for
     /// the same reason as `tool_info_uri`.
-    pub rule_help_uri: &'a str,
+    pub rule_help_uri: &'static str,
     /// Conventional config file name the adapter binary auto-discovers
     /// in the working directory (e.g., `"crap4rs.toml"` for the Rust
     /// adapter; `"crap4ts.toml"` for the TS adapter). Threaded through
     /// to `discover_config` and surfaced in `--view <preset>`
     /// error hints so users see the right file name to create.
-    pub config_file_name: &'a str,
+    pub config_file_name: &'static str,
 }
 
-impl<'a> AdapterMeta<'a> {
+impl AdapterMeta {
     /// Allocate an owned `Vec<String>` from `extensions` for inclusion
     /// in `AnalyzeOptions` (which owns its config rather than borrowing
     /// from the meta, decoupling analysis lifetime from CLI lifetime).
     pub fn extensions_owned(&self) -> Vec<String> {
         self.extensions.iter().map(|e| (*e).to_string()).collect()
+    }
+
+    /// Trip on construction with empty required strings. `extensions`
+    /// is allowed to be empty — `core::ensure_source_files_found`
+    /// surfaces a parser-neutral diagnostic when no files match. Other
+    /// fields are mandatory for help/SARIF/`--version` rendering, and a
+    /// silent empty string here would produce malformed output that's
+    /// hard to trace back to the meta. Debug-only so release builds
+    /// stay zero-cost; production binaries should never hit these
+    /// (their meta is `env!()` / `const`).
+    pub(crate) fn debug_assert_required_fields(&self) {
+        debug_assert!(
+            !self.tool_name.is_empty(),
+            "AdapterMeta.tool_name must not be empty"
+        );
+        debug_assert!(
+            !self.tool_version.is_empty(),
+            "AdapterMeta.tool_version must not be empty"
+        );
+        debug_assert!(
+            !self.long_version.is_empty(),
+            "AdapterMeta.long_version must not be empty"
+        );
+        debug_assert!(
+            !self.about.is_empty(),
+            "AdapterMeta.about must not be empty"
+        );
+        debug_assert!(
+            !self.long_about.is_empty(),
+            "AdapterMeta.long_about must not be empty"
+        );
+        debug_assert!(
+            !self.coverage_hint.is_empty(),
+            "AdapterMeta.coverage_hint must not be empty"
+        );
+        debug_assert!(
+            !self.tool_info_uri.is_empty(),
+            "AdapterMeta.tool_info_uri must not be empty"
+        );
+        debug_assert!(
+            !self.rule_help_uri.is_empty(),
+            "AdapterMeta.rule_help_uri must not be empty"
+        );
+        debug_assert!(
+            !self.config_file_name.is_empty(),
+            "AdapterMeta.config_file_name must not be empty"
+        );
     }
 }
 
@@ -676,7 +723,8 @@ impl<'a> AdapterMeta<'a> {
 /// compile time (crap-core's `0.1.0`); the adapter binary's own
 /// `CARGO_PKG_VERSION` and `<ADAPTER>_LONG_VERSION` only resolve in
 /// the binary's compile and reach us by parameter.
-pub fn parse_args(meta: &AdapterMeta<'_>) -> Cli {
+pub fn parse_args(meta: &AdapterMeta) -> Cli {
+    meta.debug_assert_required_fields();
     let cmd = build_command(meta);
     let matches = cmd.get_matches();
     Cli::from_arg_matches(&matches).unwrap_or_else(|e| e.exit())
@@ -711,24 +759,18 @@ fn current_bin_name(meta_fallback: &str) -> String {
 /// bin name through `current_bin_name` directly because
 /// `clap_complete::generate` takes the bin name as a separate arg.
 ///
-/// `version` / `long_version` / `name` / `bin_name` go through
-/// `Box::leak` because clap 4.6.0's `clap::builder::Str` implements
-/// `From<&'static str>` but **not** `From<String>` — the strings must
-/// outlive the parsed `Command`, which lives for the program's
-/// lifetime. The leak is fixed-size (≤ 4 small strings) and one-shot
-/// at startup. `about` / `long_about` / `after_help` accept
-/// `Into<StyledStr>` directly so `String` works there without
-/// leaking.
-fn build_command(meta: &AdapterMeta<'_>) -> clap::Command {
-    let bin_static: &'static str = Box::leak(current_bin_name(meta.tool_name).into_boxed_str());
-    let version_static: &'static str = Box::leak(meta.tool_version.to_string().into_boxed_str());
-    let long_version_static: &'static str =
-        Box::leak(meta.long_version.to_string().into_boxed_str());
+/// All metadata fields accept owned `String` directly thanks to clap's
+/// `string` feature, which adds `impl From<String> for clap::builder::Str`.
+/// Without the feature, `name` / `bin_name` / `version` / `long_version`
+/// require `&'static str` and the only way to satisfy that from a
+/// runtime-built `String` is `Box::leak` — see #161.
+fn build_command(meta: &AdapterMeta) -> clap::Command {
+    let bin_name = current_bin_name(meta.tool_name);
     let mut cmd = Cli::command()
-        .name(bin_static)
-        .bin_name(bin_static)
-        .version(version_static)
-        .long_version(long_version_static)
+        .name(bin_name.clone())
+        .bin_name(bin_name)
+        .version(meta.tool_version.to_string())
+        .long_version(meta.long_version.to_string())
         .about(meta.about.to_string())
         .long_about(meta.long_about.to_string());
     if !meta.after_help.is_empty() {
@@ -769,7 +811,7 @@ pub fn run<P, F>(
     cli: Cli,
     complexity: &dyn ComplexityPort,
     coverage_factory: F,
-    meta: &AdapterMeta<'_>,
+    meta: &AdapterMeta,
 ) -> ExitCode
 where
     P: ParseDiagnostic + std::fmt::Display + 'static,
@@ -789,7 +831,7 @@ fn run_inner<P, F>(
     mut cli: Cli,
     complexity: &dyn ComplexityPort,
     coverage_factory: F,
-    meta: &AdapterMeta<'_>,
+    meta: &AdapterMeta,
 ) -> Result<bool>
 where
     P: ParseDiagnostic + std::fmt::Display + 'static,
@@ -899,7 +941,7 @@ fn merge_effective_inputs(cli: &Cli, file_config: &Option<FileConfig>) -> Effect
 fn validate_runtime_inputs<'a>(
     cli: &'a Cli,
     inputs: &EffectiveInputs,
-    meta: &AdapterMeta<'_>,
+    meta: &AdapterMeta,
 ) -> Result<&'a Path> {
     // `--coverage` is required on the analysis path; subcommands like
     // `completions` skip this branch. Clap can't express "required
@@ -930,7 +972,7 @@ fn build_analyze_options(
     cli: &Cli,
     inputs: &EffectiveInputs,
     coverage: &Path,
-    meta: &AdapterMeta<'_>,
+    meta: &AdapterMeta,
 ) -> AnalyzeOptions {
     AnalyzeOptions {
         src: inputs.src.clone(),
@@ -974,7 +1016,7 @@ fn prepare_pipeline<P, F>(
     cli: &mut Cli,
     complexity: &dyn ComplexityPort,
     coverage_factory: F,
-    meta: &AdapterMeta<'_>,
+    meta: &AdapterMeta,
 ) -> Result<PipelinePrep<P>>
 where
     P: ParseDiagnostic + std::fmt::Display + 'static,
@@ -1046,7 +1088,7 @@ fn format_as_json<P: ParseDiagnostic>(
     delta_state: Option<&DeltaState<P>>,
     analysis: &AnalysisOutput<P>,
     inputs: &EffectiveInputs,
-    meta: &AdapterMeta<'_>,
+    meta: &AdapterMeta,
 ) -> Result<String> {
     let delta_ctx = delta_state.zip(delta_view).map(|(s, dv)| DeltaContext {
         view: dv,
@@ -1102,7 +1144,7 @@ fn render_format<P: ParseDiagnostic>(
     delta_state: Option<&DeltaState<P>>,
     analysis: &AnalysisOutput<P>,
     inputs: &EffectiveInputs,
-    meta: &AdapterMeta<'_>,
+    meta: &AdapterMeta,
 ) -> Result<String> {
     Ok(match spec.format {
         FormatArg::Table => reporters::format_table_with_explain(
@@ -1157,7 +1199,7 @@ fn print_formatted_output<P: ParseDiagnostic>(
     delta_state: Option<&DeltaState<P>>,
     analysis: &AnalysisOutput<P>,
     inputs: &EffectiveInputs,
-    meta: &AdapterMeta<'_>,
+    meta: &AdapterMeta,
 ) -> Result<()> {
     for spec in &cli.output.format {
         let output = render_format(
@@ -1446,7 +1488,7 @@ fn preflight_git_worktree(src: &Path) -> Result<()> {
 fn preflight_checks<P>(
     coverage: &std::path::Path,
     coverage_port: &dyn CoveragePort<Diagnostic = P>,
-    meta: &AdapterMeta<'_>,
+    meta: &AdapterMeta,
 ) -> Result<()>
 where
     P: ParseDiagnostic,
@@ -2459,5 +2501,77 @@ mod tests {
         assert!(compute_exit_code::<
             crate::test_strategies::DummyParseDiagnostic,
         >(&cli, false, None));
+    }
+
+    // ── AdapterMeta unit tests (#161) ──────────────────────────────
+
+    fn fake_meta() -> AdapterMeta {
+        AdapterMeta {
+            tool_name: "fake-adapter",
+            tool_version: "9.9.9",
+            long_version: "9.9.9 (test 2099-01-01)",
+            about: "Fake adapter for tests",
+            long_about: "Fake adapter for tests — verifies AdapterMeta plumbing without binding crap-core to any real adapter.",
+            after_help: "",
+            coverage_hint: "no coverage tool — fake adapter",
+            extensions: &["fake"],
+            tool_info_uri: "https://example.invalid/fake-adapter",
+            rule_help_uri: "https://example.invalid/fake-adapter#rules",
+            config_file_name: "fake-adapter.toml",
+        }
+    }
+
+    #[test]
+    fn adapter_meta_extensions_owned_roundtrips_to_owned_strings() {
+        let meta = AdapterMeta {
+            extensions: &["ts", "tsx", "js"],
+            ..fake_meta()
+        };
+        let owned = meta.extensions_owned();
+        assert_eq!(
+            owned,
+            vec!["ts".to_string(), "tsx".to_string(), "js".to_string()]
+        );
+        // Round-trip via Vec<&str> back to a slice-equivalent shape.
+        let back: Vec<&str> = owned.iter().map(String::as_str).collect();
+        assert_eq!(back, &["ts", "tsx", "js"]);
+    }
+
+    #[test]
+    fn adapter_meta_extensions_owned_handles_empty_slice() {
+        // `extensions` is allowed to be empty; the diagnostic surfaces
+        // downstream in `core::ensure_source_files_found`.
+        let meta = AdapterMeta {
+            extensions: &[],
+            ..fake_meta()
+        };
+        assert!(meta.extensions_owned().is_empty());
+    }
+
+    #[test]
+    #[should_panic(expected = "tool_name must not be empty")]
+    fn adapter_meta_debug_assert_trips_on_empty_tool_name() {
+        let meta = AdapterMeta {
+            tool_name: "",
+            ..fake_meta()
+        };
+        meta.debug_assert_required_fields();
+    }
+
+    #[test]
+    #[should_panic(expected = "config_file_name must not be empty")]
+    fn adapter_meta_debug_assert_trips_on_empty_config_file_name() {
+        let meta = AdapterMeta {
+            config_file_name: "",
+            ..fake_meta()
+        };
+        meta.debug_assert_required_fields();
+    }
+
+    #[test]
+    fn adapter_meta_debug_assert_passes_on_all_fields_set() {
+        // Smoke test: a meta with every required field populated should
+        // pass the debug_assert sweep without panicking.
+        fake_meta().debug_assert_required_fields();
     }
 }

--- a/crates/crap-core/src/core/mod.rs
+++ b/crates/crap-core/src/core/mod.rs
@@ -53,10 +53,13 @@ pub struct AnalyzeOptions {
     pub diff_ref: Option<String>,
     /// File extensions the walker should pick up. Adapter-specific
     /// (`["rs"]` for crap4rs; `["ts","tsx","js","jsx","mjs","cjs"]`
-    /// for crap4ts). `Default::default()` is `vec!["rs"]` so existing
-    /// library tests and snapshot baselines stay byte-identical
-    /// without an explicit set; the CLI boundary fills this from
-    /// `AdapterMeta::extensions`.
+    /// for crap4ts). `Default::default()` is `Vec::new()` since #161 —
+    /// the adapter-language coupling lives in each binary's
+    /// `AdapterMeta::extensions`, threaded into `AnalyzeOptions` at
+    /// the CLI boundary. Library tests that construct `AnalyzeOptions`
+    /// directly must set this explicitly;
+    /// `core::ensure_source_files_found` surfaces a parser-neutral
+    /// diagnostic when no files match.
     pub extensions: Vec<String>,
     /// When `true`, populate `FunctionVerdict.diagnostic` for every
     /// over-threshold verdict via `domain::diagnostic::compute_diagnostic`.

--- a/crates/crap-core/src/core/mod.rs
+++ b/crates/crap-core/src/core/mod.rs
@@ -100,10 +100,12 @@ impl Default for AnalyzeOptions {
             exclude: Vec::new(),
             respect_gitignore: true,
             diff_ref: None,
-            // `["rs"]` is the default for library tests that don't
-            // construct a full `AdapterMeta`. Adapter binaries
-            // override via `AdapterMeta::extensions`.
-            extensions: vec!["rs".to_string()],
+            // Empty by default — adapter-language coupling stays in
+            // each binary's `AdapterMeta::extensions`. Library tests
+            // that construct `AnalyzeOptions` directly must set this
+            // explicitly; `ensure_source_files_found` surfaces a
+            // parser-neutral diagnostic when nothing matches (#161).
+            extensions: Vec::new(),
             compute_diagnostics: false,
         }
     }

--- a/crates/crap4rs/tests/analyze_integration.rs
+++ b/crates/crap4rs/tests/analyze_integration.rs
@@ -47,6 +47,7 @@ fn self_referential_analysis() {
         metric: ComplexityMetric::Cognitive,
         exclude: Vec::new(),
         respect_gitignore: false,
+        extensions: vec!["rs".to_string()],
         ..AnalyzeOptions::default()
     };
 
@@ -109,6 +110,7 @@ fn self_referential_with_cyclomatic() {
         metric: ComplexityMetric::Cyclomatic,
         exclude: Vec::new(),
         respect_gitignore: false,
+        extensions: vec!["rs".to_string()],
         ..AnalyzeOptions::default()
     };
 
@@ -144,6 +146,7 @@ fn self_referential_known_functions_present() {
         metric: ComplexityMetric::Cognitive,
         exclude: Vec::new(),
         respect_gitignore: false,
+        extensions: vec!["rs".to_string()],
         ..AnalyzeOptions::default()
     };
 
@@ -194,6 +197,7 @@ fn exclude_pattern_filters_correctly() {
         metric: ComplexityMetric::Cognitive,
         exclude: Vec::new(),
         respect_gitignore: false,
+        extensions: vec!["rs".to_string()],
         ..AnalyzeOptions::default()
     };
     let all_result = analyze(&all_opts, &cx, &cov).unwrap().result;
@@ -209,6 +213,7 @@ fn exclude_pattern_filters_correctly() {
         metric: ComplexityMetric::Cognitive,
         exclude: vec!["adapters/**".to_string()],
         respect_gitignore: false,
+        extensions: vec!["rs".to_string()],
         ..AnalyzeOptions::default()
     };
     let filtered_result = analyze(&filtered_opts, &cx, &cov).unwrap().result;

--- a/crates/crap4rs/tests/analyze_pipeline_tests.rs
+++ b/crates/crap4rs/tests/analyze_pipeline_tests.rs
@@ -83,6 +83,7 @@ fn analyze_returns_results_for_simple_project() {
         metric: ComplexityMetric::Cognitive,
         exclude: Vec::new(),
         respect_gitignore: false,
+        extensions: vec!["rs".to_string()],
         ..AnalyzeOptions::default()
     };
 
@@ -110,6 +111,7 @@ fn analyze_simple_fn_fully_covered_has_low_crap() {
         metric: ComplexityMetric::Cognitive,
         exclude: Vec::new(),
         respect_gitignore: false,
+        extensions: vec!["rs".to_string()],
         ..AnalyzeOptions::default()
     };
 
@@ -141,6 +143,7 @@ fn analyze_branching_fn_partial_coverage_higher_crap() {
         metric: ComplexityMetric::Cognitive,
         exclude: Vec::new(),
         respect_gitignore: false,
+        extensions: vec!["rs".to_string()],
         ..AnalyzeOptions::default()
     };
 
@@ -172,6 +175,7 @@ fn analyze_pass_when_all_below_threshold() {
         metric: ComplexityMetric::Cognitive,
         exclude: Vec::new(),
         respect_gitignore: false,
+        extensions: vec!["rs".to_string()],
         ..AnalyzeOptions::default()
     };
 
@@ -199,6 +203,7 @@ fn analyze_at_exact_threshold_does_not_exceed() {
         metric: ComplexityMetric::Cognitive,
         exclude: Vec::new(),
         respect_gitignore: false,
+        extensions: vec!["rs".to_string()],
         ..AnalyzeOptions::default()
     };
 
@@ -230,6 +235,7 @@ fn analyze_fail_when_above_threshold() {
         metric: ComplexityMetric::Cognitive,
         exclude: Vec::new(),
         respect_gitignore: false,
+        extensions: vec!["rs".to_string()],
         ..AnalyzeOptions::default()
     };
 
@@ -255,6 +261,7 @@ fn analyze_no_functions_extracted_errors() {
         src: src_dir,
         coverage: dir.path().join("lcov.info"),
         respect_gitignore: false,
+        extensions: vec!["rs".to_string()],
         ..AnalyzeOptions::default()
     };
 
@@ -277,6 +284,7 @@ fn analyze_empty_src_dir_errors() {
     let opts = AnalyzeOptions {
         src: src_dir,
         coverage: dir.path().join("lcov.info"),
+        extensions: vec!["rs".to_string()],
         ..AnalyzeOptions::default()
     };
 
@@ -295,6 +303,7 @@ fn analyze_missing_coverage_file_errors() {
     let opts = AnalyzeOptions {
         src: src_dir,
         coverage: dir.path().join("nonexistent.info"),
+        extensions: vec!["rs".to_string()],
         ..AnalyzeOptions::default()
     };
 
@@ -329,6 +338,7 @@ fn analyze_exclude_pattern_filters_files() {
         coverage: dir.path().join("lcov.info"),
         exclude: vec!["tests/**".to_string()],
         respect_gitignore: false,
+        extensions: vec!["rs".to_string()],
         ..AnalyzeOptions::default()
     };
 
@@ -353,6 +363,7 @@ fn analyze_with_cyclomatic_metric() {
         src,
         coverage: dir.path().join("lcov.info"),
         metric: ComplexityMetric::Cyclomatic,
+        extensions: vec!["rs".to_string()],
         ..AnalyzeOptions::default()
     };
 
@@ -376,6 +387,7 @@ fn summary_computed_correctly() {
             global: DEFAULT_THRESHOLD,
             ..ThresholdConfig::default()
         },
+        extensions: vec!["rs".to_string()],
         ..AnalyzeOptions::default()
     };
 
@@ -402,6 +414,7 @@ fn analyze_diff_ref_none_is_backward_compat() {
         coverage: dir.path().join("lcov.info"),
         diff_ref: None,
         respect_gitignore: false,
+        extensions: vec!["rs".to_string()],
         ..AnalyzeOptions::default()
     };
 
@@ -427,6 +440,7 @@ fn analyze_returns_diagnostics() {
         metric: ComplexityMetric::Cognitive,
         exclude: Vec::new(),
         respect_gitignore: false,
+        extensions: vec!["rs".to_string()],
         ..AnalyzeOptions::default()
     };
 
@@ -464,6 +478,7 @@ fn analyze_diagnostics_counts_no_coverage_functions() {
         src: src_dir,
         coverage: dir.path().join("lcov.info"),
         respect_gitignore: false,
+        extensions: vec!["rs".to_string()],
         ..AnalyzeOptions::default()
     };
 
@@ -494,6 +509,7 @@ fn analyze_diagnostics_surfaces_parse_diagnostics() {
         src: src_dir,
         coverage: dir.path().join("lcov.info"),
         respect_gitignore: false,
+        extensions: vec!["rs".to_string()],
         ..AnalyzeOptions::default()
     };
 
@@ -521,6 +537,7 @@ fn analyze_with_per_path_overrides() {
         metric: ComplexityMetric::Cognitive,
         exclude: Vec::new(),
         respect_gitignore: false,
+        extensions: vec!["rs".to_string()],
         ..AnalyzeOptions::default()
     };
 
@@ -576,6 +593,7 @@ pub fn with_branch(x: i32) -> &'static str {
         src: src_dir,
         coverage: dir.path().join("lcov.info"),
         respect_gitignore: false,
+        extensions: vec!["rs".to_string()],
         ..AnalyzeOptions::default()
     };
 

--- a/crates/crap4rs/tests/cli_help_content_integration.rs
+++ b/crates/crap4rs/tests/cli_help_content_integration.rs
@@ -1,0 +1,52 @@
+//! `--help` content integration tests (#161).
+//!
+//! Verifies that the `ABOUT` / `LONG_ABOUT` strings declared in
+//! `crap4rs/src/main.rs` actually reach clap's help output via
+//! `AdapterMeta`. A regression here means the threading from binary
+//! `const` → `AdapterMeta` → `clap::Command::about/long_about` is
+//! broken — a silent failure that only surfaces when a human runs
+//! `crap4rs --help` and notices the wrong copy.
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_crap4rs");
+
+fn run_help(flag: &str) -> String {
+    let out = Command::new(BINARY)
+        .arg(flag)
+        .output()
+        .expect("failed to run crap4rs binary");
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+#[test]
+fn short_help_contains_about_string() {
+    // `-h` triggers clap's short help, which uses `about`.
+    let out = run_help("-h");
+    assert!(
+        out.contains("CRAP score analyzer for Rust"),
+        "short help must contain ABOUT from main.rs, got:\n{out}"
+    );
+}
+
+#[test]
+fn long_help_contains_long_about_phrase() {
+    // `--help` triggers clap's long help, which uses `long_about`.
+    // Anchor on a distinctive phrase from LONG_ABOUT that wouldn't
+    // appear in the default clap-derive help text.
+    let out = run_help("--help");
+    assert!(
+        out.contains("Change Risk Anti-Patterns") && out.contains("cognitive complexity"),
+        "long help must contain LONG_ABOUT from main.rs, got:\n{out}"
+    );
+}
+
+#[test]
+fn long_help_contains_after_help_examples() {
+    // `--help` should also append the AFTER_HELP block with EXAMPLES.
+    let out = run_help("--help");
+    assert!(
+        out.contains("EXAMPLES:") && out.contains("crap4rs --coverage lcov.info"),
+        "long help must contain AFTER_HELP EXAMPLES from main.rs, got:\n{out}"
+    );
+}

--- a/crates/crap4rs/tests/cli_help_content_integration.rs
+++ b/crates/crap4rs/tests/cli_help_content_integration.rs
@@ -16,6 +16,16 @@ fn run_help(flag: &str) -> String {
         .arg(flag)
         .output()
         .expect("failed to run crap4rs binary");
+    // Without this guard, a non-zero exit (e.g., clap parse failure
+    // from a future regression) would surface as a confusing
+    // "expected substring not found" downstream rather than the
+    // actual command failure.
+    assert!(
+        out.status.success(),
+        "crap4rs {flag} exited with {:?}\nstderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
     String::from_utf8_lossy(&out.stdout).into_owned()
 }
 

--- a/crates/crap4rs/tests/diff_integration.rs
+++ b/crates/crap4rs/tests/diff_integration.rs
@@ -67,6 +67,7 @@ fn make_opts(dir: &Path, diff_ref: Option<&str>) -> AnalyzeOptions {
         exclude: Vec::new(),
         respect_gitignore: false,
         diff_ref: diff_ref.map(String::from),
+        extensions: vec!["rs".to_string()],
         ..AnalyzeOptions::default()
     }
 }


### PR DESCRIPTION
## Summary

Lane 2 v1.0-prep fast-follow on PR #162's `AdapterMeta` surface. Closes the 10 polish ACs flagged by reviewers during PR C review:

- **clap `string` feature** unlocks `impl From<String> for clap::builder::Str` — three `Box::leak` calls in `build_command` deleted
- **`AdapterMeta<'a>` → `AdapterMeta`** with all `&'static` fields; lifetime parameter dropped from 11 function signatures
- **`extensions: &'a [&'a str]` → `&'static [&'static str]`** (tightens nested lifetime per type-design-analyzer flag)
- **`debug_assert_required_fields`** guard called from `parse_args` (zero-cost in release; trips on empty `tool_name` / `tool_version` / etc.)
- **`AnalyzeOptions::default().extensions`**: was `vec!["rs"]` — silent re-coupling — now `Vec::new()`. All 24 test sites updated to set explicitly.
- **CI adapter-name gate**: new step in `ast-purity` job rejects `"crap4rs"` / `"crap4ts"` string literals in `crap-core/src/`. Comments allowed; code literals fail the build.
- **AdapterMeta unit tests**: direct construction + `extensions_owned` round-trip + 2 `#[should_panic]` trips + smoke test.
- **`discover_config(name)` parameterized test**: writes `crap4ts.toml`, asserts lookup is param-driven.
- **`--help` content integration tests**: new `cli_help_content_integration.rs` asserts binary `--help` reaches `ABOUT` / `LONG_ABOUT` / `AFTER_HELP` from `main.rs`.

`format_extensions_list` dedup (AC #9) was already shipped in PR #164. Confirmed single site at `core::ensure_source_files_found`.

## Test plan

- [x] `cargo nextest run --workspace` — 933 tests passing (up from 920 — new tests added)
- [x] `cargo fmt --check && cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo +1.93 check --workspace --all-targets` (MSRV gate, with `--all-targets` per memory)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- [x] `cargo deny check` — advisories ok, bans ok, licenses ok, sources ok
- [x] `cargo test --test wire_envelope_snapshot` — byte-identical (no envelope shape change)
- [x] Local CI grep-gate emulation: confirmed `"crap4rs"` / `"crap4ts"` hits in `crap-core/src/` are all in doc comments (allowed by the awk filter)
- [x] AST-purity 3-layered grep still clean
- [x] `crap4rs --help` / `-h` smoke-tested via new integration tests (asserts the `AdapterMeta` → clap binding holds)

Closes #161.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive integration tests for CLI help output and help text contents
  * Expanded test coverage for configuration discovery, analysis pipeline, and extension handling
  * Added adapter metadata validation tests

* **Chores**
  * CI workflow: added a check to flag disallowed hardcoded tool identifiers in source
  * Workspace manifest: enabled an additional feature for the CLI dependency to support string handling

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/breezy-bays-labs/crap-rs/pull/165)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->