### PR TITLE
fix(crap4ts): #215 — normalize_path suffix-fallback for absolute paths from a different machine

### DIFF
--- a/crates/crap4ts/src/adapters/coverage/mod.rs
+++ b/crates/crap4ts/src/adapters/coverage/mod.rs
@@ -43,14 +43,16 @@
 //!
 //! ## Path normalization
 //!
-//! Mirrors `crap4rs::adapters::coverage::LcovParser::normalize_path` —
-//! a pure `strip_prefix(effective_src)`. The orchestrator pre-
-//! canonicalizes `effective_src` at the factory-closure boundary, so
-//! the parser does no filesystem I/O during path joining. Entries
-//! whose paths fall outside `effective_src` emit an
-//! `IstanbulParseDiagnostic { kind: PathUnresolved, … }` and are
-//! skipped — per Resolved Q10 in shaping, the scorecard NEVER aborts
-//! on first failure and NEVER silent-drops a record.
+//! Two-arm strategy (see `IstanbulCoverage::normalize_path`): a pure
+//! `strip_prefix(effective_src)` fast path for same-machine captures,
+//! then a bounded `.is_file()` longest-suffix reachability fallback
+//! (#215) for portable fixtures whose absolute paths were captured on
+//! a different machine and share no prefix with the local
+//! `effective_src`. The orchestrator pre-canonicalizes `effective_src`
+//! at the factory-closure boundary. Entries whose paths resolve under
+//! neither arm emit an `IstanbulParseDiagnostic { kind: PathUnresolved,
+//! … }` and are skipped — per Resolved Q10 in shaping, the scorecard
+//! NEVER aborts on first failure and NEVER silent-drops a record.
 
 use crap_core::domain::types::{BranchCoverage, CrapError, LineCoverage};
 use crap_core::ports::{CoveragePort, ParseOutput};
@@ -90,15 +92,41 @@ impl IstanbulCoverage {
         }
     }
 
-    /// Strip `effective_src` from `raw` and return a workspace-relative
-    /// path, or `None` if the entry resolves outside the source tree.
+    /// Resolve `raw` to a workspace-relative path under
+    /// `effective_src`, or `None` if it can't be resolved.
     ///
-    /// Pure: no filesystem I/O. Mirrors `LcovParser::normalize_path`
-    /// in `crap4rs`. The orchestrator canonicalizes `effective_src`
-    /// before construction, so no further `canonicalize()` walk is
-    /// needed here. Joining relative entries against `effective_src`
-    /// and stripping the prefix is the same two-step the LCOV parser
-    /// uses on its own platform.
+    /// Two-arm strategy:
+    ///
+    /// 1. **Strip-prefix fast path (pure, no I/O).** Join relative
+    ///    entries against `effective_src`, then strip the canonical
+    ///    `effective_src` prefix. This succeeds whenever the coverage
+    ///    payload was captured on the same machine/tree being analyzed
+    ///    (jest/vitest/nyc on the local checkout). The orchestrator
+    ///    pre-canonicalizes `effective_src`, so no `canonicalize()`
+    ///    walk is needed here.
+    /// 2. **Suffix-reachability fallback (bounded `.is_file()` I/O,
+    ///    #215).** When the coverage was captured on a *different*
+    ///    machine (a portable fixture: coverage produced on machine A,
+    ///    analyzed on machine B), the entry's absolute path shares no
+    ///    prefix with the local `effective_src` and arm 1 returns
+    ///    `None`. Arm 2 then walks the path's components longest →
+    ///    shortest, joining each suffix under `effective_src` and
+    ///    accepting the first suffix that resolves to a real file. The
+    ///    longest matching suffix wins, which deterministically
+    ///    disambiguates a leaf filename (e.g. `index.ts`) that exists
+    ///    in multiple directories — the longer shared path is the
+    ///    structural truth; the machine-specific absolute prefix is
+    ///    noise. If two equal-length suffixes could both match (only
+    ///    reachable via symlinks/odd trees), the first found wins.
+    ///
+    /// This is *not* a pure function and no longer mirrors
+    /// `crap4rs::adapters::coverage::LcovParser::normalize_path` (which
+    /// remains pure strip-prefix): the fallback does bounded,
+    /// OS-cached filesystem I/O (~components × `.is_file()` syscalls).
+    /// That trade buys cross-machine fixture portability. When even the
+    /// suffix match fails, this returns `None` and the caller emits
+    /// `PathUnresolved` as before — the diagnostic-and-skip contract
+    /// (D16) is preserved as the final arm.
     fn normalize_path(&self, raw: &str) -> Option<PathBuf> {
         let path = PathBuf::from(raw);
         let joined = if path.is_absolute() {
@@ -106,10 +134,46 @@ impl IstanbulCoverage {
         } else {
             self.effective_src.join(raw)
         };
-        joined
-            .strip_prefix(&self.effective_src)
-            .ok()
-            .map(|p| p.to_path_buf())
+        // Arm 1: strip the canonical effective_src prefix (W2.4 fast
+        // path — same-machine capture).
+        if let Ok(stripped) = joined.strip_prefix(&self.effective_src) {
+            return Some(stripped.to_path_buf());
+        }
+        // Arm 2: cross-machine absolute paths don't share a prefix —
+        // find the longest path suffix that resolves to a real file
+        // under effective_src (#215).
+        self.suffix_match_under(&joined)
+    }
+
+    /// Find the longest suffix of `raw` whose components, joined under
+    /// `effective_src`, resolve to a real file. Returns the
+    /// workspace-relative suffix, or `None` if no suffix is reachable.
+    ///
+    /// Iterates suffixes longest → shortest (`start` from 0 outward),
+    /// so the first reachable suffix is the longest one
+    /// (longest-suffix-wins precedence — see [`Self::normalize_path`]).
+    ///
+    /// `.is_file()` is used (not `.exists()`): one syscall, and it
+    /// prevents a directory false-positive when a raw path component
+    /// happens to match a directory name under `effective_src`.
+    ///
+    /// The `starts_with(effective_src)` guard rejects the `start == 0`
+    /// degenerate case: when `raw` is absolute, `effective_src.join(raw)`
+    /// collapses back to `raw` itself (Rust `Path::join` replaces the
+    /// base with an absolute RHS). Without the guard, an absolute path
+    /// that exists verbatim *outside* `effective_src` would leak an
+    /// out-of-tree match. The guard keeps every accepted match strictly
+    /// under the source root.
+    fn suffix_match_under(&self, raw: &Path) -> Option<PathBuf> {
+        let components: Vec<_> = raw.components().collect();
+        for start in 0..components.len() {
+            let candidate_rel: PathBuf = components[start..].iter().collect();
+            let candidate_abs = self.effective_src.join(&candidate_rel);
+            if candidate_abs.starts_with(&self.effective_src) && candidate_abs.is_file() {
+                return Some(candidate_rel);
+            }
+        }
+        None
     }
 }
 

--- a/crates/crap4ts/src/adapters/coverage/mod.rs
+++ b/crates/crap4ts/src/adapters/coverage/mod.rs
@@ -127,6 +127,22 @@ impl IstanbulCoverage {
     /// suffix match fails, this returns `None` and the caller emits
     /// `PathUnresolved` as before — the diagnostic-and-skip contract
     /// (D16) is preserved as the final arm.
+    ///
+    /// **Traversal guard (authoritative, #216).** The relative path
+    /// returned from *either* arm is rejected (`None`) if it contains a
+    /// `Component::ParentDir` (`..`). This is the single, authoritative
+    /// guard and covers both arms uniformly. It is *not* redundant with
+    /// arm 2's per-iteration filter: arm 1's `strip_prefix` is lexical,
+    /// so `effective_src = /root/project` and a user-supplied coverage
+    /// path `/root/project/../outside/secret.ts` *succeeds* arm 1 with
+    /// the relative result `../outside/secret.ts` — a path that
+    /// `.is_file()`-resolves *outside* `effective_src`. Since
+    /// `coverage-final.json` is user-supplied, the return-point guard
+    /// closes this traversal-escape for the strip-prefix fast path too,
+    /// not just the suffix fallback. (Gemini security-medium on #216,
+    /// scope-expanded beyond the stated arm-2-only finding after a
+    /// standalone `strip_prefix` repro proved arm 1 had the same
+    /// defect.)
     fn normalize_path(&self, raw: &str) -> Option<PathBuf> {
         let path = PathBuf::from(raw);
         let joined = if path.is_absolute() {
@@ -135,14 +151,25 @@ impl IstanbulCoverage {
             self.effective_src.join(raw)
         };
         // Arm 1: strip the canonical effective_src prefix (W2.4 fast
-        // path — same-machine capture).
-        if let Ok(stripped) = joined.strip_prefix(&self.effective_src) {
-            return Some(stripped.to_path_buf());
+        // path — same-machine capture). Arm 2: cross-machine absolute
+        // paths don't share a prefix — find the longest path suffix
+        // that resolves to a real file under effective_src (#215).
+        let candidate = if let Ok(stripped) = joined.strip_prefix(&self.effective_src) {
+            stripped.to_path_buf()
+        } else {
+            self.suffix_match_under(&joined)?
+        };
+        // Authoritative traversal guard (#216): both `strip_prefix`
+        // and `starts_with` are lexical, so a `..`-containing result
+        // points outside `effective_src` once resolved. Reject any
+        // ParentDir in the final relative path — covers both arms.
+        if candidate
+            .components()
+            .any(|c| c == std::path::Component::ParentDir)
+        {
+            return None;
         }
-        // Arm 2: cross-machine absolute paths don't share a prefix —
-        // find the longest path suffix that resolves to a real file
-        // under effective_src (#215).
-        self.suffix_match_under(&joined)
+        Some(candidate)
     }
 
     /// Find the longest suffix of `raw` whose components, joined under
@@ -157,17 +184,42 @@ impl IstanbulCoverage {
     /// prevents a directory false-positive when a raw path component
     /// happens to match a directory name under `effective_src`.
     ///
-    /// The `starts_with(effective_src)` guard rejects the `start == 0`
-    /// degenerate case: when `raw` is absolute, `effective_src.join(raw)`
-    /// collapses back to `raw` itself (Rust `Path::join` replaces the
-    /// base with an absolute RHS). Without the guard, an absolute path
-    /// that exists verbatim *outside* `effective_src` would leak an
-    /// out-of-tree match. The guard keeps every accepted match strictly
-    /// under the source root.
+    /// Two local guards narrow matches; the **authoritative**
+    /// traversal guard lives at [`Self::normalize_path`]'s return
+    /// point (it covers both arms uniformly — see there). These are
+    /// defense-in-depth / local perf, not the sole protection:
+    ///
+    /// - **Per-iteration ParentDir (`..`) skip.** Any suffix
+    ///   containing a `Component::ParentDir` is skipped *before* the
+    ///   `.is_file()` syscall — a small perf win (avoids a doomed
+    ///   filesystem touch) that also clarifies the local invariant.
+    ///   Filtering is per-iteration, not an up-front whole-path
+    ///   reject: a `..` only contaminates the suffixes that include
+    ///   it; a later, cleaner suffix (e.g. `c/file.ts` from
+    ///   `/a/b/../c/file.ts`) still resolves. `CurDir` (`.`) is
+    ///   harmless and left alone. The authoritative rejection is still
+    ///   `normalize_path`'s return-point guard (#216).
+    /// - **`starts_with(effective_src)` guard.** Defense-in-depth for
+    ///   the `start == 0` degenerate case: when `raw` is absolute,
+    ///   `effective_src.join(raw)` collapses back to `raw` itself
+    ///   (Rust `Path::join` replaces the base with an absolute RHS),
+    ///   so an absolute path that exists verbatim *outside*
+    ///   `effective_src` would otherwise leak an out-of-tree match.
     fn suffix_match_under(&self, raw: &Path) -> Option<PathBuf> {
         let components: Vec<_> = raw.components().collect();
         for start in 0..components.len() {
             let candidate_rel: PathBuf = components[start..].iter().collect();
+            // Reject traversal: `Path::starts_with` is lexical, so a
+            // `..` component would pass the under-root guard but
+            // `.is_file()` resolves it outside `effective_src`. Skip
+            // any suffix containing a ParentDir component before the
+            // filesystem touch (#216 gemini security-medium).
+            if candidate_rel
+                .components()
+                .any(|c| c == std::path::Component::ParentDir)
+            {
+                continue;
+            }
             let candidate_abs = self.effective_src.join(&candidate_rel);
             if candidate_abs.starts_with(&self.effective_src) && candidate_abs.is_file() {
                 return Some(candidate_rel);

--- a/crates/crap4ts/tests/istanbul_smoke.rs
+++ b/crates/crap4ts/tests/istanbul_smoke.rs
@@ -799,3 +799,210 @@ fn w24_top_level_array_emits_schema_unrecognized() {
         out.diagnostics[0].message
     );
 }
+
+// ── #215: suffix-fallback for cross-machine absolute paths ────────────
+//
+// When a portable fixture's `coverage-final.json` carries absolute
+// paths captured on machine A (e.g. `/Users/alice/Github/proj/src/...`)
+// but is analyzed on machine B under a different `--src`, the absolute
+// prefix shares nothing with the canonical `effective_src`, so
+// `strip_prefix` (arm 1) returns `None`. `normalize_path`'s arm 2
+// walks path suffixes longest → shortest under `effective_src` and
+// accepts the first that resolves to a real file. These four tests
+// lock that contract: (a) resolves a different-prefix absolute path,
+// (b) over-match guard — no false-positive when no suffix exists,
+// (c) longest-suffix-wins disambiguation, (d) e2e floor on the W3.1
+// v1.x corpus.
+
+/// Build a minimal single-statement Istanbul payload keyed by `key`
+/// whose entry `path` is the given (foreign-machine) absolute path.
+/// One statement at line 1 with one hit so a `LineCoverage` record
+/// flows when the path resolves.
+fn one_stmt_payload(key: &str, entry_path: &str) -> String {
+    format!(
+        r#"{{"{key}":{{"path":"{entry_path}","s":{{"0":1}},"statementMap":{{"0":{{"start":{{"line":1,"column":0}},"end":{{"line":1,"column":10}}}}}},"b":{{}},"branchMap":{{}},"f":{{}},"fnMap":{{}}}}}}"#
+    )
+}
+
+/// #215(a): an absolute path with a *different* machine prefix but a
+/// suffix that matches a real file under `effective_src` resolves via
+/// the suffix fallback — no `PathUnresolved`, coverage present.
+#[test]
+fn fix215_foreign_prefix_absolute_path_resolves_via_suffix_fallback() {
+    let tmp = tempfile::tempdir().unwrap();
+    let canonical = std::fs::canonicalize(tmp.path()).unwrap();
+    write_fixture(
+        &canonical,
+        "simple.ts",
+        include_str!("fixtures/ts-fixtures/simple.ts"),
+    );
+
+    // The fixture only has `simple.ts` at the root, but the coverage
+    // entry's path is an absolute path from a completely foreign tree.
+    let payload = one_stmt_payload(
+        "/some/foreign/machine/Github/proj/src/simple.ts",
+        "/some/foreign/machine/Github/proj/src/simple.ts",
+    );
+
+    let parser = IstanbulCoverage::new(canonical);
+    let out = parser
+        .parse(&payload)
+        .expect("foreign-prefix absolute path parses via suffix fallback");
+
+    assert!(
+        out.diagnostics.is_empty(),
+        "no PathUnresolved expected — suffix fallback resolves it: {:?}",
+        out.diagnostics
+    );
+    let keys: Vec<_> = out.coverage.keys().cloned().collect();
+    assert_eq!(
+        keys,
+        vec!["simple.ts".to_string()],
+        "entry resolves to the relative suffix `simple.ts`; got {keys:?}"
+    );
+    let lines = lines_for(&out, "simple.ts");
+    assert!(
+        !lines.is_empty(),
+        "coverage records flow for the matched file"
+    );
+}
+
+/// #215(b): over-match guard. An absolute path whose *no* suffix
+/// resolves to a real file under `effective_src` still emits exactly
+/// one `PathUnresolved` — the fallback must not invent a match.
+#[test]
+fn fix215_no_matching_suffix_still_emits_path_unresolved() {
+    let tmp = tempfile::tempdir().unwrap();
+    let canonical = std::fs::canonicalize(tmp.path()).unwrap();
+    write_fixture(
+        &canonical,
+        "simple.ts",
+        include_str!("fixtures/ts-fixtures/simple.ts"),
+    );
+
+    // `nonexistent.ts` has no suffix anywhere under the fixture root.
+    let payload = one_stmt_payload(
+        "/foreign/x/y/z/nonexistent.ts",
+        "/foreign/x/y/z/nonexistent.ts",
+    );
+
+    let parser = IstanbulCoverage::new(canonical);
+    let out = parser.parse(&payload).expect("parses with diagnostic");
+
+    let unresolved: Vec<_> = out
+        .diagnostics
+        .iter()
+        .filter(|d| d.kind == IstanbulDiagnosticKind::PathUnresolved)
+        .collect();
+    assert_eq!(
+        unresolved.len(),
+        1,
+        "exactly one PathUnresolved when no suffix matches: {:?}",
+        out.diagnostics
+    );
+    assert_eq!(unresolved[0].file_path, "/foreign/x/y/z/nonexistent.ts");
+    assert!(
+        out.coverage.is_empty(),
+        "no coverage for an unmatched path: {:?}",
+        out.coverage.keys().collect::<Vec<_>>()
+    );
+}
+
+/// #215(c): ambiguous suffix. With `a/util.ts` AND `b/util.ts` under
+/// the root, a coverage entry path `/foreign/x/b/util.ts` must resolve
+/// to `b/util.ts` (longest-suffix-wins, deterministic) — never the
+/// shorter leaf-only `util.ts` and never `a/util.ts`.
+#[test]
+fn fix215_ambiguous_suffix_longest_wins_deterministically() {
+    let tmp = tempfile::tempdir().unwrap();
+    let canonical = std::fs::canonicalize(tmp.path()).unwrap();
+    std::fs::create_dir_all(canonical.join("a")).unwrap();
+    std::fs::create_dir_all(canonical.join("b")).unwrap();
+    write_fixture(
+        &canonical,
+        "a/util.ts",
+        include_str!("fixtures/ts-fixtures/simple.ts"),
+    );
+    write_fixture(
+        &canonical,
+        "b/util.ts",
+        include_str!("fixtures/ts-fixtures/simple.ts"),
+    );
+
+    let payload = one_stmt_payload("/foreign/x/b/util.ts", "/foreign/x/b/util.ts");
+
+    let parser = IstanbulCoverage::new(canonical);
+    let out = parser
+        .parse(&payload)
+        .expect("ambiguous-suffix path parses");
+
+    assert!(out.diagnostics.is_empty(), "{:?}", out.diagnostics);
+    let keys: Vec<_> = out.coverage.keys().cloned().collect();
+    assert_eq!(
+        keys,
+        vec!["b/util.ts".to_string()],
+        "longest suffix `b/util.ts` wins over leaf-only `util.ts` and over `a/util.ts`; got {keys:?}"
+    );
+}
+
+/// #215(d): end-to-end floor on the W3.1 v1.x corpus. Runs the full
+/// pipeline (`crap4ts` binary) against the captured crap4ts@1.x
+/// fixture whose `coverage-final.json` carries machine-absolute paths
+/// (`/Users/cmbays/github/crap4ts/src/...`) that share no prefix with
+/// the fixture's local `--src`. Before this fix every one of the 158
+/// discovered functions reported 0% coverage. Asserts a FLOOR of
+/// ≥ 100/158 functions with non-zero coverage — exact classification
+/// is W3.2/#190's domain; a precise pin would be brittle now. This is
+/// the GATE: if it can't reach the floor, the fix is incomplete.
+#[test]
+fn fix215_v1_corpus_e2e_floor_at_least_100_of_158_functions_have_coverage() {
+    let manifest = env!("CARGO_MANIFEST_DIR");
+    let src = format!("{manifest}/tests/fixtures/crap4ts-v1/src");
+    let coverage = format!("{manifest}/tests/fixtures/crap4ts-v1/coverage-final.json");
+
+    let out = assert_cmd::Command::cargo_bin("crap4ts")
+        .expect("crap4ts binary discoverable")
+        .arg("--src")
+        .arg(&src)
+        .arg("--coverage")
+        .arg(&coverage)
+        .arg("--format")
+        .arg("json")
+        .arg("--no-fail")
+        .output()
+        .expect("crap4ts executes");
+
+    assert!(
+        out.status.success(),
+        "crap4ts exited non-zero under --no-fail: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let envelope: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("stdout is valid JSON envelope");
+    let functions = envelope["result"]["functions"]
+        .as_array()
+        .expect("result.functions array present");
+    let total = functions.len();
+    let nonzero = functions
+        .iter()
+        .filter(|f| {
+            f["scored"]["coverage_percent"]
+                .as_f64()
+                .map(|c| c > 0.0)
+                .unwrap_or(false)
+        })
+        .count();
+
+    assert_eq!(
+        total, 158,
+        "walker discovers 158 functions in the v1.x corpus (NOT a regression target — \
+         pins the denominator so the floor stays meaningful)"
+    );
+    assert!(
+        nonzero >= 100,
+        "FLOOR: expected >= 100/158 functions with non-zero coverage after the \
+         suffix-fallback fix; got {nonzero}/{total}. If this fails the fix is \
+         incomplete — re-diagnose, do not loosen the floor."
+    );
+}

--- a/crates/crap4ts/tests/istanbul_smoke.rs
+++ b/crates/crap4ts/tests/istanbul_smoke.rs
@@ -1006,3 +1006,64 @@ fn fix215_v1_corpus_e2e_floor_at_least_100_of_158_functions_have_coverage() {
          incomplete — re-diagnose, do not loosen the floor."
     );
 }
+
+/// #215 / #216 (gemini security-medium): the suffix fallback must NOT
+/// resolve a path that traverses *out* of `effective_src` via `..`.
+/// `Path::starts_with` is lexical, so without the explicit ParentDir
+/// rejection a crafted user-supplied coverage path like
+/// `<src_root>/../<sibling>/secret.ts` would pass the under-root guard
+/// but `.is_file()`-resolve to the out-of-tree sibling file. Asserts:
+/// emits exactly one `PathUnresolved`, the out-of-tree `secret.ts` is
+/// NOT bound into `out.coverage`, and the parser does not panic.
+#[test]
+fn fix216_parentdir_traversal_does_not_resolve_outside_effective_src() {
+    // `effective_src` is a subdir so a `..` can climb above it while
+    // still landing inside a real, on-disk sibling (a strong test:
+    // the escape target genuinely exists).
+    let tmp = tempfile::tempdir().unwrap();
+    let canonical_root = std::fs::canonicalize(tmp.path()).unwrap();
+    let src_root = canonical_root.join("project");
+    let sibling = canonical_root.join("outside");
+    std::fs::create_dir_all(&src_root).unwrap();
+    std::fs::create_dir_all(&sibling).unwrap();
+    // Sentinel file that genuinely exists OUTSIDE the source root.
+    write_fixture(
+        &sibling,
+        "secret.ts",
+        include_str!("fixtures/ts-fixtures/simple.ts"),
+    );
+
+    // Absolute coverage path that traverses out of src_root via `..`.
+    let escape = format!(
+        "{}/../outside/secret.ts",
+        src_root.to_string_lossy().replace('\\', "/")
+    );
+    let payload = one_stmt_payload(&escape, &escape);
+
+    let parser = IstanbulCoverage::new(src_root);
+    let out = parser
+        .parse(&payload)
+        .expect("traversal path parses (with diagnostic), no panic");
+
+    let unresolved: Vec<_> = out
+        .diagnostics
+        .iter()
+        .filter(|d| d.kind == IstanbulDiagnosticKind::PathUnresolved)
+        .collect();
+    assert_eq!(
+        unresolved.len(),
+        1,
+        "a `..`-traversal path must emit exactly one PathUnresolved \
+         (the ParentDir filter rejects every suffix that escapes root): {:?}",
+        out.diagnostics
+    );
+    assert!(
+        out.coverage.is_empty(),
+        "the out-of-tree sentinel must NOT be bound into coverage; got {:?}",
+        out.coverage.keys().collect::<Vec<_>>()
+    );
+    assert!(
+        !out.coverage.contains_key("secret.ts"),
+        "secret.ts (outside effective_src) leaked into coverage"
+    );
+}


### PR DESCRIPTION
## Summary

`crap4ts@2.x` run against the captured `crap4ts@1.x` corpus (W3.1, #189) reported **0% coverage on all 158 discovered functions** despite valid hit-count data. Root cause: `IstanbulCoverage::normalize_path` did a single `strip_prefix(effective_src)`. The v1.x corpus's `coverage-final.json` carries machine-absolute paths captured on the originating machine (`/Users/cmbays/github/crap4ts/src/...`); these share no prefix with the fixture's canonicalized `--src`, so `strip_prefix` returned `None` for every entry → 28 `PathUnresolved` diagnostics → zero coverage downstream.

This adds a **suffix-reachability fallback** (issue option (a), the chosen direction): when `strip_prefix` fails, walk the path's components longest→shortest under `effective_src` and accept the first suffix that resolves to a real file.

## Reproducer (before)

```
./target/release/crap4ts --src crates/crap4ts/tests/fixtures/crap4ts-v1/src \
  --coverage crates/crap4ts/tests/fixtures/crap4ts-v1/coverage-final.json \
  --format json --no-fail
```

Before: `min_coverage: 0.0`, `average_coverage: 0.0`, `median_coverage: 0.0`; 158 functions, **0** with non-zero coverage; **28** `PathUnresolved` parse diagnostics; one sample diagnostic path: `/Users/cmbays/github/crap4ts/src/adapters/complexity/facade.ts` (different-machine absolute prefix; the suffix `adapters/complexity/facade.ts` exists under the fixture src).

## Fix mechanism

Two-arm `normalize_path`:
1. **Strip-prefix fast path** (pure, no I/O) — unchanged W2.4 behavior for same-machine captures.
2. **Suffix-reachability fallback** (#215, bounded `.is_file()` I/O) — `suffix_match_under` iterates path-component suffixes longest→shortest, joining each under `effective_src`, returning the first that `.is_file()`-resolves. Longest-suffix-wins is deterministic (disambiguates a leaf filename present in multiple dirs). A `starts_with(effective_src)` guard rejects the degenerate `start==0` case where `effective_src.join(absolute)` collapses back to the absolute path itself (would otherwise leak an out-of-tree match). `.is_file()` chosen over `.exists()` (one syscall, no directory false-positive). `PathUnresolved` still fires as the **final** arm when no suffix matches — the D16 diagnostic-and-skip contract is preserved.

## Acceptance gates checklist

- [x] **1.** `cargo build --workspace` passes
- [x] **2.** `cargo nextest run --workspace --all-targets` — 1031 tests, all green (1027 baseline + 4 new)
- [x] **3.** New smoke tests (a)-(d) pass; (d) enforces the ≥100/158 floor as a hard assertion
- [x] **4.** `cargo fmt --check && cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] **5.** `cargo +1.93 check --workspace --all-targets` passes (MSRV)
- [x] **6.** `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` clean
- [x] **7.** `cargo deny check` clean (advisories/bans/licenses/sources ok)
- [x] **8.** `lefthook run pre-push` — skipped ("no matching push files": lefthook evaluates against the main repo's hooks-path config, not the worktree diff). Equivalent manual checks (fmt/clippy/test/doc/deny/MSRV) all green.
- [x] **9.** Wire snapshots byte-identical for BOTH crap4rs + crap4ts (`cargo nextest run` both `wire_envelope_*` binaries green, no `.snap.new` files)
- [x] **10.** No drift declared for both wire-envelope modules (see Wire-shape canary below)
- [x] **11.** Plan-of-record deviations subsection present (below)

## Sanity-check findings (before → after)

| Metric | Before | After |
|---|---|---|
| Functions with non-zero coverage | **0 / 158** | **138 / 158** |
| `average_coverage` | 0.0 | 86.35 |
| `median_coverage` | 0.0 | 100.0 |
| Parse diagnostics (`PathUnresolved`) | 28 | 4 |

The 4 remaining `PathUnresolved` are `adapters/coverage/{detect,facade,istanbul,v8}.ts` — files the v1.x corpus referenced in coverage but did **not** capture into the fixture's `src/` tree (28 coverage files vs 24 present in src). The fallback correctly does **not** invent matches for genuinely-absent files — confirms no over-match / residual bug. 138/158 comfortably clears the ≥100/158 floor.

## Plan-of-record deviations

- (i) **`normalize_path` purity invariant deliberately broken** — arm 2 does bounded, OS-cached `.is_file()` filesystem I/O. Required to bridge cross-machine portable fixtures; the pure-strip-prefix arm 1 is preserved as the fast path.
- (ii) **Docstrings updated** — removed the "Pure: no filesystem I/O" and "Mirrors `LcovParser::normalize_path`" claims from both the function docstring **and** the module-level `## Path normalization` section (the latter was an additional stale claim beyond the plan's scope; flagged + fixed).
- (iii) **D16 amended** with the suffix-fallback arm (see cross-reference below).
- (iv) **`.is_file()` chosen over the issue body's `.exists()` suggestion** — defensive tightening (one syscall; prevents a directory false-positive when a raw path component matches a directory name under root).
- (v) pure-with-injected-file-list alternative considered; rejected — requires constructor signature change beyond #215 scope.
- (vi) **lowercase-g calibration** — plan stated `/Users/cmbays/Github/...` (capital G); fixture actually carries `/Users/cmbays/github/...` (lowercase). Mechanism (prefix mismatch — different project tree, not case-sensitivity) unchanged; recorded for future-reader accuracy. No diagnosis deviation.
- **Added defensive guard beyond the plan's prescribed `normalize_path`**: a `starts_with(effective_src)` check in `suffix_match_under` rejecting the `start==0` degenerate case (absolute RHS collapses `Path::join`). Surfaced by advisor pre-implementation review; without it an absolute path existing verbatim outside `effective_src` would leak an out-of-tree match. Documented in the `suffix_match_under` docstring; exercised by test (c).
- **No existing W2.4 test changed behavior** — `w24_nyc_absolute_paths_normalize_via_strip_prefix` and `w24_orphan_path_emits_path_unresolved_and_valid_entries_still_parse` both still pass unchanged (verified). No test changes outside `istanbul_smoke.rs`.

## Wire-shape canary: no drift

`normalize_path` is parser-internal and does not surface in the JSON envelope. Both `wire_envelope_crap4rs` and `wire_envelope_crap4ts` snapshot tests pass byte-identical; no `.snap.new` files generated. **No drift for either wire-envelope module.**

## D16 amendment cross-reference

D16 (`adr-istanbul-schema-tolerance.md`) amended with a new "Suffix-fallback arm (#215)" subsection under "Path-mismatch contract", plus `#215` added to References and the "Out of scope" filesystem-canonicalization bullet updated. **This amendment lives in the separate `ops` repo (`~/Github/ops/decisions/crap-rs/adr-istanbul-schema-tolerance.md`) and is NOT part of this PR's diff.** The D16 subsection was further amended for the #216 traversal guard (see Security follow-up below).

## Security follow-up (gemini #216)

Commit `d77ede9` addresses a **gemini-code-assist security-medium** finding on `normalize_path`.

**Finding + scope expansion (honest reporting):** gemini flagged that `Path::starts_with` is lexical, so a `..`-containing suffix could pass the under-root guard in `suffix_match_under` (arm 2) yet `.is_file()`-resolve *outside* `effective_src`. A standalone repro proved **arm 1 (`strip_prefix`) has the identical defect** — it is also lexical:

```
effective_src = /tmp/x/project
raw           = /tmp/x/project/../outside/secret.ts
strip_prefix:            Ok("../outside/secret.ts")   ← succeeds, points OUT of tree
joined.starts_with(eff): true                          ← lexical, also fooled
```

Since `coverage-final.json` is **user-supplied**, a crafted `..`-traversal path could probe / bind coverage to out-of-tree files via *either* arm. The fix is therefore an **authoritative ParentDir-rejection guard at `normalize_path`'s return point, covering both arms uniformly** (broader than gemini's stated arm-2-only finding). `suffix_match_under` retains a per-iteration `..` skip as a local perf win (avoids a doomed `.is_file()` syscall) + defense-in-depth.

**New regression test (e):** `fix216_parentdir_traversal_does_not_resolve_outside_effective_src` — constructs `<src_root>/../outside/secret.ts` against a genuinely-existing on-disk sibling sentinel, asserts exactly one `PathUnresolved` and that `secret.ts` never enters `out.coverage`, no panic.

**Floor unchanged:** the #215 (d) e2e floor is still **138/158** post-`..`-filter — the traversal guard cost **zero** legitimate corpus matches (v1.x corpus paths are flat, no legitimate `..`).

**Re-verified gates post-`d77ede9`:** build / nextest --workspace --all-targets (1032 tests, all green) / clippy -D warnings / fmt --check / cargo +1.93 MSRV / doc -D warnings / cargo deny / wire-envelope byte-identical (no `.snap.new`). D16 amended (separate ops repo, not in this diff) with the traversal-guard sentence.

Closes #215

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Istanbul coverage files that contain absolute paths from different machines through enhanced path resolution and fallback matching.

* **Tests**
  * Added regression test suite for cross-machine coverage file path resolution ensuring robust portable path handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/breezy-bays-labs/crap-rs/pull/216?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
