### PR TITLE
chore(bdd): #168 — tag lexicon + retag scenarios + clean up Background

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,10 +37,14 @@ breezy-bays-labs/mokumo#370) can dogfood on us without false positives.
    ```gherkin
    @unwired
    Scenario: --top N limits the report to the N highest-CRAP functions
-     # tracked: crap-rs#168 — wire when cli_ergonomics harness expands beyond @summary
+     # tracked: crap-rs#169 — cli_ergonomics harness wires only the @summary group today
      When the operator runs `crap4rs --coverage lcov.info --top 10`
      ...
    ```
+
+   crap-rs#169 is this repo's persistent BDD wiring umbrella; new
+   `.feature` files default to pointing at it unless they have their
+   own per-file wiring issue.
 
    File the tracking issue **before** the tag lands. Same rule for
    `@wip` (issue must name the in-flight PR).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,3 +10,82 @@
 - Property tests use `proptest` — regression files in `proptest-regressions/` are committed to git, never gitignored.
 - Safety: do not push directly to `main`, always branch + PR. Do not modify `.github/workflows/*` unless the task clearly requires CI changes.
 - The `domain/` and `ports/` layers must stay language-agnostic (no `syn`, no LCOV types) — they are designed for future extraction into a shared `crap-core` library.
+
+## BDD hygiene
+
+Gherkin specs live in `crates/crap4rs/tests/features/*.feature` and are
+exercised by cucumber-rs harnesses under `crates/crap4rs/tests/*_cucumber.rs`.
+The conventions below keep the spec corpus honest about what is and
+isn't actually verified, so a future BDD-quality monitor (mokumo epic
+breezy-bays-labs/mokumo#370) can dogfood on us without false positives.
+
+**Lexicon source of truth**: `crates/crap4rs/tests/features/TAGS.toml`.
+
+### Rules
+
+1. **One status tag per scenario.** Every `Scenario` and `Scenario
+   Outline` across every `.feature` file carries exactly one tag from
+   `[status]` (`@wired`, `@unwired`, or `@wip`). Tags are applied at
+   the scenario level, never the feature level — a single feature
+   commonly mixes wired and unwired scenarios while harness coverage
+   grows.
+
+2. **`@unwired` and `@wip` require a tracking comment.** Inside the
+   scenario block, add a Gherkin comment in this exact shape so it
+   stays greppable (mirrors `~/.claude/rules/exclusions.md`):
+
+   ```gherkin
+   @unwired
+   Scenario: --top N limits the report to the N highest-CRAP functions
+     # tracked: crap-rs#168 — wire when cli_ergonomics harness expands beyond @summary
+     When the operator runs `crap4rs --coverage lcov.info --top 10`
+     ...
+   ```
+
+   File the tracking issue **before** the tag lands. Same rule for
+   `@wip` (issue must name the in-flight PR).
+
+3. **No no-op step definitions.** If a `Given`/`When`/`Then` in a
+   scenario has no executable implementation, the scenario is
+   `@unwired` — not "wired with empty step defs". Forced empty step
+   defs to skip past unwired Background blocks are forbidden:
+   `cli_ergonomics_cucumber.rs` once carried four of these (PR #167)
+   and they were removed in #168 by tagging the Background scenarios
+   `@unwired` instead.
+
+4. **`Background:` blocks must be executable.** A `Background` runs
+   before every scenario in a feature, so a non-executable Background
+   forces every scenario to be `@unwired` (or to carry no-op step
+   defs, see rule 3). If the prose belongs in scenarios instead,
+   inline it into the scenarios that need it and delete the
+   `Background:` block.
+
+5. **Cucumber harness filter pattern.** New cucumber harnesses run
+   `@wired` scenarios only, via `filter_run_and_exit`:
+
+   ```rust
+   World::cucumber()
+       .filter_run_and_exit("tests/features/<file>.feature", |_, _, sc| {
+           sc.tags.iter().any(|t| t == "wired")
+       })
+       .await;
+   ```
+
+   Existing all-wired harnesses (e.g. `json_reporter_cucumber`) may
+   continue using plain `run_and_exit` as long as every scenario in
+   the file is `@wired`. Tags inside `sc.tags` are stored without the
+   `@` prefix — verified empirically.
+
+6. **Status migration is one-way.** `@unwired` → `@wip` → `@wired`.
+   Removing a `@wired` tag back to `@unwired` requires the same
+   tracking-issue ceremony as introducing it: a comment pointing at
+   the issue that captures the regression.
+
+### When the rules bite
+
+- Adding a new spec scenario → tag `@unwired` with a `# tracked:` comment.
+- Wiring a scenario → swap `@unwired` → `@wip` while implementing,
+  then `@wip` → `@wired` when green.
+- Adding a new harness → use the `@wired` filter pattern from rule 5.
+- Touching `Background:` → re-read rule 4; non-executable Backgrounds
+  are the source of most BDD hygiene debt in this repo.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,8 +54,9 @@ breezy-bays-labs/mokumo#370) can dogfood on us without false positives.
    `@unwired` — not "wired with empty step defs". Forced empty step
    defs to skip past unwired Background blocks are forbidden:
    `cli_ergonomics_cucumber.rs` once carried four of these (PR #167)
-   and they were removed in #168 by tagging the Background scenarios
-   `@unwired` instead.
+   and they were removed in #168 by tagging the scenarios that
+   depended on the Background as `@unwired` (so the harness's
+   `@wired` filter skips them) and deleting the Background itself.
 
 4. **`Background:` blocks must be executable.** A `Background` runs
    before every scenario in a feature, so a non-executable Background

--- a/crates/crap4rs/tests/cli_ergonomics_cucumber.rs
+++ b/crates/crap4rs/tests/cli_ergonomics_cucumber.rs
@@ -1,15 +1,12 @@
-//! Cucumber-rs runner for `@summary`-tagged scenarios in
-//! `tests/features/cli_ergonomics.feature` (issue #131).
+//! Cucumber-rs runner for `@wired`-tagged scenarios in
+//! `tests/features/cli_ergonomics.feature` (issues #131, #168).
 //!
-//! Most scenarios in `cli_ergonomics.feature` are spec-only — they
-//! describe behaviour validated indirectly via the `cli_*_integration.rs`
-//! suite. The `@summary` block is wired here so the AC for #131
-//! (one-line CLI verdict) executes through the same .feature file the
-//! spec lives in. Other scenarios in the file are not wired; the
-//! harness uses `filter_run_and_exit` to load only `@summary` tagged
-//! scenarios. New BDD-driven flags can adopt their own tags and
-//! extend this harness (or land siblings) without forcing migration of
-//! the unwired specs.
+//! Most scenarios in `cli_ergonomics.feature` are spec-only and tagged
+//! `@unwired` (see `AGENTS.md` § BDD hygiene + `tests/features/TAGS.toml`).
+//! The seven wired scenarios cover the `--summary` AC for #131 (one-line
+//! CLI verdict); the harness uses `filter_run_and_exit` to execute only
+//! `@wired` scenarios. New flags wire themselves by writing executable
+//! step defs and flipping their scenarios from `@unwired` to `@wired`.
 //!
 //! Each scenario sets up a tempdir with a small synthetic LCOV +
 //! `src/lib.rs` (mirrors `cli_no_fail_integration.rs`'s pattern) and
@@ -18,7 +15,7 @@
 //! scenario commands stay relative to the tempdir cwd.
 //!
 //! The two synthetic fixtures cover the two pass/fail invariants needed
-//! by the seven `@summary` scenarios:
+//! by the seven wired scenarios:
 //! - `WITHIN_*` — three trivial covered fns; every CRAP ≤ 2, so any
 //!   reasonable threshold passes.
 //! - `EXCEEDS_*` — three branchy uncovered fns; CRAPs roughly 20+, so
@@ -102,29 +99,7 @@ fn parse_command(cmd: &str) -> Vec<String> {
     cmd.split_whitespace().skip(1).map(str::to_string).collect()
 }
 
-// ── Background no-op steps ───────────────────────────────────────────
-//
-// `cli_ergonomics.feature` declares a Background that injects four
-// descriptive Given steps (line 25-29) before every scenario. Those
-// steps are aspirational — they describe the implicit project state
-// the broader spec assumes — and have no executable step definitions
-// in the rest of the codebase. To run `@summary` scenarios at all, the
-// Background needs to "pass", so the steps below are intentional
-// no-ops. The real fixture setup happens in the @summary-specific
-// `Given a synthetic project where ...` step below.
-#[given(regex = r#"^a project with an LCOV file at "[^"]+"$"#)]
-fn given_background_lcov(_world: &mut CliWorld) {}
-
-#[given("the project's analysis produces TOTAL_FUNCTIONS functions")]
-fn given_background_total(_world: &mut CliWorld) {}
-
-#[given("VIOLATING_FUNCTIONS of those functions exceed the threshold")]
-fn given_background_violating(_world: &mut CliWorld) {}
-
-#[given("TOTAL_FUNCTIONS > 0 and VIOLATING_FUNCTIONS > 0")]
-fn given_background_positive(_world: &mut CliWorld) {}
-
-// ── Given steps (real) ───────────────────────────────────────────────
+// ── Given steps ──────────────────────────────────────────────────────
 
 #[given("a synthetic project where every function is within threshold")]
 fn given_within(world: &mut CliWorld) {
@@ -242,15 +217,17 @@ async fn main() {
     // writer for plain `cargo test`. Matches `json_reporter_cucumber`.
     //
     // `filter_run_and_exit` loads `cli_ergonomics.feature` but executes
-    // only `@summary`-tagged scenarios; other scenarios are aspirational
-    // specs validated indirectly.
+    // only `@wired`-tagged scenarios; `@unwired` scenarios are
+    // aspirational specs tracked via the umbrella issue (see
+    // `AGENTS.md` § BDD hygiene). Tags inside `sc.tags` are stored
+    // without the `@` prefix — verified empirically.
     //
     // `run_and_exit` (vs `run`) panics on scenario failure, propagating
     // a non-zero exit to CI — see memory `cucumber-run-vs-run-and-exit`.
     CliWorld::cucumber()
         .with_writer(writer::Libtest::or_basic())
         .filter_run_and_exit("tests/features/cli_ergonomics.feature", |_, _, scenario| {
-            scenario.tags.iter().any(|t| t == "summary")
+            scenario.tags.iter().any(|t| t == "wired")
         })
         .await;
 }

--- a/crates/crap4rs/tests/features/TAGS.toml
+++ b/crates/crap4rs/tests/features/TAGS.toml
@@ -1,0 +1,50 @@
+# BDD tag lexicon for crap-rs feature files.
+#
+# Every Scenario across `tests/features/*.feature` carries exactly one
+# status tag (from `[status]`). Scope tags are additive and optional.
+# See `AGENTS.md` § BDD hygiene for the full convention.
+#
+# Tags are applied at the **scenario** level, not the feature level —
+# a single feature may mix wired and unwired scenarios as the harness
+# coverage grows. `@unwired` and `@wip` scenarios must carry a
+# `# tracked: crap-rs#<n> — <reason>` comment within the scenario
+# block, mirroring `~/.claude/rules/exclusions.md`.
+#
+# This file is the source of truth for the lexicon. A future bdd-rs
+# monitor (separate crate, mokumo epic #370) will parse this file
+# to validate tag usage; for now it is documentation.
+
+[status]
+# Mutually exclusive. Every scenario MUST carry exactly one.
+
+wired = """
+Scenario has executable step definitions in a cucumber-rs harness
+under `tests/*_cucumber.rs`. Failure of a `@wired` scenario fails CI.
+This is the desired end-state for every scenario.
+"""
+
+unwired = """
+Scenario describes the spec but has no executable step definitions
+today. The scenario is parseable Gherkin and survives `cucumber-rs`
+loading, but no harness picks it up. Must carry a
+`# tracked: crap-rs#<n> — <reason>` comment pointing at the issue
+that will wire it (or that explicitly defers wiring). Never tag
+something `@unwired` without filing the tracking issue first.
+"""
+
+wip = """
+Scenario is being wired right now in the active PR. Allowed to be
+red on a feature branch but never on `main`. Must carry a
+`# tracked: crap-rs#<n>` comment naming the in-flight issue.
+Convert to `@wired` (passing) or `@unwired` (deferred) before merge.
+"""
+
+[scope]
+# Additive — a scenario may carry zero or more scope tags alongside
+# its status tag. Reserved for future selective-run patterns.
+
+smoke = """
+Minimal end-to-end coverage that should run on every commit even
+when the full BDD suite is gated. Reserved for the future bdd-rs
+monitor's "smoke" run mode; no harness uses this filter today.
+"""

--- a/crates/crap4rs/tests/features/branch_coverage.feature
+++ b/crates/crap4rs/tests/features/branch_coverage.feature
@@ -6,28 +6,38 @@ Feature: Branch coverage dark infrastructure
 
   # ── BRDA Parsing ───────────────────────────────────────────────────
 
+  @unwired
   Scenario: Valid BRDA records are parsed alongside DA records
+    # tracked: crap-rs#169 — branch-coverage cucumber harness not yet built
     Given an LCOV file with SF, DA, and BRDA records for "lib.rs"
     When the coverage is parsed
     Then ParseOutput.branches contains an entry for "lib.rs"
     And ParseOutput.coverage contains line data as before
 
+  @unwired
   Scenario: BRDA taken value "-" maps to None
+    # tracked: crap-rs#169 — branch-coverage cucumber harness not yet built
     Given a BRDA record "BRDA:10,0,0,-"
     When the record is parsed
     Then the taken value is None
 
+  @unwired
   Scenario: BRDA numeric taken value maps to Some
+    # tracked: crap-rs#169 — branch-coverage cucumber harness not yet built
     Given a BRDA record "BRDA:10,0,0,5"
     When the record is parsed
     Then the taken value is Some(5)
 
+  @unwired
   Scenario: BRDA taken value "0" maps to Some(0)
+    # tracked: crap-rs#169 — branch-coverage cucumber harness not yet built
     Given a BRDA record "BRDA:10,0,0,0"
     When the record is parsed
     Then the taken value is Some(0)
 
+  @unwired
   Scenario: Duplicate BRDA records are merged by summing taken
+    # tracked: crap-rs#169 — branch-coverage cucumber harness not yet built
     Given two BRDA records with the same line, block, and branch
       | record          |
       | BRDA:10,0,0,3   |
@@ -35,7 +45,9 @@ Feature: Branch coverage dark infrastructure
     When the coverage is parsed
     Then the merged branch has taken value Some(10)
 
+  @unwired
   Scenario: Duplicate BRDA with "-" and numeric sums only the numeric
+    # tracked: crap-rs#169 — branch-coverage cucumber harness not yet built
     Given two BRDA records with the same key
       | record          |
       | BRDA:10,0,0,-   |
@@ -43,25 +55,33 @@ Feature: Branch coverage dark infrastructure
     When the coverage is parsed
     Then the merged branch has taken value Some(5)
 
+  @unwired
   Scenario: Malformed BRDA records are skipped with diagnostic
+    # tracked: crap-rs#169 — branch-coverage cucumber harness not yet built
     Given an LCOV file containing "BRDA:not,valid"
     When the coverage is parsed
     Then a MalformedRecord diagnostic is emitted
     And parsing continues without error
 
+  @unwired
   Scenario: LCOV file with no BRDA records produces None branches
+    # tracked: crap-rs#169 — branch-coverage cucumber harness not yet built
     Given an LCOV file with only SF and DA records
     When the coverage is parsed
     Then ParseOutput.branches is None
 
   # ── Branch Domain Types ────────────────────────────────────────────
 
+  @unwired
   Scenario: BranchCoverage carries only line position and execution count
+    # tracked: crap-rs#169 — branch-coverage cucumber harness not yet built
     Given a BranchCoverage with line 10 and taken Some(3)
     Then it exposes a line number and an optional execution count
     And no format-specific identifiers are stored
 
+  @unwired
   Scenario: CoverageMetric enum has Line and Branch variants
+    # tracked: crap-rs#169 — branch-coverage cucumber harness not yet built
     Given the CoverageMetric enum
     Then it has variant Line
     And it has variant Branch
@@ -69,25 +89,33 @@ Feature: Branch coverage dark infrastructure
 
   # ── Branch Matching ────────────────────────────────────────────────
 
+  @unwired
   Scenario: Branch points within function span are matched
+    # tracked: crap-rs#169 — branch-coverage cucumber harness not yet built
     Given a function spanning lines 5-15
     And branch data with entries at lines 7, 10, and 12
     When functions are matched with branch data
     Then branch_coverage covers 3 total branches
 
+  @unwired
   Scenario: Branch points outside function span are excluded
+    # tracked: crap-rs#169 — branch-coverage cucumber harness not yet built
     Given a function spanning lines 5-15
     And branch data with entries at lines 3, 10, and 20
     When functions are matched with branch data
     Then branch_coverage covers 1 total branch
 
+  @unwired
   Scenario: Branch boundaries are inclusive
+    # tracked: crap-rs#169 — branch-coverage cucumber harness not yet built
     Given a function spanning lines 5-15
     And branch data with entries at lines 5 and 15
     When functions are matched with branch data
     Then branch_coverage covers 2 total branches
 
+  @unwired
   Scenario: Branches with taken None are excluded from ratio
+    # tracked: crap-rs#169 — branch-coverage cucumber harness not yet built
     Given a function spanning lines 5-15
     And branch data:
       | line | taken   |
@@ -99,13 +127,17 @@ Feature: Branch coverage dark infrastructure
     And branch_coverage.covered is 1
     And the None branch is excluded from the ratio
 
+  @unwired
   Scenario: Function with no branch points gets None branch_coverage
+    # tracked: crap-rs#169 — branch-coverage cucumber harness not yet built
     Given a function spanning lines 5-15
     And no branch data entries within that span
     When functions are matched with branch data
     Then FunctionCoverage.branch_coverage is None
 
+  @unwired
   Scenario: No cross-file branch leakage
+    # tracked: crap-rs#169 — branch-coverage cucumber harness not yet built
     Given function "foo" in "a.rs" spanning lines 1-10
     And function "bar" in "b.rs" spanning lines 1-10
     And branch data for "a.rs" at line 5 with taken Some(1)
@@ -116,34 +148,46 @@ Feature: Branch coverage dark infrastructure
 
   # ── Core Plumbing ──────────────────────────────────────────────────
 
+  @unwired
   Scenario: analyze() passes branch data through without affecting scores
+    # tracked: crap-rs#169 — branch-coverage cucumber harness not yet built
     Given a project with LCOV containing both DA and BRDA records
     When analyze() is called with default options
     Then CRAP scores are computed from line coverage only
     And FunctionCoverage carries branch_coverage data
 
+  @unwired
   Scenario: AnalyzeOptions defaults to Line coverage metric
+    # tracked: crap-rs#169 — branch-coverage cucumber harness not yet built
     Given default AnalyzeOptions
     Then coverage_metric is CoverageMetric::Line
 
   # ── Property Invariants ────────────────────────────────────────────
 
+  @unwired
   Scenario: Arbitrary BRDA input never panics
+    # tracked: crap-rs#169 — branch-coverage cucumber harness not yet built
     Given arbitrary strings matching "BRDA:*" patterns
     When parsed by the BRDA parser
     Then no panic occurs
 
+  @unwired
   Scenario: Branch ratios are always in [0, 100]
+    # tracked: crap-rs#169 — branch-coverage cucumber harness not yet built
     Given any set of BranchCoverage entries matched to a function
     When branch coverage is computed
     Then the percent is between 0.0 and 100.0 inclusive
 
+  @unwired
   Scenario: Branch covered is always <= total
+    # tracked: crap-rs#169 — branch-coverage cucumber harness not yet built
     Given any set of BranchCoverage entries matched to a function
     When branch coverage is computed
     Then covered is less than or equal to total
 
+  @unwired
   Scenario: No cross-file branch leakage under arbitrary input
+    # tracked: crap-rs#169 — branch-coverage cucumber harness not yet built
     Given arbitrary branch data across multiple files
     And arbitrary function spans
     When functions are matched with branch data

--- a/crates/crap4rs/tests/features/cli_ergonomics.feature
+++ b/crates/crap4rs/tests/features/cli_ergonomics.feature
@@ -22,15 +22,11 @@ Feature: CLI ergonomics — shaping the report from the command line
   #   The view module must not introduce any function with cognitive
   #   complexity above 15. CI gate enforces.
 
-  Background:
-    Given a project with an LCOV file at "lcov.info"
-    And the project's analysis produces TOTAL_FUNCTIONS functions
-    And VIOLATING_FUNCTIONS of those functions exceed the threshold
-    And TOTAL_FUNCTIONS > 0 and VIOLATING_FUNCTIONS > 0
-
   # ── --top: truncate (issue #62) ────────────────────────────────────
 
+  @unwired
   Scenario: --top N limits the report to the N highest-CRAP functions
+    # tracked: crap-rs#169 — cli_ergonomics harness wires only the @summary group today
     When the operator runs `crap4rs --coverage lcov.info --top 10`
     Then the table contains 10 rows
     And the table rows are the 10 highest-CRAP functions
@@ -38,31 +34,41 @@ Feature: CLI ergonomics — shaping the report from the command line
     And the JSON envelope reports `view.eligible_count` equal to TOTAL_FUNCTIONS
     And the JSON envelope reports `view.truncated` equal to true
 
+  @unwired
   Scenario: --top 0 means no limit
+    # tracked: crap-rs#169 — cli_ergonomics harness wires only the @summary group today
     When the operator runs `crap4rs --coverage lcov.info --top 0`
     Then the report includes every function
     And the JSON envelope reports `view.limit` equal to null
     And the JSON envelope reports `view.truncated` equal to false
 
+  @unwired
   Scenario: --top 1 surfaces only the worst function
+    # tracked: crap-rs#169 — cli_ergonomics harness wires only the @summary group today
     When the operator runs `crap4rs --coverage lcov.info --top 1`
     Then the table contains 1 row
     And that row is the highest-CRAP function in the analysis
     And the JSON envelope reports `view.truncated` equal to true
 
+  @unwired
   Scenario: --top greater than the eligible count truncates nothing
+    # tracked: crap-rs#169 — cli_ergonomics harness wires only the @summary group today
     When the operator runs `crap4rs --coverage lcov.info --top 1000000`
     Then the report includes every function
     And the JSON envelope reports `view.limit` equal to 1000000
     And the JSON envelope reports `view.truncated` equal to false
 
+  @unwired
   Scenario: --top hiding violations does not change the exit code
+    # tracked: crap-rs#169 — cli_ergonomics harness wires only the @summary group today
     When the operator runs `crap4rs --coverage lcov.info --top 5`
     Then the table shows 5 rows
     And the exit code is 1
     And the JSON envelope's `result.passed` is false
 
+  @unwired
   Scenario Outline: --top rejects non-positive-integer values
+    # tracked: crap-rs#169 — cli_ergonomics harness wires only the @summary group today
     When the operator runs `crap4rs --coverage lcov.info <flags>`
     Then the exit code is 2
     And stderr contains "<message>"
@@ -75,26 +81,36 @@ Feature: CLI ergonomics — shaping the report from the command line
 
   # ── --min-coverage / --max-coverage: range filter (issue #63) ──────
 
+  @unwired
   Scenario: --min-coverage filters out untested functions
+    # tracked: crap-rs#169 — cli_ergonomics harness wires only the @summary group today
     When the operator runs `crap4rs --coverage lcov.info --min-coverage 1`
     Then no function in the report has coverage_percent equal to 0.0
     And the JSON envelope reports `view.filters.coverage_range` as { "min": 1.0, "max": 100.0 }
 
+  @unwired
   Scenario: --max-coverage 0 surfaces only untested functions
+    # tracked: crap-rs#169 — cli_ergonomics harness wires only the @summary group today
     When the operator runs `crap4rs --coverage lcov.info --max-coverage 0`
     Then every function in the report has coverage_percent equal to 0.0
     And the JSON envelope reports `view.filters.coverage_range` as { "min": 0.0, "max": 0.0 }
 
+  @unwired
   Scenario: --min-coverage 100 surfaces only fully-tested functions
+    # tracked: crap-rs#169 — cli_ergonomics harness wires only the @summary group today
     When the operator runs `crap4rs --coverage lcov.info --min-coverage 100`
     Then every function in the report has coverage_percent equal to 100.0
 
+  @unwired
   Scenario: combining --min-coverage and --max-coverage targets partial coverage
+    # tracked: crap-rs#169 — cli_ergonomics harness wires only the @summary group today
     When the operator runs `crap4rs --coverage lcov.info --min-coverage 1 --max-coverage 90`
     Then every function in the report has coverage_percent strictly above 0 and at most 90
     And the JSON envelope reports `view.filters.coverage_range` as { "min": 1.0, "max": 90.0 }
 
+  @unwired
   Scenario Outline: invalid coverage ranges produce exit 2 with a clear stderr message
+    # tracked: crap-rs#169 — cli_ergonomics harness wires only the @summary group today
     When the operator runs `crap4rs --coverage lcov.info <flags>`
     Then the exit code is 2
     And stderr contains "<message>"
@@ -105,7 +121,9 @@ Feature: CLI ergonomics — shaping the report from the command line
       | --max-coverage 105                          | --max-coverage must be in [0, 100]   |
       | --min-coverage 90 --max-coverage 30         | --min-coverage must not exceed --max-coverage |
 
+  @unwired
   Scenario: filter hiding violations does not change the exit code
+    # tracked: crap-rs#169 — cli_ergonomics harness wires only the @summary group today
     When the operator runs `crap4rs --coverage lcov.info --min-coverage 99`
     Then the report contains zero functions
     And the exit code is 1
@@ -113,22 +131,30 @@ Feature: CLI ergonomics — shaping the report from the command line
 
   # ── --sort-by: choose sort dimension (issue #68) ───────────────────
 
+  @unwired
   Scenario: --sort-by crap is the default order (CRAP descending)
+    # tracked: crap-rs#169 — cli_ergonomics harness wires only the @summary group today
     When the operator runs `crap4rs --coverage lcov.info`
     Then the report is ordered by CRAP score descending
     And the JSON envelope reports `view.sort` equal to "crap"
 
+  @unwired
   Scenario: --sort-by coverage orders by coverage percent ascending
+    # tracked: crap-rs#169 — cli_ergonomics harness wires only the @summary group today
     When the operator runs `crap4rs --coverage lcov.info --sort-by coverage`
     Then the report is ordered by coverage percent ascending
     And the JSON envelope reports `view.sort` equal to "coverage"
 
+  @unwired
   Scenario: --sort-by complexity orders by complexity descending
+    # tracked: crap-rs#169 — cli_ergonomics harness wires only the @summary group today
     When the operator runs `crap4rs --coverage lcov.info --sort-by complexity`
     Then the report is ordered by complexity descending
     And the JSON envelope reports `view.sort` equal to "complexity"
 
+  @unwired
   Scenario: --sort-by path orders alphabetically by file, then CRAP descending within file
+    # tracked: crap-rs#169 — cli_ergonomics harness wires only the @summary group today
     # Delegates to domain SortKey::Path semantics — see view.feature
     # for the full secondary-sort spec.
     Given the project has functions in src/a.rs (CRAPs 5 and 30), src/b.rs (CRAP 10), src/c.rs (CRAPs 1 and 50)
@@ -136,41 +162,55 @@ Feature: CLI ergonomics — shaping the report from the command line
     Then the report rows appear in order: src/a.rs::CRAP 30, src/a.rs::CRAP 5, src/b.rs::CRAP 10, src/c.rs::CRAP 50, src/c.rs::CRAP 1
     And the JSON envelope reports `view.sort` equal to "path"
 
+  @unwired
   Scenario: --sort-by composes with --top to surface the lowest-coverage targets
+    # tracked: crap-rs#169 — cli_ergonomics harness wires only the @summary group today
     When the operator runs `crap4rs --coverage lcov.info --sort-by coverage --top 10`
     Then the report contains the 10 functions with the lowest coverage percent
     And the rows are ordered by coverage percent ascending
 
   # ── --no-fail: exit-code override (issue #65) ──────────────────────
 
+  @unwired
   Scenario: --no-fail returns 0 even when violations exist
+    # tracked: crap-rs#169 — cli_ergonomics harness wires only the @summary group today
     When the operator runs `crap4rs --coverage lcov.info --no-fail`
     Then the report shows every violating function
     And the exit code is 0
     And the JSON envelope's `result.passed` is false
 
+  @unwired
   Scenario: --no-fail is a no-op when there are no violations
+    # tracked: crap-rs#169 — cli_ergonomics harness wires only the @summary group today
     Given the project has zero functions exceeding the threshold
     When the operator runs `crap4rs --coverage lcov.info --no-fail`
     Then the exit code is 0
 
+  @unwired
   Scenario: --quiet alone preserves CI exit-1 behavior
+    # tracked: crap-rs#169 — cli_ergonomics harness wires only the @summary group today
     When the operator runs `crap4rs --coverage lcov.info --quiet`
     Then the report is suppressed
     And the exit code is 1
 
+  @unwired
   Scenario: --quiet --no-fail composes to silent success
+    # tracked: crap-rs#169 — cli_ergonomics harness wires only the @summary group today
     When the operator runs `crap4rs --coverage lcov.info --quiet --no-fail`
     Then the report is suppressed
     And the exit code is 0
 
+  @unwired
   Scenario: --quiet also suppresses JSON output
+    # tracked: crap-rs#169 — cli_ergonomics harness wires only the @summary group today
     When the operator runs `crap4rs --coverage lcov.info --quiet --format json`
     Then stdout is empty
 
   # ── --only-failing relocated, summary-semantics fix ────────────────
 
+  @unwired
   Scenario: --only-failing produces a self-consistent summary
+    # tracked: crap-rs#169 — cli_ergonomics harness wires only the @summary group today
     When the operator runs `crap4rs --coverage lcov.info --only-failing`
     Then the report contains only functions that exceed the threshold
     And the JSON envelope's `result.summary.total_functions` equals TOTAL_FUNCTIONS
@@ -181,24 +221,32 @@ Feature: CLI ergonomics — shaping the report from the command line
     And the JSON envelope's `result.summary.distribution` reflects all TOTAL_FUNCTIONS functions
     And the JSON envelope reports `view.filters.only_failing` equal to true
 
+  @unwired
   Scenario: --only-failing on a passing project produces an empty report and exit 0
+    # tracked: crap-rs#169 — cli_ergonomics harness wires only the @summary group today
     Given the project has zero functions exceeding the threshold
     When the operator runs `crap4rs --coverage lcov.info --only-failing`
     Then the report contains zero functions
     And the exit code is 0
 
+  @unwired
   Scenario: --only-failing composes with --sort-by coverage for the worst-tested-violations investigation
+    # tracked: crap-rs#169 — cli_ergonomics harness wires only the @summary group today
     When the operator runs `crap4rs --coverage lcov.info --only-failing --sort-by coverage`
     Then every function in the report exceeds the threshold
     And the rows are ordered by coverage percent ascending
 
+  @unwired
   Scenario: --only-failing composes with --min-coverage as AND
+    # tracked: crap-rs#169 — cli_ergonomics harness wires only the @summary group today
     When the operator runs `crap4rs --coverage lcov.info --only-failing --min-coverage 50`
     Then every function in the report exceeds the threshold AND has coverage_percent at least 50
 
   # ── JSON envelope shape ───────────────────────────────────────────
 
+  @unwired
   Scenario: view block is always present, even on default invocation
+    # tracked: crap-rs#169 — cli_ergonomics harness wires only the @summary group today
     When the operator runs `crap4rs --coverage lcov.info --format json`
     Then the JSON envelope contains a `view` block
     And `view.filters.only_failing` is false
@@ -210,43 +258,57 @@ Feature: CLI ergonomics — shaping the report from the command line
     And `view.shown` is an array
     And `view.shown_summary` contains every field of `AnalysisSummary` — `total_functions`, `total_files`, `exceeding_threshold`, `average_crap`, `median_crap`, `max_crap`, `worst_function`, and `distribution` — so a future field accidentally dropped from the serialized payload fails the assertion
 
+  @unwired
   Scenario: default invocation has shown_summary equal to result.summary
+    # tracked: crap-rs#169 — cli_ergonomics harness wires only the @summary group today
     When the operator runs `crap4rs --coverage lcov.info --format json`
     Then `view.shown_summary` is equal in every field to `result.summary`
 
+  @unwired
   Scenario: view.shown contains complete FunctionVerdict objects, not indices
+    # tracked: crap-rs#169 — cli_ergonomics harness wires only the @summary group today
     When the operator runs `crap4rs --coverage lcov.info --format json --top 3`
     Then `view.shown` is an array of length 3
     And each entry in `view.shown` contains `scored`, `threshold`, and `exceeds`
     And each entry's `scored` object contains `identity`, `complexity`, `coverage_percent`, `crap`
     And the entries are full objects, not array indices into `result.functions`
 
+  @unwired
   Scenario: view.eligible_count distinguishes filter-narrowing from truncation
+    # tracked: crap-rs#169 — cli_ergonomics harness wires only the @summary group today
     When the operator runs `crap4rs --coverage lcov.info --format json --min-coverage 1 --max-coverage 90 --top 10`
     Then `view.eligible_count` equals the count of functions with coverage_percent in [1, 90]
     And `view.shown.length` equals 10
     And `view.truncated` is true
 
+  @unwired
   Scenario: result block is invariant under any view spec
+    # tracked: crap-rs#169 — cli_ergonomics harness wires only the @summary group today
     When the operator runs `crap4rs --coverage lcov.info --format json` (the baseline)
     And the operator runs `crap4rs --coverage lcov.info --format json --top 5 --sort-by coverage --only-failing` (the shaped view)
     Then the `result` block in both invocations contains the same functions
     And the `result.summary` is identical between the two invocations
     And the `result.passed` is identical between the two invocations
 
+  @unwired
   Scenario: view block declares values according to applied flags
+    # tracked: crap-rs#169 — cli_ergonomics harness wires only the @summary group today
     When the operator runs `crap4rs --coverage lcov.info --format json --top 10 --min-coverage 5 --max-coverage 80 --sort-by complexity`
     Then `view.filters.coverage_range` is { "min": 5.0, "max": 80.0 }
     And `view.sort` is "complexity"
     And `view.limit` is 10
 
+  @unwired
   Scenario: schema_version is 2 with the additive view block
+    # tracked: crap-rs#169 — cli_ergonomics harness wires only the @summary group today
     # Bumped 1 → 2 in 0.4.0 by #107 (ComplexityContributor.column 0-based → 1-based).
     When the operator runs `crap4rs --coverage lcov.info --format json`
     Then the JSON envelope's `schema_version` is the integer 2
     And the JSON envelope key declaration order is `schema_version, tool_version, language, timestamp, metric, threshold, diff_ref, result, view`
 
+  @unwired
   Scenario: agent consumer reads the JSON envelope to plan refactor scope
+    # tracked: crap-rs#169 — cli_ergonomics harness wires only the @summary group today
     # Story E from the breadboard. Validates that the envelope contains
     # everything an agent needs without inferring or re-deriving state.
     When the operator runs `crap4rs --coverage lcov.info --format json --only-failing --sort-by crap --top 50`
@@ -258,31 +320,43 @@ Feature: CLI ergonomics — shaping the report from the command line
 
   # ── Display invariant: the optional "View" line ───────────────────
 
+  @unwired
   Scenario: default invocation shows only the Analysis summary line
+    # tracked: crap-rs#169 — cli_ergonomics harness wires only the @summary group today
     When the operator runs `crap4rs --coverage lcov.info`
     Then the table shows an "Analysis: VIOLATING_FUNCTIONS/TOTAL_FUNCTIONS over threshold" line
     And the table does not show a "View:" line
 
+  @unwired
   Scenario: --sort-by alone does not trigger the View line because sorting reorders without reducing rows
+    # tracked: crap-rs#169 — cli_ergonomics harness wires only the @summary group today
     When the operator runs `crap4rs --coverage lcov.info --sort-by coverage`
     Then the table does not show a "View:" line
 
+  @unwired
   Scenario: --top triggers the View line because rows are truncated
+    # tracked: crap-rs#169 — cli_ergonomics harness wires only the @summary group today
     When the operator runs `crap4rs --coverage lcov.info --top 10`
     Then the table shows an "Analysis:" line referencing the full TOTAL_FUNCTIONS functions
     And the table shows a "View:" line referencing the 10 shown functions
 
+  @unwired
   Scenario: a coverage filter triggers the View line because functions are excluded
+    # tracked: crap-rs#169 — cli_ergonomics harness wires only the @summary group today
     When the operator runs `crap4rs --coverage lcov.info --min-coverage 1 --max-coverage 90`
     Then the table shows a "View:" line including "filtered from <eligible_count>"
 
+  @unwired
   Scenario: --only-failing triggers the View line because violations are isolated
+    # tracked: crap-rs#169 — cli_ergonomics harness wires only the @summary group today
     When the operator runs `crap4rs --coverage lcov.info --only-failing`
     Then the table shows a "View:" line referencing the VIOLATING_FUNCTIONS violating functions
 
   # ── Composed investigation example (Story B) ───────────────────────
 
+  @unwired
   Scenario: investigator's flag-set produces a shaped report and exits 0
+    # tracked: crap-rs#169 — cli_ergonomics harness wires only the @summary group today
     When the operator runs `crap4rs --coverage lcov.info --min-coverage 1 --max-coverage 90 --sort-by coverage --top 10 --no-fail`
     Then the report contains 10 functions
     And every function has coverage_percent in [1, 90]
@@ -293,21 +367,29 @@ Feature: CLI ergonomics — shaping the report from the command line
 
   # ── First-run discoverability (V6) ────────────────────────────────
 
+  @unwired
   Scenario: --help shows a basic first-run example
+    # tracked: crap-rs#169 — cli_ergonomics harness wires only the @summary group today
     When the operator runs `crap4rs --help`
     Then the help text includes the example "crap4rs --coverage lcov.info --top 20"
 
+  @unwired
   Scenario: --help shows an investigation example
+    # tracked: crap-rs#169 — cli_ergonomics harness wires only the @summary group today
     When the operator runs `crap4rs --help`
     Then the help text includes an example using --min-coverage, --max-coverage, --sort-by, --top, and --no-fail together
 
+  @unwired
   Scenario: --only-failing appears under filter flags in --help
+    # tracked: crap-rs#169 — cli_ergonomics harness wires only the @summary group today
     # User-observable consequence of relocating --only-failing from
     # OutputArgs to FilterArgs (V1b).
     When the operator runs `crap4rs --help`
     Then the help text groups --only-failing alongside --min-coverage, --max-coverage, and --top under filter flags
 
+  @unwired
   Scenario: first-run example from --help produces a tractable report
+    # tracked: crap-rs#169 — cli_ergonomics harness wires only the @summary group today
     When the operator runs the basic `--help` example `crap4rs --coverage lcov.info --top 20`
     Then the table contains at most 20 rows
     And the table shows a "View:" line indicating truncation from TOTAL_FUNCTIONS
@@ -315,11 +397,15 @@ Feature: CLI ergonomics — shaping the report from the command line
 
   # ── Exit-code matrix summary ───────────────────────────────────────
 
+  @unwired
   Scenario: default invocation on a violating project exits 1
+    # tracked: crap-rs#169 — cli_ergonomics harness wires only the @summary group today
     When the operator runs `crap4rs --coverage lcov.info`
     Then the exit code is 1
 
+  @unwired
   Scenario Outline: exit-code matrix for flag combinations
+    # tracked: crap-rs#169 — cli_ergonomics harness wires only the @summary group today
     When the operator runs `crap4rs --coverage lcov.info <flags>`
     Then the exit code is <code>
 
@@ -347,7 +433,7 @@ Feature: CLI ergonomics — shaping the report from the command line
   # LCOV+src layout per scenario (matches `cli_no_fail_integration.rs`).
   # The rest of this feature remains spec-only.
 
-  @summary
+  @wired
   Scenario: --summary on a passing run emits a single PASS line
     Given a synthetic project where every function is within threshold
     When the operator runs `crap4rs --coverage lcov.info --src src --threshold 25 --summary`
@@ -355,7 +441,7 @@ Feature: CLI ergonomics — shaping the report from the command line
     And stdout matches "^PASS: \d+ functions \| 0 above threshold \(25\) \| worst: \d+\.\d \| avg: \d+\.\d$"
     And the exit code is 0
 
-  @summary
+  @wired
   Scenario: --summary on a failing run emits a single FAIL line
     Given a synthetic project where at least one function exceeds threshold
     When the operator runs `crap4rs --coverage lcov.info --src src --threshold 5 --summary`
@@ -363,7 +449,7 @@ Feature: CLI ergonomics — shaping the report from the command line
     And stdout matches "^FAIL: \d+ functions \| \d+ above threshold \(5\) \| worst: \d+\.\d \| avg: \d+\.\d$"
     And the exit code is 1
 
-  @summary
+  @wired
   Scenario: --summary with --no-fail keeps emitting FAIL but exits 0
     Given a synthetic project where at least one function exceeds threshold
     When the operator runs `crap4rs --coverage lcov.info --src src --threshold 5 --summary --no-fail`
@@ -371,14 +457,14 @@ Feature: CLI ergonomics — shaping the report from the command line
     And stdout starts with "FAIL:"
     And the exit code is 0
 
-  @summary
+  @wired
   Scenario: --summary with --quiet suppresses output (quiet wins)
     Given a synthetic project where at least one function exceeds threshold
     When the operator runs `crap4rs --coverage lcov.info --src src --threshold 5 --summary --quiet`
     Then stdout is empty
     And the exit code is 1
 
-  @summary
+  @wired
   Scenario: --summary short-circuits --format json (summary line wins)
     Given a synthetic project where every function is within threshold
     When the operator runs `crap4rs --coverage lcov.info --src src --threshold 25 --summary --format json`
@@ -386,14 +472,14 @@ Feature: CLI ergonomics — shaping the report from the command line
     And stdout starts with "PASS:"
     And stdout does not contain "schema_version"
 
-  @summary
+  @wired
   Scenario: --summary renders fractional threshold with decimals
     Given a synthetic project where every function is within threshold
     When the operator runs `crap4rs --coverage lcov.info --src src --threshold 25.5 --summary`
     Then stdout contains exactly one line
     And stdout contains "above threshold (25.5)"
 
-  @summary
+  @wired
   Scenario: --summary help text includes the format template
     When the operator runs `crap4rs --help`
     Then stdout contains "--summary"

--- a/crates/crap4rs/tests/features/cli_ergonomics.feature
+++ b/crates/crap4rs/tests/features/cli_ergonomics.feature
@@ -21,6 +21,19 @@ Feature: CLI ergonomics — shaping the report from the command line
   # Self-CRAP regression invariant (per shaping.md):
   #   The view module must not introduce any function with cognitive
   #   complexity above 15. CI gate enforces.
+  #
+  # Implicit context for @unwired scenarios (placeholder vocabulary):
+  #   Most @unwired scenarios below reference TOTAL_FUNCTIONS and
+  #   VIOLATING_FUNCTIONS as placeholder counts, and assume a project
+  #   exists with an LCOV file at "lcov.info". A non-executable
+  #   `Background:` block previously documented this; it was deleted
+  #   in crap-rs#168 (BDD hygiene chore) because Background blocks
+  #   must be executable (AGENTS.md § BDD hygiene rule 4). When these
+  #   scenarios are wired (tracked at crap-rs#169), the implementer
+  #   will replace the placeholders with scenario-specific Given
+  #   steps that set up concrete fixture-derived counts — just like
+  #   the @wired `--summary` scenarios do with their `Given a
+  #   synthetic project where ...` step.
 
   # ── --top: truncate (issue #62) ────────────────────────────────────
 

--- a/crates/crap4rs/tests/features/complexity_breakdown.feature
+++ b/crates/crap4rs/tests/features/complexity_breakdown.feature
@@ -6,13 +6,17 @@ Feature: Complexity breakdown
 
   # ── Contributor extraction ─────────────────────────────────────────────────
 
+  @unwired
   Scenario: Base-complexity function has empty contributors
+    # tracked: crap-rs#169 — complexity-breakdown cucumber harness not yet built
     Given a function with no decision points
     When complexity is extracted with cognitive metric
     Then the contributors list is empty
     And the complexity is 1
 
+  @unwired
   Scenario: Single if-branch produces one contributor
+    # tracked: crap-rs#169 — complexity-breakdown cucumber harness not yet built
     Given a function with a single if statement at line 3
     When complexity is extracted with cognitive metric
     Then there is 1 contributor
@@ -20,85 +24,113 @@ Feature: Complexity breakdown
     And the contributor has line 3
     And the contributor has increment 1
 
+  @unwired
   Scenario: Nested if produces nesting-adjusted increment
+    # tracked: crap-rs#169 — complexity-breakdown cucumber harness not yet built
     Given a function with an if at line 3 containing an if at line 5
     When complexity is extracted with cognitive metric
     Then the contributor at line 3 has kind "if-branch" with increment 1
     And the contributor at line 5 has kind "if-branch" with increment 2
 
+  @unwired
   Scenario: Match contributes as a single node in cognitive metric
+    # tracked: crap-rs#169 — complexity-breakdown cucumber harness not yet built
     Given a function with a match expression at line 4 with 5 arms
     When complexity is extracted with cognitive metric
     Then there is 1 match-kind contributor
     And the contributor has kind "match"
     And the contributor has increment 1
 
+  @unwired
   Scenario: Match arms each contribute in cyclomatic metric
+    # tracked: crap-rs#169 — complexity-breakdown cucumber harness not yet built
     Given a function with a match expression at line 4 with 5 arms
     When complexity is extracted with cyclomatic metric
     Then there are 4 contributors with kind "match-arm"
 
+  @unwired
   Scenario: Try operator contributes one contributor
+    # tracked: crap-rs#169 — complexity-breakdown cucumber harness not yet built
     Given a function with a single ? operator at line 7
     When complexity is extracted with cognitive metric
     Then there is 1 contributor with kind "try"
     And the contributor has line 7
     And the contributor has increment 1
 
+  @unwired
   Scenario: Let-else contributes one contributor
+    # tracked: crap-rs#169 — complexity-breakdown cucumber harness not yet built
     Given a function with a let-else at line 5
     When complexity is extracted with cognitive metric
     Then there is 1 contributor with kind "let-else"
     And the contributor has increment 1
 
+  @unwired
   Scenario: Infinite loop contributes with nesting increment
+    # tracked: crap-rs#169 — complexity-breakdown cucumber harness not yet built
     Given a function with a loop at line 4 containing an if at line 6
     When complexity is extracted with cognitive metric
     Then the contributor at line 4 has kind "loop" with increment 1
     And the contributor at line 6 has kind "if-branch" with increment 2
 
+  @unwired
   Scenario: For-loop contributes one contributor
+    # tracked: crap-rs#169 — complexity-breakdown cucumber harness not yet built
     Given a function with a for loop at line 3
     When complexity is extracted with cognitive metric
     Then there is 1 contributor with kind "for-loop"
     And the contributor has line 3
     And the contributor has increment 1
 
+  @unwired
   Scenario: While-loop contributes one contributor
+    # tracked: crap-rs#169 — complexity-breakdown cucumber harness not yet built
     Given a function with a while loop at line 3
     When complexity is extracted with cognitive metric
     Then there is 1 contributor with kind "while-loop"
     And the contributor has increment 1
 
+  @unwired
   Scenario: Logical operator chain contributes one contributor per sequence
+    # tracked: crap-rs#169 — complexity-breakdown cucumber harness not yet built
     Given a function with "a && b && c" at line 5
     When complexity is extracted with cognitive metric
     Then there is 1 contributor with kind "logical-operator"
     And the contributor has increment 1
 
+  @unwired
   Scenario: Mixed logical operator chain produces contributor per sequence switch
+    # tracked: crap-rs#169 — complexity-breakdown cucumber harness not yet built
     Given a function with "a && b || c" starting at line 5
     When complexity is extracted with cognitive metric
     Then there are 2 contributors with kind "logical-operator"
 
+  @unwired
   Scenario: Break contributes one contributor
+    # tracked: crap-rs#169 — complexity-breakdown cucumber harness not yet built
     Given a function with a break statement at line 8 inside a loop
     When complexity is extracted with cognitive metric
     Then there is 1 contributor with kind "break"
     And the contributor has increment 1
 
+  @unwired
   Scenario: Continue contributes one contributor
+    # tracked: crap-rs#169 — complexity-breakdown cucumber harness not yet built
     Given a function with a continue statement at line 8 inside a loop
     When complexity is extracted with cognitive metric
     Then there is 1 contributor with kind "continue"
     And the contributor has increment 1
 
+  @unwired
   Scenario: Closure does not contribute as a standalone contributor
+    # tracked: crap-rs#169 — complexity-breakdown cucumber harness not yet built
     Given a function containing a closure
     When complexity is extracted with cognitive metric
     Then no contributor has kind "closure"
 
+  @unwired
   Scenario: Contributors are sorted by line number
+    # tracked: crap-rs#169 — complexity-breakdown cucumber harness not yet built
     Given a function with an if at line 10 and a match at line 5
     When complexity is extracted
     Then the first contributor is at line 5
@@ -106,22 +138,30 @@ Feature: Complexity breakdown
 
   # ── Property invariant ─────────────────────────────────────────────────────
 
+  @unwired
   Scenario: Contributor increments sum to complexity minus one
+    # tracked: crap-rs#169 — complexity-breakdown cucumber harness not yet built
     Given any function with complexity C and contributors list
     Then the sum of all contributor increments equals C - 1
 
+  @unwired
   Scenario: Each contributor has increment of at least 1
+    # tracked: crap-rs#169 — complexity-breakdown cucumber harness not yet built
     Given any function with at least one contributor
     Then every contributor has increment >= 1
 
   # ── Terminal reporter: --breakdown flag ────────────────────────────────────
 
+  @unwired
   Scenario: Breakdown is off by default — no sub-rows in output
+    # tracked: crap-rs#169 — complexity-breakdown cucumber harness not yet built
     Given an analysis where "parse_record" exceeds threshold with 3 contributors
     When the table is formatted without --breakdown
     Then the output does not contain contributor sub-rows
 
+  @unwired
   Scenario: --breakdown shows contributors only for exceeding functions
+    # tracked: crap-rs#169 — complexity-breakdown cucumber harness not yet built
     Given an analysis where "parse_record" exceeds threshold at 15.23 with contributors:
       | kind       | line | increment |
       | match      | 12   | 1         |
@@ -132,41 +172,55 @@ Feature: Complexity breakdown
     Then sub-rows appear under "parse_record"
     And no sub-rows appear under "simple_fn"
 
+  @unwired
   Scenario: Sub-rows display kind and increment in tree format
+    # tracked: crap-rs#169 — complexity-breakdown cucumber harness not yet built
     Given an exceeding function with a contributor: kind "match", line 12, increment 1
     When the table is formatted with --breakdown
     Then the sub-row contains "line 12: match (+1)"
 
+  @unwired
   Scenario: Nesting increment shown with (nested) suffix
+    # tracked: crap-rs#169 — complexity-breakdown cucumber harness not yet built
     Given an exceeding function with a contributor: kind "if-branch", line 18, increment 2
     When the table is formatted with --breakdown
     Then the sub-row contains "if-branch (+2 (nested))"
 
+  @unwired
   Scenario: Last contributor uses └─ tree character
+    # tracked: crap-rs#169 — complexity-breakdown cucumber harness not yet built
     Given an exceeding function with exactly 3 contributors
     When the table is formatted with --breakdown
     Then the first two sub-rows start with "├─"
     And the last sub-row starts with "└─"
 
+  @unwired
   Scenario: Sub-rows appear sorted by line number
+    # tracked: crap-rs#169 — complexity-breakdown cucumber harness not yet built
     Given an exceeding function with contributors at lines 22, 12, and 18
     When the table is formatted with --breakdown
     Then sub-rows appear in order: line 12, line 18, line 22
 
   # ── JSON reporter: contributors always present ─────────────────────────────
 
+  @unwired
   Scenario: JSON output always includes contributors array
+    # tracked: crap-rs#169 — complexity-breakdown cucumber harness not yet built
     Given an analysis with one function having 3 contributors
     When the JSON is formatted without --breakdown
     Then each function entry contains a "contributors" array
     And the contributors array has 3 entries
 
+  @unwired
   Scenario: JSON contributors array is empty for base-complexity functions
+    # tracked: crap-rs#169 — complexity-breakdown cucumber harness not yet built
     Given an analysis with one function having complexity 1
     When the JSON is formatted
     Then the function entry's "contributors" is an empty array
 
+  @unwired
   Scenario: JSON contributor entry contains kind, line, column, and increment
+    # tracked: crap-rs#169 — complexity-breakdown cucumber harness not yet built
     Given an analysis with one function having a contributor: kind "match", line 12, column 4, increment 1
     When the JSON is formatted
     Then the contributor entry contains "kind" equal to "match"
@@ -174,19 +228,25 @@ Feature: Complexity breakdown
     And the contributor entry contains "column" equal to 4
     And the contributor entry contains "increment" equal to 1
 
+  @unwired
   Scenario: JSON contributor kind uses kebab-case
+    # tracked: crap-rs#169 — complexity-breakdown cucumber harness not yet built
     Given an analysis with contributors of kind IfBranch and ForLoop
     When the JSON is formatted
     Then contributor kinds appear as "if-branch" and "for-loop"
 
+  @unwired
   Scenario: JSON column field is null when not available
+    # tracked: crap-rs#169 — complexity-breakdown cucumber harness not yet built
     Given a contributor with no column information
     When the JSON is formatted
     Then the contributor entry contains "column" as null
 
   # ── Regression: existing complexity totals unchanged ──────────────────────
 
+  @unwired
   Scenario: Adding contributors does not change existing complexity values
+    # tracked: crap-rs#169 — complexity-breakdown cucumber harness not yet built
     Given any function that previously reported complexity C
     When complexity is extracted with contributors enabled
     Then the function still reports complexity C

--- a/crates/crap4rs/tests/features/diff_mode.feature
+++ b/crates/crap4rs/tests/features/diff_mode.feature
@@ -6,21 +6,27 @@ Feature: Diff mode
 
   # ── Core Behavior ─────────────────────────────────────────────────
 
+  @unwired
   Scenario: Only changed functions appear in output
+    # tracked: crap-rs#169 — diff-mode cucumber harness not yet built
     Given a git repo with a baseline commit containing functions foo and bar
     And a second commit that modifies only foo
     When I run crap4rs --diff <baseline> --coverage lcov.info
     Then the output includes function foo
     And the output does not include function bar
 
+  @unwired
   Scenario: New file includes all functions
+    # tracked: crap-rs#169 — diff-mode cucumber harness not yet built
     Given a git repo with a baseline commit
     And a second commit that adds a new file with functions baz and qux
     When I run crap4rs --diff <baseline> --coverage lcov.info
     Then the output includes function baz
     And the output includes function qux
 
+  @unwired
   Scenario: Hunk-level precision — untouched function in changed file excluded
+    # tracked: crap-rs#169 — diff-mode cucumber harness not yet built
     Given a git repo with a file containing functions alpha (lines 1-10) and beta (lines 20-30)
     And a commit that changes only lines 5-8
     When I run crap4rs --diff <baseline> --coverage lcov.info
@@ -29,7 +35,9 @@ Feature: Diff mode
 
   # ── Score Invariant ───────────────────────────────────────────────
 
+  @unwired
   Scenario: Diff mode produces identical scores to full analysis
+    # tracked: crap-rs#169 — diff-mode cucumber harness not yet built
     Given a git repo with a baseline commit and subsequent changes
     And a full analysis has been recorded for the changed functions
     When I run crap4rs --diff <baseline> --coverage lcov.info
@@ -37,7 +45,9 @@ Feature: Diff mode
 
   # ── Empty Diff ────────────────────────────────────────────────────
 
+  @unwired
   Scenario: Empty diff produces empty result and exit 0
+    # tracked: crap-rs#169 — diff-mode cucumber harness not yet built
     Given a git repo where HEAD matches the baseline ref
     When I run crap4rs --diff <baseline> --coverage lcov.info
     Then the output contains zero functions
@@ -46,66 +56,88 @@ Feature: Diff mode
 
   # ── Filter Composition ────────────────────────────────────────────
 
+  @unwired
   Scenario: --diff composes with --exclude as AND
+    # tracked: crap-rs#169 — diff-mode cucumber harness not yet built
     Given a git repo with changes in src/lib.rs and tests/test_lib.rs
     When I run crap4rs --diff <baseline> --exclude "tests/**" --coverage lcov.info
     Then the output includes functions from src/lib.rs
     And the output does not include functions from tests/test_lib.rs
 
+  @unwired
   Scenario: --diff composes with --only-failing as AND
+    # tracked: crap-rs#169 — diff-mode cucumber harness not yet built
     Given a git repo with changed functions, some below and some above threshold
     When I run crap4rs --diff <baseline> --only-failing --coverage lcov.info
     Then only functions that are both changed AND exceed the threshold appear
 
   # ── JSON Envelope ─────────────────────────────────────────────────
 
+  @unwired
   Scenario: JSON output includes diff_ref when --diff is used
+    # tracked: crap-rs#169 — diff-mode cucumber harness not yet built
     Given a git repo with changes
     When I run crap4rs --diff main --format json --coverage lcov.info
     Then the JSON envelope contains "diff_ref" with value "main"
 
+  @unwired
   Scenario: JSON output has null diff_ref when --diff is not used
+    # tracked: crap-rs#169 — diff-mode cucumber harness not yet built
     When I run crap4rs --format json --coverage lcov.info
     Then the JSON envelope contains "diff_ref" with value null
 
   # ── Error Handling ────────────────────────────────────────────────
 
+  @unwired
   Scenario: Error when not inside a git repository
+    # tracked: crap-rs#169 — diff-mode cucumber harness not yet built
     Given I am not inside a git repository
     When I run crap4rs --diff main --coverage lcov.info
     Then the exit code is 2
     And stderr contains "not inside a git work tree"
 
+  @unwired
   Scenario: Error when ref is invalid
+    # tracked: crap-rs#169 — diff-mode cucumber harness not yet built
     Given a git repo
     When I run crap4rs --diff nonexistent-ref-xyz --coverage lcov.info
     Then the exit code is 2
     And stderr contains an error about the invalid ref
 
+  @unwired
   Scenario: Ref starting with dash is rejected
+    # tracked: crap-rs#169 — diff-mode cucumber harness not yet built
     When I run crap4rs --diff --malicious-flag --coverage lcov.info
     Then the exit code is 2
     And stderr contains "invalid" or the ref is not passed to git
 
   # ── Edge Cases ────────────────────────────────────────────────────
 
+  @unwired
   Scenario: Non-Rust file changes are ignored
+    # tracked: crap-rs#169 — diff-mode cucumber harness not yet built
     Given a git repo with changes in both src/lib.rs and README.md
     When I run crap4rs --diff <baseline> --coverage lcov.info
     Then the output includes functions from src/lib.rs
     And no functions appear from README.md
 
+  @unwired
   Scenario: Renamed file includes functions from new path
+    # tracked: crap-rs#169 — diff-mode cucumber harness not yet built
     Given a git repo where src/old.rs was renamed to src/new.rs with modifications
     When I run crap4rs --diff <baseline> --coverage lcov.info
     Then the output includes functions from src/new.rs with the new path
 
+  @unwired
   Scenario: Deletion-only changes do not surface functions
+    # tracked: crap-rs#169 — diff-mode cucumber harness not yet built
     Given a git repo where the only change is deleting lines from a function
     When I run crap4rs --diff <baseline> --coverage lcov.info
     Then the output does not include the function with only deleted lines
 
+  @unwired
   Scenario: Path normalization matches between git diff and complexity data
+    # tracked: crap-rs#169 — diff-mode cucumber harness not yet built
     Given a git repo with changes in a nested file src/sub/mod.rs
     When I run crap4rs --diff <baseline> --coverage lcov.info
     Then functions from src/sub/mod.rs appear correctly in the output

--- a/crates/crap4rs/tests/features/format_advice.feature
+++ b/crates/crap4rs/tests/features/format_advice.feature
@@ -21,7 +21,9 @@ Feature: --format advice (issue #76)
 
   # ── Envelope shape ─────────────────────────────────────────────────
 
+  @unwired
   Scenario: --format advice emits the canonical envelope on stdout
+    # tracked: crap-rs#169 — format-advice cucumber harness not yet built
     When the operator runs `crap4rs --coverage lcov.info --format advice`
     Then stdout is parseable JSON
     And the document carries top-level `schema_version` "2"
@@ -29,19 +31,25 @@ Feature: --format advice (issue #76)
     And every `view.shown[].diagnostic` is either populated or absent
       (never `null`-with-fields-present)
 
+  @unwired
   Scenario: --format advice exit code matches --format json
+    # tracked: crap-rs#169 — format-advice cucumber harness not yet built
     Given exceeding functions exist
     When the operator runs `crap4rs --coverage lcov.info --format advice`
     Then the exit code is 1
 
   # ── Diagnostic gating (R6.4 / F2) ──────────────────────────────────
 
+  @unwired
   Scenario: Under-threshold functions carry no Diagnostic
+    # tracked: crap-rs#169 — format-advice cucumber harness not yet built
     When the operator runs `crap4rs --coverage lcov.info --format advice`
     Then for every `view.shown[]` entry where `verdict.exceeds == false`,
       `verdict.diagnostic` key is absent from the serialised JSON
 
+  @unwired
   Scenario: Over-threshold functions always carry a Diagnostic
+    # tracked: crap-rs#169 — format-advice cucumber harness not yet built
     When the operator runs `crap4rs --coverage lcov.info --format advice`
     Then for every `view.shown[]` entry where `verdict.exceeds == true`,
       `verdict.diagnostic` is populated with all four fields:
@@ -50,7 +58,9 @@ Feature: --format advice (issue #76)
 
   # ── SuggestedAction taxonomy (R1.3) ────────────────────────────────
 
+  @unwired
   Scenario: Low coverage emits AddTestsForLines
+    # tracked: crap-rs#169 — format-advice cucumber harness not yet built
     Given an over-threshold function with coverage < 100% and acceptable
       complexity
     When the operator runs `crap4rs --coverage lcov.info --format advice`
@@ -60,7 +70,9 @@ Feature: --format advice (issue #76)
       ranges in the function's span
     And that entry carries an `applicability` field
 
+  @unwired
   Scenario: High complexity with viable splits emits ExtractFunction
+    # tracked: crap-rs#169 — format-advice cucumber harness not yet built
     Given an over-threshold function with full coverage and high
       complexity
     When the operator runs `crap4rs --coverage lcov.info --format advice`
@@ -69,14 +81,18 @@ Feature: --format advice (issue #76)
     And that entry carries a non-empty `candidates: Vec<ProposedSplit>`
     And no `add_tests_for_lines` action is emitted for this function
 
+  @unwired
   Scenario: Both low coverage and high complexity emit both actions
+    # tracked: crap-rs#169 — format-advice cucumber harness not yet built
     Given an over-threshold function with coverage < 100% and high
       complexity
     When the operator runs `crap4rs --coverage lcov.info --format advice`
     Then `verdict.diagnostic.suggested_actions[]` contains both
       `add_tests_for_lines` and `extract_function` entries
 
+  @unwired
   Scenario: High complexity with zero viable splits falls back to AcceptInherentComplexity
+    # tracked: crap-rs#169 — format-advice cucumber harness not yet built
     Given an over-threshold function with full coverage and high
       complexity but no extractable subexpression
     When the operator runs `crap4rs --coverage lcov.info --format advice`
@@ -86,7 +102,9 @@ Feature: --format advice (issue #76)
 
   # ── ProposedSplit shape (R1.4) ─────────────────────────────────────
 
+  @unwired
   Scenario: Each ProposedSplit carries the five wire fields
+    # tracked: crap-rs#169 — format-advice cucumber harness not yet built
     Given an over-threshold function with high complexity
     When the operator runs `crap4rs --coverage lcov.info --format advice`
     Then for every `extract_function.candidates[]` entry, all of the
@@ -95,7 +113,9 @@ Feature: --format advice (issue #76)
     And `kind` is one of "deepest_nesting", "largest_subblock",
       "highest_branch_count"
 
+  @unwired
   Scenario: Exactly one ProposedSplit per function has recommended:true
+    # tracked: crap-rs#169 — format-advice cucumber harness not yet built
     Given an over-threshold function whose `extract_function.candidates`
       list is non-empty
     When the operator runs `crap4rs --coverage lcov.info --format advice`
@@ -103,7 +123,9 @@ Feature: --format advice (issue #76)
       `recommended` true
     And every other entry has `recommended` false
 
+  @unwired
   Scenario Outline: De-duplication priority for same-line-range candidates
+    # tracked: crap-rs#169 — format-advice cucumber harness not yet built
     Given the walker emits multiple split candidates that resolve to the
       same `line_range` with kinds <kinds_present>
     When the operator runs `crap4rs --coverage lcov.info --format advice`
@@ -119,7 +141,9 @@ Feature: --format advice (issue #76)
 
   # ── root_cause derivation (R1.2) ───────────────────────────────────
 
+  @unwired
   Scenario Outline: root_cause is derived deterministically from the action set
+    # tracked: crap-rs#169 — format-advice cucumber harness not yet built
     Given an over-threshold function whose `suggested_actions[]`
       contains <actions_present>
     When the operator runs `crap4rs --coverage lcov.info --format advice`
@@ -136,27 +160,35 @@ Feature: --format advice (issue #76)
 
   # ── Composition with View flags (R2.1) ─────────────────────────────
 
+  @unwired
   Scenario: --format advice composes with --top
+    # tracked: crap-rs#169 — format-advice cucumber harness not yet built
     Given six exceeding functions
     When the operator runs `crap4rs --coverage lcov.info --format advice --top 3`
     Then `view.shown[]` length is 3
     And every entry in `view.shown[]` carries a populated `diagnostic`
 
+  @unwired
   Scenario: --format advice composes with --sort-by coverage
+    # tracked: crap-rs#169 — format-advice cucumber harness not yet built
     Given several exceeding functions with varying coverage
     When the operator runs `crap4rs --coverage lcov.info --format advice --sort-by coverage`
     Then `view.shown[]` is ordered by `verdict.scored.coverage_percent`
       ascending
     And every entry's `diagnostic` is populated
 
+  @unwired
   Scenario: --format advice composes with --min-coverage / --max-coverage
+    # tracked: crap-rs#169 — format-advice cucumber harness not yet built
     Given a mix of over-threshold functions across the coverage spectrum
     When the operator runs `crap4rs --coverage lcov.info --format advice --min-coverage 80`
     Then `view.shown[]` contains only entries where
       `verdict.scored.coverage_percent >= 80`
     And each surviving entry carries a populated `diagnostic`
 
+  @unwired
   Scenario: --format advice composes with --no-fail
+    # tracked: crap-rs#169 — format-advice cucumber harness not yet built
     Given exceeding functions exist
     When the operator runs `crap4rs --coverage lcov.info --format advice --no-fail`
     Then the exit code is 0
@@ -165,7 +197,9 @@ Feature: --format advice (issue #76)
 
   # ── Stderr summary (R5.2 / S-8) ────────────────────────────────────
 
+  @unwired
   Scenario: --format advice emits a one-line-per-function summary on stderr
+    # tracked: crap-rs#169 — format-advice cucumber harness not yet built
     Given exceeding functions exist
     When the operator runs `crap4rs --coverage lcov.info --format advice`
     Then stdout is parseable JSON
@@ -173,20 +207,26 @@ Feature: --format advice (issue #76)
       `[crap=N.NN] file:line-line qualified::name [actions: …]`
     And stderr lines are ordered to match `view.shown[]`
 
+  @unwired
   Scenario: stdout stays JSON-only when --format advice is set
+    # tracked: crap-rs#169 — format-advice cucumber harness not yet built
     When the operator runs `crap4rs --coverage lcov.info --format advice`
     Then stdout contains no human-readable prose, banners, or table
       borders
     And stdout is parseable as a single JSON value
 
+  @unwired
   Scenario: --format json without advice emits no stderr summary
+    # tracked: crap-rs#169 — format-advice cucumber harness not yet built
     When the operator runs `crap4rs --coverage lcov.info --format json`
     Then stderr is empty (apart from operational warnings, if any)
     And stdout's `view.shown[].diagnostic` keys are absent
 
   # ── Naming / determinism (R6.3) ────────────────────────────────────
 
+  @unwired
   Scenario: Diagnostic carries no prose, no human names, no LLM-shaped guesses
+    # tracked: crap-rs#169 — format-advice cucumber harness not yet built
     When the operator runs `crap4rs --coverage lcov.info --format advice`
     Then no `diagnostic.suggested_actions[]` entry contains a `rationale`
       string field
@@ -195,7 +235,9 @@ Feature: --format advice (issue #76)
     And every `branch_path` is a `/`-joined chain of
       `ContributorKind` discriminants only
 
+  @unwired
   Scenario: Same input produces byte-identical advice JSON
+    # tracked: crap-rs#169 — format-advice cucumber harness not yet built
     When the operator runs `crap4rs --coverage lcov.info --format advice`
       twice with the same coverage file
     Then both stdout bytes are identical
@@ -203,7 +245,9 @@ Feature: --format advice (issue #76)
 
   # ── Naming conflict (R6.6 / A1) ────────────────────────────────────
 
+  @unwired
   Scenario: --explain is NOT an alias of --format advice
+    # tracked: crap-rs#169 — format-advice cucumber harness not yet built
     Given the project has at least one over-threshold function
     When the operator runs `crap4rs --coverage lcov.info --explain`
     Then stdout is the human-readable breakdown legend (PR #59
@@ -212,7 +256,9 @@ Feature: --format advice (issue #76)
 
   # ── Stability (R4.1 / G1) ──────────────────────────────────────────
 
+  @unwired
   Scenario: schema_version is 2 in v0.4.0+
+    # tracked: crap-rs#169 — format-advice cucumber harness not yet built
     # #107 bumped 1 → 2 to mark the column-convention shift.
     When the operator runs `crap4rs --coverage lcov.info --format advice`
     Then the document's top-level `schema_version` is "2"

--- a/crates/crap4rs/tests/features/group_by_file.feature
+++ b/crates/crap4rs/tests/features/group_by_file.feature
@@ -16,7 +16,9 @@ Feature: --group-by file (Bundle C, issue #64)
 
   # ── Default invocation (no --group-by) ─────────────────────────────
 
+  @unwired
   Scenario: Default invocation produces no grouped block
+    # tracked: crap-rs#169 — group-by-file cucumber harness not yet built
     When the operator runs `crap4rs --coverage lcov.info --format json`
     Then `view.grouped` is null
     And `view.spec.group_by` is null
@@ -24,7 +26,9 @@ Feature: --group-by file (Bundle C, issue #64)
 
   # ── --group-by file populates the grouped block ────────────────────
 
+  @unwired
   Scenario: --group-by file emits a grouped block in JSON
+    # tracked: crap-rs#169 — group-by-file cucumber harness not yet built
     When the operator runs `crap4rs --coverage lcov.info --group-by file --format json`
     Then `view.grouped.key` is "file"
     And `view.grouped.files.length` is 3
@@ -35,7 +39,9 @@ Feature: --group-by file (Bundle C, issue #64)
 
   # ── --top truncates files when grouped ─────────────────────────────
 
+  @unwired
   Scenario: --top N truncates to top N files when grouped
+    # tracked: crap-rs#169 — group-by-file cucumber harness not yet built
     When the operator runs `crap4rs --coverage lcov.info --group-by file --top 1 --format json`
     Then `view.grouped.files.length` is 1
     And `view.grouped.truncated` is true
@@ -45,48 +51,64 @@ Feature: --group-by file (Bundle C, issue #64)
 
   # ── --sort-by keys at file level under grouping ────────────────────
 
+  @unwired
   Scenario: --sort-by coverage --group-by file sorts files by avg coverage ascending
+    # tracked: crap-rs#169 — group-by-file cucumber harness not yet built
     When the operator runs `crap4rs --coverage lcov.info --group-by file --sort-by coverage --format json`
     Then `view.grouped.files` is sorted by `average_coverage` ascending
 
+  @unwired
   Scenario: --sort-by complexity --group-by file sorts files by max complexity descending
+    # tracked: crap-rs#169 — group-by-file cucumber harness not yet built
     When the operator runs `crap4rs --coverage lcov.info --group-by file --sort-by complexity --format json`
     Then `view.grouped.files` is sorted by `max_complexity` descending
 
+  @unwired
   Scenario: --sort-by path --group-by file sorts files alphabetically
+    # tracked: crap-rs#169 — group-by-file cucumber harness not yet built
     When the operator runs `crap4rs --coverage lcov.info --group-by file --sort-by path --format json`
     Then `view.grouped.files` is sorted by `file_path` ascending
 
   # ── --only-failing composes with --group-by file ───────────────────
 
+  @unwired
   Scenario: --only-failing --group-by file filters to files with at least one failing function
+    # tracked: crap-rs#169 — group-by-file cucumber harness not yet built
     When the operator runs `crap4rs --coverage lcov.info --only-failing --group-by file --format json`
     Then every file in `view.grouped.files` has `exceeding_count` >= 1
     And `view.grouped.files.length` is 2
 
   # ── CSV schema shifts under --group-by file ────────────────────────
 
+  @unwired
   Scenario: --format csv --group-by file emits per-file header
+    # tracked: crap-rs#169 — group-by-file cucumber harness not yet built
     When the operator runs `crap4rs --coverage lcov.info --group-by file --format csv`
     Then the first line is "file,function_count,exceeding_count,average_crap,max_crap,worst_function,distribution_low,distribution_acceptable,distribution_moderate,distribution_high"
     And subsequent lines are per-file rows
 
   # ── --minimal-view composes with --group-by file ───────────────────
 
+  @unwired
   Scenario: --minimal-view --group-by file strips view.shown but keeps view.grouped
+    # tracked: crap-rs#169 — group-by-file cucumber harness not yet built
     When the operator runs `crap4rs --coverage lcov.info --minimal-view --group-by file --format json`
     Then `view.shown` is absent from the JSON envelope
     And `view.grouped` is present and populated
 
   # ── Gate keystone: --group-by file does NOT change exit code ───────
 
+  @unwired
   Scenario: --group-by file does not change exit code on a failing analysis
+    # tracked: crap-rs#169 — group-by-file cucumber harness not yet built
     Given the unfiltered analysis would exit 1 (violations exist)
     When the operator runs `crap4rs --coverage lcov.info --group-by file`
     Then the process exits 1
     And `result.passed` is false
 
+  @unwired
   Scenario: --group-by file --top truncating files leaves the gate alone
+    # tracked: crap-rs#169 — group-by-file cucumber harness not yet built
     Given the unfiltered analysis would exit 1
     When the operator runs `crap4rs --coverage lcov.info --group-by file --top 1`
     Then the process exits 1
@@ -94,7 +116,9 @@ Feature: --group-by file (Bundle C, issue #64)
 
   # ── Help text discoverability (issue #64 acceptance criteria) ──────
 
+  @unwired
   Scenario: --help documents the --top and --sort-by semantic shift
+    # tracked: crap-rs#169 — group-by-file cucumber harness not yet built
     When the operator runs `crap4rs --help`
     Then the `--group-by` description mentions that `--top N` truncates files
     And mentions that `--sort-by` keys at the file level

--- a/crates/crap4rs/tests/features/json_reporter.feature
+++ b/crates/crap4rs/tests/features/json_reporter.feature
@@ -5,6 +5,7 @@ Feature: JSON reporter
 
   # ── Envelope Structure ─────────────────────────────────────────────
 
+  @wired
   Scenario: JSON output contains a versioned envelope
     Given an analysis result
     When the JSON is formatted
@@ -15,6 +16,7 @@ Feature: JSON reporter
     And the output contains "metric"
     And the output contains "threshold"
 
+  @wired
   Scenario: Analysis result is nested under "result" key
     Given an analysis result
     When the JSON is formatted
@@ -22,6 +24,7 @@ Feature: JSON reporter
     And the "result" object contains "summary"
     And the "result" object contains "passed"
 
+  @wired
   Scenario: Schema version is an integer
     Given an analysis result
     When the JSON is formatted
@@ -29,6 +32,7 @@ Feature: JSON reporter
 
   # ── Result Content ─────────────────────────────────────────────────
 
+  @wired
   Scenario: Function entries contain all scored fields
     Given an analysis with one function "compute_crap" in "src/domain/crap.rs" with complexity 5, coverage 80.0%, and CRAP score 5.16
     When the JSON is formatted
@@ -41,6 +45,7 @@ Feature: JSON reporter
     And the entry contains "crap" with "risk_level" equal to "acceptable"
     And the entry contains "exceeds" equal to false
 
+  @wired
   Scenario: Summary contains aggregate statistics
     Given an analysis with 10 functions, 2 exceeding threshold
     When the JSON is formatted
@@ -49,6 +54,7 @@ Feature: JSON reporter
     And "result.summary.average_crap" is a number
     And "result.summary.median_crap" is a number
 
+  @wired
   Scenario: Summary contains risk distribution
     Given an analysis with distribution low=5 acceptable=3 moderate=1 high=1
     When the JSON is formatted
@@ -57,11 +63,13 @@ Feature: JSON reporter
     And "result.summary.distribution.moderate" equals 1
     And "result.summary.distribution.high" equals 1
 
+  @wired
   Scenario: Passed reflects threshold compliance
     Given an analysis where all functions are within threshold
     When the JSON is formatted
     Then "result.passed" is true
 
+  @wired
   Scenario: Failed reflects threshold violations
     Given an analysis where 1 function exceeds the threshold
     When the JSON is formatted
@@ -69,6 +77,7 @@ Feature: JSON reporter
 
   # ── Empty Results ──────────────────────────────────────────────────
 
+  @wired
   Scenario: Empty analysis produces valid JSON
     Given an analysis with no functions
     When the JSON is formatted
@@ -79,16 +88,19 @@ Feature: JSON reporter
 
   # ── Envelope Metadata ──────────────────────────────────────────────
 
+  @wired
   Scenario: Metric field reflects the configured complexity metric
     Given the analysis used cognitive complexity
     When the JSON is formatted with metric "cognitive"
     Then "metric" equals "cognitive"
 
+  @wired
   Scenario: Threshold field reflects the configured threshold
     Given the analysis used threshold 8.0
     When the JSON is formatted with threshold 8.0
     Then "threshold" equals 8.0
 
+  @wired
   Scenario: Timestamp is a valid ISO 8601 datetime
     Given an analysis result
     When the JSON is formatted

--- a/crates/crap4rs/tests/features/lcov_parser.feature
+++ b/crates/crap4rs/tests/features/lcov_parser.feature
@@ -6,44 +6,58 @@ Feature: LCOV coverage parsing
 
   # --- Valid parsing ---
 
+  @unwired
   Scenario: Single source file with line coverage
+    # tracked: crap-rs#169 — lcov-parser cucumber harness not yet built (unit tests cover the path)
     Given LCOV data for one source file with 3 covered lines
     When the coverage is parsed
     Then the result contains 1 file
     And that file has 3 line coverage entries
     And no diagnostics are reported
 
+  @unwired
   Scenario: Multiple source files in one LCOV report
+    # tracked: crap-rs#169 — lcov-parser cucumber harness not yet built (unit tests cover the path)
     Given LCOV data for 3 source files
     When the coverage is parsed
     Then the result contains 3 files
     And each file has its own line coverage entries
 
+  @unwired
   Scenario: Line hit counts are preserved
+    # tracked: crap-rs#169 — lcov-parser cucumber harness not yet built (unit tests cover the path)
     Given a DA record "DA:42,7"
     When the coverage is parsed
     Then line 42 has 7 hits
 
+  @unwired
   Scenario: Zero-hit lines are included
+    # tracked: crap-rs#169 — lcov-parser cucumber harness not yet built (unit tests cover the path)
     Given a DA record "DA:10,0"
     When the coverage is parsed
     Then line 10 has 0 hits
 
   # --- Path normalization ---
 
+  @unwired
   Scenario: Absolute paths are stripped to project-relative
+    # tracked: crap-rs#169 — lcov-parser cucumber harness not yet built (unit tests cover the path)
     Given a root path of "/Users/dev/project"
     And an SF record "SF:/Users/dev/project/src/main.rs"
     When the coverage is parsed
     Then the file key is "src/main.rs"
 
+  @unwired
   Scenario: Non-matching paths pass through unchanged
+    # tracked: crap-rs#169 — lcov-parser cucumber harness not yet built (unit tests cover the path)
     Given a root path of "/Users/dev/project"
     And an SF record "SF:/other/path/lib.rs"
     When the coverage is parsed
     Then the file key is "/other/path/lib.rs"
 
+  @unwired
   Scenario: Path separators are normalized to forward slashes
+    # tracked: crap-rs#169 — lcov-parser cucumber harness not yet built (unit tests cover the path)
     Given a root path with platform-specific separators
     And an SF record with a matching path
     When the coverage is parsed
@@ -51,7 +65,9 @@ Feature: LCOV coverage parsing
 
   # --- Duplicate DA lines ---
 
+  @unwired
   Scenario: Duplicate DA lines for the same line number are summed
+    # tracked: crap-rs#169 — lcov-parser cucumber harness not yet built (unit tests cover the path)
     Given LCOV data with two DA records for line 42
       | record   |
       | DA:42,3  |
@@ -59,81 +75,107 @@ Feature: LCOV coverage parsing
     When the coverage is parsed
     Then line 42 has 4 hits
 
+  @unwired
   Scenario: Multiple duplicates across many lines are all summed
+    # tracked: crap-rs#169 — lcov-parser cucumber harness not yet built (unit tests cover the path)
     Given LCOV data with duplicate DA records for lines 10, 20, and 30
     When the coverage is parsed
     Then each line's hits equal the sum of all its DA entries
 
   # --- Malformed DA handling ---
 
+  @unwired
   Scenario: Malformed DA line produces a diagnostic
+    # tracked: crap-rs#169 — lcov-parser cucumber harness not yet built (unit tests cover the path)
     Given LCOV data containing "DA:not_a_number"
     When the coverage is parsed
     Then a MalformedRecord diagnostic is reported
     And the diagnostic includes the line number in the input
     And the diagnostic includes the raw content "DA:not_a_number"
 
+  @unwired
   Scenario: Malformed DA line does not prevent parsing other lines
+    # tracked: crap-rs#169 — lcov-parser cucumber harness not yet built (unit tests cover the path)
     Given LCOV data with a valid DA, then a malformed DA, then another valid DA
     When the coverage is parsed
     Then both valid lines appear in the coverage
     And exactly 1 diagnostic is reported
 
+  @unwired
   Scenario: DA line missing hit count produces a diagnostic
+    # tracked: crap-rs#169 — lcov-parser cucumber harness not yet built (unit tests cover the path)
     Given LCOV data containing "DA:42"
     When the coverage is parsed
     Then a MalformedRecord diagnostic is reported
 
+  @unwired
   Scenario: DA line with negative hit count produces a diagnostic
+    # tracked: crap-rs#169 — lcov-parser cucumber harness not yet built (unit tests cover the path)
     Given LCOV data containing "DA:42,-1"
     When the coverage is parsed
     Then a MalformedRecord diagnostic is reported
 
   # --- Block delimiters ---
 
+  @unwired
   Scenario: SF records delimit file blocks
+    # tracked: crap-rs#169 — lcov-parser cucumber harness not yet built (unit tests cover the path)
     Given LCOV data with SF then DA records for file A
     And then SF then DA records for file B
     When the coverage is parsed
     Then file A and file B each have their own coverage entries
 
+  @unwired
   Scenario: end_of_record markers are ignored
+    # tracked: crap-rs#169 — lcov-parser cucumber harness not yet built (unit tests cover the path)
     Given LCOV data with end_of_record between blocks
     When the coverage is parsed
     Then the result is identical to parsing without end_of_record
 
+  @unwired
   Scenario: Unterminated final block emits partial data
+    # tracked: crap-rs#169 — lcov-parser cucumber harness not yet built (unit tests cover the path)
     Given LCOV data that ends after DA records without end_of_record
     When the coverage is parsed
     Then the final file's coverage is included in the result
 
   # --- Empty and edge cases ---
 
+  @unwired
   Scenario: Empty input produces empty result
+    # tracked: crap-rs#169 — lcov-parser cucumber harness not yet built (unit tests cover the path)
     Given empty LCOV data
     When the coverage is parsed
     Then the result contains 0 files
     And no diagnostics are reported
 
+  @unwired
   Scenario: Empty SF path emits a diagnostic and skips the block
+    # tracked: crap-rs#169 — lcov-parser cucumber harness not yet built (unit tests cover the path)
     Given LCOV data with "SF:" followed by DA records
     When the coverage is parsed
     Then an EmptySourceFile diagnostic is reported
     And no coverage entry is created for the empty path
 
+  @unwired
   Scenario: Non-coverage LCOV records are ignored
+    # tracked: crap-rs#169 — lcov-parser cucumber harness not yet built (unit tests cover the path)
     Given LCOV data containing FN, FNDA, LF, and LH records
     When the coverage is parsed
     Then only SF, DA, and BRDA records affect the result
     And no diagnostics are reported for ignored record types
 
+  @unwired
   Scenario: BRDA records are parsed into the branches map
+    # tracked: crap-rs#169 — lcov-parser cucumber harness not yet built (unit tests cover the path)
     Given LCOV data containing well-formed BRDA records under an SF block
     When the coverage is parsed
     Then `ParseOutput.branches` reflects each BRDA entry
     And no diagnostics are reported for well-formed BRDA lines
 
+  @unwired
   Scenario: Malformed BRDA records emit a MalformedRecord diagnostic
+    # tracked: crap-rs#169 — lcov-parser cucumber harness not yet built (unit tests cover the path)
     Given LCOV data containing an unparseable BRDA record under an SF block
     When the coverage is parsed
     Then a MalformedRecord diagnostic is reported for the offending line
@@ -144,18 +186,24 @@ Feature: LCOV coverage parsing
   # These scenarios document the property test contracts.
   # Implementation uses proptest with custom strategies.
 
+  @unwired
   Scenario: Any valid LCOV input produces a result without panicking
+    # tracked: crap-rs#169 — lcov-parser cucumber harness not yet built (unit tests cover the path)
     Given any syntactically structured LCOV input
     When the coverage is parsed
     Then parsing completes without panicking
     And the result is a valid ParseOutput
 
+  @unwired
   Scenario: All hit counts in the output are non-negative
+    # tracked: crap-rs#169 — lcov-parser cucumber harness not yet built (unit tests cover the path)
     Given any LCOV input
     When the coverage is parsed
     Then every LineCoverage entry has hits >= 0
 
+  @unwired
   Scenario: Coverage is file-scoped with no cross-file leakage
+    # tracked: crap-rs#169 — lcov-parser cucumber harness not yet built (unit tests cover the path)
     Given LCOV data for files A and B with distinct DA records
     When the coverage is parsed
     Then file A's coverage contains none of file B's line numbers

--- a/crates/crap4rs/tests/features/sarif_reporter.feature
+++ b/crates/crap4rs/tests/features/sarif_reporter.feature
@@ -12,7 +12,9 @@ Feature: SARIF reporter (issue #70)
 
   # ── Envelope shape ─────────────────────────────────────────────────
 
+  @unwired
   Scenario: --format sarif emits SARIF v2.1.0 JSON
+    # tracked: crap-rs#169 — sarif-reporter cucumber harness not yet built
     When the operator runs `crap4rs --coverage lcov.info --format sarif`
     Then stdout is parseable JSON
     And the document has top-level "$schema" "https://json.schemastore.org/sarif-2.1.0.json"
@@ -21,14 +23,18 @@ Feature: SARIF reporter (issue #70)
     And `runs[0].tool.driver.version` matches the binary version
     And `runs[0].tool.driver.rules[0].id` is "crap/threshold-exceeded"
 
+  @unwired
   Scenario: One result per exceeding function
+    # tracked: crap-rs#169 — sarif-reporter cucumber harness not yet built
     When the operator runs `crap4rs --coverage lcov.info --format sarif`
     Then `runs[0].results[]` length equals the number of functions where
       `exceeds == true` in the full analysis
     And every result has a `ruleId`, `level`, `message.text`, a single
       `locations[0].physicalLocation`, and `partialFingerprints.functionIdentity`
 
+  @unwired
   Scenario: Empty results when no function exceeds the threshold
+    # tracked: crap-rs#169 — sarif-reporter cucumber harness not yet built
     Given every function is below the threshold
     When the operator runs `crap4rs --coverage lcov.info --format sarif`
     Then `runs[0].results[]` is the empty array
@@ -36,7 +42,9 @@ Feature: SARIF reporter (issue #70)
 
   # ── Severity mapping ───────────────────────────────────────────────
 
+  @unwired
   Scenario Outline: Risk level maps to SARIF severity
+    # tracked: crap-rs#169 — sarif-reporter cucumber harness not yet built
     Given an exceeding function with risk level <risk>
     When the operator runs `crap4rs --coverage lcov.info --format sarif`
     Then the result for that function has `level` <sarif_level>
@@ -50,20 +58,26 @@ Feature: SARIF reporter (issue #70)
 
   # ── Gate keystone: SARIF iterates the FULL analysis ────────────────
 
+  @unwired
   Scenario: --top does NOT truncate SARIF results
+    # tracked: crap-rs#169 — sarif-reporter cucumber harness not yet built
     Given six exceeding functions
     When the operator runs `crap4rs --coverage lcov.info --format sarif --top 2`
     Then `runs[0].results[]` length is 6
     And the View shaping (limit / truncated) does not appear in the SARIF
       output — SARIF has no `view` block, only the unshapeable gate
 
+  @unwired
   Scenario: --only-failing does NOT shrink SARIF results
+    # tracked: crap-rs#169 — sarif-reporter cucumber harness not yet built
     Given the analysis contains both passing and exceeding functions
     When the operator runs `crap4rs --coverage lcov.info --format sarif --only-failing`
     Then `runs[0].results[]` length equals the number of exceeding
       functions, identical to the run without `--only-failing`
 
+  @unwired
   Scenario: --sort-by does NOT reorder SARIF results
+    # tracked: crap-rs#169 — sarif-reporter cucumber harness not yet built
     Given several exceeding functions
     When the operator runs `crap4rs --coverage lcov.info --format sarif --sort-by coverage`
     Then `runs[0].results[]` is in the order produced by iterating
@@ -71,13 +85,17 @@ Feature: SARIF reporter (issue #70)
 
   # ── Exit code semantics ────────────────────────────────────────────
 
+  @unwired
   Scenario: Exit code is unchanged by --format sarif
+    # tracked: crap-rs#169 — sarif-reporter cucumber harness not yet built
     Given exceeding functions exist
     When the operator runs `crap4rs --coverage lcov.info --format sarif`
     Then the exit code is 1
     And stdout is non-empty SARIF JSON
 
+  @unwired
   Scenario: --no-fail still emits the truth in SARIF
+    # tracked: crap-rs#169 — sarif-reporter cucumber harness not yet built
     Given exceeding functions exist
     When the operator runs `crap4rs --coverage lcov.info --format sarif --no-fail`
     Then the exit code is 0
@@ -86,20 +104,26 @@ Feature: SARIF reporter (issue #70)
 
   # ── Location format (GitHub-compatible) ────────────────────────────
 
+  @unwired
   Scenario: Artifact URI is the repo-relative file path
+    # tracked: crap-rs#169 — sarif-reporter cucumber harness not yet built
     When the operator runs `crap4rs --coverage lcov.info --format sarif`
     Then every `result.locations[0].physicalLocation.artifactLocation.uri`
       is the same repo-relative path the table reporter uses
     And the path does not begin with "file://" or "/"
 
+  @unwired
   Scenario: Region carries the full line range from the analysis
+    # tracked: crap-rs#169 — sarif-reporter cucumber harness not yet built
     When the operator runs `crap4rs --coverage lcov.info --format sarif`
     Then every `result.locations[0].physicalLocation.region.startLine`
       equals the function's `span.start_line` (1-based)
     And every region's `endLine` equals the function's `span.end_line`
       (inclusive)
 
+  @unwired
   Scenario: Region carries column data when known (issue #105)
+    # tracked: crap-rs#169 — sarif-reporter cucumber harness not yet built
     Given the complexity adapter populates 1-based start/end columns
       from `proc_macro2::Span`
     When the operator runs `crap4rs --coverage lcov.info --format sarif`
@@ -107,7 +131,9 @@ Feature: SARIF reporter (issue #70)
     And GitHub Code Scanning underlines the exact function range in the
       PR diff instead of highlighting the entire line
 
+  @unwired
   Scenario: Region omits column keys when columns are unknown
+    # tracked: crap-rs#169 — sarif-reporter cucumber harness not yet built
     Given a span produced by an adapter that has no column data (e.g.,
       diff hunks parsed line-only)
     When the operator runs `crap4rs --coverage lcov.info --format sarif`
@@ -117,7 +143,9 @@ Feature: SARIF reporter (issue #70)
 
   # ── Fingerprints (GitHub dedup) ────────────────────────────────────
 
+  @unwired
   Scenario: partialFingerprints stable across runs and rebases
+    # tracked: crap-rs#169 — sarif-reporter cucumber harness not yet built
     When the operator runs `crap4rs --coverage lcov.info --format sarif`
     Then every result's `partialFingerprints.functionIdentity` is the
       string "{file_path}:{qualified_name}"
@@ -126,7 +154,9 @@ Feature: SARIF reporter (issue #70)
 
   # ── Diagnostic enrichment (issue #76) ──────────────────────────────
 
+  @unwired
   Scenario: result.properties.diagnostic populated when Diagnostic is computed
+    # tracked: crap-rs#169 — sarif-reporter cucumber harness not yet built
     Given exceeding functions exist
     When the operator runs `crap4rs --coverage lcov.info --format sarif`
     Then every `runs[0].results[].properties.diagnostic` carries the
@@ -135,7 +165,9 @@ Feature: SARIF reporter (issue #70)
       `view.shown[].diagnostic` would carry under
       `crap4rs --format advice`
 
+  @unwired
   Scenario: properties.diagnostic mirrors the advice wire shape
+    # tracked: crap-rs#169 — sarif-reporter cucumber harness not yet built
     Given an exceeding function whose `Diagnostic` contains an
       `extract_function` action with two `candidates[]`
     When the operator runs `crap4rs --coverage lcov.info --format sarif`
@@ -144,13 +176,17 @@ Feature: SARIF reporter (issue #70)
       "extract_function" and a non-empty `candidates[]`
     And exactly one `candidates[].recommended` is true
 
+  @unwired
   Scenario: --format sarif does NOT emit the stderr advice summary
+    # tracked: crap-rs#169 — sarif-reporter cucumber harness not yet built
     Given exceeding functions exist
     When the operator runs `crap4rs --coverage lcov.info --format sarif`
     Then stderr contains no per-function summary lines
       (the stderr summary fires only on `--format advice`)
 
+  @unwired
   Scenario: SARIF determinism preserved with diagnostic enrichment
+    # tracked: crap-rs#169 — sarif-reporter cucumber harness not yet built
     Given the same coverage file across two runs
     When the operator runs `crap4rs --coverage lcov.info --format sarif`
       twice

--- a/crates/crap4rs/tests/features/saved_view_presets.feature
+++ b/crates/crap4rs/tests/features/saved_view_presets.feature
@@ -28,7 +28,9 @@ Feature: --view saved presets (Bundle D, issue #80)
 
   # ── Resolution ─────────────────────────────────────────────────────
 
+  @unwired
   Scenario: --view ci applies every preset field to the view
+    # tracked: crap-rs#169 — saved-view-presets cucumber harness not yet built
     When the operator runs `crap4rs --coverage lcov.info --view ci --format json`
     Then `view.spec.limit` is `20`
     And `view.spec.filters.coverage_range` covers `[0, 90]`
@@ -39,17 +41,23 @@ Feature: --view saved presets (Bundle D, issue #80)
 
   # ── Override priority ──────────────────────────────────────────────
 
+  @unwired
   Scenario: --top on the CLI overrides the preset's top
+    # tracked: crap-rs#169 — saved-view-presets cucumber harness not yet built
     When the operator runs `crap4rs --coverage lcov.info --view ci --top 5 --format json`
     Then `view.spec.limit` is `5`
     And `view.spec.filters.only_failing` is true (other preset fields preserved)
 
+  @unwired
   Scenario: --no-fail OR-merges with the preset
+    # tracked: crap-rs#169 — saved-view-presets cucumber harness not yet built
     Given the analysis has threshold violations
     When the operator runs `crap4rs --coverage lcov.info --view ci --no-fail`
     Then the process exits 0 (CLI --no-fail wins)
 
+  @unwired
   Scenario: Multiple presets coexist independently
+    # tracked: crap-rs#169 — saved-view-presets cucumber harness not yet built
     When the operator runs `crap4rs --coverage lcov.info --view investigate --format json`
     Then `view.spec.sort` is `"complexity"`
     And `view.spec.limit` is `10`
@@ -57,21 +65,27 @@ Feature: --view saved presets (Bundle D, issue #80)
 
   # ── Validation errors ──────────────────────────────────────────────
 
+  @unwired
   Scenario: Unknown preset name exits 2 with available list
+    # tracked: crap-rs#169 — saved-view-presets cucumber harness not yet built
     When the operator runs `crap4rs --coverage lcov.info --view nonsense`
     Then the process exits 2
     And stderr contains "unknown view preset"
     And stderr contains "ci"
     And stderr contains "investigate"
 
+  @unwired
   Scenario: --view with no crap4rs.toml exits 2 with hint
+    # tracked: crap-rs#169 — saved-view-presets cucumber harness not yet built
     Given no `crap4rs.toml` exists
     When the operator runs `crap4rs --coverage lcov.info --view ci`
     Then the process exits 2
     And stderr contains "unknown view preset"
     And stderr contains "crap4rs.toml"
 
+  @unwired
   Scenario: Invalid preset field fails fast at config load
+    # tracked: crap-rs#169 — saved-view-presets cucumber harness not yet built
     Given `crap4rs.toml` contains:
       """
       [views.bad]
@@ -84,7 +98,9 @@ Feature: --view saved presets (Bundle D, issue #80)
 
   # ── Gate keystone ──────────────────────────────────────────────────
 
+  @unwired
   Scenario: Preset does not change exit code on a failing analysis
+    # tracked: crap-rs#169 — saved-view-presets cucumber harness not yet built
     Given the unfiltered analysis would exit 1 (violations exist)
     And the preset `ci` has `no_fail = false`
     When the operator runs `crap4rs --coverage lcov.info --view ci`
@@ -93,7 +109,9 @@ Feature: --view saved presets (Bundle D, issue #80)
 
   # ── Discoverability ────────────────────────────────────────────────
 
+  @unwired
   Scenario: --help advertises --view
+    # tracked: crap-rs#169 — saved-view-presets cucumber harness not yet built
     When the operator runs `crap4rs --help`
     Then the help text mentions "--view"
     And the help text mentions "saved view preset"

--- a/crates/crap4rs/tests/features/table_reporter.feature
+++ b/crates/crap4rs/tests/features/table_reporter.feature
@@ -5,7 +5,9 @@ Feature: Terminal table reporter
 
   # ── Sorting ────────────────────────────────────────────────────────
 
+  @unwired
   Scenario: Functions are sorted by CRAP score descending
+    # tracked: crap-rs#169 — table-reporter cucumber harness not yet built
     Given an analysis with functions scoring 5.0, 45.2, and 8.1
     When the table is formatted
     Then the first row shows the function scoring 45.2
@@ -15,7 +17,9 @@ Feature: Terminal table reporter
   # ── Risk Level Coloring ────────────────────────────────────────────
   # Boundary values (5.0, 8.0, 30.0) tested in domain/crap.rs unit tests
 
+  @unwired
   Scenario Outline: Risk level coloring
+    # tracked: crap-rs#169 — table-reporter cucumber harness not yet built
     Given a function with a CRAP score of <score>
     When the table is formatted
     Then the risk column shows "<level>" in <color>
@@ -30,7 +34,9 @@ Feature: Terminal table reporter
   # ── Coverage Coloring ──────────────────────────────────────────────
   # Boundary values (50%, 80%) deferred to unit tests
 
+  @unwired
   Scenario Outline: Coverage coloring
+    # tracked: crap-rs#169 — table-reporter cucumber harness not yet built
     Given a function with <percent>% coverage
     When the table is formatted
     Then the coverage column appears in <color>
@@ -43,13 +49,17 @@ Feature: Terminal table reporter
 
   # ── Threshold Highlighting ─────────────────────────────────────────
 
+  @unwired
   Scenario: CRAP scores exceeding threshold appear in bold red
+    # tracked: crap-rs#169 — table-reporter cucumber harness not yet built
     Given a threshold of 8.0
     And a function with a CRAP score of 15.0
     When the table is formatted
     Then the CRAP score column shows "15.00" in bold red
 
+  @unwired
   Scenario: CRAP scores within threshold appear without emphasis
+    # tracked: crap-rs#169 — table-reporter cucumber harness not yet built
     Given a threshold of 8.0
     And a function with a CRAP score of 5.0
     When the table is formatted
@@ -57,12 +67,16 @@ Feature: Terminal table reporter
 
   # ── Table Columns ──────────────────────────────────────────────────
 
+  @unwired
   Scenario: Table contains all required columns
+    # tracked: crap-rs#169 — table-reporter cucumber harness not yet built
     Given an analysis with one function
     When the table is formatted
     Then the table header contains "File", "Function", "CC", "Cov%", "CRAP", and "Risk"
 
+  @unwired
   Scenario: Function details appear in correct columns
+    # tracked: crap-rs#169 — table-reporter cucumber harness not yet built
     Given a function "parse_record" in "src/adapters/coverage/mod.rs" with complexity 6, coverage 72.5%, and CRAP score 8.13
     When the table is formatted
     Then the row shows file "src/adapters/coverage/mod.rs"
@@ -73,14 +87,18 @@ Feature: Terminal table reporter
 
   # ── Header ─────────────────────────────────────────────────────────
 
+  @unwired
   Scenario: Table starts with a version header
+    # tracked: crap-rs#169 — table-reporter cucumber harness not yet built
     Given an analysis result
     When the table is formatted
     Then the output starts with "crap4rs v" followed by the tool version
 
   # ── Summary Line ───────────────────────────────────────────────────
 
+  @unwired
   Scenario: Summary shows function count and threshold violations
+    # tracked: crap-rs#169 — table-reporter cucumber harness not yet built
     Given an analysis with 42 functions where 3 exceed threshold 8.0
     And the worst CRAP score is 45.2
     When the table is formatted
@@ -88,17 +106,23 @@ Feature: Terminal table reporter
     And the summary line contains "3 above threshold (8.0)"
     And the summary line contains "worst: 45.2"
 
+  @unwired
   Scenario: Summary shows pass when no functions exceed threshold
+    # tracked: crap-rs#169 — table-reporter cucumber harness not yet built
     Given an analysis where no functions exceed the threshold
     When the table is formatted
     Then the summary line contains "PASS"
 
+  @unwired
   Scenario: Summary shows fail when functions exceed threshold
+    # tracked: crap-rs#169 — table-reporter cucumber harness not yet built
     Given an analysis where 2 functions exceed the threshold
     When the table is formatted
     Then the summary line contains "FAIL"
 
+  @unwired
   Scenario: Second summary line shows statistics and distribution
+    # tracked: crap-rs#169 — table-reporter cucumber harness not yet built
     Given an analysis with average CRAP 7.3, median 5.1, and distribution low=30 acceptable=9 moderate=2 high=1
     When the table is formatted
     Then the second summary line contains "avg: 7.3"
@@ -110,7 +134,9 @@ Feature: Terminal table reporter
 
   # ── Empty Results ──────────────────────────────────────────────────
 
+  @unwired
   Scenario: Empty analysis shows informational message
+    # tracked: crap-rs#169 — table-reporter cucumber harness not yet built
     Given an analysis with no functions
     When the table is formatted
     Then the output contains "No functions analyzed"
@@ -118,12 +144,16 @@ Feature: Terminal table reporter
 
   # ── Decimal Precision ──────────────────────────────────────────────
 
+  @unwired
   Scenario: CRAP scores display with two decimal places
+    # tracked: crap-rs#169 — table-reporter cucumber harness not yet built
     Given a function with a CRAP score of 5.0
     When the table is formatted
     Then the CRAP column shows "5.00"
 
+  @unwired
   Scenario: Coverage displays with one decimal place
+    # tracked: crap-rs#169 — table-reporter cucumber harness not yet built
     Given a function with 85.0% coverage
     When the table is formatted
     Then the coverage column shows "85.0"

--- a/crates/crap4rs/tests/features/view.feature
+++ b/crates/crap4rs/tests/features/view.feature
@@ -30,7 +30,9 @@ Feature: View — presentation transform on analysis findings
   # integration tests should use proptest to assert across arbitrary
   # AnalysisResults, not just the Background fixture.
 
+  @unwired
   Scenario: Default spec produces a no-op view in CRAP-descending order
+    # tracked: crap-rs#169 — view-module cucumber harness not yet built
     When the default ViewSpec is applied to the analysis
     Then `view.full` references the original analysis result without copying
     And `view.shown` contains every function from the analysis
@@ -38,30 +40,40 @@ Feature: View — presentation transform on analysis findings
     And `view.eligible_count` equals the total number of functions
     And `view.truncated` is false
 
+  @unwired
   Scenario: Default spec preserves identity set
+    # tracked: crap-rs#169 — view-module cucumber harness not yet built
     When the default ViewSpec is applied to the analysis
     Then the set of FunctionIdentity values in `view.shown` equals the set in the original analysis
 
+  @unwired
   Scenario: Default spec preserves the gate summary
+    # tracked: crap-rs#169 — view-module cucumber harness not yet built
     When the default ViewSpec is applied to the analysis
     Then `view.full.summary` equals the original analysis summary exactly
     And `view.shown_summary` equals `view.full.summary`
 
   # ── Filters ────────────────────────────────────────────────────────
 
+  @unwired
   Scenario: only_failing filter retains only functions that exceed the threshold
+    # tracked: crap-rs#169 — view-module cucumber harness not yet built
     Given a ViewSpec with `filters.only_failing = true`
     When the spec is applied
     Then `view.shown` contains only functions where `exceeds` is true
     And every function in `view.shown` has CRAP score above the threshold
 
+  @unwired
   Scenario: coverage_range filter retains functions inside the inclusive range
+    # tracked: crap-rs#169 — view-module cucumber harness not yet built
     Given a ViewSpec with `filters.coverage_range = CoverageRange::new(50.0, 90.0)`
     When the spec is applied
     Then `view.shown` contains only functions whose `coverage_percent` is between 50.0 and 90.0 inclusive
     And `view.eligible_count` equals the count of matching functions
 
+  @unwired
   Scenario Outline: coverage_range boundaries are inclusive
+    # tracked: crap-rs#169 — view-module cucumber harness not yet built
     Given a ViewSpec with coverage_range from <min> to <max>
     When the spec is applied
     Then a function with coverage_percent <coverage> <inclusion> in `view.shown`
@@ -75,7 +87,9 @@ Feature: View — presentation transform on analysis findings
       | 0.0  | 0.0   | 0.0      | appears   |
       | 100.0 | 100.0 | 100.0   | appears   |
 
+  @unwired
   Scenario: Filters AND-compose
+    # tracked: crap-rs#169 — view-module cucumber harness not yet built
     # Property-test oracle: for arbitrary filter subsets, the result is
     # the intersection of each filter applied alone.
     Given a ViewSpec with `filters.only_failing = true` and `coverage_range = CoverageRange::new(50.0, 100.0)`
@@ -84,7 +98,9 @@ Feature: View — presentation transform on analysis findings
 
   # ── CoverageRange invariants (constructor) ─────────────────────────
 
+  @unwired
   Scenario Outline: CoverageRange::new validates inputs
+    # tracked: crap-rs#169 — view-module cucumber harness not yet built
     When `CoverageRange::new(<min>, <max>)` is called
     Then it returns <result>
 
@@ -100,34 +116,46 @@ Feature: View — presentation transform on analysis findings
 
   # ── Sort ───────────────────────────────────────────────────────────
 
+  @unwired
   Scenario: SortKey::Crap orders by CRAP score descending
+    # tracked: crap-rs#169 — view-module cucumber harness not yet built
     Given a ViewSpec with `sort = SortKey::Crap`
     When the spec is applied
     Then the CRAP scores in `view.shown` are in non-increasing order
 
+  @unwired
   Scenario: SortKey::Coverage orders by coverage percent ascending
+    # tracked: crap-rs#169 — view-module cucumber harness not yet built
     Given a ViewSpec with `sort = SortKey::Coverage`
     When the spec is applied
     Then the coverage percentages in `view.shown` are in non-decreasing order
 
+  @unwired
   Scenario: SortKey::Complexity orders by complexity descending
+    # tracked: crap-rs#169 — view-module cucumber harness not yet built
     Given a ViewSpec with `sort = SortKey::Complexity`
     When the spec is applied
     Then the complexity values in `view.shown` are in non-increasing order
 
+  @unwired
   Scenario: SortKey::Path orders alphabetically by file_path, then by CRAP descending within each file
+    # tracked: crap-rs#169 — view-module cucumber harness not yet built
     Given a ViewSpec with `sort = SortKey::Path`
     When the spec is applied
     Then `view.shown` is ordered by `file_path` alphabetically ascending
     And within each file, functions are ordered by CRAP score descending
 
+  @unwired
   Scenario: SortKey::Path secondary-sort with multiple files
+    # tracked: crap-rs#169 — view-module cucumber harness not yet built
     Given functions in three files: "src/a.rs" (CRAPs 5, 30), "src/b.rs" (CRAP 10), "src/c.rs" (CRAPs 1, 50)
     And a ViewSpec with `sort = SortKey::Path`
     When the spec is applied
     Then `view.shown` order is: src/a.rs::CRAP 30, src/a.rs::CRAP 5, src/b.rs::CRAP 10, src/c.rs::CRAP 50, src/c.rs::CRAP 1
 
+  @unwired
   Scenario: Sort is stable on tied keys
+    # tracked: crap-rs#169 — view-module cucumber harness not yet built
     # Catches the mutation `sort_by → sort_unstable_by` which would pass
     # all other sort scenarios.
     Given an analysis with two functions having identical CRAP scores
@@ -137,21 +165,27 @@ Feature: View — presentation transform on analysis findings
 
   # ── Truncate ───────────────────────────────────────────────────────
 
+  @unwired
   Scenario: limit truncates the sorted result to N entries
+    # tracked: crap-rs#169 — view-module cucumber harness not yet built
     Given a ViewSpec with `limit = Some(3)`
     When the spec is applied
     Then `view.shown.len()` equals 3
     And `view.eligible_count` equals 6
     And `view.truncated` is true
 
+  @unwired
   Scenario: limit greater than the eligible count truncates nothing
+    # tracked: crap-rs#169 — view-module cucumber harness not yet built
     Given a ViewSpec with `limit = Some(100)`
     When the spec is applied
     Then `view.shown.len()` equals 6
     And `view.eligible_count` equals 6
     And `view.truncated` is false
 
+  @unwired
   Scenario: limit of None means no truncation
+    # tracked: crap-rs#169 — view-module cucumber harness not yet built
     Given a ViewSpec with `limit = None`
     When the spec is applied
     Then `view.shown` contains every eligible function
@@ -159,7 +193,9 @@ Feature: View — presentation transform on analysis findings
 
   # ── Order of operations: filter → sort → truncate ─────────────────
 
+  @unwired
   Scenario: Order is filter, then sort, then truncate
+    # tracked: crap-rs#169 — view-module cucumber harness not yet built
     Given a ViewSpec with `filters.only_failing = true`, `sort = SortKey::Coverage`, `limit = Some(2)`
     When the spec is applied
     Then `view.shown` contains 2 functions
@@ -167,7 +203,9 @@ Feature: View — presentation transform on analysis findings
     And `view.shown` is ordered by coverage percent ascending
     And `view.eligible_count` equals the total count of failing functions
 
+  @unwired
   Scenario: Truncation does not change the gate
+    # tracked: crap-rs#169 — view-module cucumber harness not yet built
     Given an analysis with 3 functions exceeding threshold
     And a ViewSpec with `limit = Some(1)`
     When the spec is applied
@@ -175,7 +213,9 @@ Feature: View — presentation transform on analysis findings
     But `view.full.passed` is false
     And `view.full.summary.exceeding_threshold` equals 3
 
+  @unwired
   Scenario: Filtering does not change the gate
+    # tracked: crap-rs#169 — view-module cucumber harness not yet built
     Given an analysis with 3 functions exceeding threshold
     And a ViewSpec with `filters.coverage_range = CoverageRange::new(99.0, 100.0)`
     When the spec is applied so that `view.shown` is empty
@@ -184,7 +224,9 @@ Feature: View — presentation transform on analysis findings
 
   # ── shown_summary ──────────────────────────────────────────────────
 
+  @unwired
   Scenario: shown_summary is computed over the shown subset
+    # tracked: crap-rs#169 — view-module cucumber harness not yet built
     Given a ViewSpec with `filters.only_failing = true`
     When the spec is applied
     Then `view.shown_summary.total_functions` equals `view.shown.len()`
@@ -193,7 +235,9 @@ Feature: View — presentation transform on analysis findings
     And `view.shown_summary.median_crap` equals the median of CRAP scores in `view.shown` to within 1e-9
     And `view.shown_summary.distribution` reflects only the functions in `view.shown`
 
+  @unwired
   Scenario: shown_summary differs from full summary when the view filters out functions
+    # tracked: crap-rs#169 — view-module cucumber harness not yet built
     Given an analysis with 6 functions, 3 exceeding threshold
     And a ViewSpec with `filters.only_failing = true`
     When the spec is applied
@@ -202,7 +246,9 @@ Feature: View — presentation transform on analysis findings
 
   # ── Edge cases ─────────────────────────────────────────────────────
 
+  @unwired
   Scenario: Empty analysis applied with default spec produces empty view
+    # tracked: crap-rs#169 — view-module cucumber harness not yet built
     Given an analysis with zero functions
     When the default ViewSpec is applied
     Then `view.shown` is empty
@@ -210,7 +256,9 @@ Feature: View — presentation transform on analysis findings
     And `view.truncated` is false
     And `view.full.passed` is true
 
+  @unwired
   Scenario: All functions filtered out produces an empty shown
+    # tracked: crap-rs#169 — view-module cucumber harness not yet built
     Given an analysis where no function has coverage_percent above 95.0
     And a ViewSpec with `filters.coverage_range = CoverageRange::new(95.0, 100.0)`
     When the spec is applied
@@ -218,7 +266,9 @@ Feature: View — presentation transform on analysis findings
     And `view.eligible_count` equals 0
     And `view.truncated` is false
 
+  @unwired
   Scenario: limit of 0 is treated as no limit
+    # tracked: crap-rs#169 — view-module cucumber harness not yet built
     Given a ViewSpec built with `--top 0` semantics (limit = None)
     When the spec is applied
     Then `view.shown` contains every eligible function
@@ -226,7 +276,9 @@ Feature: View — presentation transform on analysis findings
 
   # ── view.full immutability ────────────────────────────────────────
 
+  @unwired
   Scenario: applying a view does not modify the analysis
+    # tracked: crap-rs#169 — view-module cucumber harness not yet built
     Given an analysis result owned by the caller
     When `view::apply` is called with any ViewSpec
     Then `view.full` references the original analysis result
@@ -236,13 +288,17 @@ Feature: View — presentation transform on analysis findings
   # LCOV adapters can produce coverage_percent = NaN when a function
   # has zero executable lines. The View must handle this deterministically.
 
+  @unwired
   Scenario: NaN coverage is excluded from coverage_range filter
+    # tracked: crap-rs#169 — view-module cucumber harness not yet built
     Given a function with `coverage_percent = NaN`
     And a ViewSpec with `filters.coverage_range = CoverageRange::new(0.0, 100.0)`
     When the spec is applied
     Then the function with NaN coverage does not appear in `view.shown`
 
+  @unwired
   Scenario: NaN coverage sorts last under SortKey::Coverage ascending
+    # tracked: crap-rs#169 — view-module cucumber harness not yet built
     Given functions with coverage percentages [10.0, NaN, 50.0, NaN, 90.0]
     And a ViewSpec with `sort = SortKey::Coverage`
     When the spec is applied


### PR DESCRIPTION
## Summary

BDD hygiene foundation for crap-rs. No production code changes — pure spec-file retagging, harness cleanup, and a new convention doc.

- Adds the BDD tag lexicon (`tests/features/TAGS.toml`): `@wired` / `@unwired` / `@wip` status (mutually exclusive, one per scenario) + `@smoke` scope (reserved).
- Documents the hygiene convention in `AGENTS.md`: one status tag per scenario; `@unwired`/`@wip` require `# tracked: crap-rs#<n> — reason` comments mirroring `~/.claude/rules/exclusions.md`; no no-op step defs; `Background:` must be executable; new harnesses filter on `@wired`.
- Tags every scenario across all 12 `.feature` files (262 scenarios total):
  - `json_reporter.feature` → 12 `@wired` (the existing harness runs all of them).
  - `cli_ergonomics.feature` → 7 `@wired` (formerly `@summary`) + 46 `@unwired` with `# tracked: crap-rs#169` comments.
  - 10 other files → all `@unwired` with per-file `# tracked: crap-rs#169` reasons.
- Deletes the misused `Background:` block in `cli_ergonomics.feature` (placeholder prose with all-caps variables like `TOTAL_FUNCTIONS`).
- Removes the 4 no-op `given_background_*` step definitions PR #167 added as a workaround. The harness filter swaps from `t == \"summary\"` (topic) to `t == \"wired\"` (status).

## Closes

- Closes #168

## Why a separate umbrella issue

The advisor flagged during planning: writing `# tracked: crap-rs#168` on 243 `@unwired` scenarios would point them at an issue that closes when this PR merges — the comment-and-forget anti-pattern `~/.claude/rules/exclusions.md` is designed to prevent. Filed [#169](https://github.com/breezy-bays-labs/crap-rs/issues/169) as the persistent BDD wiring umbrella; `@unwired` comments target it.

## Bot review (Step 4b)

Not load-bearing for this PR — pure hygiene, no ADR / API / schema / wire-shape change. Wire-envelope canary remains byte-identical.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` — 940 tests, all green
- [x] `cargo test --test json_reporter_cucumber` — 12 scenarios pass
- [x] `cargo test --test cli_ergonomics_cucumber` — 7 scenarios pass (filtered on `@wired`)
- [x] `RUSTDOCFLAGS=\"-D warnings\" cargo doc --workspace --no-deps`
- [x] `cargo +1.93 check --workspace --all-targets` (MSRV)
- [x] `cargo deny --workspace check`
- [x] AST-purity grep on `crates/crap-core/src/` — zero matches
- [x] Wire-envelope canary — byte-identical

## Context

Surfaced during PR #167's review discussion (the `--summary` flag work that closed #131). The cucumber harness added there needed 4 forced no-op step defs to skip past `cli_ergonomics.feature`'s aspirational `Background:` — load-bearing workaround that exposed two debts: misused `Background:` and ~250 scenarios with no executable verification yet.

Sets up crap-rs as a clean dogfood subject for the future bdd-rs monitor (mokumo epic breezy-bays-labs/mokumo#370), which will consume `TAGS.toml` + the `tracked:` comments + harness source to emit a BDD quality report. That tool is its own bet in a separate repo — this PR only establishes the conventions it needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)