### PR TITLE
feat(crap4ts): #182 — OxcWalker minimal cyclomatic walker (6 decision points) + parse-failure pattern

### DIFF
--- a/crates/crap4ts/src/adapters/walker/mod.rs
+++ b/crates/crap4ts/src/adapters/walker/mod.rs
@@ -1,25 +1,89 @@
-//! Oxc-based TypeScript complexity walker — STUB.
+//! Oxc-based TypeScript complexity walker.
 //!
-//! The real implementation will use `oxc::parser` to walk the AST and
-//! count decision points for cognitive / cyclomatic complexity, mirror-
-//! ing `crates/crap4rs/src/adapters/complexity/mod.rs`. It lands in
-//! the follow-up TypeScript-adapter pipeline.
+//! Mirrors `crates/crap4rs/src/adapters/complexity/mod.rs` in shape and
+//! responsibilities. The walker:
 //!
-//! ALPHA: invoking `extract(...)` runtime-panics with `unimplemented!`.
-//! The struct exists so the trait bound is wired and the binary's
-//! `--help` / `--version` paths (which never call into `extract`)
-//! work today.
+//! 1. Parses the source via `oxc_parser::Parser` (with `SourceType`
+//!    inferred from `file_path`'s extension via `SourceType::from_path`,
+//!    falling back to `SourceType::ts()` for unrecognised extensions —
+//!    W2.2 (#185) widens this dispatch to `.tsx` / `.jsx` / `.js` /
+//!    `.mjs` / `.cjs` while keeping the same fallback shape).
+//! 2. If `ret.errors` is non-empty, returns
+//!    `Err(CrapError::SourceParse(format!("{file_path}: {}", err)))`.
+//!    The orchestrator at `crap-core/src/core/mod.rs:286-310` catches
+//!    this and increments `AnalysisDiagnostics.files_unparseable`.
+//! 3. Otherwise walks the AST, emitting one `FunctionComplexity` per
+//!    function declaration / function expression / arrow function /
+//!    class method. Each function's contributors list captures the
+//!    decision points scored inside its own body — nested functions
+//!    accumulate independently.
+//!
+//! ## W1.2 scope (crap-rs#182)
+//!
+//! Six universal cyclomatic decision points map to existing
+//! `ContributorKind` variants:
+//!
+//! | oxc AST node                                  | ContributorKind   |
+//! |-----------------------------------------------|-------------------|
+//! | `Statement::IfStatement`                      | `IfBranch`        |
+//! | `Statement::ForStatement` / `ForOf` / `ForIn` | `ForLoop`         |
+//! | `Statement::WhileStatement`                   | `WhileLoop`       |
+//! | `Statement::DoWhileStatement`                 | `DoWhileLoop`     |
+//! | `SwitchCase` (with `test: Some(_)`)           | `CaseBranch`      |
+//! | `Expression::LogicalExpression(And\|Or)`      | `LogicalOperator` |
+//!
+//! TS-specific decision points (`?:` / `?.` / `??` / `catch` / JSX) are
+//! intentionally deferred to W2.1 (#184) with ADR (a) — the walker
+//! traverses past them without emitting contributors.
+//!
+//! ## Span semantics (Context7-verified against oxc 0.129)
+//!
+//! oxc `Span` is `[start, end)` over UTF-8 byte offsets (per
+//! `oxc_span/README.md` — inclusive start, exclusive end). The domain
+//! `SourceSpan.end_line` is 1-based **inclusive**, matching crap4rs's
+//! syn walker behaviour. The conversion at the boundary is therefore:
+//!
+//! - `start_line = byte_to_line(source, span.start)`
+//! - `end_line   = byte_to_line(source, span.end.saturating_sub(1))`
+//!
+//! i.e. `end_line` is the 1-based line of the LAST BYTE in the span.
+//! The W1.2 prompt's "add +1" claim was a secondary-source error
+//! (Context7-confirmed); see `observations.md` for the recorded pin.
 
-use crap_core::domain::types::{ComplexityMetric, CrapError, FunctionComplexity};
+use std::path::Path;
+
+use crap_core::domain::types::{
+    ComplexityContributor, ComplexityMetric, ContributorKind, CrapError, FunctionComplexity,
+    FunctionIdentity, SourceSpan,
+};
 use crap_core::ports::ComplexityPort;
+use oxc::allocator::Allocator;
+use oxc::ast::ast::{
+    ArrowFunctionExpression, BindingPattern, Class, ClassElement, Declaration, Expression,
+    ForStatementInit, ForStatementLeft, Function, FunctionBody, IfStatement, LogicalExpression,
+    MethodDefinition, ObjectExpression, ObjectPropertyKind, PropertyKey, Statement, SwitchCase,
+    VariableDeclaration,
+};
+use oxc::parser::Parser;
+use oxc::span::{SourceType, Span};
+use oxc::syntax::operator::LogicalOperator;
 
-/// Oxc-based complexity extractor — stub. Implements `ComplexityPort`
-/// so the binary's `crap_core::cli::run` dispatch picks it up.
+/// Oxc-based complexity extractor implementing `ComplexityPort`.
+///
+/// W1.2 supports cyclomatic counting only (one increment per decision
+/// point). Cognitive counting lands with W2.5 (#188) alongside the
+/// `MetricNotSupported` error variant — until then, requests for
+/// `ComplexityMetric::Cognitive` receive the same cyclomatic-style
+/// counts. The default metric for `crap4ts` flips to cyclomatic in
+/// W2.5 via `AdapterMeta::default_metric`, so end-to-end runs already
+/// converge on the right semantics.
 pub struct OxcWalker {
     _private: (),
 }
 
 impl OxcWalker {
+    /// Construct a new walker. The walker is stateless — every call to
+    /// `extract` is self-contained.
     pub fn new() -> Self {
         Self { _private: () }
     }
@@ -34,12 +98,861 @@ impl Default for OxcWalker {
 impl ComplexityPort for OxcWalker {
     fn extract(
         &self,
-        _source: &str,
-        _file_path: &str,
-        _metric: ComplexityMetric,
+        source: &str,
+        file_path: &str,
+        metric: ComplexityMetric,
     ) -> Result<Vec<FunctionComplexity>, CrapError> {
-        unimplemented!("oxc walker lands in the typescript-adapter follow-up pipeline")
+        let allocator = Allocator::default();
+        let source_type =
+            SourceType::from_path(Path::new(file_path)).unwrap_or_else(|_| SourceType::ts());
+
+        let ret = Parser::new(&allocator, source, source_type).parse();
+        if let Some(first) = ret.errors.first() {
+            return Err(CrapError::SourceParse(format!("{file_path}: {first}")));
+        }
+
+        let mut finder = FunctionFinder {
+            source,
+            file_path,
+            metric,
+            functions: Vec::new(),
+        };
+        for stmt in &ret.program.body {
+            finder.visit_top_level_statement(stmt);
+        }
+        Ok(finder.functions)
     }
+}
+
+// ── Function finder ─────────────────────────────────────────────────────
+
+/// Walks top-level program statements (and class declarations) looking
+/// for function-entry points. Each discovered function emits one
+/// `FunctionComplexity` via `record_function`, which itself recurses
+/// through the function body counting decision points and discovering
+/// nested function entries.
+struct FunctionFinder<'src> {
+    source: &'src str,
+    file_path: &'src str,
+    metric: ComplexityMetric,
+    functions: Vec<FunctionComplexity>,
+}
+
+impl<'src> FunctionFinder<'src> {
+    /// Top-level dispatch over a `Statement` looking for function
+    /// entries. Recognises:
+    /// - `function foo() {}` declarations (including those re-exported
+    ///   via `Statement::FunctionDeclaration` and the inherited
+    ///   `ExportNamedDeclaration` / `ExportDefaultDeclaration` paths)
+    /// - `const f = () => ...` / `const f = function() {}` declarators
+    /// - `class Foo { method() {} }` method definitions
+    fn visit_top_level_statement(&mut self, stmt: &Statement<'_>) {
+        match stmt {
+            Statement::FunctionDeclaration(func) => self.record_function(func, None),
+            Statement::ClassDeclaration(class) => self.visit_class(class, None),
+            Statement::VariableDeclaration(vd) => self.visit_variable_declaration(vd),
+            Statement::ExportNamedDeclaration(decl) => {
+                if let Some(inner) = &decl.declaration {
+                    self.visit_top_level_declaration(inner);
+                }
+            }
+            Statement::ExportDefaultDeclaration(decl) => {
+                self.visit_export_default(decl);
+            }
+            // All other top-level statements may still contain nested
+            // function-expression entries inside their expression trees
+            // (e.g. an IIFE at module scope). For W1.2 the fixture
+            // corpus never exercises this path; we still descend so
+            // the walker is robust against real-world code.
+            other => {
+                let mut sink = Contributors::default();
+                self.visit_statement(other, &mut sink, None);
+            }
+        }
+    }
+
+    /// Dispatch the body of `export default ...` — three branches:
+    /// declaration-flavoured (function/class) recurse straight into the
+    /// matching `record_*` helper; expression-flavoured route through
+    /// the expression visitor with a throwaway sink (top-level
+    /// expressions contribute to no parent accumulator).
+    fn visit_export_default(&mut self, decl: &oxc::ast::ast::ExportDefaultDeclaration<'_>) {
+        use oxc::ast::ast::ExportDefaultDeclarationKind as K;
+        match &decl.declaration {
+            K::FunctionDeclaration(func) => self.record_function(func, None),
+            K::ClassDeclaration(class) => self.visit_class(class, None),
+            expr_kind => {
+                if let Some(expr) = export_default_as_expression(expr_kind) {
+                    let mut sink = Contributors::default();
+                    self.visit_expression(expr, &mut sink, None);
+                }
+            }
+        }
+    }
+
+    fn visit_top_level_declaration(&mut self, decl: &Declaration<'_>) {
+        match decl {
+            Declaration::FunctionDeclaration(func) => self.record_function(func, None),
+            Declaration::ClassDeclaration(class) => self.visit_class(class, None),
+            Declaration::VariableDeclaration(vd) => self.visit_variable_declaration(vd),
+            _ => {} // TS type / interface / enum declarations have no executable bodies.
+        }
+    }
+
+    fn visit_variable_declaration(&mut self, vd: &VariableDeclaration<'_>) {
+        for declarator in &vd.declarations {
+            let Some(init) = &declarator.init else {
+                continue;
+            };
+            let name = binding_name(&declarator.id);
+            self.record_initializer(init, name);
+        }
+    }
+
+    /// Route a top-level variable initializer to the matching
+    /// function-entry recorder. Non-function initializers walk into the
+    /// expression tree purely for nested-function discovery; they
+    /// contribute no decision points to any parent accumulator.
+    fn record_initializer(&mut self, init: &Expression<'_>, name: Option<String>) {
+        match init {
+            Expression::ArrowFunctionExpression(arrow) => self.record_arrow(arrow, name),
+            Expression::FunctionExpression(func) => self.record_function(func, name),
+            Expression::ClassExpression(class) => self.visit_class(class, name),
+            other => {
+                let mut sink = Contributors::default();
+                self.visit_expression(other, &mut sink, None);
+            }
+        }
+    }
+
+    fn visit_class(&mut self, class: &Class<'_>, name_hint: Option<String>) {
+        let class_name = class
+            .id
+            .as_ref()
+            .map(|bi| bi.name.as_str().to_string())
+            .or(name_hint)
+            .unwrap_or_else(|| "<anonymous class>".to_string());
+        for element in &class.body.body {
+            if let ClassElement::MethodDefinition(method) = element {
+                self.record_method(method, &class_name);
+            }
+        }
+    }
+
+    fn record_method(&mut self, method: &MethodDefinition<'_>, class_name: &str) {
+        let method_name = property_key_name(&method.key).unwrap_or_else(|| "<computed>".into());
+        let qualified = format!("{class_name}.{method_name}");
+        // `method.value` is the Function (FunctionExpression) holding
+        // the body.
+        self.record_function(&method.value, Some(qualified));
+    }
+
+    fn record_function(&mut self, func: &Function<'_>, name_hint: Option<String>) {
+        let name = name_hint
+            .or_else(|| func.id.as_ref().map(|id| id.name.as_str().to_string()))
+            .unwrap_or_else(|| "<anonymous>".to_string());
+
+        let mut contributors = Contributors::default();
+        if let Some(body) = func.body.as_ref() {
+            self.visit_function_body(body, &mut contributors);
+        }
+
+        self.push_function(name, func.span, contributors);
+    }
+
+    fn record_arrow(&mut self, arrow: &ArrowFunctionExpression<'_>, name_hint: Option<String>) {
+        let name = name_hint.unwrap_or_else(|| "<arrow>".to_string());
+
+        let mut contributors = Contributors::default();
+        // Arrow bodies are wrapped in `FunctionBody` regardless of
+        // expression-vs-block form — the `body.statements` is a single
+        // `ReturnStatement` for expression bodies. `arrow.expression`
+        // signals which form was written; the body shape is uniform.
+        self.visit_function_body(&arrow.body, &mut contributors);
+
+        self.push_function(name, arrow.span, contributors);
+    }
+
+    fn push_function(&mut self, name: String, span: Span, contributors: Contributors) {
+        let mut emitted = contributors.list;
+        emitted.sort_by_key(|c| (c.line, c.column.unwrap_or(0)));
+        let complexity = 1 + contributors.count;
+        let span = source_span(self.source, span);
+        self.functions.push(FunctionComplexity {
+            identity: FunctionIdentity::new(self.file_path.to_string(), name, span),
+            complexity,
+            metric: self.metric,
+            contributors: emitted,
+        });
+    }
+
+    /// Walk a function body, accumulating contributors into `out` and
+    /// discovering nested function entries (which get their own
+    /// accumulator via `record_function` / `record_arrow`).
+    fn visit_function_body(&mut self, body: &FunctionBody<'_>, out: &mut Contributors) {
+        for stmt in &body.statements {
+            self.visit_statement(stmt, out, Some(0));
+        }
+    }
+
+    /// Walk a statement, charging decision points to `out` and
+    /// recursing into substructure. When `nesting` is `Some(n)`, we are
+    /// inside a function body at depth `n`; when `None`, we are at the
+    /// top level of the module (no parent function to charge).
+    fn visit_statement(
+        &mut self,
+        stmt: &Statement<'_>,
+        out: &mut Contributors,
+        nesting: Option<u32>,
+    ) {
+        match stmt {
+            // Function-entry statements (start a new accumulator).
+            Statement::FunctionDeclaration(func) => self.record_function(func, None),
+            Statement::ClassDeclaration(class) => self.visit_class(class, None),
+            Statement::VariableDeclaration(vd) => {
+                self.visit_variable_declaration_in_body(vd, out, nesting);
+            }
+
+            // Decision-point statements.
+            Statement::IfStatement(if_stmt) => self.visit_if(if_stmt, out, nesting),
+            Statement::ForStatement(for_stmt) => self.visit_for(for_stmt, out, nesting),
+            Statement::ForInStatement(for_in) => self.visit_for_in(for_in, out, nesting),
+            Statement::ForOfStatement(for_of) => self.visit_for_of(for_of, out, nesting),
+            Statement::WhileStatement(w) => self.visit_while(w, out, nesting),
+            Statement::DoWhileStatement(dw) => self.visit_do_while(dw, out, nesting),
+            Statement::SwitchStatement(sw) => self.visit_switch(sw, out, nesting),
+
+            // Recursing statements (no scoring at this node, recurse into children).
+            Statement::BlockStatement(b) => self.visit_block(&b.body, out, nesting),
+            Statement::ExpressionStatement(es) => {
+                self.visit_expression(&es.expression, out, nesting);
+            }
+            Statement::ReturnStatement(r) => {
+                if let Some(arg) = &r.argument {
+                    self.visit_expression(arg, out, nesting);
+                }
+            }
+            Statement::TryStatement(t) => self.visit_try(t, out, nesting),
+            Statement::LabeledStatement(l) => self.visit_statement(&l.body, out, nesting),
+            Statement::ThrowStatement(th) => self.visit_expression(&th.argument, out, nesting),
+
+            // Module-level statements (valid only at top-level program scope).
+            Statement::ExportNamedDeclaration(decl) => {
+                if let Some(inner) = &decl.declaration {
+                    self.visit_top_level_declaration(inner);
+                }
+            }
+
+            // Everything else is structural-only at this scope: leaf
+            // statements (break/continue/debugger/empty/with), bare
+            // module statements (re-exports / imports / TS-flavoured
+            // assignment-exports), and TypeScript type-only
+            // declarations all contribute no executable decision
+            // points to the enclosing function body.
+            _ => {}
+        }
+    }
+
+    fn visit_variable_declaration_in_body(
+        &mut self,
+        vd: &VariableDeclaration<'_>,
+        out: &mut Contributors,
+        nesting: Option<u32>,
+    ) {
+        for declarator in &vd.declarations {
+            let name = binding_name(&declarator.id);
+            let Some(init) = &declarator.init else {
+                continue;
+            };
+            match init {
+                Expression::ArrowFunctionExpression(arrow) => self.record_arrow(arrow, name),
+                Expression::FunctionExpression(func) => self.record_function(func, name),
+                Expression::ClassExpression(class) => self.visit_class(class, name),
+                other => self.visit_expression(other, out, nesting),
+            }
+        }
+    }
+
+    fn visit_block(
+        &mut self,
+        body: &[Statement<'_>],
+        out: &mut Contributors,
+        nesting: Option<u32>,
+    ) {
+        for s in body {
+            self.visit_statement(s, out, nesting);
+        }
+    }
+
+    fn visit_for(
+        &mut self,
+        for_stmt: &oxc::ast::ast::ForStatement<'_>,
+        out: &mut Contributors,
+        nesting: Option<u32>,
+    ) {
+        self.charge_for(for_stmt.span, out, nesting);
+        if let Some(init) = &for_stmt.init {
+            self.visit_for_init(init, out, nesting);
+        }
+        if let Some(test) = &for_stmt.test {
+            self.visit_expression(test, out, nesting);
+        }
+        if let Some(update) = &for_stmt.update {
+            self.visit_expression(update, out, nesting);
+        }
+        self.visit_statement(&for_stmt.body, out, nesting.map(|n| n + 1));
+    }
+
+    fn visit_for_in(
+        &mut self,
+        for_in: &oxc::ast::ast::ForInStatement<'_>,
+        out: &mut Contributors,
+        nesting: Option<u32>,
+    ) {
+        self.charge_for(for_in.span, out, nesting);
+        self.visit_for_left(&for_in.left, out, nesting);
+        self.visit_expression(&for_in.right, out, nesting);
+        self.visit_statement(&for_in.body, out, nesting.map(|n| n + 1));
+    }
+
+    fn visit_for_of(
+        &mut self,
+        for_of: &oxc::ast::ast::ForOfStatement<'_>,
+        out: &mut Contributors,
+        nesting: Option<u32>,
+    ) {
+        self.charge_for(for_of.span, out, nesting);
+        self.visit_for_left(&for_of.left, out, nesting);
+        self.visit_expression(&for_of.right, out, nesting);
+        self.visit_statement(&for_of.body, out, nesting.map(|n| n + 1));
+    }
+
+    fn visit_while(
+        &mut self,
+        w: &oxc::ast::ast::WhileStatement<'_>,
+        out: &mut Contributors,
+        nesting: Option<u32>,
+    ) {
+        if let Some(n) = nesting {
+            out.push(contributor(
+                ContributorKind::WhileLoop,
+                self.source,
+                w.span,
+                n,
+            ));
+        }
+        self.visit_expression(&w.test, out, nesting);
+        self.visit_statement(&w.body, out, nesting.map(|n| n + 1));
+    }
+
+    fn visit_do_while(
+        &mut self,
+        dw: &oxc::ast::ast::DoWhileStatement<'_>,
+        out: &mut Contributors,
+        nesting: Option<u32>,
+    ) {
+        if let Some(n) = nesting {
+            out.push(contributor(
+                ContributorKind::DoWhileLoop,
+                self.source,
+                dw.span,
+                n,
+            ));
+        }
+        self.visit_statement(&dw.body, out, nesting.map(|n| n + 1));
+        self.visit_expression(&dw.test, out, nesting);
+    }
+
+    fn visit_switch(
+        &mut self,
+        sw: &oxc::ast::ast::SwitchStatement<'_>,
+        out: &mut Contributors,
+        nesting: Option<u32>,
+    ) {
+        self.visit_expression(&sw.discriminant, out, nesting);
+        for case in &sw.cases {
+            self.visit_switch_case(case, out, nesting);
+        }
+    }
+
+    /// W1.2 walks the try block, handler body, and finalizer for
+    /// nested-function discovery + any universal decision points
+    /// inside them. It does NOT score `catch` itself — that's W2.1's
+    /// job (ADR (a) on cyclomatic decision-point mappings for TS).
+    fn visit_try(
+        &mut self,
+        t: &oxc::ast::ast::TryStatement<'_>,
+        out: &mut Contributors,
+        nesting: Option<u32>,
+    ) {
+        self.visit_block(&t.block.body, out, nesting);
+        if let Some(handler) = &t.handler {
+            self.visit_block(&handler.body.body, out, nesting);
+        }
+        if let Some(finalizer) = &t.finalizer {
+            self.visit_block(&finalizer.body, out, nesting);
+        }
+    }
+
+    fn visit_if(
+        &mut self,
+        if_stmt: &IfStatement<'_>,
+        out: &mut Contributors,
+        nesting: Option<u32>,
+    ) {
+        if let Some(n) = nesting {
+            out.push(contributor(
+                ContributorKind::IfBranch,
+                self.source,
+                if_stmt.span,
+                n,
+            ));
+        }
+        self.visit_expression(&if_stmt.test, out, nesting);
+        self.visit_statement(&if_stmt.consequent, out, nesting.map(|n| n + 1));
+        if let Some(alt) = &if_stmt.alternate {
+            // `else if (...)` is encoded as `alternate: IfStatement`;
+            // we descend without bumping nesting so the chain reads as
+            // a flat ladder (matches crap4rs's else-if continuation
+            // handling in `count_cognitive_else`).
+            match alt {
+                Statement::IfStatement(_) => self.visit_statement(alt, out, nesting),
+                _ => self.visit_statement(alt, out, nesting.map(|n| n + 1)),
+            }
+        }
+    }
+
+    fn visit_switch_case(
+        &mut self,
+        case: &SwitchCase<'_>,
+        out: &mut Contributors,
+        nesting: Option<u32>,
+    ) {
+        // `default:` has `test: None` — NOT a decision point, NOT
+        // counted (per `cyclomatic_walker.feature` outline row
+        // semantics: "case 1: ..." adds 1, fallthrough does not).
+        if let Some(test) = &case.test {
+            if let Some(n) = nesting {
+                out.push(contributor(
+                    ContributorKind::CaseBranch,
+                    self.source,
+                    case.span,
+                    n,
+                ));
+            }
+            self.visit_expression(test, out, nesting);
+        }
+        for s in &case.consequent {
+            self.visit_statement(s, out, nesting.map(|n| n + 1));
+        }
+    }
+
+    fn visit_for_init(
+        &mut self,
+        init: &ForStatementInit<'_>,
+        out: &mut Contributors,
+        nesting: Option<u32>,
+    ) {
+        match init {
+            ForStatementInit::VariableDeclaration(vd) => {
+                for d in &vd.declarations {
+                    if let Some(init_expr) = &d.init {
+                        self.visit_expression(init_expr, out, nesting);
+                    }
+                }
+            }
+            other => {
+                if let Some(expr) = for_init_as_expression(other) {
+                    self.visit_expression(expr, out, nesting);
+                }
+            }
+        }
+    }
+
+    fn visit_for_left(
+        &mut self,
+        _left: &ForStatementLeft<'_>,
+        _out: &mut Contributors,
+        _nesting: Option<u32>,
+    ) {
+        // The LHS of for-in / for-of is a BindingPattern or
+        // AssignmentTarget — no decision points are encoded there for
+        // W1.2's universal set.
+    }
+
+    /// Push a `ForLoop` contributor + recurse via the caller — separated
+    /// from the inline statement match purely so all three for-flavours
+    /// share one push site.
+    fn charge_for(&mut self, span: Span, out: &mut Contributors, nesting: Option<u32>) {
+        if let Some(n) = nesting {
+            out.push(contributor(ContributorKind::ForLoop, self.source, span, n));
+        }
+    }
+
+    /// Walk an expression, charging decision points + descending into
+    /// nested function expressions and arrow functions (which become
+    /// their own complexity sites). The arms here are intentionally
+    /// thin — each non-trivial recurser is its own helper so this
+    /// dispatch table stays a simple match.
+    fn visit_expression(
+        &mut self,
+        expr: &Expression<'_>,
+        out: &mut Contributors,
+        nesting: Option<u32>,
+    ) {
+        match expr {
+            // Decision-point expressions.
+            Expression::LogicalExpression(le) => self.visit_logical(le, out, nesting),
+
+            // Function-entry expressions (start a new accumulator).
+            Expression::ArrowFunctionExpression(arrow) => self.record_arrow(arrow, None),
+            Expression::FunctionExpression(func) => self.record_function(func, None),
+            Expression::ClassExpression(class) => self.visit_class(class, None),
+
+            // TS-specific expressions intentionally NOT counted in W1.2
+            // (deferred to W2.1, ADR (a)) — we still walk inner
+            // expressions for nested-function discovery and for any
+            // UNIVERSAL decision points inside them.
+            Expression::ConditionalExpression(ce) => self.visit_conditional(ce, out, nesting),
+            Expression::ChainExpression(ce) => {
+                // ChainExpression wraps a (member or call) expression
+                // chain that contains optional links. W1.2 traverses
+                // into the inner expression without scoring `?.` — the
+                // entire `?.` chain is W2.1 / ADR (a)'s scope. We
+                // recurse manually into ChainElement variants because
+                // ChainElement only inherits MemberExpression (not the
+                // full Expression set) so `as_expression()` isn't
+                // generated for it.
+                self.visit_chain_element(&ce.expression, out, nesting);
+            }
+
+            // Recursing expressions (universal — no scoring at this
+            // node, but children may contribute).
+            Expression::CallExpression(call) => {
+                self.visit_expression(&call.callee, out, nesting);
+                self.visit_arguments(&call.arguments, out, nesting);
+            }
+            Expression::NewExpression(new_expr) => {
+                self.visit_expression(&new_expr.callee, out, nesting);
+                self.visit_arguments(&new_expr.arguments, out, nesting);
+            }
+            Expression::ParenthesizedExpression(p) => {
+                self.visit_expression(&p.expression, out, nesting);
+            }
+            Expression::SequenceExpression(seq) => self.visit_each(&seq.expressions, out, nesting),
+            Expression::UnaryExpression(u) => self.visit_expression(&u.argument, out, nesting),
+            Expression::BinaryExpression(b) => {
+                self.visit_expression(&b.left, out, nesting);
+                self.visit_expression(&b.right, out, nesting);
+            }
+            Expression::AssignmentExpression(a) => {
+                self.visit_expression(&a.right, out, nesting);
+            }
+            Expression::ArrayExpression(arr) => {
+                self.visit_array_elements(&arr.elements, out, nesting);
+            }
+            Expression::ObjectExpression(obj) => self.visit_object_expression(obj, out, nesting),
+            Expression::TemplateLiteral(tl) => self.visit_each(&tl.expressions, out, nesting),
+            Expression::TaggedTemplateExpression(tt) => {
+                self.visit_expression(&tt.tag, out, nesting);
+                self.visit_each(&tt.quasi.expressions, out, nesting);
+            }
+            Expression::AwaitExpression(a) => self.visit_expression(&a.argument, out, nesting),
+            Expression::YieldExpression(y) => {
+                if let Some(arg) = &y.argument {
+                    self.visit_expression(arg, out, nesting);
+                }
+            }
+            Expression::ImportExpression(ie) => self.visit_expression(&ie.source, out, nesting),
+
+            // TS type-coercion wrappers — recurse into payload.
+            Expression::TSAsExpression(ts) => self.visit_expression(&ts.expression, out, nesting),
+            Expression::TSSatisfiesExpression(ts) => {
+                self.visit_expression(&ts.expression, out, nesting)
+            }
+            Expression::TSTypeAssertion(ts) => self.visit_expression(&ts.expression, out, nesting),
+            Expression::TSNonNullExpression(ts) => {
+                self.visit_expression(&ts.expression, out, nesting)
+            }
+            Expression::TSInstantiationExpression(ts) => {
+                self.visit_expression(&ts.expression, out, nesting)
+            }
+
+            // Member-expression family (inherited variants on
+            // `Expression` from `MemberExpression`). Treat as opaque
+            // receivers for W1.2; no decision-point scoring.
+            Expression::ComputedMemberExpression(m) => {
+                self.visit_expression(&m.object, out, nesting);
+                self.visit_expression(&m.expression, out, nesting);
+            }
+            Expression::StaticMemberExpression(m) => {
+                self.visit_expression(&m.object, out, nesting);
+            }
+            Expression::PrivateFieldExpression(m) => {
+                self.visit_expression(&m.object, out, nesting);
+            }
+
+            // Leaves + JSX (out of scope for W1.2) — no scoring, no
+            // recursion. JSX bodies get full coverage in W2.1.
+            _ => {}
+        }
+    }
+
+    /// Visit a `ConditionalExpression` — `?:` is NOT scored in W1.2
+    /// (W2.1 / ADR (a)) but the test/consequent/alternate may contain
+    /// universal decision points and nested functions.
+    fn visit_conditional(
+        &mut self,
+        ce: &oxc::ast::ast::ConditionalExpression<'_>,
+        out: &mut Contributors,
+        nesting: Option<u32>,
+    ) {
+        self.visit_expression(&ce.test, out, nesting);
+        self.visit_expression(&ce.consequent, out, nesting);
+        self.visit_expression(&ce.alternate, out, nesting);
+    }
+
+    fn visit_arguments(
+        &mut self,
+        args: &[oxc::ast::ast::Argument<'_>],
+        out: &mut Contributors,
+        nesting: Option<u32>,
+    ) {
+        for arg in args {
+            if let Some(e) = argument_as_expression(arg) {
+                self.visit_expression(e, out, nesting);
+            }
+        }
+    }
+
+    fn visit_array_elements(
+        &mut self,
+        elements: &[oxc::ast::ast::ArrayExpressionElement<'_>],
+        out: &mut Contributors,
+        nesting: Option<u32>,
+    ) {
+        for element in elements {
+            if let Some(e) = array_element_as_expression(element) {
+                self.visit_expression(e, out, nesting);
+            }
+        }
+    }
+
+    fn visit_each(
+        &mut self,
+        exprs: &[Expression<'_>],
+        out: &mut Contributors,
+        nesting: Option<u32>,
+    ) {
+        for e in exprs {
+            self.visit_expression(e, out, nesting);
+        }
+    }
+
+    fn visit_logical(
+        &mut self,
+        le: &LogicalExpression<'_>,
+        out: &mut Contributors,
+        nesting: Option<u32>,
+    ) {
+        // W1.2 counts `&&` and `||` but NOT `??` (Coalesce) — that
+        // lands in W2.1 with ADR (a).
+        match le.operator {
+            LogicalOperator::And | LogicalOperator::Or => {
+                if let Some(n) = nesting {
+                    out.push(contributor(
+                        ContributorKind::LogicalOperator,
+                        self.source,
+                        le.span,
+                        n,
+                    ));
+                }
+            }
+            LogicalOperator::Coalesce => {}
+        }
+        self.visit_expression(&le.left, out, nesting);
+        self.visit_expression(&le.right, out, nesting);
+    }
+
+    /// Walk a `ChainElement` — the inner of a `ChainExpression`. The
+    /// enum inherits from `MemberExpression`, so it has 5 variants in
+    /// oxc 0.129: `CallExpression`, `TSNonNullExpression`, and three
+    /// inherited member-expression variants. Each is descended for
+    /// nested-function / universal-decision-point discovery.
+    fn visit_chain_element(
+        &mut self,
+        ce: &oxc::ast::ast::ChainElement<'_>,
+        out: &mut Contributors,
+        nesting: Option<u32>,
+    ) {
+        use oxc::ast::ast::ChainElement;
+        match ce {
+            ChainElement::CallExpression(call) => {
+                self.visit_expression(&call.callee, out, nesting);
+                for arg in &call.arguments {
+                    if let Some(e) = argument_as_expression(arg) {
+                        self.visit_expression(e, out, nesting);
+                    }
+                }
+            }
+            ChainElement::TSNonNullExpression(ts) => {
+                self.visit_expression(&ts.expression, out, nesting);
+            }
+            ChainElement::ComputedMemberExpression(m) => {
+                self.visit_expression(&m.object, out, nesting);
+                self.visit_expression(&m.expression, out, nesting);
+            }
+            ChainElement::StaticMemberExpression(m) => {
+                self.visit_expression(&m.object, out, nesting);
+            }
+            ChainElement::PrivateFieldExpression(m) => {
+                self.visit_expression(&m.object, out, nesting);
+            }
+        }
+    }
+
+    fn visit_object_expression(
+        &mut self,
+        obj: &ObjectExpression<'_>,
+        out: &mut Contributors,
+        nesting: Option<u32>,
+    ) {
+        for prop in &obj.properties {
+            match prop {
+                ObjectPropertyKind::ObjectProperty(p) => {
+                    self.visit_expression(&p.value, out, nesting);
+                }
+                ObjectPropertyKind::SpreadProperty(s) => {
+                    self.visit_expression(&s.argument, out, nesting);
+                }
+            }
+        }
+    }
+}
+
+// ── Contributor accumulator ─────────────────────────────────────────────
+
+/// Per-function contributor accumulator. `count` is the running
+/// decision-point increment sum (used to compute `complexity = 1 +
+/// count`); `list` is the materialised contributor entries that ship
+/// in `FunctionComplexity.contributors`.
+#[derive(Default)]
+struct Contributors {
+    list: Vec<ComplexityContributor>,
+    count: u32,
+}
+
+impl Contributors {
+    fn push(&mut self, c: ComplexityContributor) {
+        self.count += c.increment;
+        self.list.push(c);
+    }
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+fn contributor(
+    kind: ContributorKind,
+    source: &str,
+    span: Span,
+    nesting: u32,
+) -> ComplexityContributor {
+    let (line, column) = byte_to_line_col(source, span.start);
+    let end_line = byte_to_line(source, span.end.saturating_sub(1));
+    ComplexityContributor::new(kind, line, Some(column), 1, end_line, nesting)
+}
+
+fn source_span(source: &str, span: Span) -> SourceSpan {
+    let (start_line, start_col) = byte_to_line_col(source, span.start);
+    let (end_line, end_col) = byte_to_line_col(source, span.end.saturating_sub(1));
+    SourceSpan::new(start_line, end_line, start_col as usize, end_col as usize)
+}
+
+/// Convert a UTF-8 byte offset to a 1-based line number. Clamps
+/// offsets past EOF to the source length so synthetic spans (e.g.
+/// `span.end.saturating_sub(1)` on a zero-length span at offset 0)
+/// never panic.
+fn byte_to_line(source: &str, byte: u32) -> usize {
+    let limit = (byte as usize).min(source.len());
+    source.as_bytes()[..limit]
+        .iter()
+        .filter(|&&b| b == b'\n')
+        .count()
+        + 1
+}
+
+/// Convert a UTF-8 byte offset to a (1-based line, 1-based column)
+/// pair. Columns count UTF-8 *code units* (bytes), aligning with how
+/// oxc spans are emitted (the same convention oxc uses for diagnostic
+/// label positions). `byte_to_line` is reused for the line count so
+/// the two helpers stay self-consistent on EOF clamp behaviour.
+fn byte_to_line_col(source: &str, byte: u32) -> (usize, u32) {
+    let limit = (byte as usize).min(source.len());
+    let line = byte_to_line(source, byte);
+    let prefix = &source[..limit];
+    let line_start = prefix.rfind('\n').map(|i| i + 1).unwrap_or(0);
+    let column = (limit - line_start) as u32 + 1;
+    (line, column)
+}
+
+/// Extract the simple binding name from a declarator's pattern.
+/// Object / array / assignment patterns return `None` — destructuring
+/// is uncommon for top-level function-binding declarators, and the
+/// W1.2 walker prefers `<arrow>` / `<anonymous>` sentinels over
+/// inventing a synthetic name for `const {a, b} = ...` shapes.
+fn binding_name(pattern: &BindingPattern<'_>) -> Option<String> {
+    match pattern {
+        BindingPattern::BindingIdentifier(bi) => Some(bi.name.as_str().to_string()),
+        _ => None,
+    }
+}
+
+/// Extract a string name from a property key for class-method
+/// qualification. `[computed]` keys fall back to `None` so callers
+/// substitute a sentinel name.
+fn property_key_name(key: &PropertyKey<'_>) -> Option<String> {
+    match key {
+        PropertyKey::StaticIdentifier(id) => Some(id.name.as_str().to_string()),
+        PropertyKey::PrivateIdentifier(id) => Some(format!("#{}", id.name.as_str())),
+        PropertyKey::StringLiteral(s) => Some(s.value.to_string()),
+        PropertyKey::NumericLiteral(n) => Some(n.value.to_string()),
+        _ => None,
+    }
+}
+
+/// Treat an `ExportDefaultDeclarationKind` as `Expression` when
+/// possible. Declaration variants (function/class/TS interface) are
+/// routed through bespoke arms in the caller and return `None` here.
+fn export_default_as_expression<'b>(
+    kind: &'b oxc::ast::ast::ExportDefaultDeclarationKind<'b>,
+) -> Option<&'b Expression<'b>> {
+    use oxc::ast::ast::ExportDefaultDeclarationKind as K;
+    match kind {
+        K::FunctionDeclaration(_) | K::ClassDeclaration(_) | K::TSInterfaceDeclaration(_) => None,
+        // The remaining variants `@inherit Expression`; `as_expression`
+        // is generated by `inherit_variants!` to perform the typed
+        // downcast back to `&Expression`.
+        other => other.as_expression(),
+    }
+}
+
+/// Treat `Argument` as `Expression` when possible (Argument inherits
+/// from Expression plus a `SpreadElement` variant).
+fn argument_as_expression<'b>(arg: &'b oxc::ast::ast::Argument<'b>) -> Option<&'b Expression<'b>> {
+    arg.as_expression()
+}
+
+/// Treat `ArrayExpressionElement` as `Expression` when possible.
+fn array_element_as_expression<'b>(
+    el: &'b oxc::ast::ast::ArrayExpressionElement<'b>,
+) -> Option<&'b Expression<'b>> {
+    el.as_expression()
+}
+
+/// Treat `ForStatementInit` as `Expression` when possible (the
+/// non-`VariableDeclaration` variants inherit from Expression).
+fn for_init_as_expression<'b>(init: &'b ForStatementInit<'b>) -> Option<&'b Expression<'b>> {
+    init.as_expression()
 }
 
 #[cfg(test)]
@@ -50,12 +963,5 @@ mod tests {
     fn oxc_walker_constructible() {
         let _w = OxcWalker::new();
         let _w2 = OxcWalker::default();
-    }
-
-    #[test]
-    #[should_panic(expected = "oxc walker lands in the typescript-adapter follow-up pipeline")]
-    fn oxc_walker_extract_unimplemented() {
-        let w = OxcWalker::new();
-        let _ = w.extract("", "stub.ts", ComplexityMetric::Cognitive);
     }
 }

--- a/crates/crap4ts/src/adapters/walker/mod.rs
+++ b/crates/crap4ts/src/adapters/walker/mod.rs
@@ -887,10 +887,14 @@ fn byte_to_line(source: &str, byte: u32) -> usize {
 /// label positions). `byte_to_line` is reused for the line count so
 /// the two helpers stay self-consistent on EOF clamp behaviour.
 fn byte_to_line_col(source: &str, byte: u32) -> (usize, u32) {
-    let limit = (byte as usize).min(source.len());
+    let bytes = source.as_bytes();
+    let limit = (byte as usize).min(bytes.len());
     let line = byte_to_line(source, byte);
-    let prefix = &source[..limit];
-    let line_start = prefix.rfind('\n').map(|i| i + 1).unwrap_or(0);
+    let line_start = bytes[..limit]
+        .iter()
+        .rposition(|&b| b == b'\n')
+        .map(|i| i + 1)
+        .unwrap_or(0);
     let column = (limit - line_start) as u32 + 1;
     (line, column)
 }

--- a/crates/crap4ts/tests/fixtures/ts-fixtures/broken.ts
+++ b/crates/crap4ts/tests/fixtures/ts-fixtures/broken.ts
@@ -1,0 +1,9 @@
+// W1.2 parse-failure fixture: deliberately malformed TS to trigger
+// `Err(CrapError::SourceParse)`. The orchestrator at
+// crap-core/src/core/mod.rs:286-310 catches this and increments
+// AnalysisDiagnostics.files_unparseable so the run continues.
+//
+// Multiple unclosed brace levels make this irrecoverable for the
+// oxc parser, so `ret.errors` is guaranteed non-empty (a single
+// `function foo(` could recover via tail-of-file synthesis).
+function foo(x: number {{{

--- a/crates/crap4ts/tests/fixtures/ts-fixtures/forloop.ts
+++ b/crates/crap4ts/tests/fixtures/ts-fixtures/forloop.ts
@@ -1,0 +1,27 @@
+// W1.2 ForLoop fixture: each of the three for-statement flavours in
+// its own top-level function. Each function should score cyclomatic=2
+// with exactly one `for-loop` contributor — the walker treats
+// ForStatement, ForOfStatement, and ForInStatement uniformly.
+export function sumIndices(n: number): number {
+  let total = 0;
+  for (let i = 0; i < n; i++) {
+    total += i;
+  }
+  return total;
+}
+
+export function sumValues(xs: number[]): number {
+  let total = 0;
+  for (const x of xs) {
+    total += x;
+  }
+  return total;
+}
+
+export function sumKeys(obj: Record<string, number>): number {
+  let total = 0;
+  for (const k in obj) {
+    total += obj[k];
+  }
+  return total;
+}

--- a/crates/crap4ts/tests/fixtures/ts-fixtures/ifbranch.ts
+++ b/crates/crap4ts/tests/fixtures/ts-fixtures/ifbranch.ts
@@ -1,0 +1,7 @@
+// W1.2 IfBranch fixture: one if/else, one decision point.
+export function classify(x: number): string {
+  if (x < 0) {
+    return "neg";
+  }
+  return "non-neg";
+}

--- a/crates/crap4ts/tests/fixtures/ts-fixtures/logical.ts
+++ b/crates/crap4ts/tests/fixtures/ts-fixtures/logical.ts
@@ -1,0 +1,11 @@
+// W1.2 LogicalOperator fixture: one function exercising `&&`, one
+// exercising `||`. Each scores cyclomatic=2 with exactly one
+// `logical-operator` contributor. `??` (nullish-coalescing) is
+// intentionally absent — that's W2.1's job.
+export function bothTruthy(a: boolean, b: boolean): boolean {
+  return a && b;
+}
+
+export function eitherTruthy(a: boolean, b: boolean): boolean {
+  return a || b;
+}

--- a/crates/crap4ts/tests/fixtures/ts-fixtures/nested.ts
+++ b/crates/crap4ts/tests/fixtures/ts-fixtures/nested.ts
@@ -1,0 +1,20 @@
+// W1.2 nested-function fixture: per CQO BDD audit + W1.2 advisor
+// guidance, this uses two NAMED function declarations (no arrow,
+// no ternary — those are W2.1 territory). The outer function's
+// decision points must NOT bleed into the inner function's score
+// and vice versa: each function is its own complexity site.
+//
+// Expected: outer scores cyclomatic=2 (one IfBranch) and inner
+// scores cyclomatic=2 (one IfBranch).
+export function outer(x: number): string {
+  function inner(y: number): string {
+    if (y > 0) {
+      return "pos";
+    }
+    return "non-pos";
+  }
+  if (x > 0) {
+    return inner(x);
+  }
+  return "outer-non-pos";
+}

--- a/crates/crap4ts/tests/fixtures/ts-fixtures/switch.ts
+++ b/crates/crap4ts/tests/fixtures/ts-fixtures/switch.ts
@@ -1,0 +1,13 @@
+// W1.2 Switch fixture: one switch with a single case. Per
+// `cyclomatic_walker.feature` outline row "switch (x) { case 1: ... }",
+// this should score cyclomatic=2 with exactly one `case-branch`
+// contributor (the `default:` arm is NOT counted — it's not a decision
+// point, it's the fallthrough).
+export function describe(x: number): string {
+  switch (x) {
+    case 1:
+      return "one";
+    default:
+      return "other";
+  }
+}

--- a/crates/crap4ts/tests/fixtures/ts-fixtures/whileloop.ts
+++ b/crates/crap4ts/tests/fixtures/ts-fixtures/whileloop.ts
@@ -1,0 +1,20 @@
+// W1.2 WhileLoop + DoWhileLoop fixture: one of each in its own
+// top-level function. Each scores cyclomatic=2 with exactly one
+// `while-loop` or `do-while-loop` contributor respectively.
+export function countDown(n: number): number {
+  let count = 0;
+  while (n > 0) {
+    n -= 1;
+    count += 1;
+  }
+  return count;
+}
+
+export function countUpAtLeastOnce(n: number): number {
+  let count = 0;
+  do {
+    count += 1;
+    n -= 1;
+  } while (n > 0);
+  return count;
+}

--- a/crates/crap4ts/tests/walker_smoke.rs
+++ b/crates/crap4ts/tests/walker_smoke.rs
@@ -229,6 +229,25 @@ fn nested_functions_are_separate_complexity_sites() {
 
 // ── Parse failure: malformed TS bubbles up as SourceParse ───────────────
 
+// ── Panic-safety: multi-byte UTF-8 spans don't crash byte_to_line_col ──
+
+#[test]
+fn unicode_identifiers_do_not_panic_in_span_to_column_conversion() {
+    // Regression: prior to using a byte-based scan, `byte_to_line_col`
+    // sliced `&source[..limit]` where `limit = span.end - 1` could land
+    // inside a multi-byte UTF-8 character (e.g., the trailing byte of
+    // an identifier containing non-ASCII letters), panicking with
+    // "byte index N is not a char boundary".
+    let source = "function π(αβγ: number) {\n  if (αβγ > 0) return αβγ;\n  return 0;\n}\n";
+    let fns = extract(source, "unicode.ts");
+    assert_eq!(fns.len(), 1, "expected one function in unicode.ts");
+    let f = &fns[0];
+    assert_eq!(f.identity.qualified_name, "π");
+    assert_eq!(f.complexity, 2, "if-branch contributes one decision point");
+    assert_eq!(f.contributors.len(), 1);
+    assert_eq!(f.contributors[0].kind, ContributorKind::IfBranch);
+}
+
 #[test]
 fn malformed_typescript_returns_source_parse_with_file_prefix() {
     let walker = OxcWalker::new();

--- a/crates/crap4ts/tests/walker_smoke.rs
+++ b/crates/crap4ts/tests/walker_smoke.rs
@@ -1,0 +1,251 @@
+//! Direct smoke tests for `OxcWalker`.
+//!
+//! Mirrors `istanbul_smoke.rs` in spirit — exercises the walker at the
+//! unit level (no orchestrator, no CLI). The `cyclomatic_walker.feature`
+//! contracts at `tests/features/cyclomatic_walker.feature` stay
+//! `@unwired` until W3.3 attaches cucumber-rs harnesses; these smoke
+//! tests ground-truth the same contracts directly so the W1.2 walker
+//! lands with executable verification of every acceptance criterion.
+//!
+//! Each test asserts:
+//! - exact cyclomatic complexity (decision-point count + 1)
+//! - exact contributor kinds at expected line numbers
+//! - exact contributor count (no double-counting, no skipping)
+//!
+//! Parse-failure tests assert `Err(CrapError::SourceParse(_))` with the
+//! `"file/path.ts: "` prefix the orchestrator's
+//! `extract_complexities` (`crap-core/src/core/mod.rs:286-310`) consumes
+//! to emit `warning: skipping <file>: <error>` and increment
+//! `AnalysisDiagnostics.files_unparseable`.
+
+use crap_core::domain::types::{ComplexityMetric, ContributorKind, CrapError, FunctionComplexity};
+use crap_core::ports::ComplexityPort;
+use crap4ts::adapters::walker::OxcWalker;
+
+const SIMPLE_TS: &str = include_str!("fixtures/ts-fixtures/simple.ts");
+const IFBRANCH_TS: &str = include_str!("fixtures/ts-fixtures/ifbranch.ts");
+const FORLOOP_TS: &str = include_str!("fixtures/ts-fixtures/forloop.ts");
+const WHILELOOP_TS: &str = include_str!("fixtures/ts-fixtures/whileloop.ts");
+const SWITCH_TS: &str = include_str!("fixtures/ts-fixtures/switch.ts");
+const LOGICAL_TS: &str = include_str!("fixtures/ts-fixtures/logical.ts");
+const NESTED_TS: &str = include_str!("fixtures/ts-fixtures/nested.ts");
+const BROKEN_TS: &str = include_str!("fixtures/ts-fixtures/broken.ts");
+
+fn extract(source: &str, file_path: &str) -> Vec<FunctionComplexity> {
+    let walker = OxcWalker::new();
+    walker
+        .extract(source, file_path, ComplexityMetric::Cyclomatic)
+        .unwrap_or_else(|e| panic!("expected Ok for fixture {file_path}, got Err: {e}"))
+}
+
+fn find_fn<'a>(fns: &'a [FunctionComplexity], name: &str) -> &'a FunctionComplexity {
+    fns.iter()
+        .find(|f| f.identity.qualified_name == name)
+        .unwrap_or_else(|| {
+            let names: Vec<_> = fns.iter().map(|f| &f.identity.qualified_name).collect();
+            panic!("function `{name}` not found in walker output; got: {names:?}")
+        })
+}
+
+// ── Simple: no decision points ──────────────────────────────────────────
+
+#[test]
+fn simple_function_scores_cyclomatic_one_with_no_contributors() {
+    let fns = extract(SIMPLE_TS, "simple.ts");
+    assert_eq!(fns.len(), 1, "expected one function in simple.ts");
+    let f = &fns[0];
+    assert_eq!(f.identity.qualified_name, "add");
+    assert_eq!(
+        f.complexity, 1,
+        "base complexity is 1 for a function with no decision points"
+    );
+    assert_eq!(f.metric, ComplexityMetric::Cyclomatic);
+    assert!(
+        f.contributors.is_empty(),
+        "expected no contributors for a function with no decision points; got {:?}",
+        f.contributors
+    );
+}
+
+// ── IfBranch ────────────────────────────────────────────────────────────
+
+#[test]
+fn if_branch_contributes_one_decision_point() {
+    let fns = extract(IFBRANCH_TS, "ifbranch.ts");
+    let f = find_fn(&fns, "classify");
+    assert_eq!(f.complexity, 2, "if/else adds one decision point");
+    assert_eq!(f.contributors.len(), 1);
+    let c = &f.contributors[0];
+    assert_eq!(c.kind, ContributorKind::IfBranch);
+    assert_eq!(
+        c.increment, 1,
+        "cyclomatic contributor increments are always 1"
+    );
+    // The `if` keyword lives on line 3 of the fixture (1-based).
+    assert_eq!(
+        c.line, 3,
+        "contributor should point at the `if` keyword's line"
+    );
+}
+
+// ── ForLoop (all three flavours) ────────────────────────────────────────
+
+#[test]
+fn classic_for_statement_contributes_one_for_loop() {
+    let fns = extract(FORLOOP_TS, "forloop.ts");
+    let f = find_fn(&fns, "sumIndices");
+    assert_eq!(f.complexity, 2);
+    assert_eq!(f.contributors.len(), 1);
+    assert_eq!(f.contributors[0].kind, ContributorKind::ForLoop);
+}
+
+#[test]
+fn for_of_statement_contributes_one_for_loop() {
+    let fns = extract(FORLOOP_TS, "forloop.ts");
+    let f = find_fn(&fns, "sumValues");
+    assert_eq!(f.complexity, 2);
+    assert_eq!(f.contributors.len(), 1);
+    assert_eq!(f.contributors[0].kind, ContributorKind::ForLoop);
+}
+
+#[test]
+fn for_in_statement_contributes_one_for_loop() {
+    let fns = extract(FORLOOP_TS, "forloop.ts");
+    let f = find_fn(&fns, "sumKeys");
+    assert_eq!(f.complexity, 2);
+    assert_eq!(f.contributors.len(), 1);
+    assert_eq!(f.contributors[0].kind, ContributorKind::ForLoop);
+}
+
+// ── WhileLoop + DoWhileLoop ─────────────────────────────────────────────
+
+#[test]
+fn while_statement_contributes_one_while_loop() {
+    let fns = extract(WHILELOOP_TS, "whileloop.ts");
+    let f = find_fn(&fns, "countDown");
+    assert_eq!(f.complexity, 2);
+    assert_eq!(f.contributors.len(), 1);
+    assert_eq!(f.contributors[0].kind, ContributorKind::WhileLoop);
+}
+
+#[test]
+fn do_while_statement_contributes_one_do_while_loop() {
+    let fns = extract(WHILELOOP_TS, "whileloop.ts");
+    let f = find_fn(&fns, "countUpAtLeastOnce");
+    assert_eq!(f.complexity, 2);
+    assert_eq!(f.contributors.len(), 1);
+    assert_eq!(f.contributors[0].kind, ContributorKind::DoWhileLoop);
+}
+
+// ── SwitchStatement: one case = one decision point ──────────────────────
+
+#[test]
+fn switch_case_contributes_one_case_branch_excluding_default() {
+    let fns = extract(SWITCH_TS, "switch.ts");
+    let f = find_fn(&fns, "describe");
+    // `case 1:` adds 1; `default:` does not (no decision — it's the
+    // fallthrough). Total = 1 + 1 = 2.
+    assert_eq!(f.complexity, 2);
+    let case_branches: Vec<_> = f
+        .contributors
+        .iter()
+        .filter(|c| c.kind == ContributorKind::CaseBranch)
+        .collect();
+    assert_eq!(
+        case_branches.len(),
+        1,
+        "expected exactly one case-branch contributor (default: is not counted); got contributors: {:?}",
+        f.contributors
+    );
+    assert_eq!(f.contributors.len(), 1, "default: should NOT be counted");
+}
+
+// ── LogicalOperator: && and || only, NOT ?? ─────────────────────────────
+
+#[test]
+fn logical_and_contributes_one_logical_operator() {
+    let fns = extract(LOGICAL_TS, "logical.ts");
+    let f = find_fn(&fns, "bothTruthy");
+    assert_eq!(f.complexity, 2);
+    assert_eq!(f.contributors.len(), 1);
+    assert_eq!(f.contributors[0].kind, ContributorKind::LogicalOperator);
+}
+
+#[test]
+fn logical_or_contributes_one_logical_operator() {
+    let fns = extract(LOGICAL_TS, "logical.ts");
+    let f = find_fn(&fns, "eitherTruthy");
+    assert_eq!(f.complexity, 2);
+    assert_eq!(f.contributors.len(), 1);
+    assert_eq!(f.contributors[0].kind, ContributorKind::LogicalOperator);
+}
+
+// ── Nested functions: each is its own complexity site ───────────────────
+
+#[test]
+fn nested_functions_are_separate_complexity_sites() {
+    let fns = extract(NESTED_TS, "nested.ts");
+    // Expect exactly two function entries: `outer` and `inner` (inner
+    // is `function inner` declared inside `outer`).
+    let names: Vec<_> = fns
+        .iter()
+        .map(|f| f.identity.qualified_name.clone())
+        .collect();
+    assert_eq!(
+        fns.len(),
+        2,
+        "expected outer + inner = 2 functions; got names: {names:?}"
+    );
+
+    let outer = find_fn(&fns, "outer");
+    let inner = find_fn(&fns, "inner");
+
+    // Outer has exactly one `if (x > 0)` decision point — inner's
+    // decision points must NOT bleed into outer.
+    assert_eq!(outer.complexity, 2, "outer should be 1 + 1 (one if-branch)");
+    let outer_ifs = outer
+        .contributors
+        .iter()
+        .filter(|c| c.kind == ContributorKind::IfBranch)
+        .count();
+    assert_eq!(
+        outer_ifs, 1,
+        "outer should have exactly one if-branch contributor"
+    );
+
+    // Inner has exactly one `if (y > 0)` decision point — outer's
+    // decision points must NOT bleed into inner.
+    assert_eq!(inner.complexity, 2, "inner should be 1 + 1 (one if-branch)");
+    let inner_ifs = inner
+        .contributors
+        .iter()
+        .filter(|c| c.kind == ContributorKind::IfBranch)
+        .count();
+    assert_eq!(
+        inner_ifs, 1,
+        "inner should have exactly one if-branch contributor"
+    );
+}
+
+// ── Parse failure: malformed TS bubbles up as SourceParse ───────────────
+
+#[test]
+fn malformed_typescript_returns_source_parse_with_file_prefix() {
+    let walker = OxcWalker::new();
+    let err = walker
+        .extract(BROKEN_TS, "broken.ts", ComplexityMetric::Cyclomatic)
+        .expect_err("expected parse-failure for malformed fixture");
+    match err {
+        CrapError::SourceParse(msg) => {
+            assert!(
+                msg.starts_with("broken.ts: "),
+                "expected `<file_path>: ` prefix per crap4rs syn-walker convention, got: {msg:?}"
+            );
+            assert!(
+                !msg.trim_end_matches('\n').ends_with(':'),
+                "expected the underlying oxc error message to be appended, got: {msg:?}"
+            );
+        }
+        other => panic!("expected CrapError::SourceParse, got: {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary

Replace `OxcWalker.extract`'s `unimplemented!()` body with a real oxc-based AST visitor that emits one `FunctionComplexity` per function declaration / function expression / arrow function / class method. The walker counts the six universal cyclomatic decision points (`if`, `for` / `for-of` / `for-in`, `while`, `do-while`, `switch case`, `&&` / `||`) into existing `ContributorKind` variants — no new enum variants land. TS-specific decision points (`?:`, `?.`, `??`, `catch`, JSX) are intentionally deferred to W2.1 / ADR (a) per the hard circuit breaker; the walker traverses past them without emitting contributors. Parse failures bubble up as `Err(CrapError::SourceParse("file_path: <oxc msg>"))` so the orchestrator at `crap-core/src/core/mod.rs:286-310` can continue past a malformed file and increment `AnalysisDiagnostics.files_unparseable`.

Self-CRAP on `crates/crap4ts/src/` worst-CC dropped from 44 (monolithic `visit_statement`) to 9 (`visit_for_init`) by splitting per-construct helpers in the syn-walker pattern — file weight is now comparable to `crap4rs::adapters::complexity` (`parse_brda` CC=11 is the workspace baseline). 12 `walker_smoke.rs` tests ground-truth every BDD-feature contract for W1.2 scope at the unit level (cucumber harness lands in W3.3).

## Acceptance gates

- [x] `cargo build --workspace`
- [x] `cargo nextest run --workspace --all-targets -E 'binary(walker_smoke)'` — 12 tests green
- [x] `cargo nextest run --workspace --all-targets` — 983 / 983 (was 972 / 972 pre-W1.2; +11 net = +12 new walker_smoke − 1 removed `#[should_panic]`)
- [x] `cargo +1.93 check --workspace --all-targets`
- [x] `cargo fmt --check && cargo clippy --workspace --all-targets -- -D warnings`
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps`
- [x] `cargo deny check`
- [x] AST-purity on `crap-core/src/` clean (no `oxc` / `syn` / `tree_sitter` / `swc` imports)
- [x] Wire snapshot byte-identical (`wire_envelope_snapshot::envelope` PASS)
- [x] `#[should_panic]` `oxc_walker_extract_unimplemented` test removed
- [x] oxc pinned at workspace `0.129` (no breaking API shifts; one secondary-source correction surfaced — see below)

## oxc API verification (Context7)

Verified against `oxc-project/oxc` (Context7 library id `/oxc-project/oxc`, oxc 0.129 source in cargo registry). The umbrella `oxc` crate re-exports `oxc_allocator`, `oxc_ast`, `oxc_parser`, `oxc_span`, `oxc_syntax`; the trait `Visit` lives behind a feature flag (`oxc/ast_visit`), which is NOT enabled in our workspace. We use manual recursion per the plan-of-record, matching the syn-walker shape.

**Confirmed API surface (no drift from training data):**
- `oxc::allocator::Allocator::default()`
- `oxc::parser::Parser::new(&alloc, source, source_type).parse() -> ParserReturn` with `ParserReturn.errors: Vec<OxcDiagnostic>` and `OxcDiagnostic: Display` writing the message
- `oxc::span::SourceType::from_path(P: AsRef<Path>) -> Result<Self, UnknownExtension>` (used; CEng ADVISORY-3 was correct to predict this — W2.2's dispatch becomes a near-no-op)
- `oxc::span::SourceType::ts()` (fallback for unrecognised extensions)
- `Statement::{If, For, ForIn, ForOf, While, DoWhile, Switch}Statement` — variant names match the plan
- `Expression::LogicalExpression` with `oxc::syntax::operator::LogicalOperator::{And, Or, Coalesce}` — matches the plan
- `SwitchCase { test: Option<Expression>, consequent: Vec<Statement> }` — `default:` arm has `test: None` (NOT scored, per the BDD outline row semantics)

**Drift correction (surfaced during implementation):** the W1.2 prompt and impl-plan §W1.2 both claim oxc `Span { start, end }` is inclusive on both ends and that the walker should add `+1` to `end_line` at the domain boundary. Primary sources contradict:
- `oxc_span/src/span.rs` doc-comment: `start` is the zero-based start; `end` is the zero-based end position (exclusive — empty span has `start == end`).
- `oxc_span/README.md` (Context7-fetched): "spans defined as inclusive of the start position and exclusive of the end position".
- `crap-core::domain::types::SourceSpan` (line 8): `end_line` is 1-based **inclusive**.
- `crap4rs::adapters::complexity::span_of` uses `sp.end().line` directly with NO `+1`.

Correct conversion is therefore `end_line = byte_to_line(source, span.end.saturating_sub(1))` — the 1-based line of the LAST BYTE in the span. The walker uses this convention. Recorded in `ops/workspace/crap-rs/20260513-typescript-adapter/observations.md` as a plan-of-record pin.

## Test plan

`crates/crap4ts/tests/walker_smoke.rs` (12 tests, all `binary(walker_smoke)`-matchable):

- **Baseline** (`simple.ts` — W1.1 fixture reused per CQO ADVISORY-8):
  - `simple_function_scores_cyclomatic_one_with_no_contributors` — CC=1, zero contributors, metric label preserved
- **Six universal decision points** (one fixture per construct family):
  - `if_branch_contributes_one_decision_point` — `IfBranch` at expected line
  - `classic_for_statement_contributes_one_for_loop` / `for_of_statement_contributes_one_for_loop` / `for_in_statement_contributes_one_for_loop` — all three for-flavours collapse to `ForLoop`
  - `while_statement_contributes_one_while_loop` / `do_while_statement_contributes_one_do_while_loop`
  - `switch_case_contributes_one_case_branch_excluding_default` — `case 1:` counts, `default:` does NOT
  - `logical_and_contributes_one_logical_operator` / `logical_or_contributes_one_logical_operator` — `&&` and `||` only (NOT `??`)
- **Function discovery**:
  - `nested_functions_are_separate_complexity_sites` — `outer`'s `if` does NOT leak into `inner`'s score, and vice versa
- **Parse-failure path**:
  - `malformed_typescript_returns_source_parse_with_file_prefix` — `Err(CrapError::SourceParse("broken.ts: <oxc msg>"))`, orchestrator-compatible

7 new `.ts` fixtures land under `crates/crap4ts/tests/fixtures/ts-fixtures/`; `simple.ts` is reused from W1.1.

## Wire-shape canary

**Byte-identical.** Adapter-only changes; no domain or `crap-core` source touched. `wire_envelope_snapshot::envelope` re-passes against the pre-W1.1-merge snapshot.

## Plan deviations (W1.1 discipline — surface, don't silently reinterpret)

1. **Filter expression in acceptance gates:** the W1.2 prompt and impl-plan §W1.2 both spec `cargo nextest run --workspace --all-targets -E 'test(walker_smoke)'`. Empirically, nextest's `test()` filter matches by test-name substring (so it matched zero tests because no individual `#[test]` is named `walker_smoke_*`). The correct filter is `binary(walker_smoke)`, which matches integration-test binaries. Same class of plan-of-record drift as W1.1's "aggregated-fixture" delegation prompt — flagging here per the rule established in W1.1's PR.
2. **Span semantics +1 correction** — see "oxc API verification" above.
3. **Self-CRAP refactor surfaced during implementation:** the first pass of `visit_statement` was a monolithic CC=44 cognitive match. Refactored into per-construct helpers (`visit_for`, `visit_while`, `visit_do_while`, `visit_switch`, `visit_try`, plus expression-side `visit_conditional` / `visit_arguments` / `visit_array_elements` / `visit_each`) before commit; worst walker function is now CC=9 (`visit_for_init`), comparable to the syn walker's CC=11 (`parse_brda`). Not a plan deviation per se — the plan said "manual recursion" without specifying decomposition depth — but worth noting as a self-CRAP win.

Closes #182

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented a complete TypeScript complexity analysis engine that measures cyclomatic complexity across control flow structures.
  * Added support for analyzing functions, loops, conditionals, switches, and logical operators.
  * Implemented error handling for malformed code with detailed parse error reporting.

* **Tests**
  * Added comprehensive test fixtures and smoke tests covering various code patterns and complexity scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/breezy-bays-labs/crap-rs/pull/198)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->