### PR TITLE
test(crap-core): #183 — dual wire-envelope snapshots (crap4rs rename + crap4ts new) + end-to-end smoke + insta pre-push gate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,6 +411,7 @@ dependencies = [
 name = "crap4ts"
 version = "2.0.0-alpha.1"
 dependencies = [
+ "assert_cmd",
  "crap-core",
  "napi",
  "napi-build",

--- a/crates/crap-core/tests/snapshots/wire_envelope_crap4rs__envelope.snap
+++ b/crates/crap-core/tests/snapshots/wire_envelope_crap4rs__envelope.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/crap-core/tests/wire_envelope_snapshot.rs
+source: crates/crap-core/tests/wire_envelope_crap4rs.rs
 expression: pretty
 ---
 {

--- a/crates/crap-core/tests/snapshots/wire_envelope_crap4ts__envelope.snap
+++ b/crates/crap-core/tests/snapshots/wire_envelope_crap4ts__envelope.snap
@@ -1,0 +1,580 @@
+---
+source: crates/crap-core/tests/wire_envelope_crap4ts.rs
+expression: pretty
+---
+{
+  "diff_ref": null,
+  "language": "rust",
+  "metric": "cognitive",
+  "result": {
+    "functions": [
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "Button.tsx",
+            "qualified_name": "<arrow>",
+            "span": {
+              "end_column": 49,
+              "end_line": 3,
+              "start_column": 30,
+              "start_line": 3
+            }
+          }
+        },
+        "threshold": 16.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "Button.tsx",
+            "qualified_name": "Button",
+            "span": {
+              "end_column": 1,
+              "end_line": 5,
+              "start_column": 8,
+              "start_line": 2
+            }
+          }
+        },
+        "threshold": 16.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "arrow.ts",
+            "qualified_name": "square",
+            "span": {
+              "end_column": 42,
+              "end_line": 1,
+              "start_column": 23,
+              "start_line": 1
+            }
+          }
+        },
+        "threshold": 16.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 50.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.13
+          },
+          "identity": {
+            "file_path": "arrow.ts",
+            "qualified_name": "cube",
+            "span": {
+              "end_column": 44,
+              "end_line": 2,
+              "start_column": 21,
+              "start_line": 2
+            }
+          }
+        },
+        "threshold": 16.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "map.ts",
+            "qualified_name": "<arrow>",
+            "span": {
+              "end_column": 26,
+              "end_line": 2,
+              "start_column": 17,
+              "start_line": 2
+            }
+          }
+        },
+        "threshold": 16.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "map.ts",
+            "qualified_name": "increment",
+            "span": {
+              "end_column": 1,
+              "end_line": 3,
+              "start_column": 8,
+              "start_line": 1
+            }
+          }
+        },
+        "threshold": 16.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "mixed.ts",
+            "qualified_name": "declared",
+            "span": {
+              "end_column": 40,
+              "end_line": 1,
+              "start_column": 8,
+              "start_line": 1
+            }
+          }
+        },
+        "threshold": 16.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "mixed.ts",
+            "qualified_name": "expression",
+            "span": {
+              "end_column": 50,
+              "end_line": 2,
+              "start_column": 27,
+              "start_line": 2
+            }
+          }
+        },
+        "threshold": 16.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "mixed.ts",
+            "qualified_name": "arrow",
+            "span": {
+              "end_column": 28,
+              "end_line": 3,
+              "start_column": 22,
+              "start_line": 3
+            }
+          }
+        },
+        "threshold": 16.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "simple.ts",
+            "qualified_name": "add",
+            "span": {
+              "end_column": 1,
+              "end_line": 5,
+              "start_column": 8,
+              "start_line": 3
+            }
+          }
+        },
+        "threshold": 16.0
+      }
+    ],
+    "passed": true,
+    "summary": {
+      "average_complexity": 1.0,
+      "average_coverage": 95.0,
+      "average_crap": 1.013,
+      "distribution": {
+        "acceptable": 0,
+        "high": 0,
+        "low": 10,
+        "moderate": 0
+      },
+      "exceeding_threshold": 0,
+      "max_complexity": 1,
+      "max_crap": {
+        "risk_level": "low",
+        "value": 1.13
+      },
+      "median_complexity": 1.0,
+      "median_coverage": 100.0,
+      "median_crap": 1.0,
+      "min_coverage": 50.0,
+      "total_files": 5,
+      "total_functions": 10,
+      "worst_function": {
+        "file_path": "arrow.ts",
+        "qualified_name": "cube",
+        "span": {
+          "end_column": 44,
+          "end_line": 2,
+          "start_column": 21,
+          "start_line": 2
+        }
+      }
+    }
+  },
+  "schema_version": 2,
+  "threshold": 16.0,
+  "timestamp": "[STRIPPED:timestamp]",
+  "tool_version": "[STRIPPED:tool_version]",
+  "view": {
+    "eligible_count": 10,
+    "grouped": null,
+    "shown": [
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 50.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.13
+          },
+          "identity": {
+            "file_path": "arrow.ts",
+            "qualified_name": "cube",
+            "span": {
+              "end_column": 44,
+              "end_line": 2,
+              "start_column": 21,
+              "start_line": 2
+            }
+          }
+        },
+        "threshold": 16.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "Button.tsx",
+            "qualified_name": "<arrow>",
+            "span": {
+              "end_column": 49,
+              "end_line": 3,
+              "start_column": 30,
+              "start_line": 3
+            }
+          }
+        },
+        "threshold": 16.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "Button.tsx",
+            "qualified_name": "Button",
+            "span": {
+              "end_column": 1,
+              "end_line": 5,
+              "start_column": 8,
+              "start_line": 2
+            }
+          }
+        },
+        "threshold": 16.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "arrow.ts",
+            "qualified_name": "square",
+            "span": {
+              "end_column": 42,
+              "end_line": 1,
+              "start_column": 23,
+              "start_line": 1
+            }
+          }
+        },
+        "threshold": 16.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "map.ts",
+            "qualified_name": "<arrow>",
+            "span": {
+              "end_column": 26,
+              "end_line": 2,
+              "start_column": 17,
+              "start_line": 2
+            }
+          }
+        },
+        "threshold": 16.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "map.ts",
+            "qualified_name": "increment",
+            "span": {
+              "end_column": 1,
+              "end_line": 3,
+              "start_column": 8,
+              "start_line": 1
+            }
+          }
+        },
+        "threshold": 16.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "mixed.ts",
+            "qualified_name": "declared",
+            "span": {
+              "end_column": 40,
+              "end_line": 1,
+              "start_column": 8,
+              "start_line": 1
+            }
+          }
+        },
+        "threshold": 16.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "mixed.ts",
+            "qualified_name": "expression",
+            "span": {
+              "end_column": 50,
+              "end_line": 2,
+              "start_column": 27,
+              "start_line": 2
+            }
+          }
+        },
+        "threshold": 16.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "mixed.ts",
+            "qualified_name": "arrow",
+            "span": {
+              "end_column": 28,
+              "end_line": 3,
+              "start_column": 22,
+              "start_line": 3
+            }
+          }
+        },
+        "threshold": 16.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "simple.ts",
+            "qualified_name": "add",
+            "span": {
+              "end_column": 1,
+              "end_line": 5,
+              "start_column": 8,
+              "start_line": 3
+            }
+          }
+        },
+        "threshold": 16.0
+      }
+    ],
+    "shown_summary": {
+      "average_complexity": 1.0,
+      "average_coverage": 95.0,
+      "average_crap": 1.013,
+      "distribution": {
+        "acceptable": 0,
+        "high": 0,
+        "low": 10,
+        "moderate": 0
+      },
+      "exceeding_threshold": 0,
+      "max_complexity": 1,
+      "max_crap": {
+        "risk_level": "low",
+        "value": 1.13
+      },
+      "median_complexity": 1.0,
+      "median_coverage": 100.0,
+      "median_crap": 1.0,
+      "min_coverage": 50.0,
+      "total_files": 5,
+      "total_functions": 10,
+      "worst_function": {
+        "file_path": "arrow.ts",
+        "qualified_name": "cube",
+        "span": {
+          "end_column": 44,
+          "end_line": 2,
+          "start_column": 21,
+          "start_line": 2
+        }
+      }
+    },
+    "spec": {
+      "filters": {
+        "coverage_range": null,
+        "only_failing": false
+      },
+      "group_by": null,
+      "limit": null,
+      "sort": "crap"
+    },
+    "truncated": false
+  }
+}

--- a/crates/crap-core/tests/wire_envelope_crap4rs.rs
+++ b/crates/crap-core/tests/wire_envelope_crap4rs.rs
@@ -1,7 +1,13 @@
-//! Wire-envelope shape lock for the `--format json` envelope.
+//! Wire-envelope shape lock for the crap4rs `--format json` envelope.
 //!
-//! This snapshot is the canary for the S1–S5 monorepo migration
-//! (crap4rs#132). Every PR in S2–S5 must keep this snapshot byte-
+//! This module owns the **crap4rs** half of the dual wire-envelope
+//! canary established in W1.3 (crap-rs#183). Its sibling
+//! `wire_envelope_crap4ts.rs` owns the **crap4ts** half. From W1.3
+//! onward, every W2+ PR body must declare either "no drift" or
+//! "drift documented" for BOTH snapshots.
+//!
+//! This snapshot is the original canary from the S1–S5 monorepo
+//! migration (crap4rs#132). Every PR must keep this snapshot byte-
 //! identical OR document the drift in the PR body. Drift is the
 //! deliberate breaking-change tripwire; a default-passing run means
 //! the JSON envelope is unchanged.

--- a/crates/crap-core/tests/wire_envelope_crap4ts.rs
+++ b/crates/crap-core/tests/wire_envelope_crap4ts.rs
@@ -1,0 +1,192 @@
+//! Wire-envelope shape lock for the crap4ts `--format json` envelope.
+//!
+//! Sibling of `wire_envelope_crap4rs.rs`. Together they form the dual
+//! wire-envelope canary established in W1.3 (crap-rs#183): every W2+
+//! PR body must declare either "no drift" or "drift documented" for
+//! BOTH snapshots.
+//!
+//! ## Why two modules
+//!
+//! crap-core's envelope types (`schema_version`, `metric`, `language`,
+//! `result.functions[]`, `result.summary`, `diagnostics`, ...) are
+//! shared across adapters. The serde derives enforce structural
+//! parity; this snapshot canary enforces that the *materialized*
+//! envelope for a representative TS run keeps a stable shape across
+//! refactors. Separate per-adapter snapshots give cleaner failure
+//! attribution than a single dual-fixture snapshot would.
+//!
+//! ## Why the snapshot bakes in current (W1.3-era) wrong-by-design values
+//!
+//! The current crap4ts envelope reports `language: "rust"` and
+//! `metric: "cognitive"` — both incorrect for a TS adapter. These
+//! values flip in **W2.5** (crap-rs#188) when
+//! `AdapterMeta::default_metric` lands per locked decision #2
+//! (cyclomatic for crap4ts). The flip MUST show up as a deliberate
+//! snapshot diff at W2.5 PR time; until then, locking the
+//! wrong-by-design values into the W1.3 baseline catches accidental
+//! changes between W1.3 and W2.5.
+//!
+//! ## Volatile fields stripped
+//!
+//! `tool_version`, `timestamp`, `baseline_tool_version`,
+//! `baseline_timestamp`. Same set as the crap4rs sibling.
+//!
+//! ## Fixture-path volatility
+//!
+//! The tempdir's canonical path leaks into the envelope's
+//! `file_path` fields if `IstanbulCoverage::normalize_path` fails to
+//! strip the `--src` prefix (e.g., the tempdir isn't canonicalized).
+//! Per `istanbul_smoke::build_fixture`, macOS's `/tmp` → `/private/tmp`
+//! symlink requires `std::fs::canonicalize` to keep the prefix-strip
+//! consistent. The helper below does the same canonicalization
+//! dance.
+//!
+//! To update after a deliberate envelope change:
+//!   `cargo insta review` → accept the new snapshot.
+
+use std::path::PathBuf;
+
+use assert_cmd::Command;
+use serde_json::Value;
+use tempfile::TempDir;
+
+const FIXTURE_TEMPLATE: &str =
+    include_str!("../../crap4ts/tests/fixtures/istanbul-jest/coverage-final.json");
+
+/// Strip per-build / per-run fields so the snapshot only catches
+/// shape drift, not version/timestamp churn. Mirrors the recursive
+/// strip in `wire_envelope_crap4rs.rs`.
+fn strip_volatile(value: &mut Value) {
+    match value {
+        Value::Object(map) => {
+            for key in [
+                "tool_version",
+                "timestamp",
+                "baseline_tool_version",
+                "baseline_timestamp",
+            ] {
+                if let Some(slot) = map.get_mut(key) {
+                    *slot = Value::String(format!("[STRIPPED:{key}]"));
+                }
+            }
+            for child in map.values_mut() {
+                strip_volatile(child);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                strip_volatile(item);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Build a canonicalized tempdir, write the W1.1 jest fixture sources
+/// plus a resolved `coverage-final.json` into it, and return the path
+/// pair the binary needs. `TempDir` is returned so the directory stays
+/// alive for the lifetime of the test (drop cleans up).
+fn build_fixture() -> (TempDir, PathBuf) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    // Canonicalize: macOS's /tmp routes through /private/tmp; without
+    // canonicalization the parser sees a different prefix than the
+    // fixture path entries and the snapshot bakes absolute paths.
+    let canonical = std::fs::canonicalize(tmp.path()).expect("canonicalize tempdir");
+
+    for (name, content) in [
+        (
+            "simple.ts",
+            include_str!("../../crap4ts/tests/fixtures/ts-fixtures/simple.ts"),
+        ),
+        (
+            "arrow.ts",
+            include_str!("../../crap4ts/tests/fixtures/ts-fixtures/arrow.ts"),
+        ),
+        (
+            "Button.tsx",
+            include_str!("../../crap4ts/tests/fixtures/ts-fixtures/Button.tsx"),
+        ),
+        (
+            "map.ts",
+            include_str!("../../crap4ts/tests/fixtures/ts-fixtures/map.ts"),
+        ),
+        (
+            "mixed.ts",
+            include_str!("../../crap4ts/tests/fixtures/ts-fixtures/mixed.ts"),
+        ),
+    ] {
+        std::fs::write(canonical.join(name), content).expect("write fixture");
+    }
+
+    let payload = FIXTURE_TEMPLATE.replace("{SRC_ROOT}", &canonical.to_string_lossy());
+    std::fs::write(canonical.join("coverage-final.json"), payload)
+        .expect("write coverage-final.json");
+
+    (tmp, canonical)
+}
+
+/// Replace tempdir paths in the envelope with a stable placeholder so
+/// the snapshot doesn't bake in per-run paths like
+/// `/private/var/folders/.../coverage-final.json`. The crap4ts
+/// `IstanbulCoverage::normalize_path` strips the `--src` prefix from
+/// `file_path` entries (verified by `istanbul_smoke`), so `file_path`
+/// fields should be relative (e.g., `simple.ts`) after parsing. This
+/// pass is defense-in-depth: any string value that mentions the
+/// tempdir gets neutralized.
+fn strip_tempdir_paths(value: &mut Value, tempdir: &str) {
+    match value {
+        // `str::replace` is a no-op when the needle is absent, so the
+        // common "no tempdir leak" path is a single allocation-free
+        // scan; matches clippy's collapsible-match guidance.
+        Value::String(s) => *s = s.replace(tempdir, "[TEMPDIR]"),
+        Value::Object(map) => {
+            for v in map.values_mut() {
+                strip_tempdir_paths(v, tempdir);
+            }
+        }
+        Value::Array(items) => {
+            for v in items {
+                strip_tempdir_paths(v, tempdir);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[test]
+fn envelope() {
+    let (_tmp, root) = build_fixture();
+    let coverage = root.join("coverage-final.json");
+    let tempdir_str = root.to_string_lossy().to_string();
+
+    let output = Command::cargo_bin("crap4ts")
+        .expect("crap4ts binary discoverable in workspace")
+        .args([
+            "--coverage",
+            coverage.to_str().expect("coverage path utf-8"),
+            "--src",
+            root.to_str().expect("src path utf-8"),
+            "--threshold",
+            "16",
+            "--format",
+            "json",
+            "--no-fail",
+        ])
+        .output()
+        .expect("crap4ts binary executes");
+
+    assert!(
+        output.status.success(),
+        "crap4ts exited non-zero: stdout={}\nstderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let mut envelope: Value =
+        serde_json::from_slice(&output.stdout).expect("crap4ts --format json emits valid JSON");
+    strip_volatile(&mut envelope);
+    strip_tempdir_paths(&mut envelope, &tempdir_str);
+
+    let pretty = serde_json::to_string_pretty(&envelope).expect("envelope re-serializes");
+    insta::assert_snapshot!("envelope", pretty);
+}

--- a/crates/crap-core/tests/wire_envelope_crap4ts.rs
+++ b/crates/crap-core/tests/wire_envelope_crap4ts.rs
@@ -118,7 +118,16 @@ fn build_fixture() -> (TempDir, PathBuf) {
         std::fs::write(canonical.join(name), content).expect("write fixture");
     }
 
-    let payload = FIXTURE_TEMPLATE.replace("{SRC_ROOT}", &canonical.to_string_lossy());
+    // Normalize path separators before string-substituting into the
+    // JSON template — on Windows `canonical.to_string_lossy()` returns
+    // backslashes, which would land in the JSON as unescaped `\p`-style
+    // sequences and fail JSON parsing. Forward slashes are valid path
+    // separators in JSON string values on every platform crap4ts
+    // currently parses fixtures against. No-op on macOS/linux.
+    let payload = FIXTURE_TEMPLATE.replace(
+        "{SRC_ROOT}",
+        &canonical.to_string_lossy().replace('\\', "/"),
+    );
     std::fs::write(canonical.join("coverage-final.json"), payload)
         .expect("write coverage-final.json");
 
@@ -157,21 +166,24 @@ fn strip_tempdir_paths(value: &mut Value, tempdir: &str) {
 fn envelope() {
     let (_tmp, root) = build_fixture();
     let coverage = root.join("coverage-final.json");
-    let tempdir_str = root.to_string_lossy().to_string();
+    // Match production path normalization: `crap_core::core` emits
+    // forward-slash paths in the JSON envelope on every platform, so
+    // the defense-in-depth `strip_tempdir_paths` needle must be the
+    // forward-slash form too. No-op on macOS/linux where
+    // `to_string_lossy()` already returns forward slashes.
+    let tempdir_str = root.to_string_lossy().replace('\\', "/");
 
+    // Pass `Path` references directly to `Command::arg` (Command::arg
+    // takes `AsRef<OsStr>`, which `Path` impls): avoids forcing
+    // UTF-8 validation through `to_str()` and handles platform-specific
+    // OS string representations on Windows without lossy conversion.
     let output = Command::cargo_bin("crap4ts")
         .expect("crap4ts binary discoverable in workspace")
-        .args([
-            "--coverage",
-            coverage.to_str().expect("coverage path utf-8"),
-            "--src",
-            root.to_str().expect("src path utf-8"),
-            "--threshold",
-            "16",
-            "--format",
-            "json",
-            "--no-fail",
-        ])
+        .arg("--coverage")
+        .arg(&coverage)
+        .arg("--src")
+        .arg(&root)
+        .args(["--threshold", "16", "--format", "json", "--no-fail"])
         .output()
         .expect("crap4ts binary executes");
 

--- a/crates/crap4ts/Cargo.toml
+++ b/crates/crap4ts/Cargo.toml
@@ -67,5 +67,11 @@ serde_json = { workspace = true }
 # Each scenario writes into a tempdir so the test doesn't pollute cwd.
 tempfile = { workspace = true }
 
+# End-to-end smoke tests (W1.3) invoke the `crap4ts` binary via
+# `assert_cmd::Command::cargo_bin` and assert on stdout/stderr/exit
+# code. Same cross-crate-invocation pattern crap-core uses for the
+# wire-envelope snapshot modules.
+assert_cmd = { workspace = true }
+
 [build-dependencies]
 napi-build = { workspace = true }

--- a/crates/crap4ts/tests/end_to_end_smoke.rs
+++ b/crates/crap4ts/tests/end_to_end_smoke.rs
@@ -55,7 +55,15 @@ fn build_jest_fixture() -> (TempDir, PathBuf) {
         std::fs::write(canonical.join(name), content).expect("write fixture");
     }
 
-    let payload = FIXTURE_TEMPLATE.replace("{SRC_ROOT}", &canonical.to_string_lossy());
+    // Normalize path separators before string-substituting into the
+    // JSON template — Windows backslashes would land as invalid `\p`-
+    // style escape sequences in the resulting JSON. Forward slashes
+    // are valid path separators in JSON string values on every
+    // platform. No-op on macOS/linux.
+    let payload = FIXTURE_TEMPLATE.replace(
+        "{SRC_ROOT}",
+        &canonical.to_string_lossy().replace('\\', "/"),
+    );
     std::fs::write(canonical.join("coverage-final.json"), payload)
         .expect("write coverage-final.json");
 
@@ -230,9 +238,15 @@ fn parse_failure_continues_other_files_are_analyzed() {
         }
     }"#;
     let coverage = canonical.join("coverage-final.json");
+    // Same forward-slash normalization rationale as `build_jest_fixture`:
+    // Windows backslashes break JSON parsing of the substituted
+    // template. No-op on macOS/linux.
     std::fs::write(
         &coverage,
-        coverage_template.replace("{SRC_ROOT}", &canonical.to_string_lossy()),
+        coverage_template.replace(
+            "{SRC_ROOT}",
+            &canonical.to_string_lossy().replace('\\', "/"),
+        ),
     )
     .expect("write coverage-final.json");
 

--- a/crates/crap4ts/tests/end_to_end_smoke.rs
+++ b/crates/crap4ts/tests/end_to_end_smoke.rs
@@ -1,0 +1,264 @@
+//! End-to-end smoke tests for the `crap4ts` binary.
+//!
+//! Spawns the `crap4ts` binary via `assert_cmd` against the W1.1 jest
+//! fixture (with `{SRC_ROOT}` template substituted at test time) plus
+//! the W1.2 walker. The four scenarios cover (1) the default table
+//! reporter, (2) `--format json` envelope parse-ability, (3) the
+//! markdown reporter header, and (4) the parse-failure-continues
+//! behavior where `broken.ts` is silently skipped while `simple.ts`
+//! still surfaces in the report.
+//!
+//! Owns the **wired binary canary**: if `cargo build --bin crap4ts`
+//! succeeds but the binary can't actually parse + walk + report against
+//! a real jest fixture, these tests fail.
+//!
+//! Together with `wire_envelope_crap4ts.rs` (envelope shape lock) and
+//! the existing `istanbul_smoke.rs` + `walker_smoke.rs` (unit-level
+//! contracts) these complete the W1 walking-skeleton verification.
+
+use std::path::{Path, PathBuf};
+
+use assert_cmd::Command;
+use tempfile::TempDir;
+
+const FIXTURE_TEMPLATE: &str = include_str!("fixtures/istanbul-jest/coverage-final.json");
+
+/// Build a canonicalised tempdir, copy the five W1.1 jest fixture TS
+/// files into it, and substitute `{SRC_ROOT}` in the templated
+/// `coverage-final.json` with the canonical tempdir path. Returns
+/// the `TempDir` (keep it alive for the lifetime of the test — the
+/// directory is removed on drop) plus the canonical path.
+///
+/// Mirrors `istanbul_smoke::build_fixture`'s pattern but materializes
+/// the substituted `coverage-final.json` on disk so the binary can
+/// load it via `--coverage <path>`. The two helpers stay separate by
+/// design: editing the W1.1 helper to dual-purpose it would invite
+/// drift between unit-level and end-to-end fixture loading.
+fn build_jest_fixture() -> (TempDir, PathBuf) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    // Canonicalize because macOS's /tmp redirects to /private/tmp;
+    // without canonicalization the parser sees a different prefix
+    // than the JSON's substituted paths and emits PathUnresolved
+    // for every entry (verified empirically during W1.3 eyeball).
+    let canonical = std::fs::canonicalize(tmp.path()).expect("canonicalize tempdir");
+
+    for (name, content) in [
+        ("simple.ts", include_str!("fixtures/ts-fixtures/simple.ts")),
+        ("arrow.ts", include_str!("fixtures/ts-fixtures/arrow.ts")),
+        (
+            "Button.tsx",
+            include_str!("fixtures/ts-fixtures/Button.tsx"),
+        ),
+        ("map.ts", include_str!("fixtures/ts-fixtures/map.ts")),
+        ("mixed.ts", include_str!("fixtures/ts-fixtures/mixed.ts")),
+    ] {
+        std::fs::write(canonical.join(name), content).expect("write fixture");
+    }
+
+    let payload = FIXTURE_TEMPLATE.replace("{SRC_ROOT}", &canonical.to_string_lossy());
+    std::fs::write(canonical.join("coverage-final.json"), payload)
+        .expect("write coverage-final.json");
+
+    (tmp, canonical)
+}
+
+/// Spawn `crap4ts` with the given `--src` + `--coverage` + extra args
+/// and assert the binary exists. Returns the full `std::process::Output`
+/// so callers can assert on stdout/stderr/status independently.
+fn run_crap4ts(src: &Path, coverage: &Path, extra: &[&str]) -> std::process::Output {
+    let mut cmd = Command::cargo_bin("crap4ts").expect("crap4ts binary discoverable");
+    cmd.arg("--src")
+        .arg(src)
+        .arg("--coverage")
+        .arg(coverage)
+        .arg("--threshold")
+        .arg("16")
+        .arg("--no-fail")
+        .args(extra);
+    cmd.output().expect("crap4ts executes")
+}
+
+// ── 1. Happy-path table: default reporter renders function names ──────
+
+#[test]
+fn happy_path_table_lists_simple_add_function() {
+    let (_tmp, root) = build_jest_fixture();
+    let coverage = root.join("coverage-final.json");
+    let out = run_crap4ts(&root, &coverage, &[]);
+
+    assert!(
+        out.status.success(),
+        "crap4ts exited non-zero: stdout={}\nstderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    // simple.ts contains `export function add(a, b)`. The table
+    // reporter renders `| simple.ts | add |` (column-padded).
+    assert!(
+        stdout.contains("simple.ts") && stdout.contains("add"),
+        "table output missing add/simple.ts; stdout=\n{stdout}"
+    );
+}
+
+// ── 2. JSON envelope parses + reports at least one analyzed function ──
+
+#[test]
+fn json_envelope_parses_and_reports_functions() {
+    let (_tmp, root) = build_jest_fixture();
+    let coverage = root.join("coverage-final.json");
+    let out = run_crap4ts(&root, &coverage, &["--format", "json"]);
+
+    assert!(
+        out.status.success(),
+        "crap4ts exited non-zero: stdout={}\nstderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let value: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("crap4ts --format json emits valid JSON");
+
+    // The crap-core envelope's summary block exposes `total_functions`
+    // (the count of functions the walker emitted that joined against
+    // ≥1 coverage record). The plan-of-record asserted
+    // `analysis_output.summary.functions_analyzed`; the actual field
+    // is `result.summary.total_functions` — surfaced as a W1.3 plan
+    // deviation in the PR body alongside the markdown header and
+    // shared-helper layout deviations.
+    let total_functions = value
+        .pointer("/result/summary/total_functions")
+        .and_then(|v| v.as_u64())
+        .unwrap_or_else(|| {
+            panic!("envelope missing /result/summary/total_functions; envelope={value:#}")
+        });
+    assert!(
+        total_functions >= 1,
+        "expected >=1 functions analyzed; got {total_functions}"
+    );
+}
+
+// ── 3. Markdown reporter emits the `# {tool_name} v{version}` header ──
+//
+// Plan-of-record deviation surfaced during W1.3: the orchestrator prompt
+// asserted `# CRAP Scorecard` as the markdown header, but the crap-core
+// reporter at `crates/crap-core/src/adapters/reporters/markdown.rs:86-88`
+// emits `# {tool_name} v{tool_version} — CRAP Score Analysis`. The
+// `## CRAP Scorecard` section is only appended when a delta baseline is
+// present. We assert against the actual header shape — version-prefix
+// substring keeps the test alive across alpha → rc → 2.0.0 without
+// churn. See PR body "Deviations from plan-of-record" for the full
+// reconciliation.
+
+#[test]
+fn markdown_reporter_emits_crap4ts_title_header() {
+    let (_tmp, root) = build_jest_fixture();
+    let coverage = root.join("coverage-final.json");
+    let out = run_crap4ts(&root, &coverage, &["--format", "markdown"]);
+
+    assert!(
+        out.status.success(),
+        "crap4ts exited non-zero: stdout={}\nstderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.starts_with("# crap4ts v"),
+        "markdown body should start with `# crap4ts v…`; got first line:\n{}",
+        stdout.lines().next().unwrap_or("(empty)")
+    );
+    assert!(
+        stdout.contains("— CRAP Score Analysis"),
+        "markdown body should contain `— CRAP Score Analysis`; got:\n{stdout}"
+    );
+}
+
+// ── 4. Parse-failure-with-other-files: broken.ts skipped, simple.ts kept ──
+//
+// Per `crates/crap-core/src/core/mod.rs:286-310`, when the walker
+// returns `Err(CrapError::SourceParse(_))` for one file, the
+// orchestrator emits a `warning: skipping <path>` and increments
+// `files_unparseable`, then continues with the rest of the discovered
+// files. This test exercises that with a hand-rolled mini-fixture:
+//   - tempdir contains `simple.ts` (parseable) + `broken.ts` (the W1.2
+//     malformed fixture)
+//   - coverage-final.json references only simple.ts (broken.ts has no
+//     coverage to emit; the walker discovers it through directory
+//     traversal and fails parse independently)
+
+#[test]
+fn parse_failure_continues_other_files_are_analyzed() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let canonical = std::fs::canonicalize(tmp.path()).expect("canonicalize tempdir");
+
+    // Copy the two TS fixtures into the tempdir.
+    std::fs::write(
+        canonical.join("simple.ts"),
+        include_str!("fixtures/ts-fixtures/simple.ts"),
+    )
+    .expect("write simple.ts");
+    std::fs::write(
+        canonical.join("broken.ts"),
+        include_str!("fixtures/ts-fixtures/broken.ts"),
+    )
+    .expect("write broken.ts");
+
+    // Minimal coverage-final.json referencing only simple.ts — the
+    // walker discovers broken.ts independently through file-system
+    // traversal and fails parse on it. Mirrors the per-file shape from
+    // `crates/crap4ts/tests/fixtures/istanbul-jest/coverage-final.json`
+    // but trimmed to a single entry to keep this test's coupling to
+    // the W1.1 fixture loose.
+    let coverage_template = r#"{
+        "{SRC_ROOT}/simple.ts": {
+            "path": "{SRC_ROOT}/simple.ts",
+            "statementMap": {
+                "0": { "start": { "line": 4, "column": 2 }, "end": { "line": 4, "column": 15 } }
+            },
+            "s": { "0": 3 },
+            "branchMap": {},
+            "b": {},
+            "fnMap": {
+                "0": {
+                    "name": "add",
+                    "decl": { "start": { "line": 3, "column": 16 }, "end": { "line": 3, "column": 19 } },
+                    "loc": { "start": { "line": 3, "column": 51 }, "end": { "line": 5, "column": 1 } },
+                    "line": 3
+                }
+            },
+            "f": { "0": 3 }
+        }
+    }"#;
+    let coverage = canonical.join("coverage-final.json");
+    std::fs::write(
+        &coverage,
+        coverage_template.replace("{SRC_ROOT}", &canonical.to_string_lossy()),
+    )
+    .expect("write coverage-final.json");
+
+    let out = run_crap4ts(&canonical, &coverage, &[]);
+
+    assert!(
+        out.status.success(),
+        "crap4ts exited non-zero (broken.ts should be skipped, not abort): stdout={}\nstderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+
+    // (a) simple.ts's `add` still surfaces in the table.
+    assert!(
+        stdout.contains("simple.ts") && stdout.contains("add"),
+        "expected simple.ts/add to survive broken.ts's parse failure; stdout=\n{stdout}"
+    );
+    // (b) stderr emits the per-file `warning: skipping` for broken.ts.
+    assert!(
+        stderr.contains("warning: skipping"),
+        "expected stderr to contain `warning: skipping`; got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("broken.ts"),
+        "expected stderr to name broken.ts in the skip warning; got:\n{stderr}"
+    );
+}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -58,6 +58,17 @@ pre-push:
     test:
       run: cargo nextest run --workspace --all-targets
       timeout: 300s
+    insta:
+      # Mechanical enforcement of wire-snapshot drift detection
+      # (CEng ADVISORY-7, established with the dual-snapshot canary
+      # in W1.3 / crap-rs#183). `--check` makes insta fail on pending
+      # (unaccepted / .snap.new) snapshots, catching accidental
+      # `cargo insta accept` without review and unreviewed diffs in a
+      # branch's working tree before push. Without this step,
+      # documentation alone enforces the wire-snapshot contract;
+      # "documentation rots, CI doesn't."
+      run: cargo insta test --workspace --check
+      timeout: 180s
     cucumber:
       # cucumber-rs harness=false targets bypass libtest's
       # `--list --format terse` probing, so nextest excludes them

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -67,7 +67,20 @@ pre-push:
       # branch's working tree before push. Without this step,
       # documentation alone enforces the wire-snapshot contract;
       # "documentation rots, CI doesn't."
-      run: cargo insta test --workspace --check
+      #
+      # `--test-runner=nextest` is load-bearing — the default
+      # `cargo-test` backend runs tests in-process with thread
+      # parallelism, which interacts poorly with the
+      # `colored::set_override` global mutex used by the table
+      # reporter (see `~/.claude/projects/.../feedback_colored-set-
+      # override-mutex` memory). Under non-PTY environments (lefthook,
+      # CI) one test's width-detection panic poisons the mutex and
+      # cascades into 43+ unrelated failures. Nextest runs each test
+      # in its own process, so a panic in one test doesn't poison any
+      # other test's mutex state. This is the same runner the
+      # workspace's `test:` step above uses; switching insta to it
+      # keeps the two parallel testing layers consistent.
+      run: cargo insta test --workspace --check --test-runner=nextest
       timeout: 180s
     cucumber:
       # cucumber-rs harness=false targets bypass libtest's


### PR DESCRIPTION
## Summary

**Wave 0 closer for the TS-adapter pipeline.** Establishes the dual wire-envelope snapshot canary by (a) renaming the existing `wire_envelope_snapshot.rs` → `wire_envelope_crap4rs.rs` (history preserved via `git mv`), (b) adding a new `wire_envelope_crap4ts.rs` module mirroring the shape against the crap4ts binary + W1.1 jest fixtures, (c) adding 4 end-to-end smoke tests against the crap4ts binary, and (d) wiring `cargo insta test --workspace --check --test-runner=nextest` into `lefthook.yml`'s pre-push as the mechanical drift gate (CEng ADVISORY-7).

After this PR merges, all three W1 walking-skeleton sub-issues (#181, #182, #183) are complete and W2 fan-out can open.

**Dual-snapshot canary contract is now active**: every W2+ PR body must declare either "no drift" or "drift documented" for **BOTH** `wire_envelope_crap4rs__envelope.snap` and `wire_envelope_crap4ts__envelope.snap`.

## Wire-shape canary status

- **`wire_envelope_crap4rs__envelope.snap`**: byte-identical content post-rename. Only the `source:` header inside the snapshot file changed (from `wire_envelope_snapshot.rs` to `wire_envelope_crap4rs.rs`). All other 11,317 lines unchanged.
- **`wire_envelope_crap4ts__envelope.snap`**: initial baseline accepted via `cargo insta accept`. **Deliberately bakes in `language: "rust"` and `metric: "cognitive"`** — both wrong-by-design for a TS adapter, both expected to flip in **W2.5 (crap-rs#188)** when `AdapterMeta::default_metric` lands per locked decision #2. Until then, locking the wrong-by-design values into the W1.3 baseline catches accidental changes between W1.3 and W2.5; W2.5's PR body will document the deliberate drift.

## Fixture-loading strategy

**Chose option (b) — runtime substitution helper per file** (no shared `tests/common/mod.rs`). The W1.1 jest fixture at `crates/crap4ts/tests/fixtures/istanbul-jest/coverage-final.json` uses `{SRC_ROOT}` template placeholders substituted at test time. The new `wire_envelope_crap4ts.rs` (in `crates/crap-core/tests/`) and `end_to_end_smoke.rs` (in `crates/crap4ts/tests/`) each contain their own ~30-LOC `build_fixture` helper that:

1. Creates a tempdir + canonicalizes (macOS `/tmp` → `/private/tmp` gotcha; mirrors `istanbul_smoke::build_fixture`)
2. Writes the 5 fixture `.ts` files via `include_str!`
3. Reads the templated `coverage-final.json`, substitutes `{SRC_ROOT}`, writes resolved JSON
4. Returns the `TempDir` + canonical path for the test to use

**Trade-off considered**: a shared `tests/common/mod.rs` is impossible across crate boundaries (`crap-core/tests/` and `crap4ts/tests/` are separate test-target crates). Could extract a helper into `crap4ts/tests/common/mod.rs` and `#[path]`-include it from `crap-core/tests/`, but that introduces an awkward cross-crate include for a 30-LOC helper. Per-file duplication is the cleanest layout for the current call sites; if a third caller appears in W2+, revisit. Per-prompt constraint, **did not modify `istanbul_smoke.rs`** — the W1.1 helper stays untouched.

## Deviations from plan-of-record

Three reality > plan corrections surfaced during W1.3 (same discipline as W1.2's nextest filter + Span semantics catch):

1. **Markdown header is `# crap4ts v… — CRAP Score Analysis`, NOT `# CRAP Scorecard`.** The orchestrator prompt's assertion was incorrect. The crap-core markdown reporter (`crates/crap-core/src/adapters/reporters/markdown.rs:86-88`) emits `# {tool_name} v{tool_version} — CRAP Score Analysis`; the `## CRAP Scorecard` section is only appended when a delta baseline is present. The end-to-end test asserts `starts_with("# crap4ts v")` AND `contains("— CRAP Score Analysis")` — version-prefix substring survives alpha → rc → 2.0.0 without churn.

2. **JSON envelope path is `/result/summary/total_functions`, NOT `/analysis_output/summary/functions_analyzed`.** The orchestrator prompt asserted the latter; the actual envelope schema names them differently. Verified empirically by eyeballing `crap4ts --format json --no-fail` output before writing the test.

3. **Lefthook insta gate requires `--test-runner=nextest`, NOT the default `cargo-test` backend.** Discovered while running `lefthook run pre-push` end-to-end. The default backend uses libtest's in-process thread parallelism; the table reporter's snapshot tests panic from comfy-table width detection falling back to a 1-char column width when stdout isn't a TTY. That panic poisons the `colored::set_override` global mutex and cascades into 43+ unrelated failures. Nextest runs each test in its own process, isolating the panic. Matches the runner the workspace's `test:` step already uses. Documented inline in `lefthook.yml`.

## Discovery findings

- **Pre-existing brittleness exposed but not fixed**: the comfy-table width detection under non-PTY environments + `colored::set_override` mutex-poison cascade is real and orthogonal to W1.3. The nextest runner masks it via process isolation. If a future change reverts to `cargo-test` backend or removes nextest from the toolchain, the same 43 table-reporter failures cascade. Worth a separate `type:bug priority:later` follow-up if the width detection logic ever needs a deliberate audit — not filing today because nothing is being deferred from W1.3's scope.
- **Tempdir-canonicalization is the load-bearing macOS workaround** (already known from W1.1's istanbul_smoke). The new `build_fixture` helpers canonicalize for the same reason; without it, the snapshot bakes `/private/var/folders/...` paths and CI fails on cross-machine path comparison.
- **`strip_tempdir_paths` defense-in-depth net** (the recursive walker in `wire_envelope_crap4ts.rs`) is a no-op on the happy path because `IstanbulCoverage::normalize_path` strips the `--src` prefix from `file_path` entries. Kept as a safety net for future schema additions that might emit tempdir-rooted strings.
- **Wire-snapshot canary works**: deliberately tested by changing the snapshot content during development — insta correctly surfaced the drift, accepted only after eyeballing.

## Acceptance gates

- [x] **Gate 1** `cargo build --workspace` passes
- [x] **Gate 2** `cargo nextest run --workspace --all-targets` — 989/989 pass (both wire-envelope modules + 4 end-to-end smoke + all prior tests)
- [x] **Gate 3** `cargo insta test --workspace` accepts the renamed crap4rs snapshot byte-identically
- [x] **Gate 4** new `wire_envelope_crap4ts__envelope.snap` accepted on first run; subsequent runs byte-identical
- [x] **Gate 5** `cargo +1.93 check --workspace --all-targets` passes
- [x] **Gate 6** `cargo fmt --check` clean
- [x] **Gate 7** `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] **Gate 8** `cargo doc --workspace --no-deps` with `RUSTDOCFLAGS=-D warnings` clean
- [x] **Gate 9** `cargo deny check` clean (advisories ok, bans ok, licenses ok, sources ok)
- [x] **Gate 10** AST-purity grep on `crates/crap-core/src/` clean (pure test-infra PR — no `crap-core/src/` source changes)
- [x] **Gate 11** `git log --follow crates/crap-core/tests/wire_envelope_crap4rs.rs | head` traces back through `wire_envelope_snapshot.rs` (rename history preserved)
- [x] **Gate 12** `lefthook run pre-push` succeeds end-to-end (all 9 hooks green: ast-purity, clippy, cucumber, deny, docs, fmt, insta, msrv, test)
- [x] **Gate 13** PR body documents the dual-snapshot canary contract (this section)

## Test plan

- [ ] CI: Format / Clippy / Test linux-x86 / Test macos-arm / Test macos-x86 / cargo-deny / cargo-doc / AST-purity all green
- [ ] CI: cross-crate `include_str!` in `wire_envelope_crap4ts.rs` resolves on linux-x86 (relative paths into sibling crate's `tests/fixtures/`)
- [ ] CI: crap4ts snapshot stable across runners (linux's `canonicalize` semantics should match macOS for the relevant strip behavior; safety net in `strip_tempdir_paths` if not)
- [ ] CI: mutation-testing + self-CRAP scorecard + coverage allowed to be in-flight at merge time (precedent: W1.1 + W1.2)

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage with snapshot tests for JSON wire envelope validation.
  * Introduced end-to-end smoke tests to verify binary functionality across table, JSON, and markdown output formats.
  * Added pre-push validation to detect and prevent snapshot drift in the development workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/breezy-bays-labs/crap-rs/pull/201)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->