### PR TITLE
feat: #73 — `crap4rs init` subcommand (with crap4ts inheritance via AdapterMeta)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `<adapter> init` subcommand generates a starter `crap4rs.toml`
+  (or `crap4ts.toml`) in the current directory. Auto-detects `src/`
+  → `crates/` → falls back to `src` with a hint comment. Interactive
+  by default (one prompt mapping `s|d|l` to strict/default/lenient
+  preset); `--non-interactive` for CI; `--force` to overwrite an
+  existing config. Lives in `crap-core` so both adapters inherit the
+  subcommand via `AdapterMeta` — crap4ts emits TS-flavored
+  `node_modules/**`, `dist/**`, `coverage/**` excludes; crap4rs emits
+  `tests/**`, `benches/**`, `examples/**`. (#73)
 - `--summary` flag emits a single-line analysis verdict to stdout (e.g.
   `PASS: 1082 functions | 0 above threshold (25) | worst: 13.0 | avg: 1.6`),
   matching crap4ts's `formatSummaryLine` byte-for-byte. Short-circuits
   `--format` and composes with `--no-fail` (exit 0 always, summary
   emitted) and `--quiet` (quiet wins — no output). Closes the
   2026-05-08 crap4rs ↔ crap4ts parity audit's final gap. (#131)
+
+### Changed (crap-core public API)
+
+- `AdapterMeta` gains a `default_excludes: &'static [&'static str]`
+  field — required by adapter binaries so `<adapter> init` can emit
+  per-ecosystem exclude defaults. Existing struct-literal
+  constructions in adapter `main.rs` files need this field added;
+  there is no default impl to fall back on (the type stays `Copy` /
+  per-field literal-init to keep zero-cost). Affects only adapter
+  binary crates; library consumers of `crap-core` do not construct
+  `AdapterMeta` directly. (#73)
 
 ## [0.5.0] - 2026-05-10
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,6 +418,7 @@ dependencies = [
  "oxc",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]

--- a/crates/crap-core/src/cli/init.rs
+++ b/crates/crap-core/src/cli/init.rs
@@ -1,0 +1,439 @@
+//! `init` subcommand — generates a starter config TOML in the current
+//! working directory.
+//!
+//! Lives in crap-core (not the per-adapter binary) so every adapter
+//! inherits the subcommand for free via `AdapterMeta`. The generator
+//! is parameterized on three meta fields:
+//!
+//! - `config_file_name` — `"crap4rs.toml"` vs `"crap4ts.toml"`
+//! - `tool_name` — used in header comments + next-step hint
+//! - `default_excludes` — per-ecosystem ignore patterns
+//!
+//! Auto-detect rules for `src`:
+//!   1. `src/` exists → use `"src"` (single-crate Rust, common TS layout)
+//!   2. `crates/` exists → use `"crates"` (Cargo workspace)
+//!   3. Neither → fall back to `"src"` with a hint comment so users
+//!      see the toggle point.
+//!
+//! Threshold preset: defaults to `default` (25) non-interactively;
+//! interactively reads one line from stdin and maps the first char
+//! (`s|S` → strict, `l|L` → lenient, anything else → default). No TTY
+//! detection — CI users pass `--non-interactive` to skip the prompt;
+//! tests pipe input via `Stdio::piped()`.
+
+use std::fs;
+use std::io::{self, BufRead, Write};
+use std::path::Path;
+
+use anyhow::{Context, Result, bail};
+
+use crate::cli::AdapterMeta;
+use crate::domain::threshold::ThresholdPreset;
+
+/// Handle the `init` subcommand. Writes a starter config to
+/// `meta.config_file_name` in the current directory.
+///
+/// Returns `Ok(())` on success. Bails with an actionable error message
+/// when the file already exists and `--force` was not passed.
+pub fn handle_init(force: bool, non_interactive: bool, meta: &AdapterMeta) -> Result<()> {
+    handle_init_with_io(
+        force,
+        non_interactive,
+        meta,
+        Path::new(meta.config_file_name),
+        &mut io::stdin().lock(),
+        &mut io::stderr(),
+    )
+}
+
+/// Inner handler that takes the config-file path + I/O streams as
+/// parameters so unit tests can drive the prompt + file write against
+/// a tempdir without spawning a subprocess.
+pub(crate) fn handle_init_with_io<R: BufRead, W: Write>(
+    force: bool,
+    non_interactive: bool,
+    meta: &AdapterMeta,
+    config_path: &Path,
+    stdin: &mut R,
+    stderr: &mut W,
+) -> Result<()> {
+    if config_path.exists() && !force {
+        bail!(
+            "{name} already exists in this directory.\n  hint: pass `--force` to overwrite, or edit the existing file directly",
+            name = meta.config_file_name,
+        );
+    }
+
+    let preset = if non_interactive {
+        ThresholdPreset::Default
+    } else {
+        prompt_threshold_preset(stdin, stderr)?
+    };
+
+    let detection = detect_src_layout();
+    let content = render_config(meta, preset, &detection);
+
+    fs::write(config_path, &content)
+        .with_context(|| format!("failed to write {}", config_path.display()))?;
+
+    writeln!(
+        stderr,
+        "✓ wrote {name} (preset = \"{preset_str}\", src = \"{src}\")",
+        name = meta.config_file_name,
+        preset_str = preset_str(preset),
+        src = detection.src_path,
+    )
+    .ok();
+    writeln!(
+        stderr,
+        "  next: ensure your coverage tool is installed, then run `{name} --help` to see analysis flags.",
+        name = meta.tool_name,
+    )
+    .ok();
+
+    Ok(())
+}
+
+/// Result of `detect_src_layout` — the path string we'll write into
+/// the TOML, plus whether the value came from a real directory or the
+/// fallback. The fallback flag drives the hint comment emission.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SrcDetection {
+    pub src_path: String,
+    pub is_fallback: bool,
+}
+
+/// Auto-detect the source directory. `src/` wins; `crates/` second;
+/// otherwise fall back to `"src"` with `is_fallback = true` so the
+/// generator emits a hint comment for the user to adjust.
+pub(crate) fn detect_src_layout() -> SrcDetection {
+    if Path::new("src").is_dir() {
+        SrcDetection {
+            src_path: "src".to_string(),
+            is_fallback: false,
+        }
+    } else if Path::new("crates").is_dir() {
+        SrcDetection {
+            src_path: "crates".to_string(),
+            is_fallback: false,
+        }
+    } else {
+        SrcDetection {
+            src_path: "src".to_string(),
+            is_fallback: true,
+        }
+    }
+}
+
+/// Map a `ThresholdPreset` to the string form `FileConfig` expects in
+/// the TOML's `preset = "..."` field (lowercase variant name).
+fn preset_str(preset: ThresholdPreset) -> &'static str {
+    match preset {
+        ThresholdPreset::Strict => "strict",
+        ThresholdPreset::Default => "default",
+        ThresholdPreset::Lenient => "lenient",
+    }
+}
+
+/// Render the starter config TOML. Hand-templated rather than serialized
+/// via the `toml` crate because the generated file is intentionally
+/// commented — `toml::ser` drops comments and we'd have to post-process
+/// the output anyway. A constant template with three substitutions
+/// (preset, src, excludes) is simpler and gives us complete control
+/// over comment placement.
+pub(crate) fn render_config(
+    meta: &AdapterMeta,
+    preset: ThresholdPreset,
+    detection: &SrcDetection,
+) -> String {
+    let mut out = String::with_capacity(1024);
+
+    // Header — anchors generated files so future audits can grep for
+    // "generated by `<tool> init`" to find untouched starter configs.
+    out.push_str("# ");
+    out.push_str(meta.config_file_name);
+    out.push_str(" — generated by `");
+    out.push_str(meta.tool_name);
+    out.push_str(" init`\n");
+    out.push_str("# Edit freely; the analyzer re-reads this file on every run.\n\n");
+
+    // Threshold preset — `preset` and `threshold` are mutually
+    // exclusive in `FileConfig`; we emit `preset` so the canonical
+    // values (15/25/40) stay in one place.
+    out.push_str("# Threshold preset:\n");
+    out.push_str("#   strict (15)  — high-quality libraries, safety-critical code\n");
+    out.push_str("#   default (25) — typical Rust projects (balanced)\n");
+    out.push_str("#   lenient (40) — legacy or transitional code\n");
+    out.push_str("# Use `threshold = N` instead to set a custom numeric cutoff.\n");
+    out.push_str("preset = \"");
+    out.push_str(preset_str(preset));
+    out.push_str("\"\n\n");
+
+    // Source root.
+    out.push_str("# Source root the analyzer walks.\n");
+    if detection.is_fallback {
+        out.push_str("# (auto-detect found no `src/` or `crates/` directory — adjust if your sources live elsewhere)\n");
+    }
+    out.push_str("src = \"");
+    out.push_str(&detection.src_path);
+    out.push_str("\"\n\n");
+
+    // Excludes — emitted as a single commented-out array so users can
+    // uncomment + tweak in one step. Per-adapter defaults supplied via
+    // `AdapterMeta.default_excludes`.
+    out.push_str("# Glob patterns matched against project-relative file paths.\n");
+    out.push_str("# Uncomment to ignore these directories (one common starting set):\n");
+    out.push_str("# exclude = [\n");
+    for pattern in meta.default_excludes {
+        out.push_str("#     \"");
+        out.push_str(pattern);
+        out.push_str("\",\n");
+    }
+    out.push_str("# ]\n");
+
+    out
+}
+
+/// Read one line from stdin and map the first character to a
+/// `ThresholdPreset`. Empty/whitespace/anything-else → `Default`.
+/// EOF (closed stdin) is treated as empty input — Returns `Default`.
+fn prompt_threshold_preset<R: BufRead, W: Write>(
+    stdin: &mut R,
+    stderr: &mut W,
+) -> Result<ThresholdPreset> {
+    write!(
+        stderr,
+        "Threshold preset?\n  (s)trict  = 15  high-quality libs\n  (d)efault = 25  typical projects\n  (l)enient = 40  legacy code\n[d]: "
+    )
+    .ok();
+    stderr.flush().ok();
+
+    let mut buf = String::new();
+    stdin
+        .read_line(&mut buf)
+        .context("failed to read threshold preset from stdin")?;
+    Ok(parse_preset_input(&buf))
+}
+
+/// Pure parser for the prompt input — exposed for unit testing. Picks
+/// up the first non-whitespace character; `s`/`S` → strict, `l`/`L` →
+/// lenient, anything else (empty, `d`, garbage) → default.
+pub(crate) fn parse_preset_input(input: &str) -> ThresholdPreset {
+    match input.trim().chars().next() {
+        Some('s' | 'S') => ThresholdPreset::Strict,
+        Some('l' | 'L') => ThresholdPreset::Lenient,
+        _ => ThresholdPreset::Default,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    // Generic fake adapter — kept adapter-name-agnostic to satisfy the
+    // ast-purity layer 4 gate (which structurally forbids "crap4rs" /
+    // "crap4ts" string literals anywhere in crap-core source). The
+    // `default_excludes` set mirrors the Rust adapter's because the
+    // round-trip + comment-rendering assertions are independent of
+    // which patterns are listed; only the count/presence matters.
+    fn fake_meta() -> AdapterMeta {
+        AdapterMeta {
+            tool_name: "fake-adapter",
+            tool_version: "0.5.0",
+            long_version: "0.5.0",
+            about: "test",
+            long_about: "test",
+            after_help: "",
+            coverage_hint: "test",
+            extensions: &["rs"],
+            tool_info_uri: "https://example.invalid",
+            rule_help_uri: "https://example.invalid",
+            config_file_name: "fake-adapter.toml",
+            default_excludes: &["tests/**", "benches/**", "examples/**"],
+        }
+    }
+
+    #[test]
+    fn parse_preset_input_strict_variants() {
+        assert_eq!(parse_preset_input("s"), ThresholdPreset::Strict);
+        assert_eq!(parse_preset_input("S"), ThresholdPreset::Strict);
+        assert_eq!(parse_preset_input("s\n"), ThresholdPreset::Strict);
+        assert_eq!(parse_preset_input("  s  "), ThresholdPreset::Strict);
+        assert_eq!(parse_preset_input("strict"), ThresholdPreset::Strict);
+    }
+
+    #[test]
+    fn parse_preset_input_lenient_variants() {
+        assert_eq!(parse_preset_input("l"), ThresholdPreset::Lenient);
+        assert_eq!(parse_preset_input("L"), ThresholdPreset::Lenient);
+        assert_eq!(parse_preset_input("lenient"), ThresholdPreset::Lenient);
+    }
+
+    #[test]
+    fn parse_preset_input_defaults_on_empty_or_garbage() {
+        assert_eq!(parse_preset_input(""), ThresholdPreset::Default);
+        assert_eq!(parse_preset_input("\n"), ThresholdPreset::Default);
+        assert_eq!(parse_preset_input("   "), ThresholdPreset::Default);
+        assert_eq!(parse_preset_input("d"), ThresholdPreset::Default);
+        assert_eq!(parse_preset_input("D"), ThresholdPreset::Default);
+        assert_eq!(parse_preset_input("xyz"), ThresholdPreset::Default);
+        assert_eq!(parse_preset_input("42"), ThresholdPreset::Default);
+    }
+
+    #[test]
+    fn render_config_includes_preset_and_src() {
+        let meta = fake_meta();
+        let detection = SrcDetection {
+            src_path: "src".to_string(),
+            is_fallback: false,
+        };
+        let out = render_config(&meta, ThresholdPreset::Strict, &detection);
+        assert!(out.contains("preset = \"strict\""), "preset line missing");
+        assert!(out.contains("src = \"src\""), "src line missing");
+    }
+
+    #[test]
+    fn render_config_emits_fallback_hint_only_when_detection_failed() {
+        let meta = fake_meta();
+        let detected = SrcDetection {
+            src_path: "src".to_string(),
+            is_fallback: false,
+        };
+        let fallback = SrcDetection {
+            src_path: "src".to_string(),
+            is_fallback: true,
+        };
+        let with_detect = render_config(&meta, ThresholdPreset::Default, &detected);
+        let with_fallback = render_config(&meta, ThresholdPreset::Default, &fallback);
+        assert!(!with_detect.contains("adjust if your sources live elsewhere"));
+        assert!(with_fallback.contains("adjust if your sources live elsewhere"));
+    }
+
+    #[test]
+    fn render_config_emits_commented_excludes_from_meta() {
+        let meta = fake_meta();
+        let detection = SrcDetection {
+            src_path: "src".to_string(),
+            is_fallback: false,
+        };
+        let out = render_config(&meta, ThresholdPreset::Default, &detection);
+        assert!(out.contains("# exclude = ["));
+        assert!(out.contains("tests/**"));
+        assert!(out.contains("benches/**"));
+        assert!(out.contains("examples/**"));
+    }
+
+    #[test]
+    fn render_config_includes_header_and_threshold_descriptions() {
+        let meta = fake_meta();
+        let detection = SrcDetection {
+            src_path: "src".to_string(),
+            is_fallback: false,
+        };
+        let out = render_config(&meta, ThresholdPreset::Default, &detection);
+        // Header line names the meta's config_file_name verbatim — pattern
+        // stays generic so we don't hardcode adapter names in crap-core.
+        let expected_header = format!("# {}", meta.config_file_name);
+        assert!(
+            out.contains(&expected_header),
+            "header line missing; got:\n{out}",
+        );
+        assert!(out.contains("Threshold preset"));
+        assert!(out.contains("strict (15)"));
+        assert!(out.contains("default (25)"));
+        assert!(out.contains("lenient (40)"));
+    }
+
+    #[test]
+    fn prompt_reads_strict_from_piped_stdin() {
+        let mut stdin = Cursor::new(b"s\n");
+        let mut stderr: Vec<u8> = Vec::new();
+        let preset = prompt_threshold_preset(&mut stdin, &mut stderr).unwrap();
+        assert_eq!(preset, ThresholdPreset::Strict);
+    }
+
+    #[test]
+    fn prompt_defaults_when_stdin_is_empty() {
+        let mut stdin = Cursor::new(b"");
+        let mut stderr: Vec<u8> = Vec::new();
+        let preset = prompt_threshold_preset(&mut stdin, &mut stderr).unwrap();
+        assert_eq!(preset, ThresholdPreset::Default);
+    }
+
+    #[test]
+    fn handle_init_writes_default_config_in_empty_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("crap4rs.toml");
+        let meta = fake_meta();
+        let mut stdin = Cursor::new(b"");
+        let mut stderr: Vec<u8> = Vec::new();
+        handle_init_with_io(false, true, &meta, &path, &mut stdin, &mut stderr).unwrap();
+        let content = fs::read_to_string(&path).unwrap();
+        assert!(content.contains("preset = \"default\""));
+        assert!(content.contains("src = \"src\""));
+    }
+
+    #[test]
+    fn handle_init_bails_when_file_exists_without_force() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("crap4rs.toml");
+        fs::write(&path, "preset = \"lenient\"\n").unwrap();
+        let meta = fake_meta();
+        let mut stdin = Cursor::new(b"");
+        let mut stderr: Vec<u8> = Vec::new();
+        let err = handle_init_with_io(false, true, &meta, &path, &mut stdin, &mut stderr)
+            .expect_err("init should bail when file exists without --force");
+        let msg = format!("{err:#}");
+        let expected = format!("{} already exists", meta.config_file_name);
+        assert!(msg.contains(&expected), "got: {msg}");
+        assert!(msg.contains("--force"), "got: {msg}");
+        // file content unchanged
+        let content = fs::read_to_string(&path).unwrap();
+        assert_eq!(content, "preset = \"lenient\"\n");
+    }
+
+    #[test]
+    fn handle_init_overwrites_with_force() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("crap4rs.toml");
+        fs::write(&path, "preset = \"lenient\"\n").unwrap();
+        let meta = fake_meta();
+        let mut stdin = Cursor::new(b"");
+        let mut stderr: Vec<u8> = Vec::new();
+        handle_init_with_io(true, true, &meta, &path, &mut stdin, &mut stderr).unwrap();
+        let content = fs::read_to_string(&path).unwrap();
+        assert!(content.contains("preset = \"default\""));
+        assert!(!content.contains("preset = \"lenient\""));
+    }
+
+    #[test]
+    fn handle_init_interactive_reads_preset_from_stdin() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("crap4rs.toml");
+        let meta = fake_meta();
+        let mut stdin = Cursor::new(b"s\n");
+        let mut stderr: Vec<u8> = Vec::new();
+        handle_init_with_io(false, false, &meta, &path, &mut stdin, &mut stderr).unwrap();
+        let content = fs::read_to_string(&path).unwrap();
+        assert!(content.contains("preset = \"strict\""), "got: {content}");
+    }
+
+    #[test]
+    fn generated_config_round_trips_through_loader() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("crap4rs.toml");
+        let meta = fake_meta();
+        let mut stdin = Cursor::new(b"");
+        let mut stderr: Vec<u8> = Vec::new();
+        handle_init_with_io(false, true, &meta, &path, &mut stdin, &mut stderr).unwrap();
+        let config =
+            crate::adapters::config::load_config(&path).expect("init's generated TOML must load");
+        assert_eq!(
+            config.preset,
+            Some(ThresholdPreset::Default),
+            "loaded preset should match"
+        );
+        assert_eq!(config.src.as_deref(), Some(Path::new("src")));
+    }
+}

--- a/crates/crap-core/src/cli/mod.rs
+++ b/crates/crap-core/src/cli/mod.rs
@@ -31,6 +31,7 @@ use crate::domain::view::{self, GroupKey, SortKey};
 use crate::ports::{ComplexityPort, CoveragePort, ParseDiagnostic};
 
 mod delta_args;
+mod init;
 mod view_args;
 
 // ── ValueEnum wrappers (keep domain types clap-free) ────────────────
@@ -262,6 +263,20 @@ pub enum Command {
     Completions {
         #[arg(value_enum)]
         shell: ShellArg,
+    },
+    /// Generate a starter config TOML in the current directory.
+    ///
+    /// Interactive by default (asks for a threshold preset);
+    /// `--non-interactive` uses defaults for CI/scripts. Refuses to
+    /// overwrite an existing config unless `--force` is passed.
+    Init {
+        /// Overwrite an existing config file in this directory.
+        #[arg(long)]
+        force: bool,
+        /// Skip the interactive prompt and use defaults (preset =
+        /// "default"). CI-friendly.
+        #[arg(long)]
+        non_interactive: bool,
     },
 }
 
@@ -659,6 +674,14 @@ pub struct AdapterMeta {
     /// to `discover_config` and surfaced in `--view <preset>`
     /// error hints so users see the right file name to create.
     pub config_file_name: &'static str,
+    /// Commented-out exclude patterns emitted by `init` into the
+    /// generated config (e.g., `&["tests/**", "benches/**", "examples/**"]`
+    /// for Rust; `&["node_modules/**", "dist/**", "coverage/**"]` for
+    /// TS). Adapter-specific because the convention for "where tests
+    /// and ignorable artifacts live" differs per ecosystem. May be
+    /// empty — init then emits the `# exclude = [ … ]` block without
+    /// per-language entries.
+    pub default_excludes: &'static [&'static str],
 }
 
 impl AdapterMeta {
@@ -853,9 +876,19 @@ where
     P: ParseDiagnostic + std::fmt::Display + 'static,
     F: FnOnce(&Path) -> Box<dyn CoveragePort<Diagnostic = P>>,
 {
-    if let Some(Command::Completions { shell }) = cli.command {
-        emit_completions(shell, &current_bin_name(meta.tool_name));
-        return Ok(true);
+    match cli.command {
+        Some(Command::Completions { shell }) => {
+            emit_completions(shell, &current_bin_name(meta.tool_name));
+            return Ok(true);
+        }
+        Some(Command::Init {
+            force,
+            non_interactive,
+        }) => {
+            init::handle_init(force, non_interactive, meta)?;
+            return Ok(true);
+        }
+        None => {}
     }
 
     let prep = prepare_pipeline(&mut cli, complexity, coverage_factory, meta)?;
@@ -2545,6 +2578,7 @@ mod tests {
             tool_info_uri: "https://example.invalid/fake-adapter",
             rule_help_uri: "https://example.invalid/fake-adapter#rules",
             config_file_name: "fake-adapter.toml",
+            default_excludes: &["fixtures/**"],
         }
     }
 

--- a/crates/crap-core/tests/snapshots/wire_envelope_snapshot__envelope.snap
+++ b/crates/crap-core/tests/snapshots/wire_envelope_snapshot__envelope.snap
@@ -5504,9 +5504,9 @@ expression: pretty
             "qualified_name": "main",
             "span": {
               "end_column": 1,
-              "end_line": 94,
+              "end_line": 100,
               "start_column": 1,
-              "start_line": 72
+              "start_line": 77
             }
           }
         },
@@ -11190,9 +11190,9 @@ expression: pretty
             "qualified_name": "main",
             "span": {
               "end_column": 1,
-              "end_line": 94,
+              "end_line": 100,
               "start_column": 1,
-              "start_line": 72
+              "start_line": 77
             }
           }
         },

--- a/crates/crap4rs/Cargo.toml
+++ b/crates/crap4rs/Cargo.toml
@@ -97,3 +97,7 @@ harness = false
 [[test]]
 name = "cli_ergonomics_cucumber"
 harness = false
+
+[[test]]
+name = "cli_init_cucumber"
+harness = false

--- a/crates/crap4rs/src/main.rs
+++ b/crates/crap4rs/src/main.rs
@@ -69,6 +69,11 @@ const COVERAGE_HINT: &str = "ensure tests ran with coverage enabled (`cargo llvm
 
 const EXTENSIONS: &[&str] = &["rs"];
 
+/// Common Rust-project directories `init` writes as commented-out
+/// excludes — tests, benches, examples typically run their own coverage
+/// passes and shouldn't count against the source CRAP budget.
+const DEFAULT_EXCLUDES: &[&str] = &["tests/**", "benches/**", "examples/**"];
+
 fn main() -> ExitCode {
     let meta = AdapterMeta {
         tool_name: env!("CARGO_PKG_NAME"),
@@ -82,6 +87,7 @@ fn main() -> ExitCode {
         tool_info_uri: "https://github.com/breezy-bays-labs/crap-rs",
         rule_help_uri: "https://github.com/breezy-bays-labs/crap-rs#crap-formula",
         config_file_name: "crap4rs.toml",
+        default_excludes: DEFAULT_EXCLUDES,
     };
     let cli = crap_core::cli::parse_args(&meta);
     let complexity = SynComplexityAdapter::new();

--- a/crates/crap4rs/tests/cli_init_cucumber.rs
+++ b/crates/crap4rs/tests/cli_init_cucumber.rs
@@ -1,0 +1,293 @@
+//! Cucumber-rs runner for `@wired`-tagged scenarios in
+//! `tests/features/cli_init.feature` (crap-rs#73).
+//!
+//! Each scenario sets up a tempdir (potentially with a `src/` or
+//! `crates/` subdirectory to exercise auto-detect) and invokes the
+//! `crap4rs init` subcommand via `CARGO_BIN_EXE_crap4rs`. Cross-adapter
+//! parity (`crap4ts init` writing `crap4ts.toml`) is exercised by the
+//! plain integration test at `crates/crap4ts/tests/cli_init_integration.rs`
+//! — that env var is per-package and `CARGO_BIN_EXE_crap4ts` is not
+//! available inside crap4rs's harness.
+//!
+//! The harness uses `filter_run_and_exit` with the `@wired` filter
+//! pattern per AGENTS.md § BDD hygiene rule 5; `@unwired` scenarios
+//! (if any are added) are skipped.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+
+use cucumber::{World, given, then, when, writer};
+
+const BINARY: &str = env!("CARGO_BIN_EXE_crap4rs");
+
+#[derive(Debug, Default, World)]
+struct InitWorld {
+    project_dir: Option<PathBuf>,
+    /// Held during the scenario lifetime so the directory survives;
+    /// dropped between scenarios because the World resets.
+    _tempdir: Option<tempfile::TempDir>,
+    output: Option<Output>,
+}
+
+impl InitWorld {
+    fn require_dir(&self) -> &Path {
+        self.project_dir
+            .as_deref()
+            .expect("scenario did not set up a project directory")
+    }
+
+    fn require_output(&self) -> &Output {
+        self.output
+            .as_ref()
+            .expect("scenario did not run the binary")
+    }
+
+    fn config_path(&self, name: &str) -> PathBuf {
+        self.require_dir().join(name)
+    }
+
+    fn stderr(&self) -> String {
+        String::from_utf8_lossy(&self.require_output().stderr).into_owned()
+    }
+}
+
+fn fresh_tempdir() -> (tempfile::TempDir, PathBuf) {
+    let dir = tempfile::tempdir().expect("create tempdir");
+    let path = dir.path().to_path_buf();
+    (dir, path)
+}
+
+/// Parse a backtick-wrapped `crap4rs ...` command into the args vec
+/// (drops the binary name). Returns args for `Command::args(&args)`.
+fn parse_command(cmd: &str) -> Vec<String> {
+    cmd.split_whitespace().skip(1).map(str::to_string).collect()
+}
+
+// ── Given steps ──────────────────────────────────────────────────────
+
+#[given("an empty project directory")]
+fn given_empty_dir(world: &mut InitWorld) {
+    let (dir, path) = fresh_tempdir();
+    world.project_dir = Some(path);
+    world._tempdir = Some(dir);
+}
+
+#[given(regex = r#"^a project directory with a "([^"]+)" subdirectory$"#)]
+fn given_dir_with_subdir(world: &mut InitWorld, name: String) {
+    let (dir, path) = fresh_tempdir();
+    std::fs::create_dir_all(path.join(&name)).expect("create subdir");
+    world.project_dir = Some(path);
+    world._tempdir = Some(dir);
+}
+
+#[given(
+    regex = r#"^a project directory with a "([^"]+)" subdirectory but no "([^"]+)" subdirectory$"#
+)]
+fn given_dir_with_subdir_but_not(world: &mut InitWorld, present: String, _absent: String) {
+    let (dir, path) = fresh_tempdir();
+    std::fs::create_dir_all(path.join(&present)).expect("create subdir");
+    world.project_dir = Some(path);
+    world._tempdir = Some(dir);
+}
+
+#[given(regex = r#"^a project directory with an existing "([^"]+)" containing '([^']+)'$"#)]
+fn given_dir_with_existing_config(world: &mut InitWorld, name: String, line: String) {
+    let (dir, path) = fresh_tempdir();
+    std::fs::write(path.join(&name), format!("{line}\n")).expect("seed existing config");
+    world.project_dir = Some(path);
+    world._tempdir = Some(dir);
+}
+
+// ── When steps ───────────────────────────────────────────────────────
+
+#[when(regex = r#"^the operator runs `([^`]+)`$"#)]
+fn when_run(world: &mut InitWorld, cmd: String) {
+    run_with_stdin(world, &cmd, None);
+}
+
+#[when(regex = r#"^the operator runs `([^`]+)` with stdin "(.*)"$"#)]
+fn when_run_with_stdin(world: &mut InitWorld, cmd: String, raw_stdin: String) {
+    // Cucumber doc-strings pass literal backslashes through, so decode
+    // `\n` and `\t` ourselves rather than rely on the parser.
+    let decoded = raw_stdin.replace("\\n", "\n").replace("\\t", "\t");
+    run_with_stdin(world, &cmd, Some(decoded));
+}
+
+fn run_with_stdin(world: &mut InitWorld, cmd: &str, stdin_text: Option<String>) {
+    let args = parse_command(cmd);
+    let mut command = Command::new(BINARY);
+    if let Some(dir) = world.project_dir.as_deref() {
+        command.current_dir(dir);
+    }
+    command.args(&args);
+
+    if let Some(text) = stdin_text {
+        command.stdin(Stdio::piped());
+        command.stdout(Stdio::piped());
+        command.stderr(Stdio::piped());
+        let mut child = command
+            .spawn()
+            .unwrap_or_else(|e| panic!("failed to spawn {BINARY:?}: {e}"));
+        if let Some(mut sin) = child.stdin.take() {
+            use std::io::Write;
+            sin.write_all(text.as_bytes()).expect("write stdin");
+        }
+        let output = child
+            .wait_with_output()
+            .unwrap_or_else(|e| panic!("failed to wait on {BINARY:?}: {e}"));
+        world.output = Some(output);
+    } else {
+        let output = command
+            .output()
+            .unwrap_or_else(|e| panic!("failed to invoke {BINARY:?}: {e}"));
+        world.output = Some(output);
+    }
+}
+
+// ── Then steps ───────────────────────────────────────────────────────
+
+#[then(regex = r#"^a file named "([^"]+)" exists in the project directory$"#)]
+fn then_file_exists(world: &mut InitWorld, name: String) {
+    let path = world.config_path(&name);
+    assert!(path.exists(), "expected {} to exist", path.display());
+}
+
+#[then(regex = r#"^no file named "([^"]+)" exists in the project directory$"#)]
+fn then_no_file(world: &mut InitWorld, name: String) {
+    let path = world.config_path(&name);
+    assert!(!path.exists(), "expected {} to NOT exist", path.display());
+}
+
+#[then(regex = r#"^the config file contains '([^']+)'$"#)]
+fn then_contains_single_quoted(world: &mut InitWorld, needle: String) {
+    assert_config_contains(world, &needle);
+}
+
+#[then(regex = r#"^the config file contains "([^"]+)"$"#)]
+fn then_contains_double_quoted(world: &mut InitWorld, needle: String) {
+    assert_config_contains(world, &needle);
+}
+
+#[then(regex = r#"^the config file does not contain "([^"]+)"$"#)]
+fn then_not_contains_double_quoted(world: &mut InitWorld, needle: String) {
+    assert_config_excludes(world, &needle);
+}
+
+#[then(regex = r#"^the config file does not contain '([^']+)'$"#)]
+fn then_not_contains_single_quoted(world: &mut InitWorld, needle: String) {
+    assert_config_excludes(world, &needle);
+}
+
+#[then(regex = r#"^the config file still contains '([^']+)'$"#)]
+fn then_still_contains(world: &mut InitWorld, needle: String) {
+    assert_config_contains(world, &needle);
+}
+
+fn assert_config_contains(world: &InitWorld, needle: &str) {
+    let path = world.config_path("crap4rs.toml");
+    let content =
+        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    assert!(
+        content.contains(needle),
+        "config file at {} did not contain {needle:?}\nfull content:\n{content}",
+        path.display(),
+    );
+}
+
+fn assert_config_excludes(world: &InitWorld, needle: &str) {
+    let path = world.config_path("crap4rs.toml");
+    let content =
+        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    assert!(
+        !content.contains(needle),
+        "config file at {} unexpectedly contained {needle:?}\nfull content:\n{content}",
+        path.display(),
+    );
+}
+
+#[then("the generated config file loads without error")]
+fn then_loads(world: &mut InitWorld) {
+    let path = world.config_path("crap4rs.toml");
+    let content = std::fs::read_to_string(&path).expect("read config");
+    // We don't have the loader in scope here, so smoke via the toml
+    // crate directly — the loader does the same thing.
+    let parsed: toml::Value = toml::from_str(&content)
+        .unwrap_or_else(|e| panic!("generated config did not parse as TOML: {e}\n{content}"));
+    assert!(
+        parsed.get("preset").is_some() || parsed.get("threshold").is_some(),
+        "expected preset or threshold key in parsed TOML",
+    );
+}
+
+#[then(regex = r#"^the loaded config has preset "([^"]+)"$"#)]
+fn then_loaded_preset(world: &mut InitWorld, expected: String) {
+    let path = world.config_path("crap4rs.toml");
+    let content = std::fs::read_to_string(&path).expect("read config");
+    let parsed: toml::Value = toml::from_str(&content).expect("parse config");
+    let preset = parsed
+        .get("preset")
+        .and_then(|v| v.as_str())
+        .expect("preset key missing or wrong type");
+    assert_eq!(preset, expected);
+}
+
+#[then(regex = r#"^the loaded config has src "([^"]+)"$"#)]
+fn then_loaded_src(world: &mut InitWorld, expected: String) {
+    let path = world.config_path("crap4rs.toml");
+    let content = std::fs::read_to_string(&path).expect("read config");
+    let parsed: toml::Value = toml::from_str(&content).expect("parse config");
+    let src = parsed
+        .get("src")
+        .and_then(|v| v.as_str())
+        .expect("src key missing or wrong type");
+    assert_eq!(src, expected);
+}
+
+#[then(regex = r#"^stderr contains "([^"]+)"$"#)]
+fn then_stderr_contains(world: &mut InitWorld, needle: String) {
+    let stderr = world.stderr();
+    assert!(
+        stderr.contains(&needle),
+        "stderr did not contain {needle:?}\nstderr:\n{stderr}",
+    );
+}
+
+#[then(regex = r#"^stdout contains "([^"]+)"$"#)]
+fn then_stdout_contains(world: &mut InitWorld, needle: String) {
+    let stdout = String::from_utf8_lossy(&world.require_output().stdout);
+    assert!(
+        stdout.contains(&needle),
+        "stdout did not contain {needle:?}\nstdout:\n{stdout}",
+    );
+}
+
+#[then(regex = r"^the exit code is (\d+)$")]
+fn then_exit_code(world: &mut InitWorld, expected: i32) {
+    let actual = world
+        .require_output()
+        .status
+        .code()
+        .expect("process exited via signal");
+    let stdout = String::from_utf8_lossy(&world.require_output().stdout);
+    let stderr = world.stderr();
+    assert_eq!(
+        actual, expected,
+        "exit code mismatch — expected {expected}, got {actual}\nstdout:\n{stdout}\nstderr:\n{stderr}",
+    );
+}
+
+// ── Runner ──────────────────────────────────────────────────────────
+
+#[tokio::main]
+async fn main() {
+    // `writer::Libtest::or_basic()` mirrors `cli_ergonomics_cucumber`:
+    // libtest-compatible JSON under nextest's `--list` probe, basic
+    // writer for plain `cargo test`. `filter_run_and_exit` with the
+    // `@wired` filter is the AGENTS.md § BDD hygiene rule 5 pattern.
+    InitWorld::cucumber()
+        .with_writer(writer::Libtest::or_basic())
+        .filter_run_and_exit("tests/features/cli_init.feature", |_, _, scenario| {
+            scenario.tags.iter().any(|t| t == "wired")
+        })
+        .await;
+}

--- a/crates/crap4rs/tests/features/cli_init.feature
+++ b/crates/crap4rs/tests/features/cli_init.feature
@@ -1,0 +1,137 @@
+Feature: crap4rs init subcommand
+
+  `crap4rs init` generates a starter `crap4rs.toml` in the current
+  directory. Interactive by default (one prompt: threshold preset),
+  `--non-interactive` for CI, `--force` to overwrite an existing
+  config. crap4ts inherits the same behavior via `AdapterMeta`
+  (`config_file_name`, `extensions`) and writes `crap4ts.toml`.
+
+  The generated config is self-documenting (inline comments explain
+  each option) and round-trips through `load_file_config` without
+  errors. Auto-detect rules pick `src/` then `crates/` then fall
+  back to `src` with a hint comment.
+
+  # ── Non-interactive (CI path) ──────────────────────────────────────
+
+  @wired
+  Scenario: --non-interactive writes a default config in an empty directory
+    Given an empty project directory
+    When the operator runs `crap4rs init --non-interactive`
+    Then a file named "crap4rs.toml" exists in the project directory
+    And the config file contains 'preset = "default"'
+    And the config file contains 'src = "src"'
+    And the exit code is 0
+
+  @wired
+  Scenario: --non-interactive auto-detects single-crate src layout
+    Given a project directory with a "src" subdirectory
+    When the operator runs `crap4rs init --non-interactive`
+    Then the config file contains 'src = "src"'
+    And the config file does not contain "adjust if your sources live elsewhere"
+    And the exit code is 0
+
+  @wired
+  Scenario: --non-interactive auto-detects workspace crates layout
+    Given a project directory with a "crates" subdirectory but no "src" subdirectory
+    When the operator runs `crap4rs init --non-interactive`
+    Then the config file contains 'src = "crates"'
+    And the config file does not contain "adjust if your sources live elsewhere"
+    And the exit code is 0
+
+  @wired
+  Scenario: --non-interactive falls back to src and includes a hint comment when no layout matches
+    Given an empty project directory
+    When the operator runs `crap4rs init --non-interactive`
+    Then the config file contains 'src = "src"'
+    And the config file contains "adjust if your sources live elsewhere"
+
+  @wired
+  Scenario: generated config includes commented-out common exclude patterns
+    Given an empty project directory
+    When the operator runs `crap4rs init --non-interactive`
+    Then the config file contains '# exclude = ['
+    And the config file contains "tests/**"
+    And the config file contains "benches/**"
+    And the config file contains "examples/**"
+
+  @wired
+  Scenario: generated config includes header comments explaining each option
+    Given an empty project directory
+    When the operator runs `crap4rs init --non-interactive`
+    Then the config file contains "# crap4rs.toml"
+    And the config file contains "Threshold preset"
+    And the config file contains "strict (15)"
+    And the config file contains "default (25)"
+    And the config file contains "lenient (40)"
+
+  @wired
+  Scenario: generated config round-trips through the loader
+    Given an empty project directory
+    When the operator runs `crap4rs init --non-interactive`
+    Then the generated config file loads without error
+    And the loaded config has preset "default"
+    And the loaded config has src "src"
+
+  # ── Collision handling ────────────────────────────────────────────
+
+  @wired
+  Scenario: refuses to overwrite an existing config without --force
+    Given a project directory with an existing "crap4rs.toml" containing 'preset = "lenient"'
+    When the operator runs `crap4rs init --non-interactive`
+    Then the exit code is 2
+    And stderr contains "crap4rs.toml already exists"
+    And stderr contains "--force"
+    And the config file still contains 'preset = "lenient"'
+
+  @wired
+  Scenario: --force overwrites an existing config
+    Given a project directory with an existing "crap4rs.toml" containing 'preset = "lenient"'
+    When the operator runs `crap4rs init --non-interactive --force`
+    Then the exit code is 0
+    And the config file contains 'preset = "default"'
+    And the config file does not contain 'preset = "lenient"'
+
+  # Cross-adapter parity for `crap4ts init` is exercised by the
+  # plain integration test at `crates/crap4ts/tests/cli_init_integration.rs`
+  # — the harness here cannot resolve `CARGO_BIN_EXE_crap4ts` because
+  # that env var is only set for binaries in the same package.
+
+  # ── Help text ─────────────────────────────────────────────────────
+
+  @wired
+  Scenario: init subcommand appears in --help output
+    When the operator runs `crap4rs --help`
+    Then stdout contains "init"
+    And stdout contains "starter"
+
+  @wired
+  Scenario: init --help describes the flags
+    When the operator runs `crap4rs init --help`
+    Then stdout contains "--non-interactive"
+    And stdout contains "--force"
+
+  # ── Interactive path (stdin-driven prompt) ─────────────────────────
+  #
+  # The prompt reads a single line from stdin and maps the first char
+  # to `ThresholdPreset` (s|S → Strict, l|L → Lenient, else → Default).
+  # The harness pipes input via `Command::stdin(Stdio::piped())`; no
+  # pty crate needed since the handler does no `isatty()` branching.
+  # CI users pass `--non-interactive` to skip the prompt.
+
+  @wired
+  Scenario: interactive prompt accepts "s" for strict
+    Given an empty project directory
+    When the operator runs `crap4rs init` with stdin "s\n"
+    Then the config file contains 'preset = "strict"'
+
+  @wired
+  Scenario: interactive prompt accepts "l" for lenient
+    Given an empty project directory
+    When the operator runs `crap4rs init` with stdin "l\n"
+    Then the config file contains 'preset = "lenient"'
+
+  @wired
+  Scenario: interactive prompt defaults to "default" on empty input
+    Given an empty project directory
+    When the operator runs `crap4rs init` with stdin "\n"
+    Then the config file contains 'preset = "default"'

--- a/crates/crap4ts/Cargo.toml
+++ b/crates/crap4ts/Cargo.toml
@@ -60,6 +60,10 @@ serde = { workspace = true }
 # traits for the envelope, the JSON serialization happens up in
 # crap-core's reporter layer.
 serde_json = { workspace = true }
+# `cli_init_integration` smoke-tests the `crap4ts init` subcommand
+# (crap-rs#73) which crap4ts inherits from crap-core via AdapterMeta.
+# Each scenario writes into a tempdir so the test doesn't pollute cwd.
+tempfile = { workspace = true }
 
 [build-dependencies]
 napi-build = { workspace = true }

--- a/crates/crap4ts/src/main.rs
+++ b/crates/crap4ts/src/main.rs
@@ -47,6 +47,11 @@ const COVERAGE_HINT: &str = "ensure tests ran with coverage enabled (e.g. `c8 --
 
 const EXTENSIONS: &[&str] = &["ts", "tsx", "js", "jsx", "mjs", "cjs"];
 
+/// Common TS/JS-project directories `init` writes as commented-out
+/// excludes — `node_modules` for vendored deps, build/coverage output
+/// dirs.
+const DEFAULT_EXCLUDES: &[&str] = &["node_modules/**", "dist/**", "coverage/**"];
+
 fn main() -> ExitCode {
     let meta = AdapterMeta {
         tool_name: env!("CARGO_PKG_NAME"),
@@ -60,6 +65,7 @@ fn main() -> ExitCode {
         tool_info_uri: "https://github.com/breezy-bays-labs/crap-rs",
         rule_help_uri: "https://github.com/breezy-bays-labs/crap-rs#crap-formula",
         config_file_name: "crap4ts.toml",
+        default_excludes: DEFAULT_EXCLUDES,
     };
     let cli = crap_core::cli::parse_args(&meta);
     let complexity = OxcWalker::new();

--- a/crates/crap4ts/tests/cli_init_integration.rs
+++ b/crates/crap4ts/tests/cli_init_integration.rs
@@ -1,0 +1,107 @@
+//! Integration tests for `crap4ts init` (crap-rs#73).
+//!
+//! crap4ts inherits the `init` subcommand for free via `AdapterMeta`
+//! (`config_file_name = "crap4ts.toml"`, `default_excludes = ["node_modules/**", …]`).
+//! These tests live here (not in the crap4rs cucumber harness) because
+//! `CARGO_BIN_EXE_<name>` is set per-package: from inside the crap4rs
+//! harness `CARGO_BIN_EXE_crap4ts` would be undefined.
+//!
+//! Each test writes into a fresh tempdir so cwd-pollution between
+//! parallel invocations stays impossible.
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_crap4ts");
+
+#[test]
+fn crap4ts_init_writes_crap4ts_toml_not_crap4rs_toml() {
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    let output = Command::new(BINARY)
+        .current_dir(tmp.path())
+        .args(["init", "--non-interactive"])
+        .output()
+        .expect("invoke crap4ts binary");
+
+    assert!(
+        output.status.success(),
+        "crap4ts init exited non-zero: status={:?} stderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert!(
+        tmp.path().join("crap4ts.toml").exists(),
+        "crap4ts.toml should exist after init",
+    );
+    assert!(
+        !tmp.path().join("crap4rs.toml").exists(),
+        "crap4rs.toml should NOT exist after `crap4ts init` (per-adapter file name)",
+    );
+}
+
+#[test]
+fn crap4ts_init_emits_ts_specific_excludes() {
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    Command::new(BINARY)
+        .current_dir(tmp.path())
+        .args(["init", "--non-interactive"])
+        .output()
+        .expect("invoke crap4ts binary");
+
+    let content = std::fs::read_to_string(tmp.path().join("crap4ts.toml"))
+        .expect("read generated crap4ts.toml");
+    // The default excludes for TS come from AdapterMeta.default_excludes;
+    // we assert the user-visible patterns the crap4ts main.rs declares.
+    assert!(
+        content.contains("node_modules/**"),
+        "expected TS-flavored exclude (node_modules/**) in generated config:\n{content}",
+    );
+    assert!(
+        content.contains("dist/**"),
+        "expected TS-flavored exclude (dist/**) in generated config:\n{content}",
+    );
+    // Negative: Rust-flavored defaults from crap4rs should NOT leak in.
+    assert!(
+        !content.contains("benches/**"),
+        "Rust-only exclude (benches/**) should not appear in crap4ts.toml:\n{content}",
+    );
+}
+
+#[test]
+fn crap4ts_init_refuses_to_overwrite_without_force() {
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    let cfg = tmp.path().join("crap4ts.toml");
+    std::fs::write(&cfg, "preset = \"lenient\"\n").expect("seed existing config");
+
+    let output = Command::new(BINARY)
+        .current_dir(tmp.path())
+        .args(["init", "--non-interactive"])
+        .output()
+        .expect("invoke crap4ts binary");
+
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("crap4ts.toml already exists"),
+        "expected collision error in stderr; got:\n{stderr}",
+    );
+    let preserved = std::fs::read_to_string(&cfg).expect("read config");
+    assert_eq!(preserved, "preset = \"lenient\"\n");
+}
+
+#[test]
+fn crap4ts_init_force_overwrites() {
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    let cfg = tmp.path().join("crap4ts.toml");
+    std::fs::write(&cfg, "preset = \"lenient\"\n").expect("seed existing config");
+
+    let output = Command::new(BINARY)
+        .current_dir(tmp.path())
+        .args(["init", "--non-interactive", "--force"])
+        .output()
+        .expect("invoke crap4ts binary");
+
+    assert!(output.status.success());
+    let content = std::fs::read_to_string(&cfg).expect("read config");
+    assert!(content.contains("preset = \"default\""));
+    assert!(!content.contains("preset = \"lenient\""));
+}


### PR DESCRIPTION
## Summary

Adds `<adapter> init` subcommand to crap-core's CLI shell. Generates a starter `crap4rs.toml` (or `crap4ts.toml`) in the current directory with auto-detected `src` path, prompted threshold preset, and commented-out exclude patterns. crap4ts inherits the subcommand for free via `AdapterMeta`.

Closes #73.

## Why crap-core, not the adapter binary

`AdapterMeta` already carries the two strings that vary per ecosystem (`config_file_name`, `extensions`). Putting `init` in the orchestration layer lets every future adapter inherit it the same way they inherit `completions` today. The PR adds one new `AdapterMeta` field — `default_excludes: &'static [&'static str]` — mirroring the existing `extensions` shape.

## Design decisions (resolved during shape phase)

- **UX library: roll-our-own** (`std::io::stdin().read_line`). Init is a single prompt; pulling in `dialoguer` would be overkill, and `is_terminal` was rejected because tests need to pipe input via `Stdio::piped()`.
- **TOML generation: hand-templated.** `toml::ser` drops comments and we want the generated file to self-document (each option has an inline explanation).
- **Auto-detect: `src/` → `crates/` → fallback.** Two real checks plus a fallback that emits a hint comment. Covers >95% of Rust projects; works for typical TS layouts too.
- **Threshold values: use existing canonical constants.** Emits `preset = "strict|default|lenient"` (not literal numbers), so the canonical 15/25/40 stay in one place.
- **No `cargo-llvm-cov` shellout.** Prints a next-step hint instead.

## What ships

- New `Command::Init { force, non_interactive }` variant routed through `run_inner` alongside the existing `Completions` short-circuit.
- New `crap-core::cli::init` module: parser + renderer + handler + 14 unit tests. Handler takes I/O streams as params so unit tests drive prompt/file-write against a tempdir without spawning subprocesses.
- New BDD spec `crates/crap4rs/tests/features/cli_init.feature` (14 scenarios, all `@wired`) + new harness `cli_init_cucumber.rs` using the AGENTS.md rule-5 `@wired` filter pattern.
- Cross-adapter parity smoke: `crates/crap4ts/tests/cli_init_integration.rs` (4 plain integration tests). Lives in crap4ts because `CARGO_BIN_EXE_crap4ts` is per-package — the crap4rs harness can't resolve it.
- AdapterMeta `default_excludes` field; per-adapter constants in both `main.rs` files (`["tests/**", "benches/**", "examples/**"]` for Rust, `["node_modules/**", "dist/**", "coverage/**"]` for TS).
- CHANGELOG.md entry under `## [Unreleased]` documenting both the subcommand and the `AdapterMeta` field addition.

## Acceptance criteria from #73

- [x] `crap4rs init` creates `crap4rs.toml` in cwd
- [x] Detects `src/` and `crates/` automatically; falls back with a hint comment
- [x] Asks threshold preference (strict/default/lenient); `--non-interactive` uses default
- [x] Includes commented-out common exclude patterns (`tests/**`, `benches/**`, `examples/**`)
- [x] Warns if `crap4rs.toml` already exists; refuses without `--force`
- [x] `crap4rs init --non-interactive` works for CI
- [x] Generated config has inline comments explaining each option
- [x] crap4ts inherits via AdapterMeta (writes `crap4ts.toml` with TS-flavored excludes)

## Gates (all green locally)

- `cargo fmt --check` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` clean
- `cargo +1.93 check --workspace --all-targets` clean (MSRV)
- `cargo deny check` clean
- `cargo nextest run --workspace`: **958 tests pass** (up from 940 baseline → **+18 net new entries**: 14 init unit + 4 crap4ts integration). The 14 cucumber scenarios are reported by cucumber's own runner under `harness = false`, not enumerated by nextest's count — they run as a single `cli_init_cucumber` test binary.
- 4-layer ast-purity (leading-import grep, grouped-import grep, direct-deps `cargo metadata`, adapter-name literals awk filter): all clean. The `fake_meta()` test helper in `crap-core::cli::init` uses `"fake-adapter"`/`"fake-adapter.toml"` so layer-4 stays clean.
- Wire-envelope canary: **line-shift-only drift** — `crap4rs::main`'s self-analysis span shifted by +5 lines (matches the new `DEFAULT_EXCLUDES` const + doc comment block) and grew by +1 line (matches the new struct field). JSON envelope SHAPE is byte-identical (verified by stripping line-number fields and diffing). Snapshot accepted in this PR.

## Smoke test

```
$ cd /tmp && mkdir init-smoke && cd init-smoke
$ crap4rs init --non-interactive
✓ wrote crap4rs.toml (preset = "default", src = "src")
  next: ensure your coverage tool is installed, then run `crap4rs --help` to see analysis flags.

$ cat crap4rs.toml
# crap4rs.toml — generated by `crap4rs init`
# Edit freely; the analyzer re-reads this file on every run.

# Threshold preset:
#   strict (15)  — high-quality libraries, safety-critical code
#   default (25) — typical Rust projects (balanced)
#   lenient (40) — legacy or transitional code
# Use `threshold = N` instead to set a custom numeric cutoff.
preset = "default"

# Source root the analyzer walks.
# (auto-detect found no `src/` or `crates/` directory — adjust if your sources live elsewhere)
src = "src"

# Glob patterns matched against project-relative file paths.
# Uncomment to ignore these directories (one common starting set):
# exclude = [
#     "tests/**",
#     "benches/**",
#     "examples/**",
# ]
```

`crap4ts init --non-interactive` produces the same shape with `node_modules/**`, `dist/**`, `coverage/**` excludes — same handler in crap-core, different excludes from `AdapterMeta`.

## Test plan

- [ ] CI passes (full battery: fmt, clippy, docs, deny, MSRV, ast-purity x4, nextest matrix)
- [ ] Wire-envelope canary accepted by reviewer as line-shift-only (no JSON shape change)
- [ ] Bot review (Codex/CodeRabbit) — this PR adds a new subcommand variant + new public API field; load-bearing review per Step 4b

🤖 Generated with [Claude Code](https://claude.com/claude-code)