### PR TITLE
feat(crap-core): #188 — CrapError::MetricNotSupported + AdapterMeta::default_metric + crap4ts walker check + ADR (d)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,7 +356,7 @@ checksum = "417bef24afe1460300965a25ff4a24b8b45ad011948302ec221e8a0a81eb2c79"
 
 [[package]]
 name = "crap-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ authors = ["Christopher Bays <cmbays@breezybayslabs.com>"]
 # Rust adapter. Future siblings (`crap4ts`) inherit the same pins.
 [workspace.dependencies]
 # ── In-workspace crates ──
-crap-core = { path = "crates/crap-core", version = "0.1.0" }
+crap-core = { path = "crates/crap-core", version = "0.2.0" }
 
 # ── CLI (crap4rs only today) ──
 clap = { version = "4", features = ["derive", "string"] }

--- a/crates/crap-core/Cargo.toml
+++ b/crates/crap-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crap-core"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/crap-core/src/cli/init.rs
+++ b/crates/crap-core/src/cli/init.rs
@@ -251,6 +251,11 @@ mod tests {
             rule_help_uri: "https://example.invalid",
             config_file_name: "fake-adapter.toml",
             default_excludes: &["tests/**", "benches/**", "examples/**"],
+            // Cognitive matches the pre-W2.5 fallthrough — init's
+            // round-trip / comment-rendering assertions don't probe
+            // the metric default; this keeps the field meaningful
+            // without coupling init tests to W2.5 semantics.
+            default_metric: crate::domain::types::ComplexityMetric::Cognitive,
         }
     }
 

--- a/crates/crap-core/src/cli/mod.rs
+++ b/crates/crap-core/src/cli/mod.rs
@@ -682,6 +682,16 @@ pub struct AdapterMeta {
     /// empty — init then emits the `# exclude = [ … ]` block without
     /// per-language entries.
     pub default_excludes: &'static [&'static str],
+    /// The default complexity metric the adapter binary uses when
+    /// neither CLI nor config file specifies one. crap4rs sets
+    /// `Cognitive`; crap4ts sets `Cyclomatic` (the only metric crap4ts
+    /// currently supports per `CrapError::MetricNotSupported`).
+    /// Threaded through `merge_effective_inputs` so the binary's
+    /// default flips per adapter without re-litigating the shared CLI
+    /// fallthrough. See ADR (d) `adr-adapter-meta-default-metric.md`
+    /// for the design rationale (per-adapter defaults surface through
+    /// `AdapterMeta`, not crap-core configuration).
+    pub default_metric: ComplexityMetric,
 }
 
 impl AdapterMeta {
@@ -860,10 +870,41 @@ where
         Ok(true) => ExitCode::from(0),
         Ok(false) => ExitCode::from(1),
         Err(e) => {
-            eprintln!("error: {e:#}");
+            render_error(&e, meta);
             ExitCode::from(2)
         }
     }
+}
+
+/// Render an end-of-pipeline error to stderr, special-casing the
+/// `MetricNotSupported` variant so the user sees adapter-specific
+/// phrasing without the generic `error:` prefix (per breadboard W-5
+/// + `metric_unsupported.feature` scenario 1 exact-string contract).
+///
+/// `anyhow::Error::downcast_ref` walks the source chain looking for a
+/// concrete `CrapError`; we use it (not `is::<CrapError>()`) so an
+/// error that was `.context(...)`-wrapped along the way is still
+/// detected. Every other error type falls through to the default
+/// `error: {e:#}` rendering — `{:#}` uses anyhow's alternate Display
+/// which prints the full cause chain.
+fn render_error(err: &anyhow::Error, meta: &AdapterMeta) {
+    if let Some(crap_err) = err.downcast_ref::<crate::domain::types::CrapError>()
+        && let crate::domain::types::CrapError::MetricNotSupported { metric } = crap_err
+    {
+        // Adapter-specific message: `tool_name` + `default_metric`
+        // hint + `tool_info_uri`. The domain layer's variant message
+        // stays adapter-agnostic; adapter-named phrasing lives at
+        // this rendering boundary only. `metric` (input) +
+        // `meta.default_metric` (hint) both use `ComplexityMetric`'s
+        // `Display` impl which yields lowercase wire tokens —
+        // matching CLI input (`cognitive`, not Debug `Cognitive`).
+        eprintln!(
+            "{}: complexity metric `{}` is not yet supported. Use `--metric {}` (the default for {}) or track support at {}.",
+            meta.tool_name, metric, meta.default_metric, meta.tool_name, meta.tool_info_uri,
+        );
+        return;
+    }
+    eprintln!("error: {err:#}");
 }
 
 fn run_inner<P, F>(
@@ -963,7 +1004,16 @@ struct PipelinePrep<P: ParseDiagnostic> {
     delta_state: Option<DeltaState<P>>,
 }
 
-fn merge_effective_inputs(cli: &Cli, file_config: &Option<FileConfig>) -> EffectiveInputs {
+/// Merge CLI flags, optional file config, and adapter defaults into a
+/// concrete `EffectiveInputs`. `meta.default_metric` is the
+/// load-bearing fallthrough — each adapter binary picks its own
+/// sensible default (crap4rs: `Cognitive`; crap4ts: `Cyclomatic`) so
+/// the shared CLI stays adapter-agnostic. See ADR (d).
+fn merge_effective_inputs(
+    cli: &Cli,
+    file_config: &Option<FileConfig>,
+    meta: &AdapterMeta,
+) -> EffectiveInputs {
     let src = cli
         .input
         .src
@@ -975,7 +1025,7 @@ fn merge_effective_inputs(cli: &Cli, file_config: &Option<FileConfig>) -> Effect
         .metric
         .map(Into::into)
         .or_else(|| file_config.as_ref().and_then(|c| c.metric))
-        .unwrap_or_default();
+        .unwrap_or(meta.default_metric);
     let (threshold_config, threshold) = merge_threshold(cli, file_config);
     let exclude = merge_exclude(cli, file_config);
     EffectiveInputs {
@@ -1092,7 +1142,7 @@ where
     )?;
     view_args::validate_view_args(cli)?;
 
-    let inputs = merge_effective_inputs(cli, &file_config);
+    let inputs = merge_effective_inputs(cli, &file_config, meta);
     let coverage_path = validate_runtime_inputs(cli, &inputs, meta)?;
 
     // Canonicalize the effective `src` (post-config-merge) and hand
@@ -2430,7 +2480,7 @@ mod tests {
     #[test]
     fn merge_effective_inputs_default_src() {
         let cli = parse(&["--coverage", "lcov.info"]).unwrap();
-        let inputs = merge_effective_inputs(&cli, &None);
+        let inputs = merge_effective_inputs(&cli, &None, &fake_meta());
         assert_eq!(inputs.src, PathBuf::from("src"));
     }
 
@@ -2441,7 +2491,7 @@ mod tests {
             src: Some(PathBuf::from("from-config/")),
             ..FileConfig::default()
         });
-        let inputs = merge_effective_inputs(&cli, &file_config);
+        let inputs = merge_effective_inputs(&cli, &file_config, &fake_meta());
         assert_eq!(inputs.src, PathBuf::from("crates/"));
     }
 
@@ -2452,15 +2502,38 @@ mod tests {
             src: Some(PathBuf::from("from-config/")),
             ..FileConfig::default()
         });
-        let inputs = merge_effective_inputs(&cli, &file_config);
+        let inputs = merge_effective_inputs(&cli, &file_config, &fake_meta());
         assert_eq!(inputs.src, PathBuf::from("from-config/"));
     }
 
     #[test]
-    fn merge_effective_inputs_default_metric_is_cognitive() {
+    fn merge_effective_inputs_uses_adapter_default_metric_cognitive() {
+        // Replaces the pre-W2.5 `merge_effective_inputs_default_metric_is_cognitive`
+        // test. Now that the fallthrough comes from `meta.default_metric`
+        // (not `ComplexityMetric::default()`), the assertion is "the
+        // adapter's default flows through when neither CLI nor config
+        // override it." crap4rs sets this to `Cognitive`.
         let cli = parse(&["--coverage", "lcov.info"]).unwrap();
-        let inputs = merge_effective_inputs(&cli, &None);
+        let meta = AdapterMeta {
+            default_metric: ComplexityMetric::Cognitive,
+            ..fake_meta()
+        };
+        let inputs = merge_effective_inputs(&cli, &None, &meta);
         assert!(matches!(inputs.metric, ComplexityMetric::Cognitive));
+    }
+
+    #[test]
+    fn merge_effective_inputs_uses_adapter_default_metric_cyclomatic() {
+        // Replaces the pre-W2.5 `merge_effective_inputs_default_metric_is_cognitive`
+        // test. Mirror of the Cognitive case for the crap4ts adapter
+        // (locked decision #2: crap4ts default = cyclomatic).
+        let cli = parse(&["--coverage", "lcov.info"]).unwrap();
+        let meta = AdapterMeta {
+            default_metric: ComplexityMetric::Cyclomatic,
+            ..fake_meta()
+        };
+        let inputs = merge_effective_inputs(&cli, &None, &meta);
+        assert!(matches!(inputs.metric, ComplexityMetric::Cyclomatic));
     }
 
     #[test]
@@ -2470,14 +2543,14 @@ mod tests {
             metric: Some(ComplexityMetric::Cognitive),
             ..FileConfig::default()
         });
-        let inputs = merge_effective_inputs(&cli, &file_config);
+        let inputs = merge_effective_inputs(&cli, &file_config, &fake_meta());
         assert!(matches!(inputs.metric, ComplexityMetric::Cyclomatic));
     }
 
     #[test]
     fn merge_effective_inputs_threshold_default() {
         let cli = parse(&["--coverage", "lcov.info"]).unwrap();
-        let inputs = merge_effective_inputs(&cli, &None);
+        let inputs = merge_effective_inputs(&cli, &None, &fake_meta());
         assert_eq!(inputs.threshold, DEFAULT_THRESHOLD);
     }
 
@@ -2488,8 +2561,26 @@ mod tests {
             exclude: Some(vec!["benches/**".to_string()]),
             ..FileConfig::default()
         });
-        let inputs = merge_effective_inputs(&cli, &file_config);
+        let inputs = merge_effective_inputs(&cli, &file_config, &fake_meta());
         assert_eq!(inputs.exclude, vec!["tests/**", "benches/**"]);
+    }
+
+    #[test]
+    fn merge_effective_inputs_config_metric_wins_over_adapter_default() {
+        // Config-file metric should still beat the adapter default —
+        // adapter default is the FINAL fallthrough, below CLI and
+        // config-file precedence.
+        let cli = parse(&["--coverage", "lcov.info"]).unwrap();
+        let file_config = Some(FileConfig {
+            metric: Some(ComplexityMetric::Cyclomatic),
+            ..FileConfig::default()
+        });
+        let meta = AdapterMeta {
+            default_metric: ComplexityMetric::Cognitive,
+            ..fake_meta()
+        };
+        let inputs = merge_effective_inputs(&cli, &file_config, &meta);
+        assert!(matches!(inputs.metric, ComplexityMetric::Cyclomatic));
     }
 
     // ── compute_exit_code tests ────────────────────────────────────────
@@ -2579,6 +2670,11 @@ mod tests {
             rule_help_uri: "https://example.invalid/fake-adapter#rules",
             config_file_name: "fake-adapter.toml",
             default_excludes: &["fixtures/**"],
+            // `Cognitive` preserves the pre-W2.5 fallthrough semantics
+            // for tests that don't care which default they get (the two
+            // tests that DO care construct their own AdapterMeta with
+            // an explicit `default_metric`).
+            default_metric: ComplexityMetric::Cognitive,
         }
     }
 

--- a/crates/crap-core/src/core/mod.rs
+++ b/crates/crap-core/src/core/mod.rs
@@ -297,6 +297,16 @@ impl<'a, P: ParseDiagnostic> AnalysisContext<'a, P> {
                 .extract(&source, &relative, self.options.metric)
             {
                 Ok(fns) => all_complexities.extend(fns),
+                // `MetricNotSupported` is a configuration mismatch
+                // (caller asked for a metric the adapter doesn't
+                // implement), not a per-file parse failure — bail
+                // immediately so the CLI's renderer surfaces the
+                // adapter-named hint instead of N stuttering
+                // `warning: skipping` lines followed by a
+                // misleading "no functions extracted" error.
+                Err(e @ crate::domain::types::CrapError::MetricNotSupported { .. }) => {
+                    return Err(e.into());
+                }
                 Err(e) => {
                     files_unparseable += 1;
                     eprintln!("warning: skipping {relative}: {e}");

--- a/crates/crap-core/src/domain/types.rs
+++ b/crates/crap-core/src/domain/types.rs
@@ -603,7 +603,16 @@ mod contributor_tests {
     }
 }
 
+/// Error variants returned through the crap-core analysis pipeline.
+///
+/// `#[non_exhaustive]` so adapter crates and downstream embedders can
+/// match against the variants they care about and treat new ones as
+/// "unknown" without their builds breaking — adding a variant stays
+/// non-breaking for downstream matchers. Internal exhaustive matches
+/// inside crap-core itself still need a new arm when a variant is
+/// added (the attribute affects external crates only).
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum CrapError {
     #[error("Invalid complexity value: {0}. Must be >= 1 and finite.")]
     InvalidComplexity(u32),
@@ -613,6 +622,19 @@ pub enum CrapError {
 
     #[error("Failed to parse LCOV data: {0}")]
     LcovParse(String),
+
+    /// The walker was asked to compute a metric the adapter does not
+    /// (yet) support. The variant is metric-named, not adapter-named —
+    /// adapter-specific phrasing comes from `meta.tool_name` at the
+    /// CLI rendering boundary, keeping the domain layer adapter-agnostic
+    /// (per CAO blocking finding on the W2.5 design).
+    ///
+    /// The `metric` field's `Display` impl yields the same lowercase
+    /// token used on the CLI (`cognitive` / `cyclomatic`), so the
+    /// adapter binary's error renderer can splice it directly into a
+    /// user-facing message without a Debug-format leak.
+    #[error("complexity metric `{}` is not yet supported by this adapter", metric)]
+    MetricNotSupported { metric: ComplexityMetric },
 
     #[error("Failed to parse source file: {0}")]
     SourceParse(String),

--- a/crates/crap-core/tests/snapshots/wire_envelope_crap4rs__envelope.snap
+++ b/crates/crap-core/tests/snapshots/wire_envelope_crap4rs__envelope.snap
@@ -5504,9 +5504,9 @@ expression: pretty
             "qualified_name": "main",
             "span": {
               "end_column": 1,
-              "end_line": 100,
+              "end_line": 107,
               "start_column": 1,
-              "start_line": 77
+              "start_line": 78
             }
           }
         },
@@ -11190,9 +11190,9 @@ expression: pretty
             "qualified_name": "main",
             "span": {
               "end_column": 1,
-              "end_line": 100,
+              "end_line": 107,
               "start_column": 1,
-              "start_line": 77
+              "start_line": 78
             }
           }
         },

--- a/crates/crap-core/tests/snapshots/wire_envelope_crap4ts__envelope.snap
+++ b/crates/crap-core/tests/snapshots/wire_envelope_crap4ts__envelope.snap
@@ -5,14 +5,14 @@ expression: pretty
 {
   "diff_ref": null,
   "language": "rust",
-  "metric": "cognitive",
+  "metric": "cyclomatic",
   "result": {
     "functions": [
       {
         "exceeds": false,
         "scored": {
           "complexity": 1,
-          "complexity_metric": "cognitive",
+          "complexity_metric": "cyclomatic",
           "contributors": [],
           "coverage_percent": 100.0,
           "crap": {
@@ -36,7 +36,7 @@ expression: pretty
         "exceeds": false,
         "scored": {
           "complexity": 1,
-          "complexity_metric": "cognitive",
+          "complexity_metric": "cyclomatic",
           "contributors": [],
           "coverage_percent": 100.0,
           "crap": {
@@ -60,7 +60,7 @@ expression: pretty
         "exceeds": false,
         "scored": {
           "complexity": 1,
-          "complexity_metric": "cognitive",
+          "complexity_metric": "cyclomatic",
           "contributors": [],
           "coverage_percent": 100.0,
           "crap": {
@@ -84,7 +84,7 @@ expression: pretty
         "exceeds": false,
         "scored": {
           "complexity": 1,
-          "complexity_metric": "cognitive",
+          "complexity_metric": "cyclomatic",
           "contributors": [],
           "coverage_percent": 50.0,
           "crap": {
@@ -108,7 +108,7 @@ expression: pretty
         "exceeds": false,
         "scored": {
           "complexity": 1,
-          "complexity_metric": "cognitive",
+          "complexity_metric": "cyclomatic",
           "contributors": [],
           "coverage_percent": 100.0,
           "crap": {
@@ -132,7 +132,7 @@ expression: pretty
         "exceeds": false,
         "scored": {
           "complexity": 1,
-          "complexity_metric": "cognitive",
+          "complexity_metric": "cyclomatic",
           "contributors": [],
           "coverage_percent": 100.0,
           "crap": {
@@ -156,7 +156,7 @@ expression: pretty
         "exceeds": false,
         "scored": {
           "complexity": 1,
-          "complexity_metric": "cognitive",
+          "complexity_metric": "cyclomatic",
           "contributors": [],
           "coverage_percent": 100.0,
           "crap": {
@@ -180,7 +180,7 @@ expression: pretty
         "exceeds": false,
         "scored": {
           "complexity": 1,
-          "complexity_metric": "cognitive",
+          "complexity_metric": "cyclomatic",
           "contributors": [],
           "coverage_percent": 100.0,
           "crap": {
@@ -204,7 +204,7 @@ expression: pretty
         "exceeds": false,
         "scored": {
           "complexity": 1,
-          "complexity_metric": "cognitive",
+          "complexity_metric": "cyclomatic",
           "contributors": [],
           "coverage_percent": 100.0,
           "crap": {
@@ -228,7 +228,7 @@ expression: pretty
         "exceeds": false,
         "scored": {
           "complexity": 1,
-          "complexity_metric": "cognitive",
+          "complexity_metric": "cyclomatic",
           "contributors": [],
           "coverage_percent": 100.0,
           "crap": {
@@ -296,7 +296,7 @@ expression: pretty
         "exceeds": false,
         "scored": {
           "complexity": 1,
-          "complexity_metric": "cognitive",
+          "complexity_metric": "cyclomatic",
           "contributors": [],
           "coverage_percent": 50.0,
           "crap": {
@@ -320,7 +320,7 @@ expression: pretty
         "exceeds": false,
         "scored": {
           "complexity": 1,
-          "complexity_metric": "cognitive",
+          "complexity_metric": "cyclomatic",
           "contributors": [],
           "coverage_percent": 100.0,
           "crap": {
@@ -344,7 +344,7 @@ expression: pretty
         "exceeds": false,
         "scored": {
           "complexity": 1,
-          "complexity_metric": "cognitive",
+          "complexity_metric": "cyclomatic",
           "contributors": [],
           "coverage_percent": 100.0,
           "crap": {
@@ -368,7 +368,7 @@ expression: pretty
         "exceeds": false,
         "scored": {
           "complexity": 1,
-          "complexity_metric": "cognitive",
+          "complexity_metric": "cyclomatic",
           "contributors": [],
           "coverage_percent": 100.0,
           "crap": {
@@ -392,7 +392,7 @@ expression: pretty
         "exceeds": false,
         "scored": {
           "complexity": 1,
-          "complexity_metric": "cognitive",
+          "complexity_metric": "cyclomatic",
           "contributors": [],
           "coverage_percent": 100.0,
           "crap": {
@@ -416,7 +416,7 @@ expression: pretty
         "exceeds": false,
         "scored": {
           "complexity": 1,
-          "complexity_metric": "cognitive",
+          "complexity_metric": "cyclomatic",
           "contributors": [],
           "coverage_percent": 100.0,
           "crap": {
@@ -440,7 +440,7 @@ expression: pretty
         "exceeds": false,
         "scored": {
           "complexity": 1,
-          "complexity_metric": "cognitive",
+          "complexity_metric": "cyclomatic",
           "contributors": [],
           "coverage_percent": 100.0,
           "crap": {
@@ -464,7 +464,7 @@ expression: pretty
         "exceeds": false,
         "scored": {
           "complexity": 1,
-          "complexity_metric": "cognitive",
+          "complexity_metric": "cyclomatic",
           "contributors": [],
           "coverage_percent": 100.0,
           "crap": {
@@ -488,7 +488,7 @@ expression: pretty
         "exceeds": false,
         "scored": {
           "complexity": 1,
-          "complexity_metric": "cognitive",
+          "complexity_metric": "cyclomatic",
           "contributors": [],
           "coverage_percent": 100.0,
           "crap": {
@@ -512,7 +512,7 @@ expression: pretty
         "exceeds": false,
         "scored": {
           "complexity": 1,
-          "complexity_metric": "cognitive",
+          "complexity_metric": "cyclomatic",
           "contributors": [],
           "coverage_percent": 100.0,
           "crap": {

--- a/crates/crap-core/tests/wire_envelope_crap4ts.rs
+++ b/crates/crap-core/tests/wire_envelope_crap4ts.rs
@@ -15,16 +15,16 @@
 //! refactors. Separate per-adapter snapshots give cleaner failure
 //! attribution than a single dual-fixture snapshot would.
 //!
-//! ## Why the snapshot bakes in current (W1.3-era) wrong-by-design values
+//! ## Wrong-by-design values that flipped at W2.5
 //!
-//! The current crap4ts envelope reports `language: "rust"` and
-//! `metric: "cognitive"` — both incorrect for a TS adapter. These
-//! values flip in **W2.5** (crap-rs#188) when
-//! `AdapterMeta::default_metric` lands per locked decision #2
-//! (cyclomatic for crap4ts). The flip MUST show up as a deliberate
-//! snapshot diff at W2.5 PR time; until then, locking the
-//! wrong-by-design values into the W1.3 baseline catches accidental
-//! changes between W1.3 and W2.5.
+//! Through W1.3 the snapshot baked `metric: "cognitive"` — wrong for
+//! crap4ts (no cognitive support; default should be cyclomatic).
+//! W2.5 (crap-rs#188) flips this via `AdapterMeta::default_metric`
+//! per locked decision #2. The snapshot was regenerated at W2.5 PR
+//! time; `metric: "cyclomatic"` is now baked. `language: "rust"`
+//! remains wrong-by-design — that flips later when the `Language`
+//! enum lands as part of the deferred HTML-reporter Wave 5
+//! re-launch.
 //!
 //! ## Volatile fields stripped
 //!

--- a/crates/crap4rs/src/main.rs
+++ b/crates/crap4rs/src/main.rs
@@ -16,6 +16,7 @@
 use std::process::ExitCode;
 
 use crap_core::cli::AdapterMeta;
+use crap_core::domain::types::ComplexityMetric;
 use crap4rs::adapters::complexity::SynComplexityAdapter;
 use crap4rs::adapters::coverage::LcovParser;
 
@@ -88,6 +89,12 @@ fn main() -> ExitCode {
         rule_help_uri: "https://github.com/breezy-bays-labs/crap-rs#crap-formula",
         config_file_name: "crap4rs.toml",
         default_excludes: DEFAULT_EXCLUDES,
+        // crap4rs supports both cognitive and cyclomatic. Cognitive
+        // remains the default (locked decision #2) — explicit here so
+        // the per-adapter default flows through `AdapterMeta` for both
+        // adapters uniformly (no implicit `ComplexityMetric::default()`
+        // fallthrough anywhere in crap-core).
+        default_metric: ComplexityMetric::Cognitive,
     };
     let cli = crap_core::cli::parse_args(&meta);
     let complexity = SynComplexityAdapter::new();

--- a/crates/crap4ts/src/adapters/walker/mod.rs
+++ b/crates/crap4ts/src/adapters/walker/mod.rs
@@ -70,13 +70,14 @@ use oxc::syntax::operator::LogicalOperator;
 
 /// Oxc-based complexity extractor implementing `ComplexityPort`.
 ///
-/// W1.2 supports cyclomatic counting only (one increment per decision
-/// point). Cognitive counting lands with W2.5 (#188) alongside the
-/// `MetricNotSupported` error variant — until then, requests for
-/// `ComplexityMetric::Cognitive` receive the same cyclomatic-style
-/// counts. The default metric for `crap4ts` flips to cyclomatic in
-/// W2.5 via `AdapterMeta::default_metric`, so end-to-end runs already
-/// converge on the right semantics.
+/// crap4ts 2.0.0 supports cyclomatic counting only (one increment per
+/// decision point). Cognitive counting is deferred to a follow-up
+/// issue (per shaping Q2); requests for `ComplexityMetric::Cognitive`
+/// return `CrapError::MetricNotSupported`, surfaced as an adapter-
+/// specific user message at the CLI boundary. The default metric for
+/// `crap4ts` is cyclomatic (locked decision #2) wired through
+/// `AdapterMeta::default_metric`, so end-to-end runs without an
+/// explicit `--metric` flag never trip the unsupported-metric path.
 pub struct OxcWalker {
     _private: (),
 }
@@ -102,6 +103,17 @@ impl ComplexityPort for OxcWalker {
         file_path: &str,
         metric: ComplexityMetric,
     ) -> Result<Vec<FunctionComplexity>, CrapError> {
+        // crap4ts 2.0.0 ships --metric cyclomatic only. Cognitive
+        // complexity for TS is deferred to a follow-up issue (per
+        // shaping Q2). Reject upfront so the binary's error renderer
+        // surfaces the adapter-named hint at the CLI boundary
+        // (`metric_unsupported.feature` scenario 1 contract).
+        if metric == ComplexityMetric::Cognitive {
+            return Err(CrapError::MetricNotSupported {
+                metric: ComplexityMetric::Cognitive,
+            });
+        }
+
         let allocator = Allocator::default();
         let source_type =
             SourceType::from_path(Path::new(file_path)).unwrap_or_else(|_| SourceType::ts());

--- a/crates/crap4ts/src/main.rs
+++ b/crates/crap4ts/src/main.rs
@@ -18,6 +18,7 @@
 use std::process::ExitCode;
 
 use crap_core::cli::AdapterMeta;
+use crap_core::domain::types::ComplexityMetric;
 use crap4ts::adapters::coverage::IstanbulCoverage;
 use crap4ts::adapters::walker::OxcWalker;
 
@@ -30,7 +31,8 @@ const LONG_ABOUT: &str = "CRAP (Change Risk Anti-Patterns) score analyzer for Ty
                          up ahead of the parser ship in the next pipeline.\n\n\
                          When the real adapters land, combines AST complexity (via oxc) with \
                          Istanbul JSON coverage to identify functions that are both complex \
-                         and under-tested. Default metric is cognitive complexity.";
+                         and under-tested. Default metric is cyclomatic complexity; cognitive \
+                         is not yet supported on crap4ts.";
 
 const AFTER_HELP: &str = "\
 EXAMPLES (alpha — walker not yet implemented):
@@ -66,6 +68,10 @@ fn main() -> ExitCode {
         rule_help_uri: "https://github.com/breezy-bays-labs/crap-rs#crap-formula",
         config_file_name: "crap4ts.toml",
         default_excludes: DEFAULT_EXCLUDES,
+        // crap4ts ships --metric cyclomatic as the only supported
+        // metric in 2.0.0; cognitive returns CrapError::MetricNotSupported
+        // from the walker (D5 + locked decision #2).
+        default_metric: ComplexityMetric::Cyclomatic,
     };
     let cli = crap_core::cli::parse_args(&meta);
     let complexity = OxcWalker::new();

--- a/crates/crap4ts/tests/metric_unsupported_smoke.rs
+++ b/crates/crap4ts/tests/metric_unsupported_smoke.rs
@@ -1,0 +1,220 @@
+//! Integration smoke tests for `CrapError::MetricNotSupported` rendering.
+//!
+//! W2.5 (crap-rs#188) lands `CrapError::MetricNotSupported { metric }`
+//! plus the per-adapter `AdapterMeta::default_metric` mechanism. These
+//! tests assert the four user-visible contracts from
+//! `tests/features/metric_unsupported.feature`:
+//!
+//! 1. `crap4ts --metric cognitive` exits status 2 and emits the exact
+//!    user-facing string from scenario 1 (byte-for-byte).
+//! 2. `crap4ts --metric cyclomatic` (explicit) succeeds — the walker
+//!    accepts cyclomatic; the only unsupported metric is cognitive.
+//! 3. `crap4ts` (no `--metric` flag) succeeds — exercises the new
+//!    `AdapterMeta::default_metric = Cyclomatic` plumbing for crap4ts.
+//!    Without this, the no-flag invocation would fall through to
+//!    `ComplexityMetric::default() == Cognitive` and trip the walker
+//!    guard.
+//! 4. `crap4rs` (no `--metric` flag) still succeeds with the cognitive
+//!    default — regression check for the shared `merge_effective_inputs`
+//!    signature change.
+//!
+//! The fixture-loading helper duplicates the W1.3
+//! `end_to_end_smoke::build_jest_fixture` substitution pattern (per
+//! ADR-d: per-file 30-LOC tempdir helper). Each test file owns its
+//! own helper rather than sharing — copy-2 is still under the threshold
+//! where a `crap4ts-fixtures` test-support crate would pay off.
+
+use std::path::{Path, PathBuf};
+
+use assert_cmd::Command;
+use tempfile::TempDir;
+
+const FIXTURE_TEMPLATE: &str = include_str!("fixtures/istanbul-jest/coverage-final.json");
+
+/// Build a canonicalized tempdir, copy the W1.1 jest fixture TS files
+/// into it, and write a `coverage-final.json` with `{SRC_ROOT}`
+/// substituted. Mirrors `end_to_end_smoke::build_jest_fixture` per the
+/// W1.3 substitution convention (canonicalize because macOS routes
+/// `/tmp` through `/private/tmp`; forward-slash normalize because
+/// Windows backslashes would break JSON parsing). Returns the `TempDir`
+/// guard (drop = cleanup) plus the canonical fixture root.
+fn build_jest_fixture() -> (TempDir, PathBuf) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let canonical = std::fs::canonicalize(tmp.path()).expect("canonicalize tempdir");
+
+    for (name, content) in [
+        ("simple.ts", include_str!("fixtures/ts-fixtures/simple.ts")),
+        ("arrow.ts", include_str!("fixtures/ts-fixtures/arrow.ts")),
+        (
+            "Button.tsx",
+            include_str!("fixtures/ts-fixtures/Button.tsx"),
+        ),
+        ("map.ts", include_str!("fixtures/ts-fixtures/map.ts")),
+        ("mixed.ts", include_str!("fixtures/ts-fixtures/mixed.ts")),
+    ] {
+        std::fs::write(canonical.join(name), content).expect("write fixture");
+    }
+
+    let payload = FIXTURE_TEMPLATE.replace(
+        "{SRC_ROOT}",
+        &canonical.to_string_lossy().replace('\\', "/"),
+    );
+    std::fs::write(canonical.join("coverage-final.json"), payload)
+        .expect("write coverage-final.json");
+
+    (tmp, canonical)
+}
+
+/// Spawn a binary by name with the supplied args. Used for both
+/// `crap4ts` and `crap4rs` invocations across the four tests below.
+fn run_bin(name: &str, src: &Path, coverage: &Path, extra: &[&str]) -> std::process::Output {
+    Command::cargo_bin(name)
+        .unwrap_or_else(|_| panic!("{name} binary discoverable in workspace"))
+        .arg("--coverage")
+        .arg(coverage)
+        .arg("--src")
+        .arg(src)
+        .args(extra)
+        .output()
+        .unwrap_or_else(|e| panic!("{name} executes: {e}"))
+}
+
+// ── 1. `--metric cognitive` produces the exact-string scenario-1 error ──
+
+#[test]
+fn cognitive_flag_exits_with_metric_not_supported_error() {
+    let (_tmp, root) = build_jest_fixture();
+    let coverage = root.join("coverage-final.json");
+    let out = run_bin(
+        "crap4ts",
+        &root,
+        &coverage,
+        &["--metric", "cognitive", "--no-fail"],
+    );
+
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "expected exit code 2 (CrapError); got status={:?}\nstdout={}\nstderr={}",
+        out.status,
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    // The exact-string contract from
+    // `tests/features/metric_unsupported.feature` scenario 1. Asserted
+    // via `contains` because (a) the binary prints `\n` after the
+    // message and (b) the wider stderr may include the per-file
+    // `warning: skipping` traffic from the parse-failure-continues
+    // pipeline. The user-facing line itself is byte-identical to the
+    // feature-file expected output.
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let expected = "crap4ts: complexity metric `cognitive` is not yet supported. Use `--metric cyclomatic` (the default for crap4ts) or track support at https://github.com/breezy-bays-labs/crap-rs.";
+    assert!(
+        stderr.contains(expected),
+        "stderr missing exact MetricNotSupported message.\nExpected to contain:\n{expected}\nActual stderr:\n{stderr}"
+    );
+    // Explicitly assert the `error:` prefix is NOT present — the
+    // metric-unsupported renderer bypasses the generic prefix per
+    // breadboard W-5 (CPO sharpening: direct guidance, no `run --help`
+    // indirection, no generic prefix).
+    assert!(
+        !stderr.contains("error: crap4ts:"),
+        "rendered error should not have generic `error:` prefix for MetricNotSupported; stderr=\n{stderr}"
+    );
+}
+
+// ── 2. `--metric cyclomatic` (explicit) succeeds ──────────────────────
+
+#[test]
+fn cyclomatic_flag_explicit_succeeds() {
+    let (_tmp, root) = build_jest_fixture();
+    let coverage = root.join("coverage-final.json");
+    let out = run_bin(
+        "crap4ts",
+        &root,
+        &coverage,
+        &["--metric", "cyclomatic", "--threshold", "16", "--no-fail"],
+    );
+
+    assert!(
+        out.status.success(),
+        "crap4ts --metric cyclomatic exited non-zero: stdout={}\nstderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+}
+
+// ── 3. `crap4ts` no-flag invocation defaults to cyclomatic + succeeds ─
+
+#[test]
+fn no_flag_invocation_defaults_to_cyclomatic_via_adapter_meta() {
+    // This is the load-bearing test for `AdapterMeta::default_metric`.
+    // Without the W2.5 plumbing, `crap4ts` with no `--metric` flag
+    // would fall through to `ComplexityMetric::default() == Cognitive`,
+    // trip the walker's MetricNotSupported guard, and exit 2.
+    let (_tmp, root) = build_jest_fixture();
+    let coverage = root.join("coverage-final.json");
+    let out = run_bin(
+        "crap4ts",
+        &root,
+        &coverage,
+        &["--threshold", "16", "--no-fail"],
+    );
+
+    assert!(
+        out.status.success(),
+        "crap4ts (no flag) should default to cyclomatic via AdapterMeta::default_metric; got non-zero exit\nstdout={}\nstderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    // Sanity check: stderr must not contain a MetricNotSupported
+    // signal — that would mean the no-flag invocation defaulted to
+    // cognitive (the pre-W2.5 fallthrough).
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("is not yet supported"),
+        "no-flag crap4ts emitted MetricNotSupported phrase (default fell through to cognitive?); stderr=\n{stderr}"
+    );
+}
+
+// ── 4. `crap4rs` no-flag default-cognitive regression check ───────────
+
+#[test]
+fn crap4rs_no_flag_default_cognitive_still_works() {
+    // Regression check on the shared `merge_effective_inputs` change.
+    // crap4rs's `AdapterMeta::default_metric` is `Cognitive`; the
+    // walker supports both metrics; no-flag invocation should succeed
+    // and produce a complete scorecard with cognitive scoring.
+    //
+    // We re-use crap4rs's existing self-LCOV fixture (the same one
+    // `wire_envelope_crap4rs.rs` uses) and analyze crap4rs's own
+    // source. `--no-fail` because the self-LCOV has threshold
+    // violations baked in — we only care that the binary runs
+    // green end-to-end, not that it passes the gate.
+    let out = Command::cargo_bin("crap4rs")
+        .expect("crap4rs binary discoverable in workspace")
+        .args([
+            "--coverage",
+            "../crap4rs/tests/fixtures/crap4rs-self.lcov",
+            "--src",
+            "../crap4rs/src",
+            "--threshold",
+            "25",
+            "--no-fail",
+        ])
+        .output()
+        .expect("crap4rs binary executes");
+
+    assert!(
+        out.status.success(),
+        "crap4rs (no flag) should default to cognitive via AdapterMeta::default_metric; got non-zero exit\nstdout={}\nstderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("is not yet supported"),
+        "no-flag crap4rs emitted MetricNotSupported (regression in shared merge_effective_inputs?); stderr=\n{stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

**W2.5 of the TS-adapter pipeline — PR 1 of 3 in Wave 2** (per user's Option B aggressive consolidation, decided 2026-05-14). Load-bearing crap-core bump unblocking the rest of Wave 2.

Adds `CrapError::MetricNotSupported { metric: ComplexityMetric }` (metric-named, not adapter-named per CAO blocking finding) on the now-`#[non_exhaustive]` `CrapError` enum. Extends `AdapterMeta` with a required `default_metric: ComplexityMetric` field — crap4rs supplies `Cognitive`; crap4ts supplies `Cyclomatic`. Changes `merge_effective_inputs` signature to take `meta: &AdapterMeta` so the per-adapter default flows through the shared CLI fallthrough. Walker rejects `Cognitive` for crap4ts. Binary error renderer prints adapter-specific phrasing without the generic `error:` prefix — byte-identical to `metric_unsupported.feature` scenario 1.

Resolves **CAO BLOCKING-1 + CQO BLOCKING #2** (no-flag `crap4ts` would otherwise default to `Cognitive` and trip the new walker guard — `metric_unsupported.feature` scenario 4 breaks without an explicit fix).

`Closes #188`

## Acceptance gates (15)

- [x] **1.** `cargo build --workspace` — clean
- [x] **2.** `cargo nextest run --workspace --all-targets` — **995/995** passed (added 4 new smoke tests, replaced 1 test with 3 new tests covering Cognitive/Cyclomatic adapter defaults + config-vs-adapter-default precedence)
- [x] **3.** `cargo +1.93 check --workspace --all-targets` — clean
- [x] **4.** `cargo fmt --check` — clean
- [x] **5.** `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] **6.** `RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps` — clean
- [x] **7.** `cargo deny check` — advisories ok, bans ok, licenses ok, sources ok
- [x] **8.** AST-purity grep on `crates/crap-core/src/` — no `syn`/`oxc`/etc imports added; no `\"crap4rs\"`/`\"crap4ts\"` string literals in `crates/crap-core/src/domain/types.rs`
- [x] **9.** Wire snapshots regenerated — see "Wire-shape canary" section below
- [x] **10.** `crap4rs` (no flag) defaults to cognitive — regression check in `metric_unsupported_smoke::crap4rs_no_flag_default_cognitive_still_works`
- [x] **11.** `crap4ts` (no flag) defaults to cyclomatic — new behavior verified in `metric_unsupported_smoke::no_flag_invocation_defaults_to_cyclomatic_via_adapter_meta`
- [x] **12.** `metric_unsupported.feature` (5 scenarios) — scenario 1 byte-string contract pinned in the smoke test; scenario 4 (no-flag) exercised
- [x] **13.** `crates/crap-core/Cargo.toml` — `0.1.0` → `0.2.0` (workspace dep version also updated)
- [x] **14.** ADR (d) `~/Github/ops/decisions/crap-rs/adr-adapter-meta-default-metric.md` — Y-statement format, lands in this PR
- [x] **15.** `lefthook run pre-push` — all 9 checks (ast-purity, clippy, cucumber, deny, docs, fmt, insta, msrv, test) green

## Wire-shape canary

**Both** snapshots regenerated; rationale below. The wire-snapshot canary's job is to catch envelope-SHAPE drift, not source-position drift or W1.3-anticipated semantic flips. Both deltas are within the canary's "expected, documented" envelope per locked decision #11.

### crap4ts: `metric: \"cognitive\"` → `\"cyclomatic\"` (W1.3-anticipated)

Per locked decision #2 and the explicit comment block at `crap-core/tests/wire_envelope_crap4ts.rs:18-28` (W1.3 era): the W1.3 snapshot bakes `metric: \"cognitive\"` as a wrong-by-design value flagged to flip at W2.5 PR time. This is the flip. `language: \"rust\"` remains wrong-by-design — deferred to a future pipeline.

### crap4rs: position-only drift in `main` function

`span.start_line: 77 → 78` and `span.end_line: 100 → 107` on the `main` function. Cause: `crap4rs/src/main.rs` gained ~6 lines (one `ComplexityMetric` import + 5-line rustdoc + the explicit `default_metric: ComplexityMetric::Cognitive` field). The envelope SHAPE is unchanged — only line numbers shifted because the analyzed source file grew. Envelope structural parity (every field, every nesting level) is identical; the canary is doing its job by catching the position diff and asking for confirmation.

## Plan-of-record deviations (load-bearing, per W1.* discipline)

1. **`CrapError` was NOT `#[non_exhaustive]`** — breadboard line 189 + worktree prompt step 5 claimed it was at `types.rs:606`. Verified false (the attribute was on the surrounding enum families like `ContributorKind`, not `CrapError`). Added `#[non_exhaustive]` to `CrapError` as part of this PR to make the breadboard's invariant honest AND protect the 0.1 → 0.2 bump rationale. Internal exhaustive matches in crap-core needed no updates (none existed; only constructors).

2. **`extract_complexities` short-circuit (`crap-core/src/core/mod.rs`)** — not in the plan. The walker's `Err(MetricNotSupported)` was being swallowed by the per-file "skip and continue" pattern at `core::extract_complexities`, producing N stuttering `warning: skipping <file>: complexity metric ... not supported` lines followed by a misleading `error: no functions extracted from source files`. Caught empirically by the first run of the cognitive smoke test. Fixed by short-circuiting on `MetricNotSupported` (returns early) — see ADR (d) "Consequences" section for the rationale. Per-file parse failures (`SourceParse`) still go through the skip-and-continue path; only `MetricNotSupported` short-circuits because it's a configuration mismatch, not a per-file problem.

3. **Wire snapshot drift × 2** — documented above. Prompt gate #9 claimed \"byte-identical for BOTH\"; reality (per focus.md line 48 + the wire envelope module's own docstring at lines 18-28) was \"crap4ts flips intentionally at W2.5\". Both snapshots regenerated via `cargo insta accept`; both drifts documented.

4. **`LONG_ABOUT` in `crap4ts/src/main.rs`** — updated to say cyclomatic instead of cognitive. Minor copy fix beyond strict plan scope; the pre-W2.5 copy claimed \"Default metric is cognitive complexity\" which is wrong after this PR.

5. **Extra precedence test added** — `merge_effective_inputs_config_metric_wins_over_adapter_default` (defensive; pins config > adapter-default precedence). Beyond plan's two new tests but cheap to add and prevents a precedence regression slipping through later.

## CAO BLOCKING-1 + CQO BLOCKING #2 resolution path

Path A (chosen, per ADR (d)): extend `AdapterMeta` with `default_metric: ComplexityMetric`, change `merge_effective_inputs(cli, file_config, meta: &AdapterMeta)` signature, replace `unwrap_or_default()` with `unwrap_or(meta.default_metric)`. Each adapter binary's `AdapterMeta` instantiation supplies its own default — crap4rs `Cognitive`, crap4ts `Cyclomatic` (per locked decision #2 + D5 calibration).

Cost: one production call-site change (in `prepare_pipeline`), updates to 7 test call sites + 2 `fake_meta` helpers + the existing `merge_effective_inputs_default_metric_is_cognitive` test replaced with 3 new tests. No new public trait. No `metric_unsupported_hint` field on `AdapterMeta` — the existing `tool_name` + `tool_info_uri` plus the new `default_metric` field supply every variable the error-message template needs (resolved CAO ADVISORY-4).

## Why hardcoded error template (vs separate hint field)

The error template is a single line with 4 substitutions all already available from `AdapterMeta`:

```
{meta.tool_name}: complexity metric `{metric}` is not yet supported. Use `--metric {meta.default_metric}` (the default for {meta.tool_name}) or track support at {meta.tool_info_uri}.
```

Adding a `metric_unsupported_hint: &'static str` field would force every adapter binary to spell out a per-language template literal that's structurally identical except for the substitutions — pure duplication. The variant lives in `crap-core::cli::render_error` which downcasts `anyhow::Error` to `CrapError` via `downcast_ref` (so context-wrapped errors are still detected) and bypasses the generic `error:` prefix per `metric_unsupported.feature` scenario 1's exact-string contract. Reversible at PR review if reviewers prefer the field-per-template approach.

## Test plan

- [x] `cargo nextest run --workspace --all-targets` — 995/995 pass locally (4 new smoke tests in `metric_unsupported_smoke.rs` + 3 new tests in `cli/mod.rs`)
- [x] `cargo fmt --check && cargo clippy --workspace --all-targets -- -D warnings && cargo +1.93 check --workspace --all-targets && cargo deny check && RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps` — all clean locally
- [x] `lefthook run pre-push` — all 9 checks green locally
- [ ] CI: Format / Clippy / Test linux-x86 / Test macos-arm / Test macos-x86 / cargo-deny / cargo-doc / AST-purity / Self-CRAP / Scorecard
- [ ] Mutation testing on `domain/view.rs` (can be in-flight at merge per W1.* precedent)
- [ ] Bot review (CodeRabbit) — load-bearing per `feedback_bot-review-on-adr-prs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)