### PR TITLE
chore(mutants): #95 — parallel local workflow + crash-recovery doc

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -12,15 +12,18 @@
 # crap4rs bin first. Excluding it here is scoped to mutants only.
 additional_cargo_test_args = ["--", "--skip", "envelope"]
 
-# Warm each parallel worker's scratch tree with our shared /target dir.
+# Warm each parallel worker's scratch tree with our /target dir.
 #
 # Local parallel runs (`cargo mutants -j N`) copy the source tree into
-# N scratch dirs — one per worker. Without this flag each worker rebuilds
-# every dep from scratch, which dominates the run on a cold cache.
-# `copy_target = true` hardlinks the already-built /target/ into every
-# scratch dir, so workers start with all deps pre-compiled and only burn
-# CPU on the mutated crate. See AGENTS.md "Mutation testing" for the
-# local invocation and the crash-recovery story.
+# N scratch dirs — one per worker. By default `/target` is excluded from
+# that copy, so each worker rebuilds every dep from scratch, which
+# dominates the run on a cold cache. `copy_target = true` copies the
+# already-built `/target/` into every scratch dir, so workers can reuse
+# the prebuilt artifacts and only burn CPU on the mutated crate.
+#
+# Trade-off: each worker holds its own `/target/` copy in temp space —
+# disk usage scales with `-j N`. On a workspace where `/target/` is
+# multiple GB this is the dominant cost; mind free disk on `-j 8+`.
 #
 # Ignored under `--in-place` (no copy happens), so this is CI-neutral —
 # the `mutants` job in `.github/workflows/ci.yml` still passes through

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -11,3 +11,20 @@
 # which run `cargo nextest run --workspace --all-targets` and DO build the
 # crap4rs bin first. Excluding it here is scoped to mutants only.
 additional_cargo_test_args = ["--", "--skip", "envelope"]
+
+# Warm each parallel worker's scratch tree with our shared /target dir.
+#
+# Local parallel runs (`cargo mutants -j N`) copy the source tree into
+# N scratch dirs — one per worker. Without this flag each worker rebuilds
+# every dep from scratch, which dominates the run on a cold cache.
+# `copy_target = true` hardlinks the already-built /target/ into every
+# scratch dir, so workers start with all deps pre-compiled and only burn
+# CPU on the mutated crate. See AGENTS.md "Mutation testing" for the
+# local invocation and the crash-recovery story.
+#
+# Ignored under `--in-place` (no copy happens), so this is CI-neutral —
+# the `mutants` job in `.github/workflows/ci.yml` still passes through
+# unchanged. See <https://mutants.rs/in-place> on the --in-place × --jobs
+# incompatibility: parallel workers REQUIRE copies, --in-place forbids
+# them, so `-j N` and `--in-place` are mutually exclusive by design.
+copy_target = true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,10 +126,12 @@ scratch dirs (one per worker). `--in-place` skips the copy and mutates
 the source tree directly, so it forbids `-j > 1` by design. Trying to
 combine them errors out. See <https://mutants.rs/in-place>.
 
-`.cargo/mutants.toml` sets `copy_target = true` so each local worker
-hardlinks the workspace `target/` into its scratch dir — no cold-cache
-rebuild per worker. The flag is ignored under `--in-place` (no copy
-happens), which keeps CI behaviour unchanged.
+`.cargo/mutants.toml` sets `copy_target = true` so each local worker's
+scratch dir gets a copy of the workspace `target/` — workers reuse the
+prebuilt artifacts instead of rebuilding from cold. The trade-off is
+disk usage: each worker holds its own `target/` copy in temp space, so
+free disk should be ≥ `target/` size × N. The flag is ignored under
+`--in-place` (no copy happens), which keeps CI behaviour unchanged.
 
 ### Crash recovery
 
@@ -139,12 +141,14 @@ happens), which keeps CI behaviour unchanged.
   the mutated file dirty on disk. Restore with:
 
   ```bash
-  git checkout -- crates/crap-core/src/domain/view.rs
+  # WARNING: discards any unrelated uncommitted changes to the file.
+  # If you had in-flight edits, stash them first (`git stash push -- <file>`).
+  git restore crates/crap-core/src/domain/view.rs
   ```
 
   If `cargo mutants` exits cleanly (success or failure), it restores
-  the file itself — `git checkout` is only needed after an unclean
-  shutdown.
+  the file itself — manual `git restore` is only needed after an
+  unclean shutdown.
 
 ### CI parity
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,3 +94,73 @@ breezy-bays-labs/mokumo#370) can dogfood on us without false positives.
 - Adding a new harness → use the `@wired` filter pattern from rule 5.
 - Touching `Background:` → re-read rule 4; non-executable Backgrounds
   are the source of most BDD hygiene debt in this repo.
+
+## Mutation testing
+
+`cargo mutants` is the surviving-mutant gate on `domain/view.rs` (the
+highest-complexity function family in `crap-core`). CI runs it
+sequentially on every PR; locally you'll want parallelism so a single
+file's gate finishes in minutes rather than half an hour.
+
+### Local invocation
+
+```bash
+cargo mutants -j 4 --package crap-core --file crates/crap-core/src/domain/view.rs
+```
+
+`-j N` is CLI-only — cargo-mutants 27.x's config schema does not expose
+a `jobs` field. Pick N up to your physical core count. Speedup is
+hardware-dependent: on slower boxes where each mutated build dominates
+wall-clock, `copy_target = true` removes the cold-cache penalty and
+`-j N` cuts runtime substantially. On Apple Silicon and other
+high-core-count boxes, `nextest`'s intra-test parallelism already
+saturates available compute when one mutants worker is active, so the
+marginal gain from `-j N` is smaller (~15-20% on M-series); the
+workflow still matters because it removes the `--in-place` lock-in
+that fragments local runs.
+
+### --in-place is mutually exclusive with -j N
+
+cargo-mutants implements parallelism by copying the source tree to N
+scratch dirs (one per worker). `--in-place` skips the copy and mutates
+the source tree directly, so it forbids `-j > 1` by design. Trying to
+combine them errors out. See <https://mutants.rs/in-place>.
+
+`.cargo/mutants.toml` sets `copy_target = true` so each local worker
+hardlinks the workspace `target/` into its scratch dir — no cold-cache
+rebuild per worker. The flag is ignored under `--in-place` (no copy
+happens), which keeps CI behaviour unchanged.
+
+### Crash recovery
+
+- **Local default (no `--in-place`)**: workers mutate copies. Kill mid-run
+  is safe — your source tree is never touched. Just re-run.
+- **`--in-place` (CI, or local if you opt in)**: a mid-run kill can leave
+  the mutated file dirty on disk. Restore with:
+
+  ```bash
+  git checkout -- crates/crap-core/src/domain/view.rs
+  ```
+
+  If `cargo mutants` exits cleanly (success or failure), it restores
+  the file itself — `git checkout` is only needed after an unclean
+  shutdown.
+
+### CI parity
+
+CI's `mutants` job runs `cargo mutants --package crap-core --file
+crates/crap-core/src/domain/view.rs --no-shuffle --in-place` on a single
+ubuntu-latest worker. `--in-place` keeps the run fast (no tree copy)
+and `--no-shuffle` keeps the mutant order deterministic across reruns,
+which makes flaky-mutant triage tractable. Local `-j N` runs may surface
+the same mutants in a different order — that's expected, not a
+regression.
+
+### Why `additional_cargo_test_args = ["--", "--skip", "envelope"]`
+
+The wire-envelope snapshot test (`crates/crap-core/tests/wire_envelope_snapshot.rs`)
+shells out to the `crap4rs` binary, which `cargo mutants --package
+crap-core` doesn't build. Skipping it under mutants is scoped to mutants
+only; every PR's `Test (linux-x86)` / `Test (macos-arm)` /
+`Test (macos-x86)` job still runs the canary via `cargo nextest run
+--workspace --all-targets`, which DOES build the bin first.


### PR DESCRIPTION
## Summary

Configure `.cargo/mutants.toml` so `cargo mutants -j N` is the standard
local mutation-gate invocation: parallel workers hardlink the workspace
`target/` into their scratch dirs (no cold-cache rebuild per worker).
Document the workflow, the `--in-place × -j` mutual exclusion, and the
crash-recovery flow in AGENTS.md.

Closes #95.

## What changed

- `.cargo/mutants.toml` — add `copy_target = true`. Parallel local
  workers start with the workspace `target/` hardlinked into their
  scratch dirs, so they don't pay a cold-cache rebuild penalty. The
  flag is ignored under `--in-place` (no copy happens), so CI's
  `mutants` job runs unchanged.
- `AGENTS.md` — new `## Mutation testing` section. Covers local
  invocation, `--in-place × -j` mutual exclusion (cargo-mutants 27.x
  design — verified against the config schema), crash recovery
  (`git checkout -- <file>` for `--in-place` only; local copy-based
  runs are crash-safe by design), CI parity note, and the rationale
  for the existing `--skip envelope` workaround.

## Measurements (Apple Silicon M-series, 10 physical cores)

Same target: `crates/crap-core/src/domain/view.rs`, 57 mutants, warm
worktree-local `target/`.

| Invocation | Wall-clock | CPU-sec | Mutants | Caught / Unviable |
|---|---|---|---|---|
| `cargo mutants … --no-shuffle --in-place` (CI parity) | 5m29s (329s) | 1734s | 57 | 48 / 9 |
| `cargo mutants … --no-shuffle -j 4 --config …` (without `copy_target`) | 4m35s (275s) | 1993s | 57 | 48 / 9 |
| `cargo mutants … --no-shuffle -j 4` (new local, with `copy_target = true`) | 4m31s (270s) | 1784s | 57 | 48 / 9 |

The wall-clock delta between row 2 and row 3 is ~2% (within
measurement noise), but `copy_target = true` saves ~12% of CPU-seconds
(1993 → 1784) — workers don't rebuild the workspace target from
scratch. On this 10-core box the CPU savings hide in available
parallelism; on a 4-core box where wall-clock is more directly
gated by CPU, that ~210s of CPU savings translates to ~50s of
wall-clock savings (~10% of total). The flag earns its keep on
slower hardware; on this box its observed benefit is CPU efficiency
and the convention of "warm workers" being the documented practice.

Mutant count + caught/unviable counts are identical across all three
modes — parallelism + the config change are mutation-result-neutral.

## Acceptance criteria (issue #95)

- [x] **AC #1** — `cargo mutants -j N` works locally without `--in-place`.
  Verified via `cargo mutants --emit-schema=config`: cargo-mutants 27.x
  exposes neither `jobs` nor `in_place` as config fields, so the config
  has never been able to pin `--in-place`. This PR locks the
  ergonomics in via `copy_target = true` + the AGENTS.md doc.

- [x] **AC #2 — absolute ceiling** (local mutation-gate runtime well
  under 10 min): met. `-j 4` lands at 4m31s, the `--in-place`
  baseline at 5m29s. Both well under the 10-min target.

- [~] **AC #2 — relative drop** (30 min → 10 min, i.e. ≥ 50%): not
  reproducible on this hardware. The 30-min baseline cited in #95 was
  Bundle C's environment; on M-series Apple Silicon `nextest`'s
  intra-test parallelism already saturates available compute when one
  mutants worker is active, so the wall-clock baseline is already
  5m29s and `-j 4`'s marginal wall-clock gain is ~18%. The relative
  "30→10" ratio is hardware-bound, not config-bound — on slower boxes
  where each unmutated build dominates wall-clock, `copy_target =
  true`'s cold-cache elimination compounds and `-j N` cuts more.
  See the measurements table above for the isolated probe.

- [x] **AC #3** — Crash recovery documented. AGENTS.md "Crash
  recovery" subsection: local default is copy-based and crash-safe;
  `--in-place` (CI or local opt-in) needs `git checkout -- <file>`
  after an unclean shutdown. `cargo mutants` restores the file itself
  on clean exit (success or failure) — `git checkout` is only for
  kill-9 / OOM cases.

- [x] **AC #4** — Doc note in AGENTS.md (`## Mutation testing`,
  5 subsections: local invocation, --in-place × -j incompatibility,
  crash recovery, CI parity, --skip-envelope rationale).

## Non-goals

- CI's `mutants` job stays sequential + `--in-place + --no-shuffle`
  for reproducibility. Local parallel runs may surface mutants in a
  different order; CI keeps the reference order so flaky-mutant
  triage stays tractable.
- No expansion of mutation scope beyond `domain/view.rs`. Single-file
  CI scope preserved.
- No `just` / `xtask` wrapper — the local invocation is a single
  command + doc, no scripting needed.
- Zero production source change → wire-envelope canary byte-identical.

## Gates

- [x] cargo fmt --check
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
- [x] cargo +1.93 check --workspace --all-targets (MSRV)
- [x] cargo deny check
- [x] AST-purity grep on `crates/crap-core/src/` (no AST imports)
- [x] cargo nextest run --workspace --all-targets (958 tests pass)
- [x] cargo test --test json_reporter_cucumber (12 scenarios pass)
- [x] Wire-envelope canary BYTE-IDENTICAL
  (`crap-core::wire_envelope_snapshot` passes; no source change in
  `crap-core` or `crap4rs` means no envelope shift)
- [x] Mutant count identical (57) and caught/unviable identical
  (48/9) across all three measured modes
- CI's `mutants` job will run on this PR; expected to pass since
  `copy_target = true` is no-op under `--in-place`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced mutation testing infrastructure by optimizing the cargo-mutants configuration to improve parallel execution efficiency.
  * Added comprehensive documentation on running and maintaining mutation testing locally and in CI.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/breezy-bays-labs/crap-rs/pull/172)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->