### PR TITLE
feat(crap4ts): #186 + #187 — Istanbul branch coverage + jest/vitest/nyc schema variance + path-mismatch contract + ADR (b)

### DIFF
--- a/crates/crap4ts/src/adapters/coverage/mod.rs
+++ b/crates/crap4ts/src/adapters/coverage/mod.rs
@@ -458,18 +458,45 @@ impl CoveragePort for IstanbulCoverage {
     /// Pre-flight structural check: parse the file as Istanbul JSON and
     /// require at least one entry with a non-empty `statementMap`.
     ///
+    /// **Tolerance parity with `parse`** (W2.4): mirrors the
+    /// flat-then-unwrap cascade in `parse` so the CLI's pre-flight
+    /// gate doesn't reject wrapped fixtures before parse ever runs.
+    /// The CLI calls `validate` via
+    /// `crap-core::cli::check_coverage_has_data`; a strict pre-flight
+    /// would short-circuit the parse cascade and the
+    /// `SchemaUnrecognized` diagnostic surface for valid-but-wrapped
+    /// emitters.
+    ///
     /// Returns `Err("not a recognizable Istanbul JSON shape: …")` when
-    /// `serde_json::from_str` cannot deserialize the top-level
+    /// neither the flat shape nor a single-level unwrap deserialize as
     /// `HashMap<String, IstanbulCoverageFile>` (drives the
     /// `schema-unrecognized` user-facing error). Returns
-    /// `Err("no statement coverage records")` when every entry has an
-    /// empty `statementMap` (drives the "regenerate coverage" hint).
-    /// CLI layer surfaces these via `AdapterMeta::coverage_hint`.
+    /// `Err("no statement coverage records")` when every consumable
+    /// entry has an empty `statementMap` (drives the "regenerate
+    /// coverage" hint). CLI layer surfaces these via
+    /// `AdapterMeta::coverage_hint`.
     fn validate(&self, path: &Path) -> Result<(), String> {
         let data = std::fs::read_to_string(path)
             .map_err(|e| format!("cannot open {}: {e}", path.display()))?;
-        let raw: HashMap<String, IstanbulCoverageFile> = serde_json::from_str(&data)
-            .map_err(|e| format!("not a recognizable Istanbul JSON shape: {e}"))?;
+
+        // Path 1: flat-shape fast path (jest / vitest / nyc baseline).
+        let raw = match serde_json::from_str::<HashMap<String, IstanbulCoverageFile>>(&data) {
+            Ok(raw) => raw,
+            Err(flat_err) => {
+                // Path 2: try the one-level unwrap before rejecting,
+                // so a wrapped `{"coverage-final": {…flat…}}`
+                // payload still gets through to the parse cascade.
+                // We re-parse as `Value` once and pass it to the
+                // same `try_unwrap` helper `parse` uses; this keeps
+                // the validate / parse contracts symmetric.
+                let value: Value = serde_json::from_str(&data).map_err(|json_err| {
+                    format!("not a recognizable Istanbul JSON shape: {json_err}")
+                })?;
+                Self::try_unwrap(&value)
+                    .ok_or_else(|| format!("not a recognizable Istanbul JSON shape: {flat_err}"))?
+            }
+        };
+
         if raw.values().all(|f| f.statement_map.is_empty()) {
             return Err("no statement coverage records".into());
         }

--- a/crates/crap4ts/src/adapters/coverage/mod.rs
+++ b/crates/crap4ts/src/adapters/coverage/mod.rs
@@ -1,4 +1,4 @@
-//! Istanbul JSON coverage parser — minimal statement-only implementation.
+//! Istanbul JSON coverage parser — statement + branch + schema-tolerant.
 //!
 //! Consumes the per-file `coverage-final.json` map jest, vitest, and
 //! nyc emit. Each entry maps a `path` to a `statementMap` (statement
@@ -9,16 +9,37 @@
 //! against `effective_src` so the downstream line-range join sees
 //! workspace-relative paths).
 //!
-//! ## Scope (W1.1)
+//! ## Scope
 //!
-//! - Statement coverage (`s` + `statementMap`) only. Branch coverage
-//!   (`b` + `branchMap`) lands in W2.3 — the corresponding struct
-//!   fields are declared with `#[serde(default)]` so the W2.3 PR is
-//!   purely consumer-side (no type-surface churn).
-//! - Single emitter shape: minimal jest-flavored Istanbul.
-//!   vitest / nyc + extension dispatch land in W2.4.
-//! - Single source-type dispatch happens upstream in the walker
-//!   (W1.2); this parser is metric- and language-agnostic.
+//! - **W1.1**: statement coverage (`s` + `statementMap`) + jest-flat
+//!   top-level shape + `PathUnresolved` diagnostics. Branch- /
+//!   schema-variance fields landed in W1.1's struct with
+//!   `#[serde(default)]` so the consumer-side extensions stay
+//!   type-stable.
+//! - **W2.3 (#186)**: branch coverage. Each Istanbul branchId in `b`
+//!   carries a `Vec<u64>` of per-arm hit counts; the parser fans this
+//!   into one `BranchCoverage` row per arm keyed at the `branchMap`
+//!   entry's start line. Orphan branchIds (`b` references a missing
+//!   `branchMap` entry) emit `BranchMismatch` and skip THAT branch
+//!   only — the rest of the file still parses.
+//! - **W2.4 (#187)**: jest / vitest / nyc + wrapped emitter
+//!   tolerance. The parser tries the flat `{[path]: entry}` shape
+//!   first, then a single-level unwrap (`{"coverage-final":
+//!   {...flat...}}`), then emits `SchemaUnrecognized` with the
+//!   detected top-level keys. `MissingField` covers entries that
+//!   have `s` records but an empty `statementMap` (or vice versa).
+//!
+//! ## Decision points (locked)
+//!
+//! - **No `f`/`fnMap` backfill** — W1.1 discovery 5a–5d empirically
+//!   showed `s`/`statementMap` data is sufficient for arrow-function
+//!   coverage (CLAUDE.md locked decision #13).
+//! - **`ParseOutput.branches` is internal** — `crap-core::core::analyze`
+//!   lowers branch data into per-function `branch_coverage:
+//!   Option<CoverageRatio>` records, but the JSON envelope only
+//!   surfaces `coverage_percent` (= line coverage). Branch records
+//!   never reach the wire — verified by `wire_envelope_crap4ts` (no
+//!   `branchCoverage` field in any emitted row).
 //!
 //! ## Path normalization
 //!
@@ -31,9 +52,10 @@
 //! skipped — per Resolved Q10 in shaping, the scorecard NEVER aborts
 //! on first failure and NEVER silent-drops a record.
 
-use crap_core::domain::types::{CrapError, LineCoverage};
+use crap_core::domain::types::{BranchCoverage, CrapError, LineCoverage};
 use crap_core::ports::{CoveragePort, ParseOutput};
 use serde::Deserialize;
+use serde_json::Value;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
@@ -113,23 +135,26 @@ struct IstanbulCoverageFile {
     /// `statement_id` → `{ start: {line, column}, end: {line, column} }`.
     #[serde(default)]
     statement_map: HashMap<String, StatementLoc>,
-    /// W2.3: `branch_id` → `[hit count per branch arm]`. Declared with
-    /// `#[serde(default)]` now so the W2.3 consumer-side PR introduces
-    /// no type surface churn; ignored in W1.1.
+    /// W2.3 (now consumed): `branch_id` → `[hit count per branch arm]`.
+    /// Each branchId maps to a `Vec<u64>` of arm-level hit counts; the
+    /// parser fans these into one `BranchCoverage` row per arm at the
+    /// associated `branchMap[id]` start line.
     #[serde(default)]
-    #[allow(dead_code)]
     b: HashMap<String, Vec<u64>>,
-    /// W2.3: `branch_id` → branch location. See `b` above.
+    /// W2.3 (now consumed): `branch_id` → branch location. See `b`
+    /// above.
     #[serde(default)]
-    #[allow(dead_code)]
     branch_map: HashMap<String, BranchLoc>,
-    /// W2.3 fallback: `function_id` → execution count. Declared now so
-    /// W2.3's `fnMap` backfill (if arrow-function undercount surfaces)
-    /// is purely consumer-side.
+    /// `function_id` → execution count. Locked decision #13: NOT
+    /// consumed — W1.1 discovery 5a–5d showed `s`/`statementMap` is
+    /// sufficient for arrow-function coverage. Field kept for forward
+    /// compatibility (and to keep test fixtures faithful to real
+    /// emitter output) so future inclusion is consumer-side only.
     #[serde(default)]
     #[allow(dead_code)]
     f: HashMap<String, u64>,
-    /// W2.3 fallback: `function_id` → function metadata.
+    /// `function_id` → function metadata. See `f` above; not consumed
+    /// in v2.0.0.
     #[serde(default)]
     #[allow(dead_code)]
     fn_map: HashMap<String, FnLoc>,
@@ -153,18 +178,32 @@ struct Position {
     column: u32,
 }
 
-/// W2.3: branch metadata. Declared minimal here so the type lands
-/// with the rest of the schema; `r#type` carries the kebab-cased
-/// Istanbul branch kind (`if`, `switch`, `cond-expr`, etc.).
+/// W2.3 branch metadata. `kind` (e.g. `"if"`, `"switch"`, `"cond-expr"`)
+/// is carried but not consumed by the parser — line attribution joins
+/// only on the `loc.start.line` value (or the optional emitter-set
+/// `line` field when present, which some emitters use as the
+/// branching-site line independent of `loc`).
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[allow(dead_code)]
 struct BranchLoc {
     loc: StatementLoc,
+    /// Istanbul branch kind (`if`, `switch`, `cond-expr`, `default-arg`,
+    /// `binary-expr`, etc.). Kept for downstream display only; not
+    /// consumed by the line-range join.
     #[serde(rename = "type")]
+    #[allow(dead_code)]
     kind: String,
+    /// Per-arm locations. Some emitters populate them with finer-grained
+    /// spans (e.g. switch case bodies); not consumed today since
+    /// `BranchCoverage` is line-keyed and the per-arm `taken` count
+    /// already lives in `b[branchId][arm_index]`.
     #[serde(default)]
+    #[allow(dead_code)]
     locations: Vec<StatementLoc>,
+    /// Optional emitter-set branching-site line. When present, takes
+    /// precedence over `loc.start.line` for line attribution (some
+    /// emitters set `loc` to a wide span covering both arms but pin
+    /// `line` to the branching keyword's line).
     #[serde(default)]
     line: Option<u32>,
 }
@@ -183,28 +222,25 @@ struct FnLoc {
     line: Option<u32>,
 }
 
-impl CoveragePort for IstanbulCoverage {
-    type Diagnostic = IstanbulParseDiagnostic;
-
-    /// Parse a `coverage-final.json` payload into per-file
-    /// `LineCoverage` records.
+impl IstanbulCoverage {
+    /// Build a `ParseOutput` from an already-deserialized flat map of
+    /// per-file Istanbul entries.
     ///
-    /// Top-level shape errors return `Err(CrapError::SourceParse(
-    /// "istanbul: …"))` — these are fatal because there is no
-    /// per-entry recovery path for "the whole document didn't parse."
-    /// Per-entry errors (path unresolved, missing field) push an
-    /// `IstanbulParseDiagnostic` and skip the entry; the scorecard
-    /// still produces results for the other entries. Branch
-    /// coverage parsing (`branches: Some(...)`) lands in W2.3 — for
-    /// W1.1 the field is always `None`.
-    fn parse(&self, data: &str) -> Result<ParseOutput<IstanbulParseDiagnostic>, CrapError> {
-        let raw: HashMap<String, IstanbulCoverageFile> = serde_json::from_str(data)
-            .map_err(|e| CrapError::SourceParse(format!("istanbul: {e}")))?;
-
+    /// Shared between the happy path (`parse_str` → flat) and the
+    /// one-level unwrap path (`parse_str` → wrapped → inner flat
+    /// map). Per-entry diagnostics (`PathUnresolved`, `MissingField`,
+    /// `BranchMismatch`) are emitted into `diagnostics`; the function
+    /// never aborts the whole parse and never silent-drops a record.
+    fn build_parse_output(
+        &self,
+        raw: HashMap<String, IstanbulCoverageFile>,
+    ) -> ParseOutput<IstanbulParseDiagnostic> {
         let mut coverage: HashMap<String, Vec<LineCoverage>> = HashMap::new();
+        let mut branch_map_out: HashMap<String, Vec<BranchCoverage>> = HashMap::new();
         let mut diagnostics: Vec<IstanbulParseDiagnostic> = Vec::new();
 
         for (_key, entry) in raw {
+            // ── Path normalization ──────────────────────────────────
             let Some(normalized) = self.normalize_path(&entry.path) else {
                 diagnostics.push(IstanbulParseDiagnostic {
                     file_path: entry.path.clone(),
@@ -219,6 +255,29 @@ impl CoveragePort for IstanbulCoverage {
                 continue;
             };
 
+            // ── MissingField: `s` populated but `statementMap` empty,
+            // or `statementMap` populated but `s` empty. Both cases
+            // indicate a partial / corrupt emitter record; emit and
+            // skip per breadboard W-3.
+            if entry.s.is_empty() != entry.statement_map.is_empty() {
+                let (present, missing) = if entry.s.is_empty() {
+                    ("statementMap", "s")
+                } else {
+                    ("s", "statementMap")
+                };
+                diagnostics.push(IstanbulParseDiagnostic {
+                    file_path: entry.path.clone(),
+                    kind: IstanbulDiagnosticKind::MissingField,
+                    message: format!(
+                        "entry for '{}' has `{}` records but `{}` is empty; one half of the statement-coverage pair is missing",
+                        entry.path, present, missing
+                    ),
+                    line: None,
+                });
+                continue;
+            }
+
+            // ── Line coverage (W1.1) ────────────────────────────────
             // Build per-line records by joining `s` (counts) to
             // `statementMap` (line spans). Statements whose IDs do not
             // appear in `statementMap` are skipped; statements that
@@ -238,14 +297,161 @@ impl CoveragePort for IstanbulCoverage {
             // (mirrors LCOV parser ordering).
             lines.sort_by_key(|lc| lc.line);
 
+            // ── Branch coverage (W2.3) ──────────────────────────────
+            // For each branchId in `b`, look up its `branchMap` entry.
+            // Missing branchMap entries emit `BranchMismatch` and
+            // skip THAT branch only (rest of the file still parses).
+            // Per the consumer contract at
+            // `crap-core::domain::matching::compute_branch_coverage`,
+            // each `BranchCoverage` row represents ONE branch arm —
+            // total = N records, covered = records with taken > 0.
+            // So we fan one Istanbul branchId with K arms into K
+            // separate `BranchCoverage` rows at the branching site's
+            // line, each carrying that arm's `taken` count. (Summing
+            // arm hits into a single record would collapse partial
+            // coverage into 100% — see PR body's plan-of-record
+            // deviation note for the worked example.)
+            let mut branches: Vec<BranchCoverage> = Vec::new();
+            for (branch_id, arms) in &entry.b {
+                let Some(loc) = entry.branch_map.get(branch_id) else {
+                    diagnostics.push(IstanbulParseDiagnostic {
+                        file_path: entry.path.clone(),
+                        kind: IstanbulDiagnosticKind::BranchMismatch,
+                        message: format!(
+                            "branch coverage record for branchId `{branch_id}` references no entry in branchMap. This is likely a bug in your coverage tool — report at the coverage tool's issue tracker."
+                        ),
+                        line: None,
+                    });
+                    continue;
+                };
+                // Prefer the emitter-set `line` when present (some
+                // emitters set it to the branching keyword's line
+                // independent of `loc`); fall back to
+                // `loc.start.line`.
+                let line = loc.line.unwrap_or(loc.loc.start.line) as usize;
+                for hits in arms {
+                    branches.push(BranchCoverage {
+                        line,
+                        taken: Some(*hits),
+                    });
+                }
+            }
+            // Deterministic ordering for downstream consumers.
+            branches.sort_by_key(|b| b.line);
+
             let key = normalized.to_string_lossy().into_owned();
-            coverage.insert(key, lines);
+            coverage.insert(key.clone(), lines);
+            if !branches.is_empty() {
+                branch_map_out.insert(key, branches);
+            }
         }
 
-        Ok(ParseOutput {
+        // `branches: None` ↔ "no branch data in this coverage file"
+        // (semantic distinction from `Some({})`; mirrors the LCOV
+        // adapter's `(!state.raw_branches.is_empty()).then(|| ...)`
+        // gate). This regression-pins existing W1.1 fixtures which
+        // have `"b": {}` everywhere.
+        let branches = (!branch_map_out.is_empty()).then_some(branch_map_out);
+
+        ParseOutput {
             coverage,
-            branches: None,
+            branches,
             diagnostics,
+        }
+    }
+
+    /// Try the one-level unwrap arm: `{"<single-key>": <flat-map>}`.
+    /// Returns the unwrapped flat map when the top-level value is a
+    /// single-key object whose value deserializes as Istanbul's flat
+    /// shape; returns `None` otherwise so the caller can emit
+    /// `SchemaUnrecognized`.
+    fn try_unwrap(value: &Value) -> Option<HashMap<String, IstanbulCoverageFile>> {
+        let obj = value.as_object()?;
+        if obj.len() != 1 {
+            return None;
+        }
+        // Take the single inner value and re-deserialize it as the
+        // flat shape. We use `serde_json::from_value` here (cloning
+        // is acceptable — the wrapped shape is rare and small
+        // relative to the inner flat map's deserialization cost).
+        let inner = obj.values().next()?;
+        serde_json::from_value::<HashMap<String, IstanbulCoverageFile>>(inner.clone()).ok()
+    }
+}
+
+impl CoveragePort for IstanbulCoverage {
+    type Diagnostic = IstanbulParseDiagnostic;
+
+    /// Parse a `coverage-final.json` payload into per-file
+    /// `LineCoverage` + `BranchCoverage` records.
+    ///
+    /// **Top-level shape tolerance (W2.4)**:
+    ///
+    /// 1. Try the flat `{[path]: entry}` shape first (jest, vitest,
+    ///    nyc baseline).
+    /// 2. If that fails, parse as `serde_json::Value` and try a
+    ///    single-level unwrap (`{"coverage-final": {...flat...}}`).
+    /// 3. If neither matches, emit a `SchemaUnrecognized` diagnostic
+    ///    (with detected top-level keys) and return an empty
+    ///    `ParseOutput` carrying that diagnostic — the scorecard's
+    ///    downstream "no functions extracted" path then surfaces a
+    ///    non-zero exit. Never abort first-record.
+    /// 4. If the input is not valid JSON at all,
+    ///    `Err(CrapError::SourceParse("istanbul: ..."))` propagates
+    ///    (fatal — no recovery path).
+    ///
+    /// Per-entry errors (`PathUnresolved`, `MissingField`,
+    /// `BranchMismatch`) push an `IstanbulParseDiagnostic` and skip
+    /// the entry / branch; other entries still parse cleanly.
+    fn parse(&self, data: &str) -> Result<ParseOutput<IstanbulParseDiagnostic>, CrapError> {
+        // Path 1: flat-shape fast path.
+        if let Ok(raw) = serde_json::from_str::<HashMap<String, IstanbulCoverageFile>>(data) {
+            return Ok(self.build_parse_output(raw));
+        }
+
+        // Path 2: re-parse as untyped `Value` for the unwrap arm and
+        // for top-level-key detection. If JSON itself is malformed,
+        // surface as fatal `SourceParse` per the W1.1 contract.
+        let value: Value = serde_json::from_str(data)
+            .map_err(|e| CrapError::SourceParse(format!("istanbul: {e}")))?;
+
+        if let Some(raw) = Self::try_unwrap(&value) {
+            return Ok(self.build_parse_output(raw));
+        }
+
+        // Path 3: schema unrecognized. Detect top-level keys (if the
+        // value is an object) so the diagnostic message names what we
+        // received vs what we expected. Use a single
+        // `Ok(ParseOutput { …, diagnostics: [SchemaUnrecognized] })`
+        // path so downstream "no functions extracted" produces the
+        // non-zero exit and the diagnostic surfaces in the envelope.
+        let detected_keys = match &value {
+            Value::Object(map) => {
+                let mut keys: Vec<&str> = map.keys().map(String::as_str).collect();
+                keys.sort();
+                if keys.is_empty() {
+                    "{}".to_string()
+                } else {
+                    format!("[{}]", keys.join(", "))
+                }
+            }
+            Value::Array(_) => "array".to_string(),
+            Value::String(_) => "string".to_string(),
+            Value::Number(_) => "number".to_string(),
+            Value::Bool(_) => "bool".to_string(),
+            Value::Null => "null".to_string(),
+        };
+        Ok(ParseOutput {
+            coverage: HashMap::new(),
+            branches: None,
+            diagnostics: vec![IstanbulParseDiagnostic {
+                file_path: String::new(),
+                kind: IstanbulDiagnosticKind::SchemaUnrecognized,
+                message: format!(
+                    "top-level shape not recognized as Istanbul; expected `{{[path]: {{ path, s, statementMap, … }}}}`; received keys: {detected_keys}"
+                ),
+                line: None,
+            }],
         })
     }
 

--- a/crates/crap4ts/tests/fixtures/istanbul-broken/coverage-with-missing-field.json
+++ b/crates/crap4ts/tests/fixtures/istanbul-broken/coverage-with-missing-field.json
@@ -1,0 +1,21 @@
+{
+  "{SRC_ROOT}/branch-heavy.ts": {
+    "path": "{SRC_ROOT}/branch-heavy.ts",
+    "statementMap": {
+      "0": { "start": { "line": 11, "column": 2 }, "end": { "line": 15, "column": 3 } }
+    },
+    "s": { "0": 4 },
+    "branchMap": {},
+    "b": {},
+    "fnMap": {},
+    "f": {}
+  },
+  "{SRC_ROOT}/orphan-sm.ts": {
+    "path": "{SRC_ROOT}/orphan-sm.ts",
+    "s": { "0": 3 },
+    "branchMap": {},
+    "b": {},
+    "fnMap": {},
+    "f": {}
+  }
+}

--- a/crates/crap4ts/tests/fixtures/istanbul-broken/coverage-with-orphan-branch.json
+++ b/crates/crap4ts/tests/fixtures/istanbul-broken/coverage-with-orphan-branch.json
@@ -1,0 +1,29 @@
+{
+  "{SRC_ROOT}/branch-heavy.ts": {
+    "path": "{SRC_ROOT}/branch-heavy.ts",
+    "statementMap": {
+      "0": { "start": { "line": 11, "column": 2 }, "end": { "line": 15, "column": 3 } }
+    },
+    "s": { "0": 4 },
+    "branchMap": {
+      "0": {
+        "loc": {
+          "start": { "line": 11, "column": 2 },
+          "end": { "line": 15, "column": 3 }
+        },
+        "type": "if",
+        "locations": [
+          { "start": { "line": 11, "column": 2 }, "end": { "line": 13, "column": 3 } },
+          { "start": { "line": 13, "column": 9 }, "end": { "line": 15, "column": 3 } }
+        ],
+        "line": 11
+      }
+    },
+    "b": {
+      "0": [2, 2],
+      "42": [1, 0]
+    },
+    "fnMap": {},
+    "f": {}
+  }
+}

--- a/crates/crap4ts/tests/fixtures/istanbul-broken/coverage-with-orphan-path.json
+++ b/crates/crap4ts/tests/fixtures/istanbul-broken/coverage-with-orphan-path.json
@@ -1,0 +1,24 @@
+{
+  "{SRC_ROOT}/branch-heavy.ts": {
+    "path": "{SRC_ROOT}/branch-heavy.ts",
+    "statementMap": {
+      "0": { "start": { "line": 11, "column": 2 }, "end": { "line": 15, "column": 3 } }
+    },
+    "s": { "0": 4 },
+    "branchMap": {},
+    "b": {},
+    "fnMap": {},
+    "f": {}
+  },
+  "/build/transpiled/foreign.js": {
+    "path": "/build/transpiled/foreign.js",
+    "statementMap": {
+      "0": { "start": { "line": 1, "column": 0 }, "end": { "line": 1, "column": 10 } }
+    },
+    "s": { "0": 1 },
+    "branchMap": {},
+    "b": {},
+    "fnMap": {},
+    "f": {}
+  }
+}

--- a/crates/crap4ts/tests/fixtures/istanbul-jest/coverage-with-branches.json
+++ b/crates/crap4ts/tests/fixtures/istanbul-jest/coverage-with-branches.json
@@ -1,0 +1,80 @@
+{
+  "{SRC_ROOT}/branch-heavy.ts": {
+    "path": "{SRC_ROOT}/branch-heavy.ts",
+    "statementMap": {
+      "0": { "start": { "line": 11, "column": 2 }, "end": { "line": 15, "column": 3 } },
+      "1": { "start": { "line": 12, "column": 4 }, "end": { "line": 12, "column": 24 } },
+      "2": { "start": { "line": 14, "column": 4 }, "end": { "line": 14, "column": 28 } },
+      "3": { "start": { "line": 19, "column": 2 }, "end": { "line": 19, "column": 25 } },
+      "4": { "start": { "line": 23, "column": 2 }, "end": { "line": 27, "column": 3 } }
+    },
+    "s": { "0": 4, "1": 2, "2": 2, "3": 6, "4": 4 },
+    "branchMap": {
+      "0": {
+        "loc": {
+          "start": { "line": 11, "column": 2 },
+          "end": { "line": 15, "column": 3 }
+        },
+        "type": "if",
+        "locations": [
+          { "start": { "line": 11, "column": 2 }, "end": { "line": 13, "column": 3 } },
+          { "start": { "line": 13, "column": 9 }, "end": { "line": 15, "column": 3 } }
+        ],
+        "line": 11
+      },
+      "1": {
+        "loc": {
+          "start": { "line": 19, "column": 9 },
+          "end": { "line": 19, "column": 24 }
+        },
+        "type": "cond-expr",
+        "locations": [
+          { "start": { "line": 19, "column": 16 }, "end": { "line": 19, "column": 17 } },
+          { "start": { "line": 19, "column": 20 }, "end": { "line": 19, "column": 22 } }
+        ],
+        "line": 19
+      },
+      "2": {
+        "loc": {
+          "start": { "line": 23, "column": 2 },
+          "end": { "line": 27, "column": 3 }
+        },
+        "type": "switch",
+        "locations": [
+          { "start": { "line": 24, "column": 4 }, "end": { "line": 24, "column": 19 } },
+          { "start": { "line": 25, "column": 4 }, "end": { "line": 25, "column": 18 } },
+          { "start": { "line": 26, "column": 4 }, "end": { "line": 26, "column": 20 } }
+        ],
+        "line": 23
+      }
+    },
+    "b": {
+      "0": [2, 2],
+      "1": [4, 2],
+      "2": [1, 1, 2]
+    },
+    "fnMap": {
+      "0": {
+        "name": "classify",
+        "decl": { "start": { "line": 10, "column": 16 }, "end": { "line": 10, "column": 24 } },
+        "loc": { "start": { "line": 10, "column": 41 }, "end": { "line": 16, "column": 1 } },
+        "line": 10
+      },
+      "1": {
+        "name": "sign",
+        "decl": { "start": { "line": 18, "column": 16 }, "end": { "line": 18, "column": 20 } },
+        "loc": { "start": { "line": 18, "column": 37 }, "end": { "line": 20, "column": 1 } },
+        "line": 18
+      },
+      "2": {
+        "name": "bucket",
+        "decl": { "start": { "line": 22, "column": 16 }, "end": { "line": 22, "column": 22 } },
+        "loc": { "start": { "line": 22, "column": 39 }, "end": { "line": 28, "column": 1 } },
+        "line": 22
+      }
+    },
+    "f": { "0": 4, "1": 6, "2": 4 },
+    "hash": "branch-heavy-h",
+    "contentHash": "branch-heavy-c"
+  }
+}

--- a/crates/crap4ts/tests/fixtures/istanbul-nyc/coverage-final.json
+++ b/crates/crap4ts/tests/fixtures/istanbul-nyc/coverage-final.json
@@ -1,0 +1,57 @@
+{
+  "{SRC_ROOT}/simple.ts": {
+    "path": "{SRC_ROOT}/simple.ts",
+    "statementMap": {
+      "0": { "start": { "line": 4, "column": 2 }, "end": { "line": 4, "column": 15 } }
+    },
+    "s": { "0": 3 },
+    "branchMap": {},
+    "b": {},
+    "fnMap": {
+      "0": {
+        "name": "add",
+        "decl": { "start": { "line": 3, "column": 16 }, "end": { "line": 3, "column": 19 } },
+        "loc": { "start": { "line": 3, "column": 51 }, "end": { "line": 5, "column": 1 } },
+        "line": 3
+      }
+    },
+    "f": { "0": 3 }
+  },
+  "{SRC_ROOT}/arrow.ts": {
+    "path": "{SRC_ROOT}/arrow.ts",
+    "statementMap": {
+      "0": { "start": { "line": 1, "column": 0 }, "end": { "line": 1, "column": 44 } },
+      "1": { "start": { "line": 1, "column": 37 }, "end": { "line": 1, "column": 42 } }
+    },
+    "s": { "0": 1, "1": 100 },
+    "branchMap": {},
+    "b": {},
+    "fnMap": {
+      "0": {
+        "name": "square",
+        "decl": { "start": { "line": 1, "column": 13 }, "end": { "line": 1, "column": 19 } },
+        "loc": { "start": { "line": 1, "column": 37 }, "end": { "line": 1, "column": 42 } },
+        "line": 1
+      }
+    },
+    "f": { "0": 100 }
+  },
+  "{SRC_ROOT}/map.ts": {
+    "path": "{SRC_ROOT}/map.ts",
+    "statementMap": {
+      "0": { "start": { "line": 2, "column": 2 }, "end": { "line": 2, "column": 26 } }
+    },
+    "s": { "0": 1 },
+    "branchMap": {},
+    "b": {},
+    "fnMap": {
+      "0": {
+        "name": "increment",
+        "decl": { "start": { "line": 1, "column": 16 }, "end": { "line": 1, "column": 25 } },
+        "loc": { "start": { "line": 1, "column": 51 }, "end": { "line": 3, "column": 1 } },
+        "line": 1
+      }
+    },
+    "f": { "0": 1 }
+  }
+}

--- a/crates/crap4ts/tests/fixtures/istanbul-vitest/coverage-final.json
+++ b/crates/crap4ts/tests/fixtures/istanbul-vitest/coverage-final.json
@@ -1,0 +1,69 @@
+{
+  "{SRC_ROOT}/simple.ts": {
+    "path": "{SRC_ROOT}/simple.ts",
+    "all": false,
+    "statementMap": {
+      "0": { "start": { "line": 4, "column": 2 }, "end": { "line": 4, "column": 15 } }
+    },
+    "s": { "0": 3 },
+    "branchMap": {},
+    "b": {},
+    "fnMap": {
+      "0": {
+        "name": "add",
+        "decl": { "start": { "line": 3, "column": 16 }, "end": { "line": 3, "column": 19 } },
+        "loc": { "start": { "line": 3, "column": 51 }, "end": { "line": 5, "column": 1 } },
+        "line": 3
+      }
+    },
+    "f": { "0": 3 },
+    "hash": "vitest-h-simple",
+    "_coverageSchema": "1a1c01bbd47fc00a2c39e90264f33305004495a9",
+    "inputSourceMap": null
+  },
+  "{SRC_ROOT}/arrow.ts": {
+    "path": "{SRC_ROOT}/arrow.ts",
+    "all": false,
+    "statementMap": {
+      "0": { "start": { "line": 1, "column": 0 }, "end": { "line": 1, "column": 44 } },
+      "1": { "start": { "line": 1, "column": 37 }, "end": { "line": 1, "column": 42 } }
+    },
+    "s": { "0": 1, "1": 100 },
+    "branchMap": {},
+    "b": {},
+    "fnMap": {
+      "0": {
+        "name": "square",
+        "decl": { "start": { "line": 1, "column": 13 }, "end": { "line": 1, "column": 19 } },
+        "loc": { "start": { "line": 1, "column": 37 }, "end": { "line": 1, "column": 42 } },
+        "line": 1
+      }
+    },
+    "f": { "0": 100 },
+    "hash": "vitest-h-arrow",
+    "_coverageSchema": "1a1c01bbd47fc00a2c39e90264f33305004495a9",
+    "inputSourceMap": null
+  },
+  "{SRC_ROOT}/map.ts": {
+    "path": "{SRC_ROOT}/map.ts",
+    "all": false,
+    "statementMap": {
+      "0": { "start": { "line": 2, "column": 2 }, "end": { "line": 2, "column": 26 } }
+    },
+    "s": { "0": 1 },
+    "branchMap": {},
+    "b": {},
+    "fnMap": {
+      "0": {
+        "name": "increment",
+        "decl": { "start": { "line": 1, "column": 16 }, "end": { "line": 1, "column": 25 } },
+        "loc": { "start": { "line": 1, "column": 51 }, "end": { "line": 3, "column": 1 } },
+        "line": 1
+      }
+    },
+    "f": { "0": 1 },
+    "hash": "vitest-h-map",
+    "_coverageSchema": "1a1c01bbd47fc00a2c39e90264f33305004495a9",
+    "inputSourceMap": null
+  }
+}

--- a/crates/crap4ts/tests/fixtures/istanbul-wrapped/coverage-final.json
+++ b/crates/crap4ts/tests/fixtures/istanbul-wrapped/coverage-final.json
@@ -1,0 +1,33 @@
+{
+  "coverage-final": {
+    "{SRC_ROOT}/simple.ts": {
+      "path": "{SRC_ROOT}/simple.ts",
+      "statementMap": {
+        "0": { "start": { "line": 4, "column": 2 }, "end": { "line": 4, "column": 15 } }
+      },
+      "s": { "0": 3 },
+      "branchMap": {},
+      "b": {},
+      "fnMap": {
+        "0": {
+          "name": "add",
+          "decl": { "start": { "line": 3, "column": 16 }, "end": { "line": 3, "column": 19 } },
+          "loc": { "start": { "line": 3, "column": 51 }, "end": { "line": 5, "column": 1 } },
+          "line": 3
+        }
+      },
+      "f": { "0": 3 }
+    },
+    "{SRC_ROOT}/arrow.ts": {
+      "path": "{SRC_ROOT}/arrow.ts",
+      "statementMap": {
+        "0": { "start": { "line": 1, "column": 0 }, "end": { "line": 1, "column": 44 } }
+      },
+      "s": { "0": 1 },
+      "branchMap": {},
+      "b": {},
+      "fnMap": {},
+      "f": {}
+    }
+  }
+}

--- a/crates/crap4ts/tests/fixtures/ts-fixtures/branch-heavy.ts
+++ b/crates/crap4ts/tests/fixtures/ts-fixtures/branch-heavy.ts
@@ -1,0 +1,28 @@
+// Branch-heavy fixture for W2.3 — exercises 3 branch kinds:
+// - if/else (binary branch at line 4)
+// - ternary (binary branch at line 7)
+// - switch (3-arm branch at line 10)
+//
+// Used by `istanbul_smoke::w23_branch_coverage_*` tests and the
+// matching `coverage-with-branches.json` Istanbul fixture, which
+// records per-arm hit counts that the parser fans out into one
+// `BranchCoverage` row per arm per line.
+export function classify(n: number): string {
+  if (n > 0) {                          // line 11 — if/else (2 arms)
+    return "positive";
+  } else {
+    return "non-positive";
+  }
+}
+
+export function sign(n: number): number {
+  return n >= 0 ? 1 : -1;               // line 19 — ternary (2 arms)
+}
+
+export function bucket(n: number): string {
+  switch (n) {                          // line 23 — switch (3 arms)
+    case 0: return "zero";
+    case 1: return "one";
+    default: return "other";
+  }
+}

--- a/crates/crap4ts/tests/istanbul_smoke.rs
+++ b/crates/crap4ts/tests/istanbul_smoke.rs
@@ -365,3 +365,367 @@ fn arrow_ac_5d_mixed_bodies_all_covered() {
 fn _coverage_shape_compiles(out: &ParseOutput<crap4ts::parse_diagnostic::IstanbulParseDiagnostic>) {
     let _map: &HashMap<String, Vec<LineCoverage>> = &out.coverage;
 }
+
+// ─────────────────────────────────────────────────────────────────────
+// W2.3 (#186) — Branch coverage (b + branchMap)
+// W2.4 (#187) — Schema variance + path-mismatch + missing-field paths
+// ─────────────────────────────────────────────────────────────────────
+
+const BRANCHES_FIXTURE: &str = include_str!("fixtures/istanbul-jest/coverage-with-branches.json");
+const ORPHAN_BRANCH_FIXTURE: &str =
+    include_str!("fixtures/istanbul-broken/coverage-with-orphan-branch.json");
+const ORPHAN_PATH_FIXTURE: &str =
+    include_str!("fixtures/istanbul-broken/coverage-with-orphan-path.json");
+const MISSING_FIELD_FIXTURE: &str =
+    include_str!("fixtures/istanbul-broken/coverage-with-missing-field.json");
+const VITEST_FIXTURE: &str = include_str!("fixtures/istanbul-vitest/coverage-final.json");
+const NYC_FIXTURE: &str = include_str!("fixtures/istanbul-nyc/coverage-final.json");
+const WRAPPED_FIXTURE: &str = include_str!("fixtures/istanbul-wrapped/coverage-final.json");
+
+/// Set up a tempdir with the branch-heavy source written and the
+/// `{SRC_ROOT}` placeholder substituted in the payload. Used by all
+/// W2.3 branch-coverage smoke tests.
+fn build_branch_heavy_fixture(payload_template: &str) -> (TempDir, PathBuf, String) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let canonical = std::fs::canonicalize(tmp.path()).expect("canonicalize tempdir");
+    write_fixture(
+        &canonical,
+        "branch-heavy.ts",
+        include_str!("fixtures/ts-fixtures/branch-heavy.ts"),
+    );
+    let payload = payload_template.replace("{SRC_ROOT}", &canonical.to_string_lossy());
+    (tmp, canonical, payload)
+}
+
+/// Set up a tempdir with the three vitest/nyc fixture sources written.
+/// Returns the canonical root + the resolved payload.
+fn build_three_file_fixture(payload_template: &str) -> (TempDir, PathBuf, String) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let canonical = std::fs::canonicalize(tmp.path()).expect("canonicalize tempdir");
+    write_fixture(
+        &canonical,
+        "simple.ts",
+        include_str!("fixtures/ts-fixtures/simple.ts"),
+    );
+    write_fixture(
+        &canonical,
+        "arrow.ts",
+        include_str!("fixtures/ts-fixtures/arrow.ts"),
+    );
+    write_fixture(
+        &canonical,
+        "map.ts",
+        include_str!("fixtures/ts-fixtures/map.ts"),
+    );
+    let payload = payload_template.replace("{SRC_ROOT}", &canonical.to_string_lossy());
+    (tmp, canonical, payload)
+}
+
+/// W2.3: fixture with full `b:` + `branchMap` records populates
+/// `ParseOutput.branches`. Verifies (a) the option is `Some(...)`, (b)
+/// the file key is present, (c) per-arm fan-out matches the fixture
+/// arms (3 branchIds × {2, 2, 3} arms = 7 BranchCoverage rows).
+#[test]
+fn w23_branches_populated_when_b_records_present() {
+    let (_tmp, canonical, payload) = build_branch_heavy_fixture(BRANCHES_FIXTURE);
+    let parser = IstanbulCoverage::new(canonical);
+    let out = parser.parse(&payload).expect("branch-heavy parses");
+
+    let branches = out
+        .branches
+        .as_ref()
+        .expect("branch-heavy fixture populates Some(branches)");
+    let file_branches = branches
+        .get("branch-heavy.ts")
+        .expect("branch-heavy.ts keyed in branches map");
+    // 2 (if arms) + 2 (ternary arms) + 3 (switch arms) = 7.
+    assert_eq!(
+        file_branches.len(),
+        7,
+        "expected one BranchCoverage row per arm; got {file_branches:?}"
+    );
+    // No diagnostics on the clean fixture.
+    assert!(out.diagnostics.is_empty(), "{:?}", out.diagnostics);
+}
+
+/// W2.3: branch arms expand to per-arm `taken` counts (NOT summed
+/// per branchId). The fixture's `b` records are:
+///   branchId 0 (if at line 11): [2, 2]   → 2 rows at line 11
+///   branchId 1 (ternary at line 19): [4, 2] → 2 rows at line 19
+///   branchId 2 (switch at line 23): [1, 1, 2] → 3 rows at line 23
+/// Per the matching consumer at
+/// `crap-core::domain::matching::compute_branch_coverage`, this is
+/// what produces the correct N-of-M arm-level coverage ratios.
+#[test]
+fn w23_branch_arms_fan_to_per_arm_rows_not_summed() {
+    let (_tmp, canonical, payload) = build_branch_heavy_fixture(BRANCHES_FIXTURE);
+    let parser = IstanbulCoverage::new(canonical);
+    let out = parser.parse(&payload).expect("branch-heavy parses");
+
+    let branches = out.branches.unwrap();
+    let file_branches = branches.get("branch-heavy.ts").unwrap();
+
+    // Group by line for inspection.
+    let mut by_line: HashMap<usize, Vec<u64>> = HashMap::new();
+    for b in file_branches {
+        by_line
+            .entry(b.line)
+            .or_default()
+            .push(b.taken.expect("Istanbul always provides taken count"));
+    }
+    let mut line11 = by_line.remove(&11).unwrap_or_default();
+    let mut line19 = by_line.remove(&19).unwrap_or_default();
+    let mut line23 = by_line.remove(&23).unwrap_or_default();
+    line11.sort_unstable();
+    line19.sort_unstable();
+    line23.sort_unstable();
+    assert_eq!(line11, vec![2, 2], "if-arms");
+    assert_eq!(line19, vec![2, 4], "ternary-arms (sorted)");
+    assert_eq!(line23, vec![1, 1, 2], "switch-arms (sorted)");
+}
+
+/// W2.3: orphan branchId (`b` references a missing `branchMap`
+/// entry) emits `BranchMismatch` and skips ONLY that branch — the
+/// rest of the file's branch records still populate, and the file's
+/// statement coverage is intact.
+#[test]
+fn w23_orphan_branch_id_emits_branch_mismatch_and_skips_only_that_branch() {
+    let (_tmp, canonical, payload) = build_branch_heavy_fixture(ORPHAN_BRANCH_FIXTURE);
+    let parser = IstanbulCoverage::new(canonical);
+    let out = parser.parse(&payload).expect("orphan-branch parses");
+
+    // Exactly one `BranchMismatch` diagnostic — for branchId 42.
+    let mismatches: Vec<_> = out
+        .diagnostics
+        .iter()
+        .filter(|d| d.kind == IstanbulDiagnosticKind::BranchMismatch)
+        .collect();
+    assert_eq!(
+        mismatches.len(),
+        1,
+        "expected exactly one BranchMismatch; got {:?}",
+        out.diagnostics
+    );
+    let d = mismatches[0];
+    assert!(d.message.contains("`42`"), "{:?}", d.message);
+    assert!(
+        d.message.contains("coverage tool's issue tracker"),
+        "{:?}",
+        d.message
+    );
+
+    // The valid branch (id 0) still produced its 2 arms at line 11.
+    let file_branches = out
+        .branches
+        .as_ref()
+        .expect("valid branchId still populates Some(branches)")
+        .get("branch-heavy.ts")
+        .expect("branch-heavy.ts keyed");
+    assert_eq!(
+        file_branches.len(),
+        2,
+        "only the non-orphan branchId's 2 arms survive; got {file_branches:?}"
+    );
+    // The file's statement coverage is intact (1 statement at line 11).
+    let lines = lines_for(&out, "branch-heavy.ts");
+    assert!(!lines.is_empty(), "line coverage survives the orphan");
+}
+
+/// W2.3 regression: a fixture with no `b:` records keeps
+/// `ParseOutput.branches.is_none()`. Re-runs the W1.1 happy path and
+/// re-asserts. Locks the regression-pin gate in focus.md AC #15.
+#[test]
+fn w23_regression_no_b_records_leaves_branches_none() {
+    let (_tmp, canonical, payload) = build_fixture();
+    let parser = IstanbulCoverage::new(canonical);
+    let out = parser.parse(&payload).expect("happy path");
+    assert!(
+        out.branches.is_none(),
+        "W1.1 jest fixture has `\"b\": {{}}` for every entry — branches must stay None"
+    );
+}
+
+/// W2.4: vitest-emitted shape (close to jest plus emitter-specific
+/// metadata fields like `_coverageSchema`, `all`, `inputSourceMap`)
+/// parses cleanly with no diagnostics — `#[serde(default)]` already
+/// tolerates unknown fields.
+#[test]
+fn w24_vitest_shape_parses_with_no_diagnostics() {
+    let (_tmp, canonical, payload) = build_three_file_fixture(VITEST_FIXTURE);
+    let parser = IstanbulCoverage::new(canonical);
+    let out = parser.parse(&payload).expect("vitest parses");
+
+    let keys: Vec<_> = out.coverage.keys().cloned().collect();
+    assert!(keys.contains(&"simple.ts".to_string()), "keys: {keys:?}");
+    assert!(keys.contains(&"arrow.ts".to_string()), "keys: {keys:?}");
+    assert!(keys.contains(&"map.ts".to_string()), "keys: {keys:?}");
+    assert!(out.diagnostics.is_empty(), "{:?}", out.diagnostics);
+    assert!(out.branches.is_none());
+}
+
+/// W2.4: nyc-emitted shape uses absolute paths; the existing
+/// `normalize_path` strip-prefix handles this since the
+/// `{SRC_ROOT}` substitution canonicalizes paths to be tempdir-rooted.
+#[test]
+fn w24_nyc_absolute_paths_normalize_via_strip_prefix() {
+    let (_tmp, canonical, payload) = build_three_file_fixture(NYC_FIXTURE);
+    let parser = IstanbulCoverage::new(canonical);
+    let out = parser.parse(&payload).expect("nyc parses");
+
+    let keys: Vec<_> = out.coverage.keys().cloned().collect();
+    assert!(keys.contains(&"simple.ts".to_string()), "keys: {keys:?}");
+    assert!(keys.contains(&"arrow.ts".to_string()), "keys: {keys:?}");
+    assert!(keys.contains(&"map.ts".to_string()), "keys: {keys:?}");
+    assert!(out.diagnostics.is_empty(), "{:?}", out.diagnostics);
+}
+
+/// W2.4: wrapped shape `{"coverage-final": {...flat...}}` parses via
+/// the one-level unwrap arm; the inner flat map is consumed normally.
+#[test]
+fn w24_wrapped_shape_parses_via_single_level_unwrap() {
+    let tmp = tempfile::tempdir().unwrap();
+    let canonical = std::fs::canonicalize(tmp.path()).unwrap();
+    write_fixture(
+        &canonical,
+        "simple.ts",
+        include_str!("fixtures/ts-fixtures/simple.ts"),
+    );
+    write_fixture(
+        &canonical,
+        "arrow.ts",
+        include_str!("fixtures/ts-fixtures/arrow.ts"),
+    );
+    let payload = WRAPPED_FIXTURE.replace("{SRC_ROOT}", &canonical.to_string_lossy());
+
+    let parser = IstanbulCoverage::new(canonical);
+    let out = parser.parse(&payload).expect("wrapped parses via unwrap");
+
+    let keys: Vec<_> = out.coverage.keys().cloned().collect();
+    assert!(keys.contains(&"simple.ts".to_string()), "keys: {keys:?}");
+    assert!(keys.contains(&"arrow.ts".to_string()), "keys: {keys:?}");
+    assert!(out.diagnostics.is_empty(), "{:?}", out.diagnostics);
+}
+
+/// W2.4: a JSON shape that is neither flat-Istanbul nor wrapped-
+/// Istanbul emits exactly one `SchemaUnrecognized` diagnostic whose
+/// message lists the detected top-level keys in sorted order — the
+/// "received: [...]" hint per breadboard W-3.
+#[test]
+fn w24_unrecognized_shape_emits_schema_unrecognized_with_detected_keys() {
+    let parser = IstanbulCoverage::new(PathBuf::from("/tmp"));
+    let out = parser
+        .parse(r#"{"foo": "bar", "baz": 42}"#)
+        .expect("parse returns Ok with diagnostic; downstream produces non-zero exit");
+
+    assert!(out.coverage.is_empty(), "no coverage on unrecognized shape");
+    assert!(out.branches.is_none());
+    assert_eq!(out.diagnostics.len(), 1, "{:?}", out.diagnostics);
+    let d = &out.diagnostics[0];
+    assert_eq!(d.kind, IstanbulDiagnosticKind::SchemaUnrecognized);
+    assert_eq!(d.file_path, "");
+    assert!(
+        d.message
+            .contains("top-level shape not recognized as Istanbul"),
+        "{:?}",
+        d.message
+    );
+    // Keys are sorted; expect "[baz, foo]" in the received-keys hint.
+    assert!(d.message.contains("[baz, foo]"), "{:?}", d.message);
+}
+
+/// W2.4: orphan-path entries emit `PathUnresolved` but the valid
+/// entries in the same fixture still parse — never abort first-record,
+/// never silent-drop.
+#[test]
+fn w24_orphan_path_emits_path_unresolved_and_valid_entries_still_parse() {
+    let (_tmp, canonical, payload) = build_branch_heavy_fixture(ORPHAN_PATH_FIXTURE);
+    let parser = IstanbulCoverage::new(canonical);
+    let out = parser.parse(&payload).expect("orphan-path parses");
+
+    let unresolved: Vec<_> = out
+        .diagnostics
+        .iter()
+        .filter(|d| d.kind == IstanbulDiagnosticKind::PathUnresolved)
+        .collect();
+    assert_eq!(unresolved.len(), 1, "{:?}", out.diagnostics);
+    assert_eq!(unresolved[0].file_path, "/build/transpiled/foreign.js");
+    assert!(
+        unresolved[0]
+            .message
+            .contains("/build/transpiled/foreign.js"),
+        "{:?}",
+        unresolved[0].message
+    );
+
+    // The valid entry still parsed.
+    let keys: Vec<_> = out.coverage.keys().cloned().collect();
+    assert!(
+        keys.contains(&"branch-heavy.ts".to_string()),
+        "valid entry survives orphan-path; keys: {keys:?}"
+    );
+    let lines = lines_for(&out, "branch-heavy.ts");
+    assert!(!lines.is_empty(), "valid line coverage intact");
+}
+
+/// W2.4: an entry that has `s` records but an empty `statementMap`
+/// emits `MissingField` and skips only that entry — the valid entry
+/// in the same fixture still parses.
+#[test]
+fn w24_missing_field_emits_diagnostic_and_skips_only_that_entry() {
+    let (_tmp, canonical, payload) = build_branch_heavy_fixture(MISSING_FIELD_FIXTURE);
+    let parser = IstanbulCoverage::new(canonical);
+    let out = parser.parse(&payload).expect("missing-field parses");
+
+    let missing: Vec<_> = out
+        .diagnostics
+        .iter()
+        .filter(|d| d.kind == IstanbulDiagnosticKind::MissingField)
+        .collect();
+    assert_eq!(missing.len(), 1, "{:?}", out.diagnostics);
+    let d = missing[0];
+    assert!(d.message.contains("orphan-sm.ts"), "{:?}", d.message);
+    assert!(d.message.contains("`s`"), "{:?}", d.message);
+    assert!(d.message.contains("`statementMap`"), "{:?}", d.message);
+
+    // The valid entry still parsed.
+    let keys: Vec<_> = out.coverage.keys().cloned().collect();
+    assert!(
+        keys.contains(&"branch-heavy.ts".to_string()),
+        "valid entry survives missing-field skip; keys: {keys:?}"
+    );
+}
+
+/// W2.4 regression: malformed JSON (not even valid JSON syntax)
+/// continues to fail fatally with `Err(CrapError::SourceParse(
+/// "istanbul: …"))` — the schema-tolerance arms do NOT swallow a
+/// fundamental "this isn't JSON" error.
+#[test]
+fn w24_truly_malformed_json_still_returns_source_parse_error() {
+    let parser = IstanbulCoverage::new(PathBuf::from("/tmp"));
+    let err = parser.parse("{not json at all").unwrap_err();
+    match err {
+        CrapError::SourceParse(msg) => assert!(msg.starts_with("istanbul: "), "msg: {msg}"),
+        other => panic!("expected SourceParse, got {other:?}"),
+    }
+}
+
+/// W2.4: a valid JSON array (e.g. `[]` or `["foo"]`) is not Istanbul
+/// shape and emits `SchemaUnrecognized` with `received keys: array`
+/// as the detected-type hint (objects-only get key listings).
+#[test]
+fn w24_top_level_array_emits_schema_unrecognized() {
+    let parser = IstanbulCoverage::new(PathBuf::from("/tmp"));
+    let out = parser
+        .parse(r#"["not", "istanbul"]"#)
+        .expect("returns Ok with diagnostic");
+    assert_eq!(out.diagnostics.len(), 1);
+    assert_eq!(
+        out.diagnostics[0].kind,
+        IstanbulDiagnosticKind::SchemaUnrecognized
+    );
+    assert!(
+        out.diagnostics[0].message.contains("received keys: array"),
+        "{:?}",
+        out.diagnostics[0].message
+    );
+}

--- a/crates/crap4ts/tests/istanbul_smoke.rs
+++ b/crates/crap4ts/tests/istanbul_smoke.rs
@@ -709,6 +709,26 @@ fn w24_truly_malformed_json_still_returns_source_parse_error() {
     }
 }
 
+/// W2.4 parity: `validate()` accepts wrapped shape so the CLI's
+/// pre-flight gate doesn't short-circuit the parse cascade. Without
+/// this parity, `IstanbulCoverage::validate` would reject
+/// `{"coverage-final": {...}}` with "not a recognizable Istanbul JSON
+/// shape" before parse ever ran the unwrap arm, defeating W2.4 at the
+/// CLI layer.
+#[test]
+fn w24_validate_accepts_wrapped_shape_for_cli_parity_with_parse() {
+    let tmp = tempfile::tempdir().unwrap();
+    let canonical = std::fs::canonicalize(tmp.path()).unwrap();
+    let payload = WRAPPED_FIXTURE.replace("{SRC_ROOT}", &canonical.to_string_lossy());
+    let cov_path = canonical.join("coverage-final.json");
+    std::fs::write(&cov_path, payload).unwrap();
+
+    let parser = IstanbulCoverage::new(canonical);
+    parser
+        .validate(&cov_path)
+        .expect("validate accepts wrapped shape (parity with parse)");
+}
+
 /// W2.4: a valid JSON array (e.g. `[]` or `["foo"]`) is not Istanbul
 /// shape and emits `SchemaUnrecognized` with `received keys: array`
 /// as the detected-type hint (objects-only get key listings).


### PR DESCRIPTION
## Summary

PR 3 of 3 in the **Wave 2 consolidation** of the TypeScript adapter pipeline (`crap-rs/20260513-typescript-adapter`). Closes 2 sub-issues — pipeline-final Istanbul coverage breadth. Per the Option B aggressive PR-reduction precedent set by PR 2 (#204), this PR consolidates W2.3 (#186) and W2.4 (#187): both touch a single file (`crates/crap4ts/src/adapters/coverage/mod.rs`), share the parse pipeline, and present a single review surface. With this merge, Wave 2 closes and the pipeline becomes ready for Wave 3 (W3.1 #189 — crap4ts@1.x corpus + reference capture).

## Acceptance gates (15 — all checked)

- [x] 1. `cargo build --workspace`
- [x] 2. `cargo nextest run --workspace --all-targets` — **1025 passed, 0 skipped** (1013 baseline + 12 new smoke tests)
- [x] 3. `cargo +1.93 check --workspace --all-targets`
- [x] 4. `cargo fmt --check`
- [x] 5. `cargo clippy --workspace --all-targets -- -D warnings`
- [x] 6. `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps`
- [x] 7. `cargo deny check`
- [x] 8. AST-purity grep on `crates/crap-core/src/` clean (PR 3 touches only crap4ts — gate stays green)
- [x] 9. **Wire snapshots byte-identical for BOTH crap4rs and crap4ts** (see canary section below)
- [x] 10. `lefthook` pre-push insta gate green (`cargo insta test --check --test-runner=nextest` — no snapshots to review)
- [x] 11. PR body declares wire-snapshot status for both modules + closes 2 issues + consolidation rationale + ADR (b) link
- [ ] 12. CI: 16+ checks SUCCESS (pending CI; mutation testing on `domain/view.rs` may still be in-flight at merge per W1.* / W2.5 / W2.1+W2.2+#199 precedent)
- [x] 13. `branch_coverage.feature` (4 scenarios — W2.3) contracts grounded by smoke tests `w23_branches_populated_when_b_records_present`, `w23_branch_arms_fan_to_per_arm_rows_not_summed`, `w23_orphan_branch_id_emits_branch_mismatch_and_skips_only_that_branch`, `w23_regression_no_b_records_leaves_branches_none`
- [x] 14. `istanbul_parser.feature` per-emitter + per-failure-mode scenarios (vitest + nyc + wrapped + orphan-path + schema-unrecognized + missing-field) grounded by `w24_*` smoke tests
- [x] 15. `ParseOutput.branches.is_some()` regression — fixtures without `b:` records keep `.is_none()`; fixtures with `b:` records populate `Some(...)`. Regression-pinned by `w23_regression_no_b_records_leaves_branches_none`

## Consolidation rationale

Same file (`crates/crap4ts/src/adapters/coverage/mod.rs`), contextually related Istanbul-parser breadth (branch coverage + schema variance + path-mismatch + missing-field — all flowing through one parse pipeline), single review surface, single ADR. Identical pattern to PR 2 (`a1fb4b1`) which consolidated #184 + #185 + #199 (OxcWalker breadth) into a single review surface.

## What changed

### W2.3 (#186) — Istanbul branch coverage (`b:` + `branchMap`)

`IstanbulCoverage::parse` now consumes the per-file `b: HashMap<String, Vec<u64>>` + `branchMap: HashMap<String, BranchLoc>` records. For each Istanbul branchId, the parser:

1. Looks up the branchId in `branchMap`. If missing → emits `IstanbulDiagnosticKind::BranchMismatch` with the redirect-to-coverage-tool-issue-tracker message + **skips THAT branch only** (the rest of the file still parses).
2. Otherwise, takes the line attribution as `branchMap[id].line` (when set) falling back to `branchMap[id].loc.start.line`.
3. Fans out the arm-level hit counts in `b[id]` into one `BranchCoverage { line, taken: Some(arm_hits) }` row PER ARM.

The aggregated map flows into `ParseOutput.branches` per CAO advisory A-3 — the existing `Option<HashMap<String, Vec<BranchCoverage>>>` slot (no parallel seam). `branches = (!branch_map.is_empty()).then_some(branch_map)` mirrors the LCOV adapter's gate — fixtures with `\"b\": {}` everywhere keep `.is_none()` (W1.1 jest fixture regression-pinned).

### W2.4 (#187) — Schema variance + path-mismatch contract

`IstanbulCoverage::parse` now runs a three-arm top-level cascade:

1. **Flat** `{[path]: entry}` (jest / vitest / nyc baseline — `#[serde(default)]` on every optional field tolerates emitter-specific metadata absences)
2. **Single-level unwrap** `{\"coverage-final\": {…flat…}}` (defensive against community wrappers that re-publish coverage payloads)
3. **`SchemaUnrecognized`** with the detected top-level keys hint (e.g. `received keys: [coverage-final, meta, version]`) — returns `Ok(ParseOutput { coverage: empty, branches: None, diagnostics: [...] })` so downstream \"no functions extracted\" surfaces a non-zero exit while the diagnostic flows into the envelope. Never abort first-record.

Truly malformed JSON (not parseable as any JSON value) continues to fail fatally with `Err(CrapError::SourceParse(\"istanbul: …\"))` per W1.1.

Per-entry diagnostic kinds (the four W1.1 variants — **no new variants per locked decision**):

| Variant | Trigger | Skip granularity |
|---|---|---|
| `PathUnresolved` | `normalize_path` returns `None` | the entry |
| `MissingField` | `s` non-empty but `statementMap` empty (or vice versa) | the entry |
| `SchemaUnrecognized` | top-level neither flat nor wrapped | whole parse (empty `ParseOutput` + diagnostic) |
| `BranchMismatch` | `b` references a missing `branchMap` entry | the branch |

### New fixtures (7)

| Path | Purpose |
|---|---|
| `crates/crap4ts/tests/fixtures/ts-fixtures/branch-heavy.ts` | 3 branch kinds (if/else, ternary, switch) — base source for W2.3 |
| `crates/crap4ts/tests/fixtures/istanbul-jest/coverage-with-branches.json` | jest-shaped fixture with full `b:` + `branchMap` covering `branch-heavy.ts` |
| `crates/crap4ts/tests/fixtures/istanbul-broken/coverage-with-orphan-branch.json` | branchId `42` referenced by `b` but not `branchMap` |
| `crates/crap4ts/tests/fixtures/istanbul-broken/coverage-with-orphan-path.json` | entry pointing at `/build/transpiled/foreign.js` + a valid entry |
| `crates/crap4ts/tests/fixtures/istanbul-broken/coverage-with-missing-field.json` | one entry has `s` records but no `statementMap` |
| `crates/crap4ts/tests/fixtures/istanbul-vitest/coverage-final.json` | vitest-shaped (jest + `_coverageSchema`, `all`, `inputSourceMap`) |
| `crates/crap4ts/tests/fixtures/istanbul-nyc/coverage-final.json` | nyc-shaped (jest with no per-file metadata, exercises absolute-path normalization) |
| `crates/crap4ts/tests/fixtures/istanbul-wrapped/coverage-final.json` | `{\"coverage-final\": {...flat...}}` shape, exercises one-level unwrap |

### Smoke tests (12 new; 9 W1.1 retained → 21 total)

- `w23_branches_populated_when_b_records_present` — `Some(branches)` + 7 rows for the 3 branch kinds
- `w23_branch_arms_fan_to_per_arm_rows_not_summed` — verifies per-arm fan-out matches the BDD scenario 3 arithmetic
- `w23_orphan_branch_id_emits_branch_mismatch_and_skips_only_that_branch`
- `w23_regression_no_b_records_leaves_branches_none` — locks AC #15
- `w24_vitest_shape_parses_with_no_diagnostics`
- `w24_nyc_absolute_paths_normalize_via_strip_prefix`
- `w24_wrapped_shape_parses_via_single_level_unwrap`
- `w24_unrecognized_shape_emits_schema_unrecognized_with_detected_keys`
- `w24_orphan_path_emits_path_unresolved_and_valid_entries_still_parse`
- `w24_missing_field_emits_diagnostic_and_skips_only_that_entry`
- `w24_truly_malformed_json_still_returns_source_parse_error`
- `w24_top_level_array_emits_schema_unrecognized`

## Discovery findings

- **`f`/`fnMap` backfill deferral stays sound.** Locked decision #13 — W1.1 discovery 5a–5d empirically showed `s`/`statementMap` is sufficient for arrow-function coverage. No reintroduction. The fixtures keep `f` + `fnMap` records faithful to real emitter output (visible to readers) but the parser does NOT consume them.
- **vitest emitter shape verified through constructed fixture**, not sampled from `~/Github/crap4ts/` (the user's local install is at crap4ts@1.0.1 which has its own coverage pipeline). The `#[serde(default)]` tolerance against the W1.1 minimal struct is sufficient to absorb `_coverageSchema`, `inputSourceMap`, `all` — confirmed by `w24_vitest_shape_parses_with_no_diagnostics`.
- **nyc absolute-path handling reuses W1.1's `normalize_path`** unchanged — the `{SRC_ROOT}` fixture-substitution mechanism in the smoke tests faithfully reproduces what an nyc emitter would write (canonical absolute paths under a project root that matches `--src`).

## Plan-of-record deviations (mandatory subsection)

**One material deviation surfaced and is documented here per the load-bearing plan-of-record discipline (now 6 sessions deep: W1.1, W1.2, W1.3, W2.5, W2.1+W2.2+#199, this).**

### Per-arm fan-out, NOT per-branchId sum

The session prompt (and the plan's W2.3 prompt) instructed:

> For each branchId in `b`: \"sum its per-arm hit counts (each `Vec<u32>` is hit counts per arm)\", look up the location in `branchMap`, emit `BranchCoverage` records keyed by file path

I verified empirically against the downstream consumer at `crap-core/src/domain/matching.rs:101-114` (`compute_branch_coverage`):

```rust
for branch in branches {
    if branch.line in span && let Some(taken) = branch.taken {
        total += 1;
        if taken > 0 { covered += 1; }
    }
}
```

Each `BranchCoverage` row counts as **one branch arm** — `total = N rows`, `covered = N rows with taken > 0`. Summing arm hits per branchId would collapse N arms into 1 row, falsely reporting 100% on partially-covered branches (e.g., arms `[5, 3, 0]` → sum=8 → 1 row with `taken: Some(8)` → reports 1/1 = 100% instead of the actual 2/3 = 66.7%).

The `branch_coverage.feature` scenario 3 arithmetic corroborates: \"4 of 6 branches hit (66% branch coverage)\" — the \"of 6\" arithmetic only works with per-arm fan-out (3 branchIds × 2 arms = 6 records), not per-branchId summing.

I emitted **per-arm** records (one `BranchCoverage` per element of `b[branchId]`, each carrying that arm's `taken` count). The matching consumer's contract is the ground truth; the prompt's instruction was the deviation. Smoke test `w23_branch_arms_fan_to_per_arm_rows_not_summed` regression-pins the contract; the test name advertises the constraint to future maintainers.

This pattern — \"empirical reality (consumer + BDD arithmetic) beats prompt assertions\" — matches the rule restated across 5 prior sessions.

### Non-material variances (logged, no escalation)

- `BranchLoc` field-doc churn: removed `#[allow(dead_code)]` from `b`, `branch_map`, `BranchLoc` (now consumed); added docstrings explaining that `kind` and `locations` remain unconsumed (line-keyed BranchCoverage doesn't need finer-grained spans). Comment-only — no API surface change.
- `BranchLoc::line` precedence: when both `loc` and the optional emitter-set `line` are present, the parser prefers `line` (some emitters set `loc` to a wide span covering both arms but pin `line` to the branching keyword's line). Falls back to `loc.start.line`. Documented inline.

## Wire-shape canary

**Both snapshots byte-identical — confirmed via `cargo nextest run -p crap-core --test wire_envelope_crap4rs --test wire_envelope_crap4ts` (no insta drift).**

- **`wire_envelope_crap4rs__envelope.snap`**: byte-identical. PR 3 does not touch `crap4rs/src/main.rs` or any crap4rs source; the W2.5-discovered drift mechanism (main.rs LOC changes shift span positions) does not apply.
- **`wire_envelope_crap4ts__envelope.snap`**: byte-identical per locked decision #12. `ParseOutput.branches` is consumed by `core::analyze` at `crap-core/src/core/mod.rs:197` and lowered into `FunctionCoverage.branch_coverage: Option<CoverageRatio>` — but **the JSON envelope's `result.functions[].scored` shape only surfaces `coverage_percent` (lowered from `line_coverage.percent`)**, not `branch_coverage`. Branch records never reach the wire. Empirically verified: `grep -i 'branch' wire_envelope_crap4ts__envelope.snap` returns no matches. The W1.3 e2e fixture `simple.ts` also doesn't exercise the new W2.3 / W2.4 paths (`\"b\": {}`, flat shape, paths resolve cleanly), so this is doubly safe.

## ADR (b) — D16 Istanbul JSON schema tolerance

Filed at <https://github.com/breezy-bays-labs/ops/blob/main/decisions/crap-rs/adr-istanbul-schema-tolerance.md> (commit `5d8e047` in `breezy-bays-labs/ops`). Y-statement format. Captures (i) the 3-emitter top-level cascade, (ii) the four-variant per-entry diagnostic surface, (iii) the path-mismatch contract (\"never silently drop, never abort first-record\"), and (iv) the per-arm fan-out invariant documented above.

## Closes

Closes #186, #187.

> **Closeout reminder for the multi-issue auto-close gotcha** (W2.1+W2.2+#199 precedent): GitHub's squash-merge body templating only honored `Closes #184` historically. If #186 or #187 stays open post-merge, manually `gh issue close <n> --comment \"Closed by #<pr> (merged at <sha>)\"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added branch coverage metrics support to Istanbul coverage adapter
  * Enhanced parsing to support coverage output from multiple tools (Jest, NYC, Vitest)

* **Bug Fixes**
  * Improved error handling and diagnostics for incomplete or malformed coverage data
  * Better path validation with clearer error reporting

* **Tests**
  * Added comprehensive smoke tests for branch coverage and schema variations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/breezy-bays-labs/crap-rs/pull/210)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->