### PR TITLE
feat(cli): #131 — --summary one-line analysis verdict flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `--summary` flag emits a single-line analysis verdict to stdout (e.g.
+  `PASS: 1082 functions | 0 above threshold (25) | worst: 13.0 | avg: 1.6`),
+  matching crap4ts's `formatSummaryLine` byte-for-byte. Short-circuits
+  `--format` and composes with `--no-fail` (exit 0 always, summary
+  emitted) and `--quiet` (quiet wins — no output). Closes the
+  2026-05-08 crap4rs ↔ crap4ts parity audit's final gap. (#131)
+
 ## [0.5.0] - 2026-05-10
 
 The workspace-extraction milestone. `crap4rs` becomes one of three

--- a/crates/crap-core/src/adapters/reporters/mod.rs
+++ b/crates/crap-core/src/adapters/reporters/mod.rs
@@ -7,6 +7,7 @@ pub mod json;
 pub mod markdown;
 pub mod sarif;
 pub mod scorecard_row;
+pub mod summary;
 pub mod table;
 
 pub use advice_summary::render_summary as render_advice_summary;
@@ -16,6 +17,7 @@ pub use json::{JsonConfig, format_json};
 pub use markdown::format_markdown;
 pub use sarif::format_sarif;
 pub use scorecard_row::format_scorecard_row;
+pub use summary::format_summary_line;
 pub use table::{format_table, format_table_with_explain};
 
 #[cfg(test)]

--- a/crates/crap-core/src/adapters/reporters/summary.rs
+++ b/crates/crap-core/src/adapters/reporters/summary.rs
@@ -1,0 +1,148 @@
+//! One-line analysis verdict reporter (`--summary`).
+//!
+//! Emits a single human-and-CI-friendly line summarising the run:
+//!
+//! ```text
+//! PASS: 1082 functions | 0 above threshold (25) | worst: 13.0 | avg: 1.6
+//! FAIL: 412 functions | 7 above threshold (25) | worst: 47.5 | avg: 3.2
+//! ```
+//!
+//! Mirrors crap4ts's `formatSummaryLine` byte-for-byte for the shared
+//! subset (status, function count, exceeding count, threshold, worst,
+//! avg) so a CI line-template can match either tool. Threshold formats
+//! integer-when-whole via Rust's default `f64` Display, which matches
+//! TypeScript's `Number.toString()`. Worst and average are fixed at one
+//! decimal place to match `Number.toFixed(1)`.
+//!
+//! Empty-analysis behaviour (`summary.max_crap = None`): renders
+//! `worst: 0.0`. Documented choice — neither the issue's AC nor
+//! crap4ts's reference specifies it (crap4ts would throw on the missing
+//! deref).
+
+use crate::domain::types::AnalysisResult;
+
+/// Format the single-line analysis verdict.
+///
+/// `threshold` is the effective post-merge display threshold (after
+/// `--strict` / `--lenient` / config-file precedence), not the raw
+/// `cli.output.threshold`. Pass `inputs.threshold` from the dispatch
+/// site.
+pub fn format_summary_line(result: &AnalysisResult, threshold: f64) -> String {
+    let status = if result.passed { "PASS" } else { "FAIL" };
+    let worst = result
+        .summary
+        .max_crap
+        .as_ref()
+        .map(|c| c.value)
+        .unwrap_or(0.0);
+    format!(
+        "{status}: {total} functions | {exceeding} above threshold ({threshold}) | worst: {worst:.1} | avg: {avg:.1}",
+        total = result.summary.total_functions,
+        exceeding = result.summary.exceeding_threshold,
+        avg = result.summary.average_crap,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adapters::reporters::test_fixtures::{
+        make_empty_result, make_multi_function_result, make_single_function_result,
+    };
+    use crate::domain::types::RiskLevel;
+
+    #[test]
+    fn pass_line_shape_matches_crap4ts() {
+        let result = make_single_function_result(
+            "tiny_fn",
+            "src/lib.rs",
+            1,
+            100.0,
+            1.0,
+            RiskLevel::Low,
+            25.0,
+        );
+        let line = format_summary_line(&result, 25.0);
+        assert_eq!(
+            line,
+            "PASS: 1 functions | 0 above threshold (25) | worst: 1.0 | avg: 1.0"
+        );
+    }
+
+    #[test]
+    fn fail_line_shape_matches_crap4ts() {
+        let mut result = make_single_function_result(
+            "scary_fn",
+            "src/lib.rs",
+            20,
+            30.0,
+            47.5,
+            RiskLevel::High,
+            25.0,
+        );
+        // single_function_result derived .passed from exceeds vs threshold 25.0,
+        // and average_crap from crap_value — both match what we want.
+        result.summary.average_crap = 3.2;
+        let line = format_summary_line(&result, 25.0);
+        assert_eq!(
+            line,
+            "FAIL: 1 functions | 1 above threshold (25) | worst: 47.5 | avg: 3.2"
+        );
+    }
+
+    #[test]
+    fn threshold_renders_as_integer_when_whole() {
+        let result = make_empty_result();
+        let line = format_summary_line(&result, 25.0);
+        assert!(line.contains("(25)"), "expected '(25)' in {line:?}");
+        assert!(!line.contains("(25.0)"), "should not include '.0'");
+    }
+
+    #[test]
+    fn threshold_renders_with_decimals_when_fractional() {
+        let result = make_empty_result();
+        let line = format_summary_line(&result, 25.5);
+        assert!(line.contains("(25.5)"), "expected '(25.5)' in {line:?}");
+    }
+
+    #[test]
+    fn empty_analysis_renders_worst_zero() {
+        let result = make_empty_result();
+        assert!(result.summary.max_crap.is_none());
+        let line = format_summary_line(&result, 25.0);
+        assert_eq!(
+            line,
+            "PASS: 0 functions | 0 above threshold (25) | worst: 0.0 | avg: 0.0"
+        );
+    }
+
+    #[test]
+    fn worst_and_avg_fixed_one_decimal() {
+        let mut result = make_multi_function_result();
+        // multi-function fixture already gives max_crap = 45.2 (high),
+        // average_crap computed from compute_summary — overwrite to a
+        // known float to assert the {:.1} formatter.
+        result.summary.max_crap = Some(crate::domain::types::CrapScore {
+            value: 13.04,
+            risk_level: RiskLevel::Moderate,
+        });
+        result.summary.average_crap = 1.642;
+        let line = format_summary_line(&result, 25.0);
+        assert!(
+            line.contains("worst: 13.0"),
+            "expected 'worst: 13.0' in {line:?}"
+        );
+        assert!(line.contains("avg: 1.6"), "expected 'avg: 1.6' in {line:?}");
+    }
+
+    #[test]
+    fn pass_status_from_result_passed_field() {
+        let mut result = make_empty_result();
+        result.passed = false;
+        let line = format_summary_line(&result, 25.0);
+        assert!(
+            line.starts_with("FAIL:"),
+            "expected FAIL prefix in {line:?}"
+        );
+    }
+}

--- a/crates/crap-core/src/cli/mod.rs
+++ b/crates/crap-core/src/cli/mod.rs
@@ -380,6 +380,19 @@ pub struct OutputArgs {
     /// with `--format json`.
     #[arg(long)]
     pub minimal_view: bool,
+
+    /// Emit a single-line analysis verdict instead of the full report.
+    ///
+    /// Format: `<STATUS>: <N> functions | <M> above threshold (<T>) | worst: <W> | avg: <A>`
+    /// (e.g., `PASS: 1082 functions | 0 above threshold (25) | worst: 13.0 | avg: 1.6`).
+    /// Short-circuits `--format`: when set, the format dispatch is
+    /// skipped and only the summary line is printed to stdout.
+    /// Composes with `--no-fail` (exit 0 always when set, summary still
+    /// emitted) and `--quiet` (quiet wins — no output, exit code only).
+    /// Matches crap4ts's `--summary` shape byte-for-byte for the shared
+    /// subset so a CI line-template can match either tool.
+    #[arg(long)]
+    pub summary: bool,
 }
 
 #[derive(Debug, Args)]
@@ -1204,6 +1217,17 @@ fn print_formatted_output<P: ParseDiagnostic>(
     inputs: &EffectiveInputs,
     meta: &AdapterMeta,
 ) -> Result<()> {
+    // `--summary` short-circuits `--format` dispatch entirely. `--quiet`
+    // already gates this entire function at the caller (run_inner), so
+    // the precedence is `--quiet > --summary > --format`. Mirrors
+    // crap4ts's implicit precedence (its formatSummaryLine bypasses the
+    // reporter switch when set).
+    if cli.output.summary {
+        let line = reporters::format_summary_line(view.full, inputs.threshold);
+        println!("{line}");
+        return Ok(());
+    }
+
     for spec in &cli.output.format {
         let output = render_format(
             cli,

--- a/crates/crap4rs/Cargo.toml
+++ b/crates/crap4rs/Cargo.toml
@@ -93,3 +93,7 @@ tokio = { workspace = true }
 [[test]]
 name = "json_reporter_cucumber"
 harness = false
+
+[[test]]
+name = "cli_ergonomics_cucumber"
+harness = false

--- a/crates/crap4rs/tests/cli_ergonomics_cucumber.rs
+++ b/crates/crap4rs/tests/cli_ergonomics_cucumber.rs
@@ -1,0 +1,256 @@
+//! Cucumber-rs runner for `@summary`-tagged scenarios in
+//! `tests/features/cli_ergonomics.feature` (issue #131).
+//!
+//! Most scenarios in `cli_ergonomics.feature` are spec-only — they
+//! describe behaviour validated indirectly via the `cli_*_integration.rs`
+//! suite. The `@summary` block is wired here so the AC for #131
+//! (one-line CLI verdict) executes through the same .feature file the
+//! spec lives in. Other scenarios in the file are not wired; the
+//! harness uses `filter_run_and_exit` to load only `@summary` tagged
+//! scenarios. New BDD-driven flags can adopt their own tags and
+//! extend this harness (or land siblings) without forcing migration of
+//! the unwired specs.
+//!
+//! Each scenario sets up a tempdir with a small synthetic LCOV +
+//! `src/lib.rs` (mirrors `cli_no_fail_integration.rs`'s pattern) and
+//! invokes the binary via `CARGO_BIN_EXE_crap4rs`. The harness does
+//! NOT depend on the workspace's self-fixture LCOV, so paths in
+//! scenario commands stay relative to the tempdir cwd.
+//!
+//! The two synthetic fixtures cover the two pass/fail invariants needed
+//! by the seven `@summary` scenarios:
+//! - `WITHIN_*` — three trivial covered fns; every CRAP ≤ 2, so any
+//!   reasonable threshold passes.
+//! - `EXCEEDS_*` — three branchy uncovered fns; CRAPs roughly 20+, so
+//!   `--threshold 5` deliberately trips the gate.
+
+use std::path::{Path, PathBuf};
+use std::process::Output;
+
+use cucumber::{World, given, then, when, writer};
+
+const BINARY: &str = env!("CARGO_BIN_EXE_crap4rs");
+
+const WITHIN_SRC: &str = "\
+pub fn one() -> i32 { 1 }
+pub fn two() -> i32 { 2 }
+pub fn three() -> i32 { 3 }
+";
+
+const WITHIN_LCOV: &str = "\
+SF:lib.rs
+DA:1,1
+DA:2,1
+DA:3,1
+end_of_record
+";
+
+const EXCEEDS_SRC: &str = "\
+pub fn branchy_a(x: i32) -> i32 { if x > 0 { if x > 5 { 1 } else { 2 } } else { 3 } }
+pub fn branchy_b(x: i32) -> i32 { if x > 0 { if x > 5 { 1 } else { 2 } } else { 3 } }
+pub fn branchy_c(x: i32) -> i32 { if x > 0 { if x > 5 { 1 } else { 2 } } else { 3 } }
+";
+
+const EXCEEDS_LCOV: &str = "\
+SF:lib.rs
+DA:1,1
+DA:2,0
+DA:3,0
+end_of_record
+";
+
+#[derive(Debug, Default, World)]
+struct CliWorld {
+    project_dir: Option<PathBuf>,
+    /// Held during the scenario lifetime so the directory survives;
+    /// dropped between scenarios because the World resets.
+    _tempdir: Option<tempfile::TempDir>,
+    output: Option<Output>,
+}
+
+impl CliWorld {
+    fn require_dir(&self) -> &Path {
+        self.project_dir
+            .as_deref()
+            .expect("scenario did not set up a project directory")
+    }
+
+    fn require_output(&self) -> &Output {
+        self.output
+            .as_ref()
+            .expect("scenario did not run the binary")
+    }
+
+    fn stdout(&self) -> String {
+        String::from_utf8_lossy(&self.require_output().stdout).into_owned()
+    }
+}
+
+fn setup_project(world: &mut CliWorld, src: &str, lcov: &str) {
+    let dir = tempfile::tempdir().expect("create tempdir");
+    let path = dir.path().to_path_buf();
+    std::fs::create_dir_all(path.join("src")).expect("create src dir");
+    std::fs::write(path.join("src/lib.rs"), src).expect("write src/lib.rs");
+    std::fs::write(path.join("lcov.info"), lcov).expect("write lcov.info");
+    world.project_dir = Some(path);
+    world._tempdir = Some(dir);
+}
+
+/// Parse a backtick-wrapped `crap4rs ...` command into the args vec
+/// (drops the binary name). Returns args for `Command::args(&args)`.
+fn parse_command(cmd: &str) -> Vec<String> {
+    cmd.split_whitespace().skip(1).map(str::to_string).collect()
+}
+
+// ── Background no-op steps ───────────────────────────────────────────
+//
+// `cli_ergonomics.feature` declares a Background that injects four
+// descriptive Given steps (line 25-29) before every scenario. Those
+// steps are aspirational — they describe the implicit project state
+// the broader spec assumes — and have no executable step definitions
+// in the rest of the codebase. To run `@summary` scenarios at all, the
+// Background needs to "pass", so the steps below are intentional
+// no-ops. The real fixture setup happens in the @summary-specific
+// `Given a synthetic project where ...` step below.
+#[given(regex = r#"^a project with an LCOV file at "[^"]+"$"#)]
+fn given_background_lcov(_world: &mut CliWorld) {}
+
+#[given("the project's analysis produces TOTAL_FUNCTIONS functions")]
+fn given_background_total(_world: &mut CliWorld) {}
+
+#[given("VIOLATING_FUNCTIONS of those functions exceed the threshold")]
+fn given_background_violating(_world: &mut CliWorld) {}
+
+#[given("TOTAL_FUNCTIONS > 0 and VIOLATING_FUNCTIONS > 0")]
+fn given_background_positive(_world: &mut CliWorld) {}
+
+// ── Given steps (real) ───────────────────────────────────────────────
+
+#[given("a synthetic project where every function is within threshold")]
+fn given_within(world: &mut CliWorld) {
+    setup_project(world, WITHIN_SRC, WITHIN_LCOV);
+}
+
+#[given("a synthetic project where at least one function exceeds threshold")]
+fn given_exceeds(world: &mut CliWorld) {
+    setup_project(world, EXCEEDS_SRC, EXCEEDS_LCOV);
+}
+
+// ── When step ────────────────────────────────────────────────────────
+
+#[when(regex = r#"^the operator runs `([^`]+)`$"#)]
+fn when_run(world: &mut CliWorld, cmd: String) {
+    let args = parse_command(&cmd);
+    let needs_project = cmd.contains("--coverage") && !cmd.contains("--help");
+
+    let mut command = std::process::Command::new(BINARY);
+    if needs_project {
+        let dir = world.require_dir();
+        command.current_dir(dir);
+    }
+    command.args(&args);
+
+    let output = command
+        .output()
+        .unwrap_or_else(|e| panic!("failed to invoke crap4rs binary at {BINARY:?}: {e}"));
+    world.output = Some(output);
+}
+
+// ── Then steps ───────────────────────────────────────────────────────
+
+#[then("stdout contains exactly one line")]
+fn then_one_line(world: &mut CliWorld) {
+    let stdout = world.stdout();
+    let trimmed = stdout.trim_end_matches('\n');
+    let line_count = if trimmed.is_empty() {
+        0
+    } else {
+        trimmed.lines().count()
+    };
+    assert_eq!(
+        line_count, 1,
+        "expected exactly one line on stdout, got {line_count}:\n{stdout}"
+    );
+}
+
+#[then(regex = r#"^stdout matches "(.+)"$"#)]
+fn then_matches(world: &mut CliWorld, pattern: String) {
+    let stdout = world.stdout();
+    let line = stdout.trim_end_matches('\n');
+    let re =
+        regex::Regex::new(&pattern).unwrap_or_else(|e| panic!("invalid regex {pattern:?}: {e}"));
+    assert!(
+        re.is_match(line),
+        "stdout did not match {pattern:?}:\nstdout:\n{stdout}"
+    );
+}
+
+#[then(regex = r#"^stdout starts with "([^"]+)"$"#)]
+fn then_starts_with(world: &mut CliWorld, prefix: String) {
+    let stdout = world.stdout();
+    assert!(
+        stdout.starts_with(&prefix),
+        "stdout did not start with {prefix:?}:\nstdout:\n{stdout}"
+    );
+}
+
+#[then(regex = r#"^stdout contains "([^"]+)"$"#)]
+fn then_contains(world: &mut CliWorld, needle: String) {
+    let stdout = world.stdout();
+    assert!(
+        stdout.contains(&needle),
+        "stdout did not contain {needle:?}:\nstdout:\n{stdout}"
+    );
+}
+
+#[then(regex = r#"^stdout does not contain "([^"]+)"$"#)]
+fn then_not_contains(world: &mut CliWorld, needle: String) {
+    let stdout = world.stdout();
+    assert!(
+        !stdout.contains(&needle),
+        "stdout unexpectedly contained {needle:?}:\nstdout:\n{stdout}"
+    );
+}
+
+#[then("stdout is empty")]
+fn then_empty(world: &mut CliWorld) {
+    let stdout = world.stdout();
+    assert!(stdout.is_empty(), "expected empty stdout, got:\n{stdout}");
+}
+
+#[then(regex = r"^the exit code is (\d+)$")]
+fn then_exit_code(world: &mut CliWorld, expected: i32) {
+    let actual = world
+        .require_output()
+        .status
+        .code()
+        .expect("process exited via signal");
+    let stdout = world.stdout();
+    let stderr = String::from_utf8_lossy(&world.require_output().stderr);
+    assert_eq!(
+        actual, expected,
+        "exit code mismatch — expected {expected}, got {actual}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}
+
+// ── Runner ──────────────────────────────────────────────────────────
+
+#[tokio::main]
+async fn main() {
+    // `writer::Libtest::or_basic()` emits libtest-compatible JSON under
+    // nextest (which probes `--list`) and falls back to the basic
+    // writer for plain `cargo test`. Matches `json_reporter_cucumber`.
+    //
+    // `filter_run_and_exit` loads `cli_ergonomics.feature` but executes
+    // only `@summary`-tagged scenarios; other scenarios are aspirational
+    // specs validated indirectly.
+    //
+    // `run_and_exit` (vs `run`) panics on scenario failure, propagating
+    // a non-zero exit to CI — see memory `cucumber-run-vs-run-and-exit`.
+    CliWorld::cucumber()
+        .with_writer(writer::Libtest::or_basic())
+        .filter_run_and_exit("tests/features/cli_ergonomics.feature", |_, _, scenario| {
+            scenario.tags.iter().any(|t| t == "summary")
+        })
+        .await;
+}

--- a/crates/crap4rs/tests/features/cli_ergonomics.feature
+++ b/crates/crap4rs/tests/features/cli_ergonomics.feature
@@ -336,3 +336,65 @@ Feature: CLI ergonomics — shaping the report from the command line
       | --max-coverage 105                                 | 2    |
       | --min-coverage 90 --max-coverage 30                | 2    |
       | --top -3                                           | 2    |
+
+  # ── --summary: one-line CLI output (issue #131) ────────────────────
+  #
+  # crap4ts parity. Format:
+  #   `<STATUS>: <N> functions | <M> above threshold (<T>) | worst: <W> | avg: <A>`
+  # Status from `result.passed`, threshold formatted integer-when-whole,
+  # worst/avg one decimal place. The tagged scenarios below are wired
+  # to the `cli_ergonomics_cucumber` harness, which sets up a synthetic
+  # LCOV+src layout per scenario (matches `cli_no_fail_integration.rs`).
+  # The rest of this feature remains spec-only.
+
+  @summary
+  Scenario: --summary on a passing run emits a single PASS line
+    Given a synthetic project where every function is within threshold
+    When the operator runs `crap4rs --coverage lcov.info --src src --threshold 25 --summary`
+    Then stdout contains exactly one line
+    And stdout matches "^PASS: \d+ functions \| 0 above threshold \(25\) \| worst: \d+\.\d \| avg: \d+\.\d$"
+    And the exit code is 0
+
+  @summary
+  Scenario: --summary on a failing run emits a single FAIL line
+    Given a synthetic project where at least one function exceeds threshold
+    When the operator runs `crap4rs --coverage lcov.info --src src --threshold 5 --summary`
+    Then stdout contains exactly one line
+    And stdout matches "^FAIL: \d+ functions \| \d+ above threshold \(5\) \| worst: \d+\.\d \| avg: \d+\.\d$"
+    And the exit code is 1
+
+  @summary
+  Scenario: --summary with --no-fail keeps emitting FAIL but exits 0
+    Given a synthetic project where at least one function exceeds threshold
+    When the operator runs `crap4rs --coverage lcov.info --src src --threshold 5 --summary --no-fail`
+    Then stdout contains exactly one line
+    And stdout starts with "FAIL:"
+    And the exit code is 0
+
+  @summary
+  Scenario: --summary with --quiet suppresses output (quiet wins)
+    Given a synthetic project where at least one function exceeds threshold
+    When the operator runs `crap4rs --coverage lcov.info --src src --threshold 5 --summary --quiet`
+    Then stdout is empty
+    And the exit code is 1
+
+  @summary
+  Scenario: --summary short-circuits --format json (summary line wins)
+    Given a synthetic project where every function is within threshold
+    When the operator runs `crap4rs --coverage lcov.info --src src --threshold 25 --summary --format json`
+    Then stdout contains exactly one line
+    And stdout starts with "PASS:"
+    And stdout does not contain "schema_version"
+
+  @summary
+  Scenario: --summary renders fractional threshold with decimals
+    Given a synthetic project where every function is within threshold
+    When the operator runs `crap4rs --coverage lcov.info --src src --threshold 25.5 --summary`
+    Then stdout contains exactly one line
+    And stdout contains "above threshold (25.5)"
+
+  @summary
+  Scenario: --summary help text includes the format template
+    When the operator runs `crap4rs --help`
+    Then stdout contains "--summary"
+    And stdout contains "single-line analysis verdict"


### PR DESCRIPTION
## Summary

Adds `--summary` to emit a single-line analysis verdict (`PASS: <N> functions | <M> above threshold (<T>) | worst: <W> | avg: <A>`) matching crap4ts's `formatSummaryLine` byte-for-byte. Closes the **last** gap from the [2026-05-08 crap4rs ↔ crap4ts parity audit](https://github.com/breezy-bays-labs/crap-rs/issues/131) and ends Lane 2 (v1.0 prep tech-debt sprint).

Closes #131. Closes the audit pipeline at `~/Github/ops/workspace/crap4rs/20260508-parity-audit/`.

## What ships

- **Flag** on `crap-core::cli::OutputArgs` — language-agnostic, so the same flag will work for crap4ts when its CLI ports to crap-core.
- **Formatter** in `crap-core::adapters::reporters::summary::format_summary_line(&AnalysisResult, threshold: f64) -> String`. Threshold renders integer-when-whole via Rust's default `f64` Display (matches TypeScript's `Number.toString()`); worst/avg use `{:.1}` to match `Number.toFixed(1)`.
- **Short-circuit** in `print_formatted_output`. `--quiet` already gates the whole function at `run_inner`, so precedence falls out as `--quiet > --summary > --format` with no second gate.
- **BDD**: 7 `@summary`-tagged scenarios in `tests/features/cli_ergonomics.feature` wired through a new `cli_ergonomics_cucumber` harness (`filter_run_and_exit` on tag, binary invocation via `CARGO_BIN_EXE_crap4rs` against per-scenario tempdir, mirrors `cli_no_fail_integration.rs`).
- **CHANGELOG** under `## Unreleased`.

## Design choices flagged for review

1. **Empty-analysis rendering** (`summary.max_crap = None`) → `worst: 0.0`. Documented in the formatter's module docs. Neither the AC nor crap4ts specify this (crap4ts dereferences `summary.maxCrap.value` unconditionally and would throw). Locking it in here means crap4ts users see `0.0` when its CLI eventually ports to crap-core — calling it out so it's not a surprise.
2. **`--summary` + `--format json:envelope.json`** writes no file. The short-circuit skips the entire `--format` loop, so file targets are dropped silently. Help text says "format dispatch is skipped"; intentional per the design (`--summary` short-circuits) but non-obvious. Open to adding an explicit note in the help text if reviewers want.
3. **Stderr warnings still fire under `--summary`**. AC says "single line on stdout, no other output" — read as "stdout = one line; stderr advisor warnings are unchanged." Matches pre-existing behaviour (`apply_diagnostics` runs before output dispatch).

## Cucumber harness pragmatics

`cli_ergonomics.feature` has a `Background:` with four aspirational Given steps and ~30 unwired Scenarios that describe behaviour validated indirectly via `cli_*_integration.rs`. To run the `@summary` scenarios, the harness includes 4 no-op step definitions for the Background. This is intentional but creates a quality-debt question (raised separately by Christopher) about how to keep `.feature` files honest as scrap-rs lands. **Tracking issue to follow** — Lane 3 / v1.1 work, not this PR.

## Gates

- `cargo fmt --check` ✔
- `cargo clippy --workspace --all-targets -- -D warnings` ✔
- `cargo nextest run --workspace` — **940 tests pass**
- `cargo test --test cli_ergonomics_cucumber --test json_reporter_cucumber` — **7 + 12 scenarios, 100 steps pass**
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` ✔
- `cargo +1.93 check --workspace --all-targets` ✔ (MSRV)
- `cargo deny --workspace check` ✔
- ast-purity grep (leading-token + grouped) on `crates/crap-core/src/` — zero matches
- `wire_envelope_snapshot` — **byte-identical to main**

## End-to-end smoke

Against `crates/crap4rs/tests/fixtures/crap4rs-self.lcov` from the workspace root:

```
$ crap4rs --coverage … --src crates/crap4rs/src --threshold 25 --summary
FAIL: 202 functions | 6 above threshold (25) | worst: 132.0 | avg: 5.7
exit=1

$ crap4rs --coverage … --src crates/crap4rs/src --threshold 1000 --summary
PASS: 202 functions | 0 above threshold (1000) | worst: 132.0 | avg: 5.7
exit=0

$ crap4rs --coverage … --threshold 1 --summary --no-fail
FAIL: 202 functions | 202 above threshold (1) | worst: 132.0 | avg: 5.7
exit=0

$ crap4rs --coverage … --threshold 1 --summary --quiet
(no output)
exit=1
```

## Test plan

- [x] `cargo nextest run --workspace` green
- [x] Both cucumber harnesses pass via `cargo test --test`
- [x] End-to-end smoke against self-fixture (PASS / FAIL / --no-fail / --quiet)
- [x] Help text exposes `--summary` with format template

## Bot review note (Step 4b)

No ADR change, no wire-envelope shape change. Step 4b is not load-bearing for this PR. Codex + CodeRabbit reviews still welcome for general quality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)