### PR TITLE
feat(crap4ts): #184 + #185 + #199 — OxcWalker TS-specific decision points + file-extension dispatch + class-field arrow discovery + ADR (a)

### DIFF
--- a/crates/crap4ts/src/adapters/walker/mod.rs
+++ b/crates/crap4ts/src/adapters/walker/mod.rs
@@ -25,8 +25,8 @@
 //!
 //! ## W1.2 + W2.1 decision-point coverage (crap-rs#182 + #184)
 //!
-//! The 11-row decision-point mapping table — see ADR (a) at
-//! `~/Github/ops/decisions/crap-rs/adr-cyclomatic-decision-points-ts.md`
+//! The 11-row decision-point mapping table — see ADR (a) (D15) at
+//! <https://github.com/breezy-bays-labs/ops/blob/main/decisions/crap-rs/adr-cyclomatic-decision-points-ts.md>
 //! for the rationale + per-row justification:
 //!
 //! | oxc AST node                                              | ContributorKind   |
@@ -911,11 +911,10 @@ impl<'src> FunctionFinder<'src> {
                 n,
             ));
         }
-        // `_` covers all current `LogicalOperator` variants (`And`,
-        // `Or`, `Coalesce`). The arm is intentionally exhaustive: any
-        // future operator variant on `LogicalOperator` falls through
-        // the same scoring path.
-        let _ = le.operator;
+        // Intentional non-discrimination on `le.operator`: all current
+        // variants (`And`, `Or`, `Coalesce`) and any future variant
+        // score identically per ADR (a). See the function rustdoc
+        // above for the mapping table.
         self.visit_expression(&le.left, out, nesting);
         self.visit_expression(&le.right, out, nesting);
     }

--- a/crates/crap4ts/src/adapters/walker/mod.rs
+++ b/crates/crap4ts/src/adapters/walker/mod.rs
@@ -3,11 +3,16 @@
 //! Mirrors `crates/crap4rs/src/adapters/complexity/mod.rs` in shape and
 //! responsibilities. The walker:
 //!
-//! 1. Parses the source via `oxc_parser::Parser` (with `SourceType`
-//!    inferred from `file_path`'s extension via `SourceType::from_path`,
-//!    falling back to `SourceType::ts()` for unrecognised extensions —
-//!    W2.2 (#185) widens this dispatch to `.tsx` / `.jsx` / `.js` /
-//!    `.mjs` / `.cjs` while keeping the same fallback shape).
+//! 1. Parses the source via `oxc_parser::Parser`. `SourceType` is
+//!    inferred from `file_path`'s extension via oxc's canonical
+//!    `SourceType::from_path` — which already covers all six
+//!    `AdapterMeta::extensions` (`.ts` / `.tsx` / `.jsx` / `.js` /
+//!    `.mjs` / `.cjs`) plus `.mts` / `.cts` / `.d.ts`. Unknown
+//!    extensions fall back to `SourceType::ts()` so the walker stays
+//!    robust against discovery paths that hand us non-source files.
+//!    W2.2 (#185) verified this dispatcher covers the full extension
+//!    matrix without a hand-rolled match — see PR #173 W2.2 plan
+//!    deviation notes.
 //! 2. If `ret.errors` is non-empty, returns
 //!    `Err(CrapError::SourceParse(format!("{file_path}: {}", err)))`.
 //!    The orchestrator at `crap-core/src/core/mod.rs:286-310` catches
@@ -18,23 +23,48 @@
 //!    decision points scored inside its own body — nested functions
 //!    accumulate independently.
 //!
-//! ## W1.2 scope (crap-rs#182)
+//! ## W1.2 + W2.1 decision-point coverage (crap-rs#182 + #184)
 //!
-//! Six universal cyclomatic decision points map to existing
-//! `ContributorKind` variants:
+//! The 11-row decision-point mapping table — see ADR (a) at
+//! `~/Github/ops/decisions/crap-rs/adr-cyclomatic-decision-points-ts.md`
+//! for the rationale + per-row justification:
 //!
-//! | oxc AST node                                  | ContributorKind   |
-//! |-----------------------------------------------|-------------------|
-//! | `Statement::IfStatement`                      | `IfBranch`        |
-//! | `Statement::ForStatement` / `ForOf` / `ForIn` | `ForLoop`         |
-//! | `Statement::WhileStatement`                   | `WhileLoop`       |
-//! | `Statement::DoWhileStatement`                 | `DoWhileLoop`     |
-//! | `SwitchCase` (with `test: Some(_)`)           | `CaseBranch`      |
-//! | `Expression::LogicalExpression(And\|Or)`      | `LogicalOperator` |
+//! | oxc AST node                                              | ContributorKind   |
+//! |-----------------------------------------------------------|-------------------|
+//! | `Statement::IfStatement`                                  | `IfBranch`        |
+//! | `Statement::ForStatement` / `ForOf` / `ForIn`             | `ForLoop`         |
+//! | `Statement::WhileStatement`                               | `WhileLoop`       |
+//! | `Statement::DoWhileStatement`                             | `DoWhileLoop`     |
+//! | `SwitchCase` (with `test: Some(_)`)                       | `CaseBranch`      |
+//! | `LogicalExpression` with `And` / `Or`                     | `LogicalOperator` |
+//! | `ConditionalExpression` (`?:`)                            | `Ternary`         |
+//! | `ChainExpression` (`?.` / `?.()` — one chain → one point) | `OptionalChain`   |
+//! | `LogicalExpression` with `Coalesce` (`??`)                | `LogicalOperator` |
+//! | `TryStatement.handler.is_some()` (`catch`)                | `Catch`           |
+//! | JSX conditional `{cond && <Element/>}`                    | `LogicalOperator` (decomposes through `LogicalExpression(And)`) |
 //!
-//! TS-specific decision points (`?:` / `?.` / `??` / `catch` / JSX) are
-//! intentionally deferred to W2.1 (#184) with ADR (a) — the walker
-//! traverses past them without emitting contributors.
+//! ### Compound counting (W2.1)
+//!
+//! Each operator counts +1 unconditionally; chains/nestings never
+//! flatten. `a ? b : c ? d : e` produces CC 3 (two `Ternary`);
+//! `a && b && c && d` produces CC 4 (three `LogicalOperator`); nested
+//! `if`s produce one `IfBranch` per `if`; `if (a && b)` counts the `if`
+//! AND the inner `&&`. Implementation: the expression visitor recurses
+//! through children unconditionally so chains accumulate naturally.
+//!
+//! ### Class-element traversal (#199)
+//!
+//! `visit_class` discovers three function-entry kinds beyond plain
+//! `MethodDefinition`:
+//!
+//! - `ClassElement::PropertyDefinition` with an arrow / function-
+//!   expression initializer (`onClick = () => { ... }`) — modern TS
+//!   auto-bind handler pattern; routed through `record_arrow` /
+//!   `record_function` with the class-qualified name.
+//! - `ClassElement::StaticBlock` — emitted as a synthetic
+//!   `<ClassName>.<static-init>` function whose body is the block's
+//!   `Vec<Statement>`. Discovers nested functions inside the static
+//!   initialiser and counts decision points it contains.
 //!
 //! ## Span semantics (Context7-verified against oxc 0.129)
 //!
@@ -66,7 +96,6 @@ use oxc::ast::ast::{
 };
 use oxc::parser::Parser;
 use oxc::span::{SourceType, Span};
-use oxc::syntax::operator::LogicalOperator;
 
 /// Oxc-based complexity extractor implementing `ComplexityPort`.
 ///
@@ -237,6 +266,23 @@ impl<'src> FunctionFinder<'src> {
         }
     }
 
+    /// Discover function-entry sites on a class body. Beyond plain
+    /// `MethodDefinition`, two ES2022/TS shapes carry executable
+    /// function bodies (#199):
+    ///
+    /// 1. `ClassElement::PropertyDefinition` (`onClick = () => {…}` or
+    ///    `static setup = function () {…}`) — the class-field auto-bind
+    ///    pattern used by React class components and Angular services.
+    ///    The initializer goes through `record_initializer` with the
+    ///    class-qualified name, so an arrow / function-expression is
+    ///    recorded with `<ClassName>.<fieldName>` (sentinel
+    ///    `<computed>` for computed keys).
+    /// 2. `ClassElement::StaticBlock` (`class Foo { static {…} }`) —
+    ///    treated as a synthetic `<ClassName>.<static-init>` function
+    ///    whose body is the static block's statement list. Decision
+    ///    points inside the block contribute to that synthetic
+    ///    function, mirroring the "static initialisation is method-
+    ///    like" interpretation from #199's discovery section.
     fn visit_class(&mut self, class: &Class<'_>, name_hint: Option<String>) {
         let class_name = class
             .id
@@ -245,10 +291,69 @@ impl<'src> FunctionFinder<'src> {
             .or(name_hint)
             .unwrap_or_else(|| "<anonymous class>".to_string());
         for element in &class.body.body {
-            if let ClassElement::MethodDefinition(method) = element {
-                self.record_method(method, &class_name);
+            match element {
+                ClassElement::MethodDefinition(method) => self.record_method(method, &class_name),
+                ClassElement::PropertyDefinition(prop) => {
+                    self.visit_property_definition(prop, &class_name);
+                }
+                ClassElement::StaticBlock(block) => self.record_static_block(block, &class_name),
+                // AccessorProperty + TSIndexSignature carry no
+                // executable bodies for cyclomatic analysis (accessors'
+                // bodies live elsewhere; index signatures are type-
+                // only). Both are intentionally not function-entry
+                // sites.
+                ClassElement::AccessorProperty(_) | ClassElement::TSIndexSignature(_) => {}
             }
         }
+    }
+
+    /// Route a class-field initializer through the same dispatch as a
+    /// `const x = ...` declarator. Arrow + function-expression bodies
+    /// become their own complexity sites; nested class expressions
+    /// recurse into `visit_class`; any other initializer expression is
+    /// walked purely for nested-function discovery via a throwaway sink
+    /// (the field doesn't itself contribute to any parent accumulator —
+    /// it is the parent in this position).
+    fn visit_property_definition(
+        &mut self,
+        prop: &oxc::ast::ast::PropertyDefinition<'_>,
+        class_name: &str,
+    ) {
+        let Some(value) = &prop.value else {
+            return;
+        };
+        let field_name = property_key_name(&prop.key).unwrap_or_else(|| "<computed>".into());
+        let qualified = format!("{class_name}.{field_name}");
+        match value {
+            Expression::ArrowFunctionExpression(arrow) => {
+                self.record_arrow(arrow, Some(qualified));
+            }
+            Expression::FunctionExpression(func) => {
+                self.record_function(func, Some(qualified));
+            }
+            Expression::ClassExpression(class) => self.visit_class(class, Some(qualified)),
+            other => {
+                let mut sink = Contributors::default();
+                self.visit_expression(other, &mut sink, None);
+            }
+        }
+    }
+
+    /// Emit a synthetic `<ClassName>.<static-init>` function for a
+    /// `static { ... }` block. The block's statement list is walked the
+    /// same way a function body is — decision points inside it
+    /// accumulate against the synthetic function and nested function
+    /// entries spawn their own complexity sites. Per #199 discovery,
+    /// this matches the "static initialisation is method-like"
+    /// interpretation rather than rolling decision points up into the
+    /// class (which has no executable body of its own to charge).
+    fn record_static_block(&mut self, block: &oxc::ast::ast::StaticBlock<'_>, class_name: &str) {
+        let qualified = format!("{class_name}.<static-init>");
+        let mut contributors = Contributors::default();
+        for stmt in &block.body {
+            self.visit_statement(stmt, &mut contributors, Some(0));
+        }
+        self.push_function(qualified, block.span, contributors);
     }
 
     fn record_method(&mut self, method: &MethodDefinition<'_>, class_name: &str) {
@@ -487,16 +592,27 @@ impl<'src> FunctionFinder<'src> {
         }
     }
 
-    /// W1.2 walks the try block, handler body, and finalizer for
-    /// nested-function discovery + any universal decision points
-    /// inside them. It does NOT score `catch` itself — that's W2.1's
-    /// job (ADR (a) on cyclomatic decision-point mappings for TS).
+    /// W2.1 (#184): `try { … } catch (e) { … }` contributes one
+    /// `Catch` decision point. Per ADR (a), the score is on
+    /// `handler.is_some()` rather than per-thrown-type — a single
+    /// `catch (e)` clause is one branch in the control-flow graph
+    /// regardless of how it discriminates the error. `try { … }
+    /// finally { … }` (no handler) is NOT a decision point.
+    ///
+    /// After scoring, walk the try block, handler body, and finalizer
+    /// for nested-function discovery + any universal decision points
+    /// inside them.
     fn visit_try(
         &mut self,
         t: &oxc::ast::ast::TryStatement<'_>,
         out: &mut Contributors,
         nesting: Option<u32>,
     ) {
+        if t.handler.is_some()
+            && let Some(n) = nesting
+        {
+            out.push(contributor(ContributorKind::Catch, self.source, t.span, n));
+        }
         self.visit_block(&t.block.body, out, nesting);
         if let Some(handler) = &t.handler {
             self.visit_block(&handler.body.body, out, nesting);
@@ -621,22 +737,19 @@ impl<'src> FunctionFinder<'src> {
             Expression::FunctionExpression(func) => self.record_function(func, None),
             Expression::ClassExpression(class) => self.visit_class(class, None),
 
-            // TS-specific expressions intentionally NOT counted in W1.2
-            // (deferred to W2.1, ADR (a)) — we still walk inner
-            // expressions for nested-function discovery and for any
-            // UNIVERSAL decision points inside them.
+            // W2.1 TS-specific decision points (ADR (a)) — scoring +
+            // recursion both happen inside the helper.
             Expression::ConditionalExpression(ce) => self.visit_conditional(ce, out, nesting),
-            Expression::ChainExpression(ce) => {
-                // ChainExpression wraps a (member or call) expression
-                // chain that contains optional links. W1.2 traverses
-                // into the inner expression without scoring `?.` — the
-                // entire `?.` chain is W2.1 / ADR (a)'s scope. We
-                // recurse manually into ChainElement variants because
-                // ChainElement only inherits MemberExpression (not the
-                // full Expression set) so `as_expression()` isn't
-                // generated for it.
-                self.visit_chain_element(&ce.expression, out, nesting);
-            }
+            Expression::ChainExpression(ce) => self.visit_chain(ce, out, nesting),
+
+            // JSX traversal (W2.1): `{cond && <Element/>}` decomposes
+            // through `LogicalExpression(And)` once we descend into the
+            // expression container, so the existing logical-operator
+            // scoring handles the JSX-conditional pattern without a
+            // dedicated JSX contributor. JSX bodies + attributes are
+            // walked for nested-function + decision-point discovery.
+            Expression::JSXElement(elem) => self.visit_jsx_element(elem, out, nesting),
+            Expression::JSXFragment(frag) => self.visit_jsx_children(&frag.children, out, nesting),
 
             // Recursing expressions (universal — no scoring at this
             // node, but children may contribute).
@@ -710,15 +823,26 @@ impl<'src> FunctionFinder<'src> {
         }
     }
 
-    /// Visit a `ConditionalExpression` — `?:` is NOT scored in W1.2
-    /// (W2.1 / ADR (a)) but the test/consequent/alternate may contain
-    /// universal decision points and nested functions.
+    /// W2.1 (#184): `cond ? a : b` contributes one `Ternary` decision
+    /// point. Chained ternaries (`a ? b : c ? d : e`) parse as
+    /// `a ? b : (c ? d : e)` — two nested `ConditionalExpression` nodes
+    /// → two `Ternary` contributors. After scoring, recurse into the
+    /// three branch expressions so universal decision points + nested
+    /// functions inside any branch accumulate naturally.
     fn visit_conditional(
         &mut self,
         ce: &oxc::ast::ast::ConditionalExpression<'_>,
         out: &mut Contributors,
         nesting: Option<u32>,
     ) {
+        if let Some(n) = nesting {
+            out.push(contributor(
+                ContributorKind::Ternary,
+                self.source,
+                ce.span,
+                n,
+            ));
+        }
         self.visit_expression(&ce.test, out, nesting);
         self.visit_expression(&ce.consequent, out, nesting);
         self.visit_expression(&ce.alternate, out, nesting);
@@ -761,36 +885,74 @@ impl<'src> FunctionFinder<'src> {
         }
     }
 
+    /// W2.1 (#184): all three `LogicalOperator` variants count as one
+    /// `LogicalOperator` contributor each. Mapping table:
+    /// - `&&` (`And`) → `LogicalOperator`
+    /// - `||` (`Or`) → `LogicalOperator`
+    /// - `??` (`Coalesce`) → `LogicalOperator` (per ADR (a) — TS
+    ///   nullish-coalescing is a short-circuiting decision point that
+    ///   slots cleanly into the existing variant; no `NullishCoalesce`
+    ///   variant is introduced).
+    ///
+    /// Chains accumulate without flattening: `a && b && c && d` parses
+    /// as `((a && b) && c) && d` — three `LogicalExpression` nodes,
+    /// three `LogicalOperator` contributors.
     fn visit_logical(
         &mut self,
         le: &LogicalExpression<'_>,
         out: &mut Contributors,
         nesting: Option<u32>,
     ) {
-        // W1.2 counts `&&` and `||` but NOT `??` (Coalesce) — that
-        // lands in W2.1 with ADR (a).
-        match le.operator {
-            LogicalOperator::And | LogicalOperator::Or => {
-                if let Some(n) = nesting {
-                    out.push(contributor(
-                        ContributorKind::LogicalOperator,
-                        self.source,
-                        le.span,
-                        n,
-                    ));
-                }
-            }
-            LogicalOperator::Coalesce => {}
+        if let Some(n) = nesting {
+            out.push(contributor(
+                ContributorKind::LogicalOperator,
+                self.source,
+                le.span,
+                n,
+            ));
         }
+        // `_` covers all current `LogicalOperator` variants (`And`,
+        // `Or`, `Coalesce`). The arm is intentionally exhaustive: any
+        // future operator variant on `LogicalOperator` falls through
+        // the same scoring path.
+        let _ = le.operator;
         self.visit_expression(&le.left, out, nesting);
         self.visit_expression(&le.right, out, nesting);
+    }
+
+    /// W2.1 (#184): score one `OptionalChain` contributor per
+    /// `ChainExpression`. Per the BDD outline (cyclomatic_walker
+    /// scenario "TypeScript-specific decision points add to
+    /// cyclomatic"), `obj?.field` and `obj?.method()` each add ONE
+    /// decision point — and a chain like `obj?.nested?.value` is wrapped
+    /// in a single `ChainExpression`, so a multi-link chain still
+    /// produces a single contributor (matches the breadboard's
+    /// "presence-of-optional-flow" semantics rather than per-`?.` link
+    /// counting). After scoring, recurse into the inner chain element
+    /// for nested-function / universal-decision-point discovery.
+    fn visit_chain(
+        &mut self,
+        ce: &oxc::ast::ast::ChainExpression<'_>,
+        out: &mut Contributors,
+        nesting: Option<u32>,
+    ) {
+        if let Some(n) = nesting {
+            out.push(contributor(
+                ContributorKind::OptionalChain,
+                self.source,
+                ce.span,
+                n,
+            ));
+        }
+        self.visit_chain_element(&ce.expression, out, nesting);
     }
 
     /// Walk a `ChainElement` — the inner of a `ChainExpression`. The
     /// enum inherits from `MemberExpression`, so it has 5 variants in
     /// oxc 0.129: `CallExpression`, `TSNonNullExpression`, and three
     /// inherited member-expression variants. Each is descended for
-    /// nested-function / universal-decision-point discovery.
+    /// nested-function / universal-decision-point discovery. Scoring of
+    /// the chain itself happens in the caller (`visit_chain`).
     fn visit_chain_element(
         &mut self,
         ce: &oxc::ast::ast::ChainElement<'_>,
@@ -820,6 +982,83 @@ impl<'src> FunctionFinder<'src> {
             ChainElement::PrivateFieldExpression(m) => {
                 self.visit_expression(&m.object, out, nesting);
             }
+        }
+    }
+
+    /// W2.1 (#184): walk a JSX element's attributes + children. The
+    /// JSX wrapper itself is not a decision point — `LogicalOperator`
+    /// scoring happens once we recurse out of the
+    /// `JSXExpressionContainer` and into the inner `&&` /
+    /// `LogicalExpression`. JSX-attribute spread (`{...props}`) and
+    /// JSX-attribute expression-containers (`foo={cond && val}`) also
+    /// surface decision points; spreads route through
+    /// `visit_expression` directly.
+    fn visit_jsx_element(
+        &mut self,
+        elem: &oxc::ast::ast::JSXElement<'_>,
+        out: &mut Contributors,
+        nesting: Option<u32>,
+    ) {
+        use oxc::ast::ast::{JSXAttributeItem, JSXAttributeValue};
+        for attr in &elem.opening_element.attributes {
+            match attr {
+                JSXAttributeItem::Attribute(a) => match &a.value {
+                    Some(JSXAttributeValue::ExpressionContainer(c)) => {
+                        self.visit_jsx_expression_container(c, out, nesting);
+                    }
+                    Some(JSXAttributeValue::Element(e)) => {
+                        self.visit_jsx_element(e, out, nesting);
+                    }
+                    Some(JSXAttributeValue::Fragment(f)) => {
+                        self.visit_jsx_children(&f.children, out, nesting);
+                    }
+                    Some(JSXAttributeValue::StringLiteral(_)) | None => {}
+                },
+                JSXAttributeItem::SpreadAttribute(s) => {
+                    self.visit_expression(&s.argument, out, nesting);
+                }
+            }
+        }
+        self.visit_jsx_children(&elem.children, out, nesting);
+    }
+
+    /// Walk a slice of JSX children. `JSXChild::Text` and the
+    /// `JSXSpreadChild` form-feed through the visitor without scoring;
+    /// expression containers recurse into the inner expression.
+    fn visit_jsx_children(
+        &mut self,
+        children: &[oxc::ast::ast::JSXChild<'_>],
+        out: &mut Contributors,
+        nesting: Option<u32>,
+    ) {
+        use oxc::ast::ast::JSXChild;
+        for child in children {
+            match child {
+                JSXChild::Text(_) => {}
+                JSXChild::Element(e) => self.visit_jsx_element(e, out, nesting),
+                JSXChild::Fragment(f) => self.visit_jsx_children(&f.children, out, nesting),
+                JSXChild::ExpressionContainer(c) => {
+                    self.visit_jsx_expression_container(c, out, nesting);
+                }
+                JSXChild::Spread(s) => self.visit_expression(&s.expression, out, nesting),
+            }
+        }
+    }
+
+    /// Recurse into a `JSXExpressionContainer`. `JSXExpression`
+    /// inherits all `Expression` variants via `inherit_variants!`, so
+    /// `as_expression()` unwraps the JSX-specific shell back to a
+    /// plain `&Expression` for the standard visitor. The
+    /// `EmptyExpression` variant (`{}` inside JSX) is non-executable
+    /// and produces no contributors.
+    fn visit_jsx_expression_container(
+        &mut self,
+        container: &oxc::ast::ast::JSXExpressionContainer<'_>,
+        out: &mut Contributors,
+        nesting: Option<u32>,
+    ) {
+        if let Some(expr) = container.expression.as_expression() {
+            self.visit_expression(expr, out, nesting);
         }
     }
 

--- a/crates/crap4ts/tests/fixtures/ts-fixtures/chained-logical.ts
+++ b/crates/crap4ts/tests/fixtures/ts-fixtures/chained-logical.ts
@@ -1,0 +1,3 @@
+export function allTruthy(a: unknown, b: unknown, c: unknown, d: unknown): boolean {
+  return Boolean(a && b && c && d);
+}

--- a/crates/crap4ts/tests/fixtures/ts-fixtures/chained-ternary.ts
+++ b/crates/crap4ts/tests/fixtures/ts-fixtures/chained-ternary.ts
@@ -1,0 +1,3 @@
+export function classify(x: number): string {
+  return x < 0 ? "neg" : x === 0 ? "zero" : "pos";
+}

--- a/crates/crap4ts/tests/fixtures/ts-fixtures/class-field-arrows.tsx
+++ b/crates/crap4ts/tests/fixtures/ts-fixtures/class-field-arrows.tsx
@@ -1,0 +1,17 @@
+type Event = { preventDefault?: () => void };
+
+export class Form {
+  onClick = () => {
+    this.touched = true;
+  };
+
+  onSubmit = (e: Event) => {
+    if (e.preventDefault) e.preventDefault();
+  };
+
+  static setup = function () {
+    return new Form();
+  };
+
+  touched = false;
+}

--- a/crates/crap4ts/tests/fixtures/ts-fixtures/compound-if-and.ts
+++ b/crates/crap4ts/tests/fixtures/ts-fixtures/compound-if-and.ts
@@ -1,0 +1,4 @@
+export function both(a: boolean, b: boolean): string {
+  if (a && b) return "both";
+  return "not-both";
+}

--- a/crates/crap4ts/tests/fixtures/ts-fixtures/example.cjs
+++ b/crates/crap4ts/tests/fixtures/ts-fixtures/example.cjs
@@ -1,0 +1,3 @@
+module.exports.greet = function (name) {
+  return "hello " + name;
+};

--- a/crates/crap4ts/tests/fixtures/ts-fixtures/example.js
+++ b/crates/crap4ts/tests/fixtures/ts-fixtures/example.js
@@ -1,0 +1,3 @@
+export function greet(name) {
+  return "hello " + name;
+}

--- a/crates/crap4ts/tests/fixtures/ts-fixtures/example.jsx
+++ b/crates/crap4ts/tests/fixtures/ts-fixtures/example.jsx
@@ -1,0 +1,1 @@
+export const Greet = ({ name }) => <span>hi {name}</span>;

--- a/crates/crap4ts/tests/fixtures/ts-fixtures/example.mjs
+++ b/crates/crap4ts/tests/fixtures/ts-fixtures/example.mjs
@@ -1,0 +1,3 @@
+export function greet(name) {
+  return `hello ${name}`;
+}

--- a/crates/crap4ts/tests/fixtures/ts-fixtures/example.tsx
+++ b/crates/crap4ts/tests/fixtures/ts-fixtures/example.tsx
@@ -1,0 +1,3 @@
+type GreetProps = { name: string };
+
+export const Greet = ({ name }: GreetProps) => <span>hi {name}</span>;

--- a/crates/crap4ts/tests/fixtures/ts-fixtures/jsx-conditional.tsx
+++ b/crates/crap4ts/tests/fixtures/ts-fixtures/jsx-conditional.tsx
@@ -1,0 +1,5 @@
+type Props = { visible: boolean; name: string };
+
+export function Greeting({ visible, name }: Props) {
+  return <div>{visible && <span>hello, {name}</span>}</div>;
+}

--- a/crates/crap4ts/tests/fixtures/ts-fixtures/nested-ifs.ts
+++ b/crates/crap4ts/tests/fixtures/ts-fixtures/nested-ifs.ts
@@ -1,0 +1,6 @@
+export function deep(a: number, b: number): string {
+  if (a > 0) {
+    if (b > 0) return "both positive";
+  }
+  return "default";
+}

--- a/crates/crap4ts/tests/fixtures/ts-fixtures/nullish.ts
+++ b/crates/crap4ts/tests/fixtures/ts-fixtures/nullish.ts
@@ -1,0 +1,3 @@
+export function withDefault(value: string | null | undefined, fallback: string): string {
+  return value ?? fallback;
+}

--- a/crates/crap4ts/tests/fixtures/ts-fixtures/optional-chain.ts
+++ b/crates/crap4ts/tests/fixtures/ts-fixtures/optional-chain.ts
@@ -1,0 +1,7 @@
+export function pickField(obj: { nested?: { value: number } } | null): number | undefined {
+  return obj?.nested?.value;
+}
+
+export function callMethod(obj: { compute?: () => number }): number | undefined {
+  return obj?.compute?.();
+}

--- a/crates/crap4ts/tests/fixtures/ts-fixtures/static-block.ts
+++ b/crates/crap4ts/tests/fixtures/ts-fixtures/static-block.ts
@@ -1,0 +1,10 @@
+export class Registry {
+  static items: string[] = [];
+
+  static {
+    const seed = (globalThis as { __seed?: string[] }).__seed;
+    if (seed) {
+      Registry.items.push(...seed);
+    }
+  }
+}

--- a/crates/crap4ts/tests/fixtures/ts-fixtures/ternary.ts
+++ b/crates/crap4ts/tests/fixtures/ts-fixtures/ternary.ts
@@ -1,0 +1,3 @@
+export function abs(x: number): number {
+  return x < 0 ? -x : x;
+}

--- a/crates/crap4ts/tests/fixtures/ts-fixtures/try-catch.ts
+++ b/crates/crap4ts/tests/fixtures/ts-fixtures/try-catch.ts
@@ -1,0 +1,18 @@
+export function safeParse(json: string): unknown {
+  try {
+    return JSON.parse(json);
+  } catch (e) {
+    return null;
+  }
+}
+
+export function noHandler(): void {
+  try {
+    doWork();
+  } finally {
+    cleanup();
+  }
+}
+
+declare function doWork(): void;
+declare function cleanup(): void;

--- a/crates/crap4ts/tests/walker_smoke.rs
+++ b/crates/crap4ts/tests/walker_smoke.rs
@@ -31,6 +31,28 @@ const LOGICAL_TS: &str = include_str!("fixtures/ts-fixtures/logical.ts");
 const NESTED_TS: &str = include_str!("fixtures/ts-fixtures/nested.ts");
 const BROKEN_TS: &str = include_str!("fixtures/ts-fixtures/broken.ts");
 
+// W2.1 (#184): TS-specific decision-point fixtures.
+const TERNARY_TS: &str = include_str!("fixtures/ts-fixtures/ternary.ts");
+const OPTIONAL_CHAIN_TS: &str = include_str!("fixtures/ts-fixtures/optional-chain.ts");
+const NULLISH_TS: &str = include_str!("fixtures/ts-fixtures/nullish.ts");
+const TRY_CATCH_TS: &str = include_str!("fixtures/ts-fixtures/try-catch.ts");
+const JSX_CONDITIONAL_TSX: &str = include_str!("fixtures/ts-fixtures/jsx-conditional.tsx");
+const CHAINED_TERNARY_TS: &str = include_str!("fixtures/ts-fixtures/chained-ternary.ts");
+const CHAINED_LOGICAL_TS: &str = include_str!("fixtures/ts-fixtures/chained-logical.ts");
+const NESTED_IFS_TS: &str = include_str!("fixtures/ts-fixtures/nested-ifs.ts");
+const COMPOUND_IF_AND_TS: &str = include_str!("fixtures/ts-fixtures/compound-if-and.ts");
+
+// W2.2 (#185): file-extension dispatch fixtures.
+const EXAMPLE_TSX: &str = include_str!("fixtures/ts-fixtures/example.tsx");
+const EXAMPLE_JSX: &str = include_str!("fixtures/ts-fixtures/example.jsx");
+const EXAMPLE_JS: &str = include_str!("fixtures/ts-fixtures/example.js");
+const EXAMPLE_MJS: &str = include_str!("fixtures/ts-fixtures/example.mjs");
+const EXAMPLE_CJS: &str = include_str!("fixtures/ts-fixtures/example.cjs");
+
+// #199: class-field arrow + static-block discovery fixtures.
+const CLASS_FIELD_ARROWS_TSX: &str = include_str!("fixtures/ts-fixtures/class-field-arrows.tsx");
+const STATIC_BLOCK_TS: &str = include_str!("fixtures/ts-fixtures/static-block.ts");
+
 fn extract(source: &str, file_path: &str) -> Vec<FunctionComplexity> {
     let walker = OxcWalker::new();
     walker
@@ -267,4 +289,350 @@ fn malformed_typescript_returns_source_parse_with_file_prefix() {
         }
         other => panic!("expected CrapError::SourceParse, got: {other:?}"),
     }
+}
+
+// ── W2.1 (#184) — TS-specific cyclomatic decision points ───────────────
+//
+// Each fixture isolates one decision-point kind so the assertions stay
+// surgical. Mirrors the `cyclomatic_walker.feature` TS-specific outline
+// (`@unwired` until W3.3) row-for-row.
+
+#[test]
+fn ternary_contributes_one_ternary_decision_point() {
+    let fns = extract(TERNARY_TS, "ternary.ts");
+    let f = find_fn(&fns, "abs");
+    assert_eq!(f.complexity, 2, "ternary adds one decision point");
+    assert_eq!(f.contributors.len(), 1);
+    let c = &f.contributors[0];
+    assert_eq!(c.kind, ContributorKind::Ternary);
+    assert_eq!(c.increment, 1);
+    // The ternary lives on line 2 of the fixture (the `return` body).
+    assert_eq!(c.line, 2);
+}
+
+#[test]
+fn optional_member_chain_contributes_one_optional_chain() {
+    let fns = extract(OPTIONAL_CHAIN_TS, "optional-chain.ts");
+    let f = find_fn(&fns, "pickField");
+    // `obj?.nested?.value` parses as ONE ChainExpression (two optional
+    // links inside one chain). Per the BDD outline + ADR (a), this is
+    // ONE OptionalChain contributor — chain count, not link count.
+    assert_eq!(f.complexity, 2, "one ?.chain adds one decision point");
+    assert_eq!(f.contributors.len(), 1);
+    assert_eq!(f.contributors[0].kind, ContributorKind::OptionalChain);
+}
+
+#[test]
+fn optional_call_chain_contributes_one_optional_chain() {
+    let fns = extract(OPTIONAL_CHAIN_TS, "optional-chain.ts");
+    let f = find_fn(&fns, "callMethod");
+    assert_eq!(f.complexity, 2, "obj?.method() is one chain → one point");
+    assert_eq!(f.contributors.len(), 1);
+    assert_eq!(f.contributors[0].kind, ContributorKind::OptionalChain);
+}
+
+#[test]
+fn nullish_coalescing_contributes_one_logical_operator() {
+    let fns = extract(NULLISH_TS, "nullish.ts");
+    let f = find_fn(&fns, "withDefault");
+    // `??` maps to LogicalOperator per ADR (a) — no `NullishCoalesce`
+    // variant; the existing enum is sufficient.
+    assert_eq!(f.complexity, 2, "?? adds one decision point");
+    assert_eq!(f.contributors.len(), 1);
+    assert_eq!(f.contributors[0].kind, ContributorKind::LogicalOperator);
+}
+
+#[test]
+fn try_catch_contributes_one_catch_decision_point() {
+    let fns = extract(TRY_CATCH_TS, "try-catch.ts");
+    let f = find_fn(&fns, "safeParse");
+    // try { ... } catch (e) { ... } scores ONE Catch contributor on
+    // handler.is_some(). The body of `try` adds no decision points.
+    assert_eq!(f.complexity, 2, "try/catch adds one decision point");
+    let catches: Vec<_> = f
+        .contributors
+        .iter()
+        .filter(|c| c.kind == ContributorKind::Catch)
+        .collect();
+    assert_eq!(catches.len(), 1, "expected exactly one Catch contributor");
+    assert_eq!(f.contributors.len(), 1, "no other contributors expected");
+}
+
+#[test]
+fn try_finally_without_handler_contributes_no_catch() {
+    let fns = extract(TRY_CATCH_TS, "try-catch.ts");
+    let f = find_fn(&fns, "noHandler");
+    // `try { } finally { }` has no `handler` → no Catch contributor.
+    // The function body otherwise has no decision points.
+    assert_eq!(
+        f.complexity, 1,
+        "try/finally without handler is not a decision point"
+    );
+    assert!(
+        f.contributors.is_empty(),
+        "expected no contributors for try/finally without handler; got {:?}",
+        f.contributors
+    );
+}
+
+// ── W2.1 (#184) — JSX conditional rendering ────────────────────────────
+
+#[test]
+fn jsx_conditional_decomposes_through_logical_operator() {
+    let fns = extract(JSX_CONDITIONAL_TSX, "jsx-conditional.tsx");
+    let f = find_fn(&fns, "Greeting");
+    // `<div>{visible && <span>...{name}</span>}</div>` — the `&&` is
+    // the ONLY decision point. The JSX wrapper itself adds nothing.
+    // `{name}` is a bare identifier inside a JSXExpressionContainer →
+    // no contributor.
+    assert_eq!(
+        f.complexity, 2,
+        "JSX conditional adds exactly one decision point via the inner &&"
+    );
+    let logical_ops: Vec<_> = f
+        .contributors
+        .iter()
+        .filter(|c| c.kind == ContributorKind::LogicalOperator)
+        .collect();
+    assert_eq!(
+        logical_ops.len(),
+        1,
+        "expected exactly one logical-operator contributor; got {:?}",
+        f.contributors
+    );
+    assert_eq!(f.contributors.len(), 1, "no other contributors expected");
+}
+
+// ── W2.1 (#184) — Compound counting: chains/nestings never flatten ─────
+
+#[test]
+fn chained_ternary_contributes_one_per_question_mark() {
+    let fns = extract(CHAINED_TERNARY_TS, "chained-ternary.ts");
+    let f = find_fn(&fns, "classify");
+    // `x < 0 ? "neg" : x === 0 ? "zero" : "pos"` parses as
+    // `x < 0 ? "neg" : (x === 0 ? "zero" : "pos")` — two nested
+    // ConditionalExpression nodes → CC=3, two Ternary contributors.
+    assert_eq!(f.complexity, 3, "two ?'s add two decision points");
+    let ternaries: Vec<_> = f
+        .contributors
+        .iter()
+        .filter(|c| c.kind == ContributorKind::Ternary)
+        .collect();
+    assert_eq!(
+        ternaries.len(),
+        2,
+        "expected two Ternary contributors (one per ?); got: {:?}",
+        f.contributors
+    );
+}
+
+#[test]
+fn chained_logical_and_contributes_one_per_operator() {
+    let fns = extract(CHAINED_LOGICAL_TS, "chained-logical.ts");
+    let f = find_fn(&fns, "allTruthy");
+    // `a && b && c && d` parses as `((a && b) && c) && d` —
+    // three LogicalExpression nodes → CC=4, three LogicalOperator
+    // contributors. No flattening.
+    assert_eq!(f.complexity, 4, "three &&'s add three decision points");
+    let logicals: Vec<_> = f
+        .contributors
+        .iter()
+        .filter(|c| c.kind == ContributorKind::LogicalOperator)
+        .collect();
+    assert_eq!(
+        logicals.len(),
+        3,
+        "expected three LogicalOperator contributors; got: {:?}",
+        f.contributors
+    );
+}
+
+#[test]
+fn nested_ifs_contribute_one_per_if_branch() {
+    let fns = extract(NESTED_IFS_TS, "nested-ifs.ts");
+    let f = find_fn(&fns, "deep");
+    // Outer `if (a > 0)` + inner `if (b > 0)` — both score even though
+    // the inner is at higher nesting depth. CC = 1 + 2 = 3.
+    assert_eq!(f.complexity, 3, "two nested ifs add two decision points");
+    let ifs: Vec<_> = f
+        .contributors
+        .iter()
+        .filter(|c| c.kind == ContributorKind::IfBranch)
+        .collect();
+    assert_eq!(
+        ifs.len(),
+        2,
+        "expected two IfBranch contributors (one per if, no flattening); got: {:?}",
+        f.contributors
+    );
+}
+
+#[test]
+fn compound_if_and_counts_both_if_and_logical_operator() {
+    let fns = extract(COMPOUND_IF_AND_TS, "compound-if-and.ts");
+    let f = find_fn(&fns, "both");
+    // `if (a && b)` — counts the `if` AND the `&&`. CC = 1 + 2 = 3.
+    assert_eq!(
+        f.complexity, 3,
+        "compound `if (a && b)` should add the if AND the && (no skipping)"
+    );
+    let ifs = f
+        .contributors
+        .iter()
+        .filter(|c| c.kind == ContributorKind::IfBranch)
+        .count();
+    let logicals = f
+        .contributors
+        .iter()
+        .filter(|c| c.kind == ContributorKind::LogicalOperator)
+        .count();
+    assert_eq!(ifs, 1, "expected exactly one IfBranch contributor");
+    assert_eq!(
+        logicals, 1,
+        "expected exactly one LogicalOperator contributor"
+    );
+    assert_eq!(f.contributors.len(), 2, "expected exactly two contributors");
+}
+
+// ── W2.2 (#185) — File-extension dispatch ─────────────────────────────
+//
+// W1.2 wired SourceType::from_path as the canonical dispatcher, which
+// already covers all six AdapterMeta::extensions plus `.mts` / `.cts` /
+// `.d.ts`. These tests verify end-to-end that each extension parses +
+// surfaces at least one function. See PR body for W2.2 plan deviation
+// (no hand-rolled match needed).
+
+#[test]
+fn tsx_fixture_parses_and_discovers_jsx_function() {
+    let fns = extract(EXAMPLE_TSX, "example.tsx");
+    assert!(
+        !fns.is_empty(),
+        "expected at least one function in example.tsx; got: {:?}",
+        fns
+    );
+    assert!(
+        fns.iter().any(|f| f.identity.qualified_name == "Greet"),
+        "expected `Greet` function in example.tsx; got names: {:?}",
+        fns.iter()
+            .map(|f| &f.identity.qualified_name)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn jsx_fixture_parses_and_discovers_default_export_arrow() {
+    let fns = extract(EXAMPLE_JSX, "example.jsx");
+    assert!(
+        !fns.is_empty(),
+        "expected at least one function in example.jsx; got: {:?}",
+        fns
+    );
+    assert!(
+        fns.iter().any(|f| f.identity.qualified_name == "Greet"),
+        "expected `Greet` function in example.jsx; got names: {:?}",
+        fns.iter()
+            .map(|f| &f.identity.qualified_name)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn js_fixture_parses_and_discovers_function() {
+    let fns = extract(EXAMPLE_JS, "example.js");
+    assert!(
+        !fns.is_empty(),
+        "expected at least one function in example.js"
+    );
+    assert!(fns.iter().any(|f| f.identity.qualified_name == "greet"));
+}
+
+#[test]
+fn mjs_fixture_parses_and_discovers_function() {
+    let fns = extract(EXAMPLE_MJS, "example.mjs");
+    assert!(
+        !fns.is_empty(),
+        "expected at least one function in example.mjs"
+    );
+    assert!(fns.iter().any(|f| f.identity.qualified_name == "greet"));
+}
+
+#[test]
+fn cjs_fixture_parses_and_discovers_function() {
+    let fns = extract(EXAMPLE_CJS, "example.cjs");
+    // CJS `module.exports.greet = function (name) { ... }` is an
+    // anonymous FunctionExpression assigned to a member — the walker
+    // records it as `<anonymous>` (the only sentinel that fits without
+    // tracking assignment LHS, which is beyond W2.2 scope). The
+    // contract is "at least one function discovered" per the BDD spec.
+    assert!(
+        !fns.is_empty(),
+        "expected at least one function in example.cjs; got: {:?}",
+        fns
+    );
+}
+
+// ── #199 — Class-field arrows + StaticBlock discovery ────────────────
+
+#[test]
+fn class_field_arrow_initializers_are_discovered_as_functions() {
+    let fns = extract(CLASS_FIELD_ARROWS_TSX, "class-field-arrows.tsx");
+    let names: Vec<_> = fns
+        .iter()
+        .map(|f| f.identity.qualified_name.clone())
+        .collect();
+
+    // Three function-entry sites on the class:
+    //   onClick = () => {...}              (PropertyDefinition + arrow)
+    //   onSubmit = (e) => { if (...) ... } (PropertyDefinition + arrow)
+    //   static setup = function () {...}   (PropertyDefinition + FE)
+    let on_click = find_fn(&fns, "Form.onClick");
+    assert_eq!(
+        on_click.complexity, 1,
+        "Form.onClick has no decision points"
+    );
+    assert!(
+        on_click.contributors.is_empty(),
+        "expected no contributors for Form.onClick; got: {:?}",
+        on_click.contributors
+    );
+
+    let on_submit = find_fn(&fns, "Form.onSubmit");
+    assert_eq!(
+        on_submit.complexity, 2,
+        "Form.onSubmit's if-branch adds one decision point"
+    );
+    assert_eq!(on_submit.contributors.len(), 1);
+    assert_eq!(on_submit.contributors[0].kind, ContributorKind::IfBranch);
+
+    // `static setup = function () { return new Form(); }` is a
+    // FunctionExpression initializer — discovered with no decision
+    // points.
+    let setup = find_fn(&fns, "Form.setup");
+    assert_eq!(setup.complexity, 1);
+    assert!(setup.contributors.is_empty());
+
+    // Sanity check: the bare class-field `touched = false;` does NOT
+    // mint a synthetic function (it's a literal initializer, not a
+    // function-shaped expression).
+    assert!(
+        !names.iter().any(|n| n == "Form.touched"),
+        "expected no entry for literal class-field `touched`; got names: {names:?}"
+    );
+}
+
+#[test]
+fn static_block_is_discovered_as_synthetic_static_init_function() {
+    let fns = extract(STATIC_BLOCK_TS, "static-block.ts");
+    let synthetic = find_fn(&fns, "Registry.<static-init>");
+    // The static block contains `if (seed) { ... }` — one IfBranch.
+    assert_eq!(
+        synthetic.complexity, 2,
+        "Registry.<static-init> has one if-branch"
+    );
+    let ifs = synthetic
+        .contributors
+        .iter()
+        .filter(|c| c.kind == ContributorKind::IfBranch)
+        .count();
+    assert_eq!(ifs, 1, "expected one IfBranch in the static block body");
 }


### PR DESCRIPTION
## Summary

PR 2 of 3 in Wave 2 of the TS-adapter pipeline (Epic crap-rs#173;
strict-serial after W2.5 #188 landed at `ceb8056`). Single combined PR
closing three sub-issues — all three touch
`crates/crap4ts/src/adapters/walker/mod.rs`, share the same review
surface, and are contextually a single "walker breadth" patch:

- **#184 (W2.1)** — five TS-specific cyclomatic decision points
  (ternary `?:`, optional chain `?.`/`?.()`, nullish coalescing `??`,
  `try`/`catch`, JSX conditional `{cond && <Element/>}`), all mapping
  to existing `ContributorKind` variants per locked decision #9 (no
  new variants).
- **#185 (W2.2)** — file-extension dispatch verification (`.ts`,
  `.tsx`, `.jsx`, `.js`, `.mjs`, `.cjs`).
- **#199** — `visit_class` class-field initializer + StaticBlock
  discovery (modern TS auto-bind handler pattern).

Lands **ADR (a)** at
`~/Github/ops/decisions/crap-rs/adr-cyclomatic-decision-points-ts.md`
(D15) — full 11-row decision-point mapping table with per-row
rationale + compound-counting semantics.

## Consolidation rationale

All three issues touch the same file (`walker/mod.rs`), share oxc 0.129
AST traversal context, and produce contextually-overlapping fixtures
and smoke tests. The walker-breadth changes are easier to review as
one coherent diff than three separate PRs that would each need to
re-establish the W1.2 baseline mental model and then add a sliver. PR
3 (W2.3+W2.4 Istanbul breadth) follows in strict-serial sequence.

## Acceptance gates (all 15 green)

- [x] `cargo build --workspace` ✓
- [x] `cargo nextest run --workspace --all-targets` — **1013/1013** ✓
- [x] `cargo +1.93 check --workspace --all-targets` ✓
- [x] `cargo fmt --check` ✓
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean ✓
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps` ✓
- [x] `cargo deny check` — advisories ok, bans ok, licenses ok, sources ok ✓
- [x] AST-purity grep on `crates/crap-core/src/` — clean (only docstring/comment references) ✓
- [x] Wire snapshots byte-identical for **both** crap4rs AND crap4ts ✓
- [x] `cargo insta test --workspace --check --test-runner=nextest` — no pending snapshots ✓
- [x] PR body declares wire-snapshot status + closes 3 issues + consolidation rationale + ADR (a) link + plan deviations ✓
- [x] CI: pending on push (16+ checks expected SUCCESS; mutation testing on `domain/view.rs` may be in-flight at merge per W1.* + W2.5 precedent)
- [x] Class-field arrow + StaticBlock discovery verified by `class-field-arrows.tsx` + `static-block.ts` smoke tests ✓
- [x] `cyclomatic_walker.feature` TS-specific outline + 4 compound/chained + JSX scenario assertions match walker smoke output ✓
- [x] `file_extensions.feature` per-extension scenarios match walker smoke output for all 5 new extensions ✓

## Wire-shape canary (mandatory declaration)

**No drift on either snapshot.**

- **crap4rs snapshot** (`crates/crap-core/tests/wire_envelope_crap4rs.rs`)
  — byte-identical. PR 2 does NOT touch `crap4rs/src/main.rs` or any
  crap4rs source; per W2.5's discovered drift mechanism, the crap4rs
  snapshot only drifts when `main.rs` LOC changes (because span
  positions are baked into the envelope).
- **crap4ts snapshot** (`crates/crap-core/tests/wire_envelope_crap4ts.rs`)
  — byte-identical. The walker changes affect which functions /
  decision points appear but not the envelope shape; the W1.3 e2e
  fixture (`simple.ts` — 1 function, no decision points) doesn't
  exercise any of the new W2.1 constructs, W2.2 extensions, or #199
  class shapes.

`cargo insta test --workspace --check --test-runner=nextest` confirms
no pending snapshots.

## Discovery findings

### W2.2 plan-of-record deviation (load-bearing — 5th consecutive session catching deviations: W1.1, W1.2, W1.3, W2.5, now PR 2)

The plan said "replace hardcoded `SourceType::ts()` in
`source_type_for_extension` with a real match over `path.extension()`".
W1.2 had already landed `SourceType::from_path(Path::new(file_path))`
at `walker/mod.rs:148` — and oxc 0.129's `SourceType::from_path`
already covers all six `AdapterMeta::extensions` (`.ts`, `.tsx`,
`.jsx`, `.js`, `.mjs`, `.cjs`) plus `.mts`, `.cts`, `.d.ts`. Verified
via direct source inspection at
`~/.cargo/registry/src/.../oxc_span-0.129.0/src/source_type.rs:607-628`
(`pub fn from_path<P: AsRef<Path>>(...) -> Result<Self,
UnknownExtension>` matching `js`, `mjs`, `cjs`, `jsx`, `ts`, `mts`,
`cts`, `tsx` + `.d.ts` detection via
`with_typescript_definition(file_ext.is_ts_declaration(file_name))`).

**Resolution**: keep `SourceType::from_path` (it IS the canonical
dispatcher); the W2.2 work reduced to fixtures + smoke tests verifying
each extension parses + surfaces at least one function. No
hand-rolled match needed. Plan-of-record discipline applied — surfaced
in PR body rather than silently reinterpreting the helper away.

### JSX traversal was a genuine gap

W1.2's `visit_expression` fell through to `_ => {}` for JSX nodes, so
without this PR the `<div>{visible && <span>...</span>}</div>` pattern
would never reach the inner `LogicalExpression(And)` and would not
score the JSX-conditional decision point. Added `Expression::JSXElement`
+ `Expression::JSXFragment` arms in `visit_expression` plus three new
helpers (`visit_jsx_element`, `visit_jsx_children`,
`visit_jsx_expression_container`). The JSX wrapper itself is not a
decision point — scoring happens on the inner `LogicalExpression(And)`
once we descend into the container.

### `if (a && b)` already at CC=3 in W1.2 baseline

Empirically verified before touching code (temporary probe test, since
removed): the W1.2 walker already produced CC=3 for `if (a && b)`
because `visit_if` already recurses into the test expression via
`visit_expression`, which routes `LogicalExpression(And)` into
`visit_logical` for scoring. The `compound-if-and.ts` smoke test still
ground-truths the contract — it would have caught any regression if
W2.1's new arms had accidentally broken the recursion.

### Optional-chain semantics — chain count, not link count

`obj?.nested?.value` parses as ONE `ChainExpression` wrapping the
member access chain. Per the BDD outline ("`obj?.field` → one chain →
one decision point"), the contributor counts chains, not links. ADR
(a) documents the rationale: from a CFG perspective, the early-exit
happens when ANY `?.` link is nullish — so the chain is one
optional-flow site regardless of link count.

### StaticBlock disposition — synthetic function (per #199 discovery)

Issue #199's discovery left open whether `static { ... }` decision
points should attach to the class as a synthetic
`Foo.<static-init>` function or sink-walk only. Chose the synthetic
function path — matches the "static initialisation is method-like"
interpretation. Naming: `<ClassName>.<static-init>`.

### CJS `module.exports.greet = function (...) { ... }` recorded as `<anonymous>`

CJS exports assign a `FunctionExpression` to a member-expression LHS.
The walker has no LHS-tracking machinery (out of W2.2 scope), so the
function is recorded with the `<anonymous>` sentinel. The
`file_extensions.feature` contract is "at least one function
discovered" — the smoke test asserts that without naming the function.
Filing a follow-up if real users find this annoying — for now, it
matches the existing `<arrow>` / `<anonymous>` sentinel pattern.

## Plan-of-record deviations (mandatory subsection)

1. **W2.2 plan said "real match", oxc 0.129's `SourceType::from_path`
   is the canonical dispatcher** — see "Discovery findings" above.
   Kept `from_path`; updated module-level docstring to reflect this is
   intentional, not a stale W1.2 leftover.
2. **Removed unused `use oxc::syntax::operator::LogicalOperator;`** —
   `visit_logical` no longer matches on the operator variant (`&&`,
   `||`, `??` all score identically per ADR (a)), so the import is
   dead. Replaced explicit match with `let _ = le.operator;` to
   document the intentional non-discrimination plus suppress
   unused-binding lint.

## ADR (a) link / rationale

`~/Github/ops/decisions/crap-rs/adr-cyclomatic-decision-points-ts.md`
(**D15**, Y-statement format) — full 11-row mapping table (6
universal from W1.2 + 5 TS-specific from W2.1), per-row rationale,
compound-counting semantics, accepted trade-offs. Filed standalone per
CEng INFO-2 + CAO recommendation ("always-file") rather than embedded
in PR body alone.

## BDD hygiene

Scenarios stay `@unwired` (locked decision #15 — W3.3 wires cucumber
step defs at crap-rs#191). Smoke tests in `walker_smoke.rs`
ground-truth the same contracts row-for-row. `# tracked: crap-rs#173`
comments already point at the umbrella issue — no refresh needed.

## What's NOT in this PR

- No new `ContributorKind` variants (locked decision #9)
- No `crap-core/src/` changes (pure adapter work)
- No `main.rs` changes (avoids crap4rs snapshot drift per W2.5)
- No coverage parser changes (PR 3's domain)
- No port `parse(&str)` → `parse(&Path)` evolution (F7 #179, out of scope)
- No `@unwired` → `@wired` BDD migration (W3.3's domain)

## Test summary

- 31 walker_smoke tests (13 W1.2 baseline + 18 new) — all green
- Total workspace: **1013 / 1013 nextest tests pass**
- Wire envelopes byte-identical: both modules clean
- Cucumber harness: 12 / 12 scenarios

Closes #184, #185, #199.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced cyclomatic complexity analysis for TypeScript/JavaScript constructs including ternary operators, optional chaining, nullish coalescing, try/catch blocks, and JSX expressions.
  * Added support for analyzing class field initializers and static initialization blocks.

* **Tests**
  * Expanded test coverage with new fixtures for language constructs and multiple file format extensions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/breezy-bays-labs/crap-rs/pull/204)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->