### PR TITLE
feat(crap4ts): #200 + #205 + #207 + #209 — walker traversal recursion + proptest suite + mutation surface

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -31,3 +31,28 @@ additional_cargo_test_args = ["--", "--skip", "envelope"]
 # incompatibility: parallel workers REQUIRE copies, --in-place forbids
 # them, so `-j N` and `--in-place` are mutually exclusive by design.
 copy_target = true
+
+# Residual walker mutation-coverage gaps (crap-rs#209 initial run).
+#
+# These 4 mutants survive because the crap-rs#207 proptest grammar
+# (`crates/crap4ts/tests/walker_proptest.rs`) does not yet generate the
+# TS construct that makes the corresponding recursion arm load-bearing.
+# The walker behaviour is VERIFIED CORRECT in every case (it discovers
+# the nested function) — these are test-coverage gaps, NOT walker bugs,
+# so they are excluded-with-tracking-issue per ~/.claude/rules/
+# exclusions.md rather than filed as type:bug. The issue (#219) owns the
+# grammar extension that lifts each exclusion; it was opened BEFORE this
+# exclusion landed and is wired as a sub-issue of epic #173.
+#
+# Restoration condition: crap-rs#219 extends the proptest grammar so
+# each mutant is CAUGHT, then deletes the matching line below.
+exclude_re = [
+  # tracked: crap-rs#219 — grammar has no `export default` container; walker recurses it correctly (export default (()=>{fn})() discovers the fn)
+  "replace FunctionFinder<'src>::visit_export_default with \\(\\)",
+  # tracked: crap-rs#219 — grammar never nests a class inside a function body; walker recurses it correctly (function o(){ class C{m(){}} } discovers C.m)
+  "delete match arm Statement::ClassDeclaration\\(class\\) in FunctionFinder<'src>::visit_statement",
+  # tracked: crap-rs#219 — grammar has no labeled statements; walker recurses it correctly (lbl: { function inner(){} } discovers inner)
+  "delete match arm Statement::LabeledStatement\\(l\\) in FunctionFinder<'src>::visit_statement",
+  # tracked: crap-rs#219 — grammar has no `throw`; walker recurses it correctly (throw (()=>{fn})() discovers the fn)
+  "delete match arm Statement::ThrowStatement\\(th\\) in FunctionFinder<'src>::visit_statement",
+]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,7 @@ jobs:
           PY
 
   mutants:
-    name: Mutation testing on domain/view.rs
+    name: Mutation testing (crap-core view.rs + crap4ts walker)
     runs-on: ubuntu-latest
     needs: [test]
     steps:
@@ -212,6 +212,31 @@ jobs:
         # S2 (#134) moved view.rs from crap4rs to crap-core. Update
         # both --package and --file to follow the move.
         run: cargo mutants --package crap-core --file crates/crap-core/src/domain/view.rs --no-shuffle --in-place
+      - name: Run cargo mutants on crates/crap4ts/src/adapters/walker/mod.rs
+        # crap-rs#209: the walker is the highest-leverage file in the
+        # crap4ts adapter (every decision-point + function-discovery +
+        # span-to-line decision routes through it). The `--skip
+        # envelope` test-arg the crap-core run relies on is NOT passed
+        # inline: it lives in the repo-global `.cargo/mutants.toml`
+        # (`additional_cargo_test_args = ["--", "--skip", "envelope"]`)
+        # which cargo-mutants applies to EVERY invocation in this
+        # workspace, so it is replicated automatically for the crap4ts
+        # run — see AGENTS.md "Why additional_cargo_test_args …".
+        #
+        # Deliberate asymmetry vs the view.rs step above: the walker is
+        # ~5× view.rs's mutant count (157 vs ~30). Single-worker
+        # `--in-place` on 157 mutants is ~1 h wall-clock — far past the
+        # crap-rs#209 ≤8-min budget AC (plan-of-record deviation,
+        # documented in the PR). So this step uses `-j 4` copy mode
+        # (parallel workers, each reusing the prebuilt `target/` via
+        # `.cargo/mutants.toml`'s `copy_target = true`). `-j N` and
+        # `--in-place` are mutually exclusive by design (parallel
+        # workers REQUIRE source copies) — see AGENTS.md "Mutation
+        # testing". `--no-shuffle` keeps mutant order deterministic for
+        # flaky-mutant triage. This is the dual-file mutation surface;
+        # the two steps run sequentially within the single `mutants`
+        # job.
+        run: cargo mutants -j 4 --package crap4ts --file crates/crap4ts/src/adapters/walker/mod.rs --no-shuffle
 
   scorecard-smoke:
     # Two-layer smoke for the composite action:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,27 +215,39 @@ jobs:
       - name: Run cargo mutants on crates/crap4ts/src/adapters/walker/mod.rs
         # crap-rs#209: the walker is the highest-leverage file in the
         # crap4ts adapter (every decision-point + function-discovery +
-        # span-to-line decision routes through it). The `--skip
-        # envelope` test-arg the crap-core run relies on is NOT passed
-        # inline: it lives in the repo-global `.cargo/mutants.toml`
-        # (`additional_cargo_test_args = ["--", "--skip", "envelope"]`)
-        # which cargo-mutants applies to EVERY invocation in this
-        # workspace, so it is replicated automatically for the crap4ts
-        # run — see AGENTS.md "Why additional_cargo_test_args …".
+        # span-to-line decision routes through it).
         #
-        # Deliberate asymmetry vs the view.rs step above: the walker is
-        # ~5× view.rs's mutant count (157 vs ~30). Single-worker
-        # `--in-place` on 157 mutants is ~1 h wall-clock — far past the
-        # crap-rs#209 ≤8-min budget AC (plan-of-record deviation,
-        # documented in the PR). So this step uses `-j 4` copy mode
-        # (parallel workers, each reusing the prebuilt `target/` via
-        # `.cargo/mutants.toml`'s `copy_target = true`). `-j N` and
+        # PER-MERGE GATE (not per-PR). The `on:` block restricts CI to
+        # `push: [main]` + `pull_request: [main]`, so a `push` event is
+        # exactly a merge-to-main. This step's `if:` therefore runs the
+        # walker mutation pass ONLY on merge-to-main; the view.rs step
+        # above has no `if:` and stays per-PR. Rationale (crap-rs#209 AC
+        # amended from "≤8 min per-PR" → "per-merge"): the walker has
+        # ~5× view.rs's mutant count (157 vs ~30) and a full pass is
+        # ~1 h even under `-j 4` copy mode — a recurring per-PR tax that
+        # is not worth it for a file that changes rarely once Cluster W
+        # (#200/#205/#207/#209) lands. Gating at merge keeps every
+        # crap4ts PR fast while still gating the walker before
+        # crap4ts@2.0.0 GA. Trade-off: a walker regression surfaces at
+        # merge, not on the introducing PR (acceptable — the #207
+        # proptest suite is the per-PR behavioural net; mutants is the
+        # deeper periodic gate). User-confirmed sequencing decision
+        # 2026-05-16.
+        #
+        # `-j 4` copy mode (parallel workers, each reusing the prebuilt
+        # `target/` via `.cargo/mutants.toml`'s `copy_target = true`)
+        # keeps even the per-merge run tractable. `-j N` and
         # `--in-place` are mutually exclusive by design (parallel
         # workers REQUIRE source copies) — see AGENTS.md "Mutation
         # testing". `--no-shuffle` keeps mutant order deterministic for
-        # flaky-mutant triage. This is the dual-file mutation surface;
-        # the two steps run sequentially within the single `mutants`
-        # job.
+        # flaky-mutant triage. The `--skip envelope` test-arg the
+        # crap-core run relies on is NOT passed inline: it lives in the
+        # repo-global `.cargo/mutants.toml`
+        # (`additional_cargo_test_args = ["--", "--skip", "envelope"]`)
+        # which cargo-mutants applies to EVERY invocation in this
+        # workspace, so it is replicated automatically here — see
+        # AGENTS.md "Why additional_cargo_test_args …".
+        if: github.event_name == 'push'
         run: cargo mutants -j 4 --package crap4ts --file crates/crap4ts/src/adapters/walker/mod.rs --no-shuffle
 
   scorecard-smoke:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,9 +105,19 @@ surface** — the two highest-leverage files in the workspace:
 | `crates/crap-core/src/domain/view.rs` | highest-complexity function family in `crap-core` (view-projection / column logic) | `crap-core` |
 | `crates/crap4ts/src/adapters/walker/mod.rs` | every decision-point decision + every function-discovery decision + every span-to-line conversion in the TS adapter routes through it (crap-rs#209) | `crap4ts` |
 
-CI runs both **sequentially within one `mutants` job** on every PR (the
-`view.rs` step then the walker step); locally you'll want parallelism
-so a single file's gate finishes in minutes rather than half an hour.
+CI runs both in one `mutants` job but on **different cadences**: the
+`view.rs` step runs **per-PR** (small, ~30 mutants, minutes); the
+walker step runs **per-merge only** — gated `if: github.event_name ==
+'push'`, which (given CI triggers on `push: [main]` /
+`pull_request: [main]`) means it fires on merge-to-main, not on PR
+pushes. Rationale: the walker's ~157-mutant pass is ~1 h even under
+`-j 4`; a per-PR tax that size is not worth it for a file that changes
+rarely once Cluster W (#200/#205/#207/#209) lands, while a per-merge
+gate still catches walker regressions before crap4ts@2.0.0 GA. The
+per-PR behavioural net for the walker is the `walker_proptest.rs`
+suite (crap-rs#207); mutants is the deeper periodic gate. Locally
+you'll want parallelism so a single file's gate finishes in minutes
+rather than half an hour.
 
 ### Local invocation
 
@@ -169,25 +179,30 @@ free disk should be ≥ `target/` size × N. The flag is ignored under
 
 ### CI parity
 
-CI's `mutants` job runs **two sequential steps** on a single
-ubuntu-latest worker:
+CI's `mutants` job runs **two steps on different cadences** on a
+single ubuntu-latest worker:
 
 ```bash
+# per-PR (no `if:`):
 cargo mutants    --package crap-core --file crates/crap-core/src/domain/view.rs      --no-shuffle --in-place
+# per-merge only (`if: github.event_name == 'push'`):
 cargo mutants -j 4 --package crap4ts --file crates/crap4ts/src/adapters/walker/mod.rs --no-shuffle
 ```
 
-**The two steps deliberately differ in execution mode.** The
-`view.rs` step (~30 mutants) uses `--in-place` single-worker — fast
-enough, no tree copy. The walker step has ~5× the mutant count (157);
-single-worker `--in-place` on 157 mutants is ~1 h wall-clock, so it
-uses `-j 4` copy mode instead (parallel workers, each reusing the
-prebuilt `target/` via `.cargo/mutants.toml`'s `copy_target = true`).
-`-j N` and `--in-place` are mutually exclusive by design (see the
-section below), which is why the walker step drops `--in-place`. The
-crap-rs#209 ≤8-min budget AC is **not met by single-worker in-place on
-the walker** — that is a recorded plan-of-record deviation, not a
-regression; `-j 4` copy mode is the chosen mitigation. `--no-shuffle`
+**The two steps deliberately differ in cadence AND execution mode.**
+The `view.rs` step (~30 mutants) runs per-PR with `--in-place`
+single-worker — fast enough, no tree copy. The walker step has ~5× the
+mutant count (157); a single-worker `--in-place` pass is ~1 h
+wall-clock, so it (a) runs **per-merge only** (`if: github.event_name
+== 'push'` — a `push` event under this repo's `on:` triggers is a
+merge-to-main), keeping every PR fast, and (b) uses `-j 4` copy mode
+(parallel workers, each reusing the prebuilt `target/` via
+`.cargo/mutants.toml`'s `copy_target = true`) so even the per-merge
+run is tractable. `-j N` and `--in-place` are mutually exclusive by
+design (see the section below), which is why the walker step drops
+`--in-place`. crap-rs#209's original "≤8 min per-PR" budget AC was
+**amended to per-merge gating** (user-confirmed 2026-05-16) — that is
+a resolved sequencing decision, not an open deviation. `--no-shuffle`
 on both keeps mutant order deterministic across reruns, which makes
 flaky-mutant triage tractable. The walker proptest suite
 (`walker_proptest.rs`, crap-rs#207 — including the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,16 +97,33 @@ breezy-bays-labs/mokumo#370) can dogfood on us without false positives.
 
 ## Mutation testing
 
-`cargo mutants` is the surviving-mutant gate on `domain/view.rs` (the
-highest-complexity function family in `crap-core`). CI runs it
-sequentially on every PR; locally you'll want parallelism so a single
-file's gate finishes in minutes rather than half an hour.
+`cargo mutants` is the surviving-mutant gate on a **dual-file
+surface** — the two highest-leverage files in the workspace:
+
+| File | Why it's gated | Crate |
+|------|----------------|-------|
+| `crates/crap-core/src/domain/view.rs` | highest-complexity function family in `crap-core` (view-projection / column logic) | `crap-core` |
+| `crates/crap4ts/src/adapters/walker/mod.rs` | every decision-point decision + every function-discovery decision + every span-to-line conversion in the TS adapter routes through it (crap-rs#209) | `crap4ts` |
+
+CI runs both **sequentially within one `mutants` job** on every PR (the
+`view.rs` step then the walker step); locally you'll want parallelism
+so a single file's gate finishes in minutes rather than half an hour.
 
 ### Local invocation
 
 ```bash
+# crap-core view.rs
 cargo mutants -j 4 --package crap-core --file crates/crap-core/src/domain/view.rs
+# crap4ts walker (crap-rs#209) — same flag shape, different package+file
+cargo mutants -j 4 --package crap4ts --file crates/crap4ts/src/adapters/walker/mod.rs
 ```
+
+The walker is ~1.2k LOC with 11 decision-point variants + nested-fn +
+JSX + class-field/namespace traversal, so its mutant count is several
+times `view.rs`'s. Run it **after** the `walker_proptest.rs` suite
+(crap-rs#207) is green locally — the proptests kill a large fraction of
+walker mutants without any per-mutant fixture work, leaving a much
+smaller, more meaningful surviving set to triage.
 
 `-j N` is CLI-only — cargo-mutants 27.x's config schema does not expose
 a `jobs` field. Pick N up to your physical core count. Speedup is
@@ -152,19 +169,44 @@ free disk should be ≥ `target/` size × N. The flag is ignored under
 
 ### CI parity
 
-CI's `mutants` job runs `cargo mutants --package crap-core --file
-crates/crap-core/src/domain/view.rs --no-shuffle --in-place` on a single
-ubuntu-latest worker. `--in-place` keeps the run fast (no tree copy)
-and `--no-shuffle` keeps the mutant order deterministic across reruns,
-which makes flaky-mutant triage tractable. Local `-j N` runs may surface
-the same mutants in a different order — that's expected, not a
-regression.
+CI's `mutants` job runs **two sequential steps** on a single
+ubuntu-latest worker:
+
+```bash
+cargo mutants    --package crap-core --file crates/crap-core/src/domain/view.rs      --no-shuffle --in-place
+cargo mutants -j 4 --package crap4ts --file crates/crap4ts/src/adapters/walker/mod.rs --no-shuffle
+```
+
+**The two steps deliberately differ in execution mode.** The
+`view.rs` step (~30 mutants) uses `--in-place` single-worker — fast
+enough, no tree copy. The walker step has ~5× the mutant count (157);
+single-worker `--in-place` on 157 mutants is ~1 h wall-clock, so it
+uses `-j 4` copy mode instead (parallel workers, each reusing the
+prebuilt `target/` via `.cargo/mutants.toml`'s `copy_target = true`).
+`-j N` and `--in-place` are mutually exclusive by design (see the
+section below), which is why the walker step drops `--in-place`. The
+crap-rs#209 ≤8-min budget AC is **not met by single-worker in-place on
+the walker** — that is a recorded plan-of-record deviation, not a
+regression; `-j 4` copy mode is the chosen mitigation. `--no-shuffle`
+on both keeps mutant order deterministic across reruns, which makes
+flaky-mutant triage tractable. The walker proptest suite
+(`walker_proptest.rs`, crap-rs#207 — including the
+`walker_nesting_depth_matches_oracle` invariant added specifically to
+kill the `nesting.map(|n| n + 1)` arithmetic mutant class) keeps the
+surviving set — hence the triage cost — small.
 
 ### Why `additional_cargo_test_args = ["--", "--skip", "envelope"]`
 
-The wire-envelope snapshot test (`crates/crap-core/tests/wire_envelope_snapshot.rs`)
-shells out to the `crap4rs` binary, which `cargo mutants --package
-crap-core` doesn't build. Skipping it under mutants is scoped to mutants
-only; every PR's `Test (linux-x86)` / `Test (macos-arm)` /
-`Test (macos-x86)` job still runs the canary via `cargo nextest run
---workspace --all-targets`, which DOES build the bin first.
+The wire-envelope snapshot tests
+(`crates/crap-core/tests/wire_envelope_crap4rs.rs` and
+`wire_envelope_crap4ts.rs`, test name `envelope`) shell out to the
+`crap4rs` / `crap4ts` binaries, which a scoped `cargo mutants --package
+crap-core` (or `--package crap4ts`) doesn't necessarily build. The
+skip lives in the **repo-global** `.cargo/mutants.toml`, so
+cargo-mutants applies it to **every** invocation in this workspace —
+both the `view.rs` step and the walker step inherit it automatically;
+there is no per-step inline `--skip` to maintain. Skipping it under
+mutants is scoped to mutants only; every PR's `Test (linux-x86)` /
+`Test (macos-arm)` / `Test (macos-x86)` job still runs both canaries
+via `cargo nextest run --workspace --all-targets`, which DOES build the
+bins first.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,6 +417,7 @@ dependencies = [
  "napi-build",
  "napi-derive",
  "oxc",
+ "proptest",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/crap4ts/Cargo.toml
+++ b/crates/crap4ts/Cargo.toml
@@ -73,5 +73,12 @@ tempfile = { workspace = true }
 # wire-envelope snapshot modules.
 assert_cmd = { workspace = true }
 
+# Property-test invariant suite for the oxc walker (crap-rs#207). A
+# constrained AST grammar generates valid TS source to assert the 6
+# cyclomatic invariants over generated (not hand-picked) inputs —
+# independent-axis verification for the #200/#205 traversal arms.
+# Regression files in `proptest-regressions/` are committed to git.
+proptest = { workspace = true }
+
 [build-dependencies]
 napi-build = { workspace = true }

--- a/crates/crap4ts/src/adapters/walker/mod.rs
+++ b/crates/crap4ts/src/adapters/walker/mod.rs
@@ -331,11 +331,11 @@ impl<'src> FunctionFinder<'src> {
         prop: &oxc::ast::ast::PropertyDefinition<'_>,
         class_name: &str,
     ) {
-        if prop.computed {
-            if let Some(key_expr) = prop.key.as_expression() {
-                let mut sink = Contributors::default();
-                self.visit_expression(key_expr, &mut sink, None);
-            }
+        if prop.computed
+            && let Some(key_expr) = prop.key.as_expression()
+        {
+            let mut sink = Contributors::default();
+            self.visit_expression(key_expr, &mut sink, None);
         }
         let Some(value) = &prop.value else {
             return;
@@ -1141,10 +1141,10 @@ impl<'src> FunctionFinder<'src> {
         for prop in &obj.properties {
             match prop {
                 ObjectPropertyKind::ObjectProperty(p) => {
-                    if p.computed {
-                        if let Some(key_expr) = p.key.as_expression() {
-                            self.visit_expression(key_expr, out, nesting);
-                        }
+                    if p.computed
+                        && let Some(key_expr) = p.key.as_expression()
+                    {
+                        self.visit_expression(key_expr, out, nesting);
                     }
                     self.visit_expression(&p.value, out, nesting);
                 }

--- a/crates/crap4ts/src/adapters/walker/mod.rs
+++ b/crates/crap4ts/src/adapters/walker/mod.rs
@@ -314,11 +314,29 @@ impl<'src> FunctionFinder<'src> {
     /// walked purely for nested-function discovery via a throwaway sink
     /// (the field doesn't itself contribute to any parent accumulator —
     /// it is the parent in this position).
+    ///
+    /// #205 (class side): a **computed** property key
+    /// (`class Foo { [(() => "x")()]: 42 = 0 }`) is an arbitrary
+    /// expression that can embed nested functions or decision points,
+    /// exactly like the object-literal case (#200 item 1). When
+    /// `prop.computed` is set we recurse into the key expression first,
+    /// through a throwaway sink because the class element is its own
+    /// root — it has no parent function accumulator to charge. This
+    /// runs even when `prop.value` is `None` (`class Foo { [k()]; }`),
+    /// so the early `let-else` return below must NOT short-circuit the
+    /// key recursion. The non-`Expression` `PropertyKey` variants yield
+    /// `None` from `as_expression`, so non-computed keys are untouched.
     fn visit_property_definition(
         &mut self,
         prop: &oxc::ast::ast::PropertyDefinition<'_>,
         class_name: &str,
     ) {
+        if prop.computed {
+            if let Some(key_expr) = prop.key.as_expression() {
+                let mut sink = Contributors::default();
+                self.visit_expression(key_expr, &mut sink, None);
+            }
+        }
         let Some(value) = &prop.value else {
             return;
         };
@@ -458,6 +476,18 @@ impl<'src> FunctionFinder<'src> {
                 if let Some(inner) = &decl.declaration {
                     self.visit_top_level_declaration(inner);
                 }
+            }
+
+            // #200 item 2: TS namespaces / modules. A
+            // `namespace Foo { function bar() {} }` carries an
+            // executable body whose statements must be walked so `bar`
+            // (and any decision points / nested functions) are
+            // discovered. This single arm covers both the top-level
+            // path (the catch-all in `visit_top_level_statement` routes
+            // unmatched statements here) and the nested-in-a-function
+            // path (a `namespace` declared inside a function body).
+            Statement::TSModuleDeclaration(ns) => {
+                self.visit_ts_module_declaration(ns, out, nesting);
             }
 
             // Everything else is structural-only at this scope: leaf
@@ -771,7 +801,35 @@ impl<'src> FunctionFinder<'src> {
                 self.visit_expression(&b.right, out, nesting);
             }
             Expression::AssignmentExpression(a) => {
+                // #200 item 3: a computed-member LHS
+                // (`x[foo()] = 1`) embeds an arbitrary index
+                // expression that can contain a nested function (e.g.
+                // an IIFE) or decision points. The pre-#200 arm
+                // discarded `a.left` entirely; now, when the target is
+                // a computed member access, recurse into both the
+                // object and the index expression before the RHS. Other
+                // `AssignmentTarget` variants (plain identifier, static
+                // member, destructuring patterns) hold no embedded
+                // index expression worth descending for nested-function
+                // discovery, so they remain no-ops here.
+                if let oxc::ast::ast::AssignmentTarget::ComputedMemberExpression(m) = &a.left {
+                    self.visit_expression(&m.object, out, nesting);
+                    self.visit_expression(&m.expression, out, nesting);
+                }
                 self.visit_expression(&a.right, out, nesting);
+            }
+            // #200 item 4: `x[foo()]++` / `--y[bar()]`. The
+            // `UpdateExpression` operand is a `SimpleAssignmentTarget`;
+            // when it is a computed member access the index expression
+            // can embed a nested function or decision points. Pre-#200
+            // this whole arm was dropped by the `_ => {}` fallthrough.
+            Expression::UpdateExpression(u) => {
+                if let oxc::ast::ast::SimpleAssignmentTarget::ComputedMemberExpression(m) =
+                    &u.argument
+                {
+                    self.visit_expression(&m.object, out, nesting);
+                    self.visit_expression(&m.expression, out, nesting);
+                }
             }
             Expression::ArrayExpression(arr) => {
                 self.visit_array_elements(&arr.elements, out, nesting);
@@ -1061,6 +1119,19 @@ impl<'src> FunctionFinder<'src> {
         }
     }
 
+    /// Walk an object literal's properties for nested-function +
+    /// decision-point discovery.
+    ///
+    /// #200 item 1 / #205 (object side): a **computed** property key
+    /// (`{ [foo()]: 1 }`, `{ [a && b]: 1 }`) is an arbitrary expression
+    /// that can embed nested functions or decision points. When
+    /// `p.computed` is set we recurse into the key expression via the
+    /// `inherit_variants!`-generated `PropertyKey::as_expression`
+    /// downcast — the two non-`Expression` `PropertyKey` variants
+    /// (`StaticIdentifier`, `PrivateIdentifier`) hold no executable
+    /// sub-tree and yield `None`, so a non-computed `a: 1` key never
+    /// touches the visitor. Spread properties (`{ ...rest }`) are
+    /// unchanged.
     fn visit_object_expression(
         &mut self,
         obj: &ObjectExpression<'_>,
@@ -1070,11 +1141,59 @@ impl<'src> FunctionFinder<'src> {
         for prop in &obj.properties {
             match prop {
                 ObjectPropertyKind::ObjectProperty(p) => {
+                    if p.computed {
+                        if let Some(key_expr) = p.key.as_expression() {
+                            self.visit_expression(key_expr, out, nesting);
+                        }
+                    }
                     self.visit_expression(&p.value, out, nesting);
                 }
                 ObjectPropertyKind::SpreadProperty(s) => {
                     self.visit_expression(&s.argument, out, nesting);
                 }
+            }
+        }
+    }
+
+    /// #200 item 2: walk a `TSModuleDeclaration` (`namespace Foo { … }`
+    /// / `module "x" { … }`). `body` is `Option` — declaration-only
+    /// forms (`declare namespace Foo;`, ambient module headers) carry
+    /// `None` and are handled cleanly as no-ops. The body is one of two
+    /// `TSModuleDeclarationBody` variants:
+    ///
+    /// - `TSModuleBlock` — the executable `{ … }` block; its statement
+    ///   list is walked exactly like a function/block body so nested
+    ///   `function bar()` declarations become their own
+    ///   `FunctionComplexity` sites and any decision points inside the
+    ///   block charge the enclosing accumulator.
+    /// - `TSModuleDeclaration` — a dotted-namespace continuation
+    ///   (`namespace A.B { … }` parses as `A` whose body is the nested
+    ///   declaration `B`); recurse so the eventual block is reached.
+    ///
+    /// `nesting`/`out` are threaded straight through: a `namespace`
+    /// nested inside a function body is uncommon but legal in `.ts`, and
+    /// in that position its block's decision points belong to the
+    /// enclosing function. At module scope `nesting` is `None` so
+    /// top-level decision points in the block are not charged to any
+    /// (non-existent) parent, matching the rest of the walker.
+    fn visit_ts_module_declaration(
+        &mut self,
+        ns: &oxc::ast::ast::TSModuleDeclaration<'_>,
+        out: &mut Contributors,
+        nesting: Option<u32>,
+    ) {
+        use oxc::ast::ast::TSModuleDeclarationBody;
+        let Some(body) = &ns.body else {
+            return;
+        };
+        match body {
+            TSModuleDeclarationBody::TSModuleBlock(block) => {
+                for stmt in &block.body {
+                    self.visit_statement(stmt, out, nesting);
+                }
+            }
+            TSModuleDeclarationBody::TSModuleDeclaration(inner) => {
+                self.visit_ts_module_declaration(inner, out, nesting);
             }
         }
     }

--- a/crates/crap4ts/src/adapters/walker/mod.rs
+++ b/crates/crap4ts/src/adapters/walker/mod.rs
@@ -801,34 +801,60 @@ impl<'src> FunctionFinder<'src> {
                 self.visit_expression(&b.right, out, nesting);
             }
             Expression::AssignmentExpression(a) => {
-                // #200 item 3: a computed-member LHS
-                // (`x[foo()] = 1`) embeds an arbitrary index
-                // expression that can contain a nested function (e.g.
-                // an IIFE) or decision points. The pre-#200 arm
-                // discarded `a.left` entirely; now, when the target is
-                // a computed member access, recurse into both the
-                // object and the index expression before the RHS. Other
-                // `AssignmentTarget` variants (plain identifier, static
-                // member, destructuring patterns) hold no embedded
-                // index expression worth descending for nested-function
-                // discovery, so they remain no-ops here.
-                if let oxc::ast::ast::AssignmentTarget::ComputedMemberExpression(m) = &a.left {
-                    self.visit_expression(&m.object, out, nesting);
-                    self.visit_expression(&m.expression, out, nesting);
+                // #200 item 3 (+ gemini review on PR #220): a
+                // member-expression LHS embeds sub-expressions that can
+                // contain a nested function (e.g. an IIFE) or decision
+                // points. The pre-#200 arm discarded `a.left` entirely.
+                // `AssignmentTarget` flattens `MemberExpression`'s three
+                // variants via `inherit_variants!`:
+                //  - Computed (`x[foo()] = 1`): recurse object + the
+                //    index expression.
+                //  - Static (`getObj().p = 1`): recurse object — the
+                //    `.property` is a bare `IdentifierName`, no
+                //    sub-expression. `getObj()` may be an IIFE.
+                //  - PrivateField (`getObj().#p = 1`): recurse object —
+                //    `.field` is a bare `PrivateIdentifier`.
+                // Other targets (plain identifier, destructuring
+                // patterns) hold no embedded expression worth
+                // descending, so remain no-ops here.
+                use oxc::ast::ast::AssignmentTarget as AT;
+                match &a.left {
+                    AT::ComputedMemberExpression(m) => {
+                        self.visit_expression(&m.object, out, nesting);
+                        self.visit_expression(&m.expression, out, nesting);
+                    }
+                    AT::StaticMemberExpression(m) => {
+                        self.visit_expression(&m.object, out, nesting);
+                    }
+                    AT::PrivateFieldExpression(m) => {
+                        self.visit_expression(&m.object, out, nesting);
+                    }
+                    _ => {}
                 }
                 self.visit_expression(&a.right, out, nesting);
             }
-            // #200 item 4: `x[foo()]++` / `--y[bar()]`. The
-            // `UpdateExpression` operand is a `SimpleAssignmentTarget`;
-            // when it is a computed member access the index expression
-            // can embed a nested function or decision points. Pre-#200
-            // this whole arm was dropped by the `_ => {}` fallthrough.
+            // #200 item 4 (+ gemini review on PR #220): `x[foo()]++`,
+            // `getObj().p++`, `getObj().#p++`. The `UpdateExpression`
+            // operand is a `SimpleAssignmentTarget`, which flattens the
+            // same three `MemberExpression` variants; recurse their
+            // sub-expressions for nested-function discovery (Static /
+            // PrivateField carry only `.object`; Computed also carries
+            // the index `.expression`). Pre-#200 the whole arm was
+            // dropped by the `_ => {}` fallthrough.
             Expression::UpdateExpression(u) => {
-                if let oxc::ast::ast::SimpleAssignmentTarget::ComputedMemberExpression(m) =
-                    &u.argument
-                {
-                    self.visit_expression(&m.object, out, nesting);
-                    self.visit_expression(&m.expression, out, nesting);
+                use oxc::ast::ast::SimpleAssignmentTarget as SAT;
+                match &u.argument {
+                    SAT::ComputedMemberExpression(m) => {
+                        self.visit_expression(&m.object, out, nesting);
+                        self.visit_expression(&m.expression, out, nesting);
+                    }
+                    SAT::StaticMemberExpression(m) => {
+                        self.visit_expression(&m.object, out, nesting);
+                    }
+                    SAT::PrivateFieldExpression(m) => {
+                        self.visit_expression(&m.object, out, nesting);
+                    }
+                    _ => {}
                 }
             }
             Expression::ArrayExpression(arr) => {
@@ -1176,6 +1202,13 @@ impl<'src> FunctionFinder<'src> {
     /// enclosing function. At module scope `nesting` is `None` so
     /// top-level decision points in the block are not charged to any
     /// (non-existent) parent, matching the rest of the walker.
+    ///
+    /// Known limitation: functions discovered inside a namespace keep
+    /// their **bare local name** (`bar`), not a namespace-qualified one
+    /// (`Foo.bar`) — unlike class methods, which qualify as `C.m`. The
+    /// `#200` AC only requires separate-`FunctionComplexity` discovery
+    /// (satisfied); qualified naming is a tracked enhancement.
+    /// tracked: crap-rs#221 — namespace-qualified function names
     fn visit_ts_module_declaration(
         &mut self,
         ns: &oxc::ast::ast::TSModuleDeclaration<'_>,

--- a/crates/crap4ts/tests/fixtures/ts-fixtures/assignment-computed-lhs.ts
+++ b/crates/crap4ts/tests/fixtures/ts-fixtures/assignment-computed-lhs.ts
@@ -1,0 +1,14 @@
+// #200 item 3 — computed-member assignment LHS embedding a nested
+// function. `target[(() => { ... })()]` has an IIFE arrow in the
+// index expression; the arrow must be discovered as its own
+// FunctionComplexity (with its own `if`), separate from `assign`.
+function assign(target: Record<string, number>, flag: boolean): void {
+  target[
+    (() => {
+      if (flag) {
+        return "yes";
+      }
+      return "no";
+    })()
+  ] = 1;
+}

--- a/crates/crap4ts/tests/fixtures/ts-fixtures/assignment-static-member-object.ts
+++ b/crates/crap4ts/tests/fixtures/ts-fixtures/assignment-static-member-object.ts
@@ -1,0 +1,15 @@
+// gemini PR #220 review (#200 item 3 follow-up) — a STATIC-member
+// assignment LHS whose member *object* is an IIFE embedding a nested
+// function: `(() => { if … })().prop = 1`. The arrow must be
+// discovered as its own FunctionComplexity (with its own `if`),
+// separate from `assignStatic`. Pre-fix the walker only recursed the
+// COMPUTED-member case and dropped the static-member object entirely.
+function assignStatic(flag: boolean): void {
+  (() => {
+    const o: { prop: number } = { prop: 0 };
+    if (flag) {
+      o.prop = 1;
+    }
+    return o;
+  })().prop = 1;
+}

--- a/crates/crap4ts/tests/fixtures/ts-fixtures/computed-class-key.ts
+++ b/crates/crap4ts/tests/fixtures/ts-fixtures/computed-class-key.ts
@@ -1,0 +1,16 @@
+// #205 (class side) — computed class PropertyDefinition key embedding
+// an IIFE arrow function. `[(() => "x")()]` is a computed key; the
+// arrow must be discovered as its own FunctionComplexity, separate
+// from the class's regular method `regular`.
+class Widget {
+  [(() => {
+    return "dynamicKey";
+  })()]: number = 0;
+
+  regular(n: number): number {
+    if (n > 0) {
+      return n;
+    }
+    return 0;
+  }
+}

--- a/crates/crap4ts/tests/fixtures/ts-fixtures/computed-object-key.ts
+++ b/crates/crap4ts/tests/fixtures/ts-fixtures/computed-object-key.ts
@@ -1,0 +1,11 @@
+// #200 item 1 — computed object property key embedding a decision
+// point. `[a && b]` is a computed key whose `&&` is a LogicalOperator
+// that must charge the enclosing function `build`. A spread property
+// is included to confirm spread handling is unchanged.
+function build(a: boolean, b: boolean, rest: object): object {
+  const obj = {
+    [a && b]: 1,
+    ...rest,
+  };
+  return obj;
+}

--- a/crates/crap4ts/tests/fixtures/ts-fixtures/namespace.ts
+++ b/crates/crap4ts/tests/fixtures/ts-fixtures/namespace.ts
@@ -1,0 +1,15 @@
+// #200 item 2 — TS namespace with a nested function declaration.
+// `bar` must be discovered as its own FunctionComplexity, and its
+// `if` must charge `bar` (not leak to module scope).
+namespace Foo {
+  export function bar(n: number): number {
+    if (n > 0) {
+      return n;
+    }
+    return 0;
+  }
+}
+
+// Declaration-only ambient module — `body` is None. Must be handled
+// cleanly (no panic, no synthetic function discovered).
+declare module "side-effect-only";

--- a/crates/crap4ts/tests/fixtures/ts-fixtures/update-computed-operand.ts
+++ b/crates/crap4ts/tests/fixtures/ts-fixtures/update-computed-operand.ts
@@ -1,0 +1,14 @@
+// #200 item 4 — UpdateExpression on a computed-member operand whose
+// index expression embeds a nested function. `counters[(() => {
+// ... })()]++` — the IIFE arrow must be discovered as its own
+// FunctionComplexity (with its own `if`), separate from `bump`.
+function bump(counters: Record<string, number>, flag: boolean): void {
+  counters[
+    (() => {
+      if (flag) {
+        return "a";
+      }
+      return "b";
+    })()
+  ]++;
+}

--- a/crates/crap4ts/tests/fixtures/ts-fixtures/update-static-member-object.ts
+++ b/crates/crap4ts/tests/fixtures/ts-fixtures/update-static-member-object.ts
@@ -1,0 +1,15 @@
+// gemini PR #220 review (#200 item 4 follow-up) — an UpdateExpression
+// on a STATIC-member operand whose member *object* is an IIFE
+// embedding a nested function: `(() => { if … })().prop++`. The arrow
+// must be discovered as its own FunctionComplexity (with its own
+// `if`), separate from `bumpStatic`. Pre-fix the walker only recursed
+// the COMPUTED-member operand and dropped the static-member object.
+function bumpStatic(flag: boolean): void {
+  (() => {
+    const o: { prop: number } = { prop: 0 };
+    if (flag) {
+      o.prop = 1;
+    }
+    return o;
+  })().prop++;
+}

--- a/crates/crap4ts/tests/walker_proptest.rs
+++ b/crates/crap4ts/tests/walker_proptest.rs
@@ -11,7 +11,10 @@
 //! TS source spanning every construct (simple/nested functions, class
 //! methods + computed-key fields + static blocks, namespaces, all 11
 //! decision-point kinds, JSX conditionals) across all six file
-//! extensions, and asserts six invariants on every parseable input.
+//! extensions, and asserts the six #207 invariants — plus a seventh,
+//! a `contributor.nesting`-depth oracle, added to mechanically kill
+//! the `nesting.map(|n| n + 1)` arithmetic mutant class surfaced by
+//! the crap-rs#209 walker mutation run — on every parseable input.
 //!
 //! ## The grammar carries its own oracle
 //!
@@ -88,6 +91,79 @@ enum Stmt {
     /// the enclosing function (invariant 4 — isolation); the nested
     /// function is its own complexity site.
     NestedFn(Box<Body>),
+    /// An IIFE arrow `(() => { <inner> })()` embedded inside a chosen
+    /// expression context (`await`, array element, template-literal
+    /// substitution, sequence, unary, `as`/`satisfies`/`!`,
+    /// computed-member, throw argument, ternary branch). Emits
+    /// `const _wN = <wrap>;`. The wrapper itself adds ZERO decision
+    /// points to the enclosing function and the IIFE arrow is a
+    /// SEPARATE complexity site (so `<inner>`'s decision points charge
+    /// the arrow, not the enclosing function). Its purpose is mutation
+    /// coverage: each `WrapKind` routes the discoverable IIFE through a
+    /// different `visit_expression` recursion arm, so DELETING any of
+    /// those arms (or replacing a recursion helper with `()`) drops the
+    /// arrow from the discovered-function set and
+    /// `walker_nested_function_isolation` catches it. Adds 1 to the
+    /// enclosing function's `nested_fn_count`.
+    ExprWrap(WrapKind, Box<Body>),
+}
+
+/// The expression context an [`Stmt::ExprWrap`] routes its
+/// discoverable IIFE arrow through. Each variant exercises a distinct
+/// `visit_expression` recursion arm in the walker.
+#[derive(Debug, Clone, Copy)]
+enum WrapKind {
+    /// `await (IIFE)` — `Expression::AwaitExpression` arm.
+    Await,
+    /// `[IIFE][0]` — `Expression::ArrayExpression` arm.
+    Array,
+    /// `` `${IIFE}` `` — `Expression::TemplateLiteral` arm.
+    Template,
+    /// `(0, IIFE)` — `Expression::SequenceExpression` arm.
+    Sequence,
+    /// `void IIFE` — `Expression::UnaryExpression` arm.
+    Unary,
+    /// `(IIFE as unknown)` — `Expression::TSAsExpression` arm.
+    TsAs,
+    /// `(IIFE satisfies unknown)` — `Expression::TSSatisfiesExpression`.
+    TsSatisfies,
+    /// `(IIFE)!` — `Expression::TSNonNullExpression` arm.
+    TsNonNull,
+    /// `({ k: 0 })[(IIFE, "k") as any]` — `ComputedMemberExpression`.
+    ComputedMember,
+    /// `(true ? IIFE : 0)` — `Expression::ConditionalExpression` branch
+    /// recursion (consequent).
+    TernaryBranch,
+    /// `` IIFE`x` `` — `Expression::TaggedTemplateExpression` tag arm.
+    TaggedTemplate,
+    /// `(import((IIFE as any)) as unknown)` — `ImportExpression` arm
+    /// (the IIFE is the dynamic-import source expression). NOTE: no
+    /// `.catch(…)` / `.then(…)` — those would inject a stray arrow
+    /// site and corrupt the nested-fn oracle.
+    ImportSource,
+}
+
+impl WrapKind {
+    /// Emit `<wrap>` where `iife` is the already-rendered
+    /// `(() => { … })()` text. The result is a single expression.
+    fn wrap(self, iife: &str) -> String {
+        match self {
+            WrapKind::Await => format!("await ({iife})"),
+            WrapKind::Array => format!("[{iife}][0]"),
+            WrapKind::Template => format!("`${{{iife}}}`"),
+            WrapKind::Sequence => format!("(0, {iife})"),
+            WrapKind::Unary => format!("void ({iife})"),
+            WrapKind::TsAs => format!("(({iife}) as unknown)"),
+            WrapKind::TsSatisfies => format!("(({iife}) satisfies unknown)"),
+            WrapKind::TsNonNull => format!("(({iife})!)"),
+            WrapKind::ComputedMember => {
+                format!("(({{ k: 0 }}) as any)[(({iife}), \"k\") as any]")
+            }
+            WrapKind::TernaryBranch => format!("(true ? ({iife}) : 0)"),
+            WrapKind::TaggedTemplate => format!("(({iife}) as any)`x`"),
+            WrapKind::ImportSource => format!("(import((({iife}) as any)) as unknown)"),
+        }
+    }
 }
 
 impl Stmt {
@@ -98,7 +174,10 @@ impl Stmt {
             // the enclosing function — its body is a separate site
             // (invariant 4). `TryFinally` is not a decision point but
             // still recurses into its `try` body.
-            Stmt::Noop | Stmt::NestedFn(_) => 0,
+            // `ExprWrap`'s decision points live inside its IIFE arrow
+            // (a separate site), so it charges ZERO to the enclosing
+            // function — same isolation as `NestedFn`.
+            Stmt::Noop | Stmt::NestedFn(_) | Stmt::ExprWrap(..) => 0,
             Stmt::TryFinally(b) => b.increments(),
             // One decision point + whatever the inner body charges.
             Stmt::If(b)
@@ -207,6 +286,27 @@ impl Stmt {
                 b.emit(out, ctr, indent + 1);
                 out.push_str(&format!("{pad}}}\n"));
             }
+            Stmt::ExprWrap(kind, b) => {
+                // Two nested function sites:
+                //   outer async IIFE  — makes `await` always legal
+                //                        regardless of the enclosing
+                //                        container's async-ness
+                //   inner IIFE arrow  — holds <body>; routed through
+                //                        the chosen wrapper expression
+                //                        so DELETING the matching
+                //                        `visit_expression` recursion
+                //                        arm drops it from the
+                //                        discovered-function set.
+                let mut inner_body = String::new();
+                b.emit(&mut inner_body, ctr, indent + 3);
+                let inner_iife = format!("(() => {{\n{inner_body}{pad}    }})()");
+                let wrapped = kind.wrap(&inner_iife);
+                out.push_str(&format!("{pad}const _w{id}: unknown = (async () => {{\n"));
+                out.push_str(&format!("{pad}  const _r{id}: unknown = {wrapped};\n"));
+                out.push_str(&format!("{pad}  return _r{id};\n"));
+                out.push_str(&format!("{pad}}})();\n"));
+                out.push_str(&format!("{pad}void _w{id};\n"));
+            }
         }
     }
 
@@ -231,6 +331,68 @@ impl Stmt {
             | Stmt::TryCatch(b)
             | Stmt::TryFinally(b) => b.nested_fn_count(),
             Stmt::NestedFn(b) => 1 + b.nested_fn_count(),
+            // The wrapper introduces TWO IIFE sites (outer async +
+            // inner); the inner's body may itself introduce more.
+            Stmt::ExprWrap(_, b) => 2 + b.nested_fn_count(),
+        }
+    }
+
+    /// Append the nesting depth the walker assigns to each decision
+    /// point this node charges to the *enclosing* function, given the
+    /// statement itself sits at `depth`. Mirrors the walker's exact
+    /// `nesting` arithmetic (the `nesting.map(|n| n + 1)` recursion):
+    ///
+    /// - A control-flow statement (`if`/`for*`/`while`/`do-while`)
+    ///   scores its own contributor at `depth`, then its body recurses
+    ///   at `depth + 1`.
+    /// - `switch` scores `CaseBranch` at `depth`; the case consequent
+    ///   recurses at `depth + 1`.
+    /// - `try { } catch { }` scores `Catch` at `depth`, but the
+    ///   try-block body recurses at the **same** `depth` (the walker's
+    ///   `visit_try` does NOT bump nesting — verified asymmetry vs the
+    ///   loop/if family). `try { } finally { }` likewise recurses its
+    ///   body at the same `depth` with no contributor.
+    /// - A leaf expression decision point (`&&`/`||`/`??`/`?:`/`?.`)
+    ///   scores at `depth` (it is visited with the statement's own
+    ///   `nesting`, never bumped).
+    /// - `NestedFn` introduces a SEPARATE function whose body restarts
+    ///   at its own depth 0 — it contributes NOTHING to the enclosing
+    ///   function's nesting multiset (invariant 4).
+    ///
+    /// This is the independent oracle for invariant 7: a mutant that
+    /// turns `n + 1` into `n * 1`, `n - 1`, etc. produces a different
+    /// nesting multiset and is caught here even though complexity (1 +
+    /// sum) is unchanged.
+    fn expected_nestings(&self, depth: u32, out: &mut Vec<u32>) {
+        match self {
+            // `ExprWrap`'s decision points live in its separate IIFE
+            // arrow, so it contributes NOTHING to the enclosing
+            // function's nesting multiset (same as `NestedFn`).
+            Stmt::Noop | Stmt::NestedFn(_) | Stmt::ExprWrap(..) => {}
+            Stmt::If(b)
+            | Stmt::For(b)
+            | Stmt::ForIn(b)
+            | Stmt::ForOf(b)
+            | Stmt::While(b)
+            | Stmt::DoWhile(b)
+            | Stmt::Switch(b) => {
+                out.push(depth);
+                b.collect_nestings(depth + 1, out);
+            }
+            Stmt::TryCatch(b) => {
+                out.push(depth);
+                // try-block body is NOT depth-bumped by visit_try.
+                b.collect_nestings(depth, out);
+            }
+            Stmt::TryFinally(b) => {
+                // No contributor; body recurses at same depth.
+                b.collect_nestings(depth, out);
+            }
+            Stmt::LogicalAnd
+            | Stmt::LogicalOr
+            | Stmt::Nullish
+            | Stmt::Ternary
+            | Stmt::OptionalChain => out.push(depth),
         }
     }
 }
@@ -242,6 +404,25 @@ struct Body(Vec<Stmt>);
 impl Body {
     fn increments(&self) -> u32 {
         self.0.iter().map(Stmt::increments).sum()
+    }
+
+    /// Accumulate (unsorted) the nesting depths of every decision
+    /// point in this body, given the body starts at `depth`. Recursive
+    /// worker for [`Body::expected_nestings`].
+    fn collect_nestings(&self, depth: u32, out: &mut Vec<u32>) {
+        for s in &self.0 {
+            s.expected_nestings(depth, out);
+        }
+    }
+
+    /// The multiset (collected as a sorted Vec) of contributor nesting
+    /// depths the walker should emit for this body, given it starts at
+    /// `base_depth`. See [`Stmt::expected_nestings`].
+    fn expected_nestings(&self, base_depth: u32) -> Vec<u32> {
+        let mut v = Vec::new();
+        self.collect_nestings(base_depth, &mut v);
+        v.sort_unstable();
+        v
     }
     fn nested_fn_count(&self) -> u32 {
         self.0.iter().map(Stmt::nested_fn_count).sum()
@@ -267,6 +448,23 @@ fn leaf_stmt() -> impl Strategy<Value = Stmt> {
     ]
 }
 
+fn wrapkind_strategy() -> impl Strategy<Value = WrapKind> {
+    prop_oneof![
+        Just(WrapKind::Await),
+        Just(WrapKind::Array),
+        Just(WrapKind::Template),
+        Just(WrapKind::Sequence),
+        Just(WrapKind::Unary),
+        Just(WrapKind::TsAs),
+        Just(WrapKind::TsSatisfies),
+        Just(WrapKind::TsNonNull),
+        Just(WrapKind::ComputedMember),
+        Just(WrapKind::TernaryBranch),
+        Just(WrapKind::TaggedTemplate),
+        Just(WrapKind::ImportSource),
+    ]
+}
+
 /// A recursively-nested statement. `prop::collection::vec` bounds the
 /// body so generated programs stay parseable + fast.
 fn stmt_strategy() -> impl Strategy<Value = Stmt> {
@@ -282,7 +480,8 @@ fn stmt_strategy() -> impl Strategy<Value = Stmt> {
             body.clone().prop_map(|b| Stmt::Switch(Box::new(b))),
             body.clone().prop_map(|b| Stmt::TryCatch(Box::new(b))),
             body.clone().prop_map(|b| Stmt::TryFinally(Box::new(b))),
-            body.prop_map(|b| Stmt::NestedFn(Box::new(b))),
+            body.clone().prop_map(|b| Stmt::NestedFn(Box::new(b))),
+            (wrapkind_strategy(), body).prop_map(|(k, b)| Stmt::ExprWrap(k, Box::new(b))),
         ]
     })
 }
@@ -427,14 +626,21 @@ impl Program {
                 out.push_str("  }\n}\n");
             }
             Container::ComputedObjectKey => {
-                // `[(_kx as any) && 1]` is a computed key whose `&&` is
-                // a LogicalOperator that charges the enclosing IIFE
-                // arrow; the IIFE arrow also holds <body>.
+                // `[(_kx as any) && 1]` is a computed key whose `&&`
+                // is a LogicalOperator charging the *enclosing*
+                // function — here module scope (the `const o = {…}`
+                // is top-level), so it charges nobody (verified
+                // empirically against the walker). The body holder is
+                // a NAMED const arrow `_holder` (not an anonymous
+                // value IIFE) so it stays uniquely findable even when
+                // <body> spawns more anonymous `<arrow>` sites via
+                // `ExprWrap`.
                 out.push_str("const _kx: unknown = 1;\n");
+                out.push_str("const _holder = () => {\n");
+                self.body.emit(&mut out, &mut ctr, 1);
+                out.push_str("};\n");
                 out.push_str("const o = {\n");
-                out.push_str("  [((_kx as any) && 1) as any]: (() => {\n");
-                self.body.emit(&mut out, &mut ctr, 2);
-                out.push_str("  })(),\n");
+                out.push_str("  [((_kx as any) && 1) as any]: _holder(),\n");
                 out.push_str("};\nvoid o;\n");
             }
             Container::JsxConditional => {
@@ -551,7 +757,9 @@ proptest! {
             Container::ClassMethod
             | Container::ClassComputedKey => "C.m",
             Container::StaticBlock => "C.<static-init>",
-            Container::ComputedObjectKey => "<arrow>",
+            // Named const arrow — unique even when <body> spawns
+            // anonymous `<arrow>` sites via ExprWrap.
+            Container::ComputedObjectKey => "_holder",
         };
         let Some(holder) = fns
             .iter()
@@ -571,6 +779,63 @@ proptest! {
             holder.complexity,
             prog.expected_body_holder_complexity(),
             src
+        );
+    }
+
+    /// Invariant 7 (independent oracle for the nesting-depth
+    /// arithmetic): the multiset of `contributor.nesting` values on the
+    /// body holder equals exactly what the grammar predicts from the
+    /// walker's `nesting.map(|n| n + 1)` recursion. This is the
+    /// independent-axis kill for the entire `replace + with *` /
+    /// `replace + with -` / `delete nesting bump` mutant class on
+    /// `visit_for*` / `visit_while` / `visit_do_while` / `visit_if` /
+    /// `visit_switch_case`: those mutations leave complexity (1 + sum)
+    /// untouched but corrupt the nesting depth, which `walker_core_
+    /// invariants` and `walker_matches_independent_oracle` do not
+    /// observe. Restricted to the containers whose holder contributor
+    /// set is exactly the generated body's (the two computed-key /
+    /// JSX containers add a container-intrinsic `&&` that is accounted
+    /// separately and excluded here for a clean oracle).
+    #[test]
+    fn walker_nesting_depth_matches_oracle(prog in program_strategy()) {
+        // Exclude the containers that inject a non-body decision point
+        // into (or adjacent to) the holder — their nesting oracle is
+        // covered transitively by the complexity oracle; this test
+        // isolates the body-recursion arithmetic.
+        prop_assume!(!matches!(
+            prog.container,
+            Container::ComputedObjectKey | Container::JsxConditional
+        ));
+        let src = prog.source();
+        let path = prog.file_path();
+        let Some(fns) = walk(&src, &path) else { return Ok(()); };
+
+        let holder_name: &str = match prog.container {
+            Container::FunctionDecl
+            | Container::Namespace
+            | Container::ArrowConst => "top",
+            Container::ClassMethod | Container::ClassComputedKey => "C.m",
+            Container::StaticBlock => "C.<static-init>",
+            Container::ComputedObjectKey | Container::JsxConditional => unreachable!(),
+        };
+        let Some(holder) = fns
+            .iter()
+            .find(|f| f.identity.qualified_name == holder_name)
+        else {
+            return Ok(());
+        };
+
+        // The body holder's body is visited starting at nesting 0
+        // (visit_function_body → visit_statement(.., Some(0)); a static
+        // block likewise seeds Some(0)).
+        let expected = prog.body.expected_nestings(0);
+        let mut actual: Vec<u32> = holder.contributors.iter().map(|c| c.nesting_depth).collect();
+        actual.sort_unstable();
+        prop_assert_eq!(
+            &actual,
+            &expected,
+            "holder {:?} contributor nesting multiset {:?} != grammar oracle {:?}\n--- source ---\n{}",
+            holder_name, actual, expected, src
         );
     }
 

--- a/crates/crap4ts/tests/walker_proptest.rs
+++ b/crates/crap4ts/tests/walker_proptest.rs
@@ -1,0 +1,691 @@
+//! Property-test invariant suite for `OxcWalker` (crap-rs#207).
+//!
+//! This is the **independent-axis verification** for the #200/#205
+//! traversal arms (and the whole W1.2 + W2.1 decision-point surface).
+//! `walker_smoke.rs` exercises the walker against hand-picked fixtures;
+//! a hand-picked fixture only proves the walker behaves on the inputs
+//! the author thought to write. The failure mode this suite exists to
+//! prevent is the one #218 shipped masked: a code path that "looks
+//! right" and passes every fixture the author chose, but is wrong on
+//! inputs nobody hand-wrote. A constrained AST grammar generates valid
+//! TS source spanning every construct (simple/nested functions, class
+//! methods + computed-key fields + static blocks, namespaces, all 11
+//! decision-point kinds, JSX conditionals) across all six file
+//! extensions, and asserts six invariants on every parseable input.
+//!
+//! ## The grammar carries its own oracle
+//!
+//! Each generated `Program` knows the exact number of cyclomatic
+//! decision points its body holder should report
+//! (`expected_body_holder_complexity`). Invariant 3 is therefore also
+//! checked against an **independent count** computed by the generator,
+//! not only against the walker's own arithmetic — a mutated or buggy
+//! walker that miscounts is caught even if its
+//! `complexity == 1 + sum(increments)` internal consistency still holds.
+//!
+//! ## Disposition discipline (crap-rs#207 AC)
+//!
+//! A failing seed is a real walker bug, never a generator bug to paper
+//! over. The contract: file a separate `type:bug` issue with the seed +
+//! minimal reproducer, commit the `proptest-regressions/` entry, do NOT
+//! mutate the grammar until the assertion passes. See the PR body for
+//! the recorded disposition of this suite's initial run.
+
+use std::collections::BTreeMap;
+
+use crap_core::domain::types::{ComplexityMetric, FunctionComplexity};
+use crap_core::ports::ComplexityPort;
+use crap4ts::adapters::walker::OxcWalker;
+use proptest::prelude::*;
+use proptest::strategy::ValueTree;
+
+// ── Constrained AST grammar ─────────────────────────────────────────────
+//
+// `Body` is a list of statements that live inside a function body. Each
+// variant emits valid TS *and* reports how many cyclomatic decision
+// points it adds to the *enclosing* function (nested functions carry
+// their own count and never add to the parent — invariant 4).
+
+/// One statement inside a function body. `increments()` is the oracle:
+/// the exact number of decision points this node charges to the
+/// function that contains it (excluding anything inside a nested
+/// function it introduces).
+#[derive(Debug, Clone)]
+enum Stmt {
+    /// `const _vN = 0;` — no decision point.
+    Noop,
+    /// `if (a) { <inner> }` — one IfBranch + inner's increments.
+    If(Box<Body>),
+    /// `for (let i = 0; i < 1; i++) { <inner> }` — one ForLoop.
+    For(Box<Body>),
+    /// `for (const k in o) { <inner> }` — one ForLoop.
+    ForIn(Box<Body>),
+    /// `for (const v of a) { <inner> }` — one ForLoop.
+    ForOf(Box<Body>),
+    /// `while (a) { <inner> }` — one WhileLoop.
+    While(Box<Body>),
+    /// `do { <inner> } while (a);` — one DoWhileLoop.
+    DoWhile(Box<Body>),
+    /// `switch (x) { case 1: <inner>; break; default: break; }` —
+    /// one CaseBranch (default is NOT a decision point).
+    Switch(Box<Body>),
+    /// `const _bN = a && b;` — one LogicalOperator.
+    LogicalAnd,
+    /// `const _bN = a || b;` — one LogicalOperator.
+    LogicalOr,
+    /// `const _bN = a ?? b;` — one LogicalOperator (?? maps to it).
+    Nullish,
+    /// `const _tN = a ? 1 : 0;` — one Ternary.
+    Ternary,
+    /// `const _cN = obj?.maybe?.deep;` — one OptionalChain (the whole
+    /// chain is ONE ChainExpression → one contributor).
+    OptionalChain,
+    /// `try { <inner> } catch (e) {}` — one Catch + inner's increments.
+    TryCatch(Box<Body>),
+    /// `try { <inner> } finally {}` — NOT a decision point.
+    TryFinally(Box<Body>),
+    /// A nested `function _fnN() { <inner> }` declaration. Adds ZERO to
+    /// the enclosing function (invariant 4 — isolation); the nested
+    /// function is its own complexity site.
+    NestedFn(Box<Body>),
+}
+
+impl Stmt {
+    /// Decision points this node charges to the *enclosing* function.
+    fn increments(&self) -> u32 {
+        match self {
+            // No decision point of its own. `NestedFn` charges ZERO to
+            // the enclosing function — its body is a separate site
+            // (invariant 4). `TryFinally` is not a decision point but
+            // still recurses into its `try` body.
+            Stmt::Noop | Stmt::NestedFn(_) => 0,
+            Stmt::TryFinally(b) => b.increments(),
+            // One decision point + whatever the inner body charges.
+            Stmt::If(b)
+            | Stmt::For(b)
+            | Stmt::ForIn(b)
+            | Stmt::ForOf(b)
+            | Stmt::While(b)
+            | Stmt::DoWhile(b)
+            | Stmt::Switch(b)
+            | Stmt::TryCatch(b) => 1 + b.increments(),
+            // Leaf decision points — exactly one each.
+            Stmt::LogicalAnd
+            | Stmt::LogicalOr
+            | Stmt::Nullish
+            | Stmt::Ternary
+            | Stmt::OptionalChain => 1,
+        }
+    }
+
+    /// Emit valid TS source for this statement, into `out`, using
+    /// `ctr` to mint unique identifiers so generated programs never
+    /// shadow / redeclare.
+    fn emit(&self, out: &mut String, ctr: &mut u32, indent: usize) {
+        let pad = "  ".repeat(indent);
+        let id = {
+            *ctr += 1;
+            *ctr
+        };
+        match self {
+            Stmt::Noop => {
+                out.push_str(&format!("{pad}const _v{id} = {id};\n"));
+            }
+            Stmt::If(b) => {
+                out.push_str(&format!("{pad}if (_p{id} > 0) {{\n"));
+                out.push_str(&format!("{pad}  const _p{id} = {id};\n"));
+                b.emit(out, ctr, indent + 1);
+                out.push_str(&format!("{pad}}}\n"));
+            }
+            Stmt::For(b) => {
+                out.push_str(&format!(
+                    "{pad}for (let _i{id} = 0; _i{id} < 1; _i{id}++) {{\n"
+                ));
+                b.emit(out, ctr, indent + 1);
+                out.push_str(&format!("{pad}}}\n"));
+            }
+            Stmt::ForIn(b) => {
+                out.push_str(&format!(
+                    "{pad}for (const _k{id} in {{ a: 1 }}) {{ void _k{id};\n"
+                ));
+                b.emit(out, ctr, indent + 1);
+                out.push_str(&format!("{pad}}}\n"));
+            }
+            Stmt::ForOf(b) => {
+                out.push_str(&format!("{pad}for (const _e{id} of [1]) {{ void _e{id};\n"));
+                b.emit(out, ctr, indent + 1);
+                out.push_str(&format!("{pad}}}\n"));
+            }
+            Stmt::While(b) => {
+                out.push_str(&format!("{pad}while (_w{id} === undefined) {{\n"));
+                out.push_str(&format!("{pad}  const _w{id} = {id}; break;\n"));
+                b.emit(out, ctr, indent + 1);
+                out.push_str(&format!("{pad}}}\n"));
+            }
+            Stmt::DoWhile(b) => {
+                out.push_str(&format!("{pad}do {{\n"));
+                b.emit(out, ctr, indent + 1);
+                out.push_str(&format!("{pad}}} while (false);\n"));
+            }
+            Stmt::Switch(b) => {
+                out.push_str(&format!("{pad}switch ({id}) {{\n"));
+                out.push_str(&format!("{pad}  case {id}: {{\n"));
+                b.emit(out, ctr, indent + 2);
+                out.push_str(&format!("{pad}  }} break;\n"));
+                out.push_str(&format!("{pad}  default: break;\n"));
+                out.push_str(&format!("{pad}}}\n"));
+            }
+            Stmt::LogicalAnd => {
+                out.push_str(&format!("{pad}const _b{id} = (_x{id} as any) && {id};\n"));
+            }
+            Stmt::LogicalOr => {
+                out.push_str(&format!("{pad}const _b{id} = (_x{id} as any) || {id};\n"));
+            }
+            Stmt::Nullish => {
+                out.push_str(&format!("{pad}const _b{id} = (_x{id} as any) ?? {id};\n"));
+            }
+            Stmt::Ternary => {
+                out.push_str(&format!("{pad}const _t{id} = ((_x{id} as any) ? 1 : 0);\n"));
+            }
+            Stmt::OptionalChain => {
+                out.push_str(&format!(
+                    "{pad}const _c{id} = (_o{id} as any)?.maybe?.deep;\n"
+                ));
+            }
+            Stmt::TryCatch(b) => {
+                out.push_str(&format!("{pad}try {{\n"));
+                b.emit(out, ctr, indent + 1);
+                out.push_str(&format!("{pad}}} catch (_err{id}) {{ void _err{id}; }}\n"));
+            }
+            Stmt::TryFinally(b) => {
+                out.push_str(&format!("{pad}try {{\n"));
+                b.emit(out, ctr, indent + 1);
+                out.push_str(&format!("{pad}}} finally {{ }}\n"));
+            }
+            Stmt::NestedFn(b) => {
+                out.push_str(&format!("{pad}function _fn{id}(): void {{\n"));
+                b.emit(out, ctr, indent + 1);
+                out.push_str(&format!("{pad}}}\n"));
+            }
+        }
+    }
+
+    /// Every function-entry site this statement introduces, including
+    /// itself if it is a nested function, plus recursion into bodies.
+    /// Used by invariant 4's enclosing-function expectation.
+    fn nested_fn_count(&self) -> u32 {
+        match self {
+            Stmt::Noop
+            | Stmt::LogicalAnd
+            | Stmt::LogicalOr
+            | Stmt::Nullish
+            | Stmt::Ternary
+            | Stmt::OptionalChain => 0,
+            Stmt::If(b)
+            | Stmt::For(b)
+            | Stmt::ForIn(b)
+            | Stmt::ForOf(b)
+            | Stmt::While(b)
+            | Stmt::DoWhile(b)
+            | Stmt::Switch(b)
+            | Stmt::TryCatch(b)
+            | Stmt::TryFinally(b) => b.nested_fn_count(),
+            Stmt::NestedFn(b) => 1 + b.nested_fn_count(),
+        }
+    }
+}
+
+/// A function body: an ordered list of statements.
+#[derive(Debug, Clone)]
+struct Body(Vec<Stmt>);
+
+impl Body {
+    fn increments(&self) -> u32 {
+        self.0.iter().map(Stmt::increments).sum()
+    }
+    fn nested_fn_count(&self) -> u32 {
+        self.0.iter().map(Stmt::nested_fn_count).sum()
+    }
+    fn emit(&self, out: &mut String, ctr: &mut u32, indent: usize) {
+        for s in &self.0 {
+            s.emit(out, ctr, indent);
+        }
+    }
+}
+
+// ── proptest strategies ─────────────────────────────────────────────────
+
+/// Leaf statements (no recursion) — the strategy base case.
+fn leaf_stmt() -> impl Strategy<Value = Stmt> {
+    prop_oneof![
+        Just(Stmt::Noop),
+        Just(Stmt::LogicalAnd),
+        Just(Stmt::LogicalOr),
+        Just(Stmt::Nullish),
+        Just(Stmt::Ternary),
+        Just(Stmt::OptionalChain),
+    ]
+}
+
+/// A recursively-nested statement. `prop::collection::vec` bounds the
+/// body so generated programs stay parseable + fast.
+fn stmt_strategy() -> impl Strategy<Value = Stmt> {
+    leaf_stmt().prop_recursive(4, 24, 4, |inner| {
+        let body = prop::collection::vec(inner, 0..3).prop_map(Body);
+        prop_oneof![
+            body.clone().prop_map(|b| Stmt::If(Box::new(b))),
+            body.clone().prop_map(|b| Stmt::For(Box::new(b))),
+            body.clone().prop_map(|b| Stmt::ForIn(Box::new(b))),
+            body.clone().prop_map(|b| Stmt::ForOf(Box::new(b))),
+            body.clone().prop_map(|b| Stmt::While(Box::new(b))),
+            body.clone().prop_map(|b| Stmt::DoWhile(Box::new(b))),
+            body.clone().prop_map(|b| Stmt::Switch(Box::new(b))),
+            body.clone().prop_map(|b| Stmt::TryCatch(Box::new(b))),
+            body.clone().prop_map(|b| Stmt::TryFinally(Box::new(b))),
+            body.prop_map(|b| Stmt::NestedFn(Box::new(b))),
+        ]
+    })
+}
+
+fn body_strategy() -> impl Strategy<Value = Body> {
+    prop::collection::vec(stmt_strategy(), 0..4).prop_map(Body)
+}
+
+/// Which top-level container the generated body is wrapped in. Each
+/// shape is a distinct walker entry path so the suite exercises the
+/// FunctionFinder dispatch surface, not just `visit_statement`.
+#[derive(Debug, Clone, Copy)]
+enum Container {
+    /// `function top() { <body> }`
+    FunctionDecl,
+    /// `const top = () => { <body> };`
+    ArrowConst,
+    /// `class C { m() { <body> } }`
+    ClassMethod,
+    /// `class C { [(() => "k")()] = 0; m() { <body> } }` — #205
+    /// computed class key (the IIFE arrow is its own site) + a method
+    /// carrying the body.
+    ClassComputedKey,
+    /// `class C { static { <body> } }` — synthetic `<static-init>`.
+    StaticBlock,
+    /// `namespace N { export function top() { <body> } }` — #200 item 2.
+    Namespace,
+    /// `const o = { [a && b]: (() => { <body> })() };` — #200 item 1
+    /// computed object key wrapping the body in an IIFE arrow.
+    ComputedObjectKey,
+    /// `function top() { return <div>{c && <span/>}</div>; <body> }`
+    /// in a `.tsx` file — JSX-conditional decision point.
+    JsxConditional,
+}
+
+fn container_strategy() -> impl Strategy<Value = Container> {
+    prop_oneof![
+        Just(Container::FunctionDecl),
+        Just(Container::ArrowConst),
+        Just(Container::ClassMethod),
+        Just(Container::ClassComputedKey),
+        Just(Container::StaticBlock),
+        Just(Container::Namespace),
+        Just(Container::ComputedObjectKey),
+        Just(Container::JsxConditional),
+    ]
+}
+
+/// All six `AdapterMeta` extensions. JSX-bearing containers force a
+/// `.tsx`/`.jsx` extension at emit time regardless of this pick.
+fn ext_strategy() -> impl Strategy<Value = &'static str> {
+    prop_oneof![
+        Just("ts"),
+        Just("tsx"),
+        Just("jsx"),
+        Just("js"),
+        Just("mjs"),
+        Just("cjs"),
+    ]
+}
+
+/// A whole generated program: a container, its body, a file extension,
+/// and whether identifiers carry a non-ASCII suffix (invariant 6 — the
+/// W1.2 unicode span-to-line regression pin).
+#[derive(Debug, Clone)]
+struct Program {
+    container: Container,
+    body: Body,
+    ext: &'static str,
+    unicode: bool,
+}
+
+fn program_strategy() -> impl Strategy<Value = Program> {
+    (
+        container_strategy(),
+        body_strategy(),
+        ext_strategy(),
+        any::<bool>(),
+    )
+        .prop_map(|(container, body, ext, unicode)| Program {
+            container,
+            body,
+            ext,
+            unicode,
+        })
+}
+
+impl Program {
+    /// File path the walker sees — drives `SourceType::from_path`.
+    fn file_path(&self) -> String {
+        let ext = match self.container {
+            // JSX only parses under a JSX-capable source type. `.ts`
+            // does NOT enable JSX in oxc, so force `.tsx` for the
+            // JSX-conditional container; everything else honours the
+            // generated extension.
+            Container::JsxConditional => "tsx",
+            _ => self.ext,
+        };
+        format!("prop{}.{ext}", if self.unicode { "_uni" } else { "" })
+    }
+
+    /// Emit the full program source.
+    fn source(&self) -> String {
+        let mut out = String::new();
+        let mut ctr = 0u32;
+        // Optional unicode identifier in scope — exercises the W1.2
+        // byte_to_line_col multi-byte boundary fix on a real span.
+        if self.unicode {
+            out.push_str("const \u{03c0}\u{03b1} = 3;\nvoid \u{03c0}\u{03b1};\n");
+        }
+        match self.container {
+            Container::FunctionDecl => {
+                out.push_str("function top(): void {\n");
+                self.body.emit(&mut out, &mut ctr, 1);
+                out.push_str("}\n");
+            }
+            Container::ArrowConst => {
+                out.push_str("const top = (): void => {\n");
+                self.body.emit(&mut out, &mut ctr, 1);
+                out.push_str("};\n");
+            }
+            Container::ClassMethod => {
+                out.push_str("class C {\n  m(): void {\n");
+                self.body.emit(&mut out, &mut ctr, 2);
+                out.push_str("  }\n}\n");
+            }
+            Container::ClassComputedKey => {
+                out.push_str("class C {\n");
+                out.push_str("  [(() => \"k\")()]: number = 0;\n");
+                out.push_str("  m(): void {\n");
+                self.body.emit(&mut out, &mut ctr, 2);
+                out.push_str("  }\n}\n");
+            }
+            Container::StaticBlock => {
+                out.push_str("class C {\n  static {\n");
+                self.body.emit(&mut out, &mut ctr, 2);
+                out.push_str("  }\n}\n");
+            }
+            Container::Namespace => {
+                out.push_str("namespace N {\n  export function top(): void {\n");
+                self.body.emit(&mut out, &mut ctr, 2);
+                out.push_str("  }\n}\n");
+            }
+            Container::ComputedObjectKey => {
+                // `[(_kx as any) && 1]` is a computed key whose `&&` is
+                // a LogicalOperator that charges the enclosing IIFE
+                // arrow; the IIFE arrow also holds <body>.
+                out.push_str("const _kx: unknown = 1;\n");
+                out.push_str("const o = {\n");
+                out.push_str("  [((_kx as any) && 1) as any]: (() => {\n");
+                self.body.emit(&mut out, &mut ctr, 2);
+                out.push_str("  })(),\n");
+                out.push_str("};\nvoid o;\n");
+            }
+            Container::JsxConditional => {
+                out.push_str("function top(): unknown {\n");
+                out.push_str("  const _cond: unknown = 1;\n");
+                self.body.emit(&mut out, &mut ctr, 1);
+                out.push_str("  return <div>{(_cond as any) && <span />}</div>;\n");
+                out.push_str("}\n");
+            }
+        }
+        out
+    }
+
+    /// Independent oracle: the cyclomatic complexity the function
+    /// *holding `body`* should report. Used by invariant 3 as a check
+    /// the walker does NOT compute, so a miscounting walker is caught
+    /// even if its internal `1 + sum` arithmetic is self-consistent.
+    fn expected_body_holder_complexity(&self) -> u32 {
+        let extra = match self.container {
+            // ComputedObjectKey: the `&&` is in the object property's
+            // *key*, a sibling of the *value* IIFE arrow that holds the
+            // body — NOT inside the arrow. Per #200 item 1 the key's
+            // decision point charges the *enclosing function*, which
+            // here is module scope (the `const o = {…}` is top-level),
+            // so it charges nobody and the body-holding arrow's
+            // complexity is just `1 + body.increments()`. (Verified
+            // empirically against the walker: the key's `&&` lands on
+            // the enclosing function when one exists, never on the
+            // value arrow.)
+            Container::ComputedObjectKey => 0,
+            // JsxConditional: `return <div>{_cond && <span/>}</div>;`
+            // — the `&&` is inside `top`, the same function that holds
+            // the body, so it adds one. (Verified empirically.)
+            Container::JsxConditional => 1,
+            _ => 0,
+        };
+        1 + self.body.increments() + extra
+    }
+}
+
+// ── Invariant harness ───────────────────────────────────────────────────
+
+fn walk(src: &str, path: &str) -> Option<Vec<FunctionComplexity>> {
+    OxcWalker::new()
+        .extract(src, path, ComplexityMetric::Cyclomatic)
+        .ok()
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(400))]
+
+    /// Invariants 1, 2, 3 over every generated program. (4 and 5 and 6
+    /// have dedicated tests below for readable failure messages.)
+    #[test]
+    fn walker_core_invariants(prog in program_strategy()) {
+        let src = prog.source();
+        let path = prog.file_path();
+        // Parse failures are not invariant violations — a constrained
+        // grammar can still occasionally emit an edge the parser
+        // rejects under a given SourceType (e.g. a `.cjs` strict-mode
+        // interaction). The contract is "for every *parseable* input".
+        let Some(fns) = walk(&src, &path) else { return Ok(()); };
+
+        for f in &fns {
+            // Invariant 1: complexity >= 1 for every function entry.
+            prop_assert!(
+                f.complexity >= 1,
+                "complexity {} < 1 for {:?}\n--- source ---\n{src}",
+                f.complexity, f.identity.qualified_name
+            );
+
+            // Invariant 3 (walker-internal consistency): complexity
+            // equals 1 + sum of contributor increments.
+            let sum: u32 = f.contributors.iter().map(|c| c.increment).sum();
+            prop_assert_eq!(
+                f.complexity, 1 + sum,
+                "complexity {} != 1 + sum(increments) {} for {:?}\n--- source ---\n{}",
+                f.complexity, 1 + sum, f.identity.qualified_name, src
+            );
+
+            // Invariant 2: every contributor line is within its
+            // function's [start_line, end_line] span (no off-by-one,
+            // no cross-function drift).
+            let (lo, hi) = (f.identity.span.start_line, f.identity.span.end_line);
+            for c in &f.contributors {
+                prop_assert!(
+                    c.line >= lo && c.line <= hi,
+                    "contributor line {} outside fn {:?} span [{lo}, {hi}]\n--- source ---\n{src}",
+                    c.line, f.identity.qualified_name
+                );
+            }
+        }
+    }
+
+    /// Invariant 3 (independent oracle): the function that holds the
+    /// generated body reports exactly the complexity the GRAMMAR
+    /// predicts — a count the walker never computes. This is the
+    /// independent-axis check: a walker that miscounts decision points
+    /// (e.g. a mutant that drops a `+1`) fails here even though
+    /// `walker_core_invariants`' internal `1 + sum` check still holds.
+    #[test]
+    fn walker_matches_independent_oracle(prog in program_strategy()) {
+        let src = prog.source();
+        let path = prog.file_path();
+        let Some(fns) = walk(&src, &path) else { return Ok(()); };
+
+        // Identify the function holding the generated body. Its name
+        // depends on the container shape.
+        let holder_name: &str = match prog.container {
+            Container::FunctionDecl
+            | Container::Namespace
+            | Container::JsxConditional => "top",
+            Container::ArrowConst => "top",
+            Container::ClassMethod
+            | Container::ClassComputedKey => "C.m",
+            Container::StaticBlock => "C.<static-init>",
+            Container::ComputedObjectKey => "<arrow>",
+        };
+        let Some(holder) = fns
+            .iter()
+            .find(|f| f.identity.qualified_name == holder_name)
+        else {
+            // If the body is empty + container minted no holder (e.g.
+            // an empty static block still mints one, but be defensive)
+            // there is nothing to check.
+            return Ok(());
+        };
+
+        prop_assert_eq!(
+            holder.complexity,
+            prog.expected_body_holder_complexity(),
+            "holder {:?} complexity {} != grammar oracle {}\n--- source ---\n{}",
+            holder_name,
+            holder.complexity,
+            prog.expected_body_holder_complexity(),
+            src
+        );
+    }
+
+    /// Invariant 4: nested-function isolation. The number of discovered
+    /// functions equals 1 (the container's body holder) + the grammar's
+    /// nested-function count + any container-intrinsic extra sites
+    /// (e.g. the IIFE arrow a computed class/object key introduces).
+    /// A contributor never bleeds from a nested function into its
+    /// parent — verified transitively: if isolation broke, the holder's
+    /// independent-oracle complexity (previous test) would also break,
+    /// and the per-function count here would drift.
+    #[test]
+    fn walker_nested_function_isolation(prog in program_strategy()) {
+        let src = prog.source();
+        let path = prog.file_path();
+        let Some(fns) = walk(&src, &path) else { return Ok(()); };
+
+        let intrinsic_extra = match prog.container {
+            // ClassComputedKey's key is `[(() => "k")()]` — the key
+            // IIFE arrow is one extra discovered site beyond the `C.m`
+            // body holder.
+            Container::ClassComputedKey => 1,
+            // ComputedObjectKey's key is `[((_kx as any) && 1) as any]`
+            // — no function in the key; the body holder IS the value
+            // IIFE arrow, so there is NO extra site beyond it.
+            _ => 0,
+        };
+        let expected = 1 + prog.body.nested_fn_count() + intrinsic_extra;
+        prop_assert_eq!(
+            fns.len() as u32, expected,
+            "discovered {} functions, grammar predicts {}\n--- source ---\n{}",
+            fns.len(), expected, src
+        );
+    }
+
+    /// Invariant 5: determinism. The same source parsed twice yields a
+    /// byte-identical `Vec<FunctionComplexity>` (Debug-equal — the type
+    /// is not `PartialEq`, but its `Debug` is total and stable).
+    #[test]
+    fn walker_is_deterministic(prog in program_strategy()) {
+        let src = prog.source();
+        let path = prog.file_path();
+        let a = walk(&src, &path);
+        let b = walk(&src, &path);
+        prop_assert_eq!(
+            format!("{a:?}"),
+            format!("{b:?}"),
+            "non-deterministic walker output\n--- source ---\n{}", src
+        );
+    }
+}
+
+/// Invariant 6: unicode identifiers never panic span-to-line
+/// conversion. A focused (non-proptest) battery of multi-byte
+/// identifier shapes around every span boundary the walker computes
+/// (function span end, contributor span start/end). Regression-pins
+/// the W1.2 `byte_to_line_col` char-boundary fix; a property generator
+/// rarely lands a multi-byte byte exactly on a `span.end - 1` boundary,
+/// so this is asserted directly with adversarial inputs.
+#[test]
+fn unicode_identifiers_never_panic_span_conversion() {
+    let cases = [
+        "function \u{1f600}π(αβγ: number) { if (αβγ > 0) return αβγ; return 0; }\n",
+        "const \u{4e2d}\u{6587} = () => { for (const \u{e9}l of [1]) { void \u{e9}l; } };\n",
+        "class \u{5b50} { \u{65b9}\u{6cd5}() { return (1 as any) ?? 2; } }\n",
+        "namespace \u{547d}\u{540d} { export function \u{51fd}() { try { } catch (\u{e8}) {} } }\n",
+        "const o = { [(\u{3b1} as any) && 1]: 0 }; void o; const \u{3b1} = 1;\n",
+        "\u{1f4a9}",
+        "function f() {}\u{0}\u{1f680}",
+    ];
+    for (i, src) in cases.iter().enumerate() {
+        // Must not panic. Ok or Err(SourceParse) are both fine — the
+        // invariant is "no char-boundary panic", not "parses".
+        let _ = std::panic::catch_unwind(|| {
+            OxcWalker::new().extract(src, &format!("uni{i}.tsx"), ComplexityMetric::Cyclomatic)
+        })
+        .unwrap_or_else(|_| panic!("walker PANICKED on unicode case {i}: {src:?}"));
+    }
+}
+
+/// Sanity meta-test: the grammar actually emits the constructs it
+/// claims to (so a degenerate strategy can't make the invariants
+/// vacuously true). Generates a fixed corpus and tallies coverage.
+#[test]
+fn grammar_covers_every_decision_point_kind() {
+    use crap_core::domain::types::ContributorKind as K;
+    let mut seen: BTreeMap<String, u32> = BTreeMap::new();
+    let mut runner = proptest::test_runner::TestRunner::deterministic();
+    for _ in 0..600 {
+        let prog = program_strategy().new_tree(&mut runner).unwrap().current();
+        let Some(fns) = walk(&prog.source(), &prog.file_path()) else {
+            continue;
+        };
+        for f in &fns {
+            for c in &f.contributors {
+                *seen.entry(format!("{:?}", c.kind)).or_default() += 1;
+            }
+        }
+    }
+    for kind in [
+        K::IfBranch,
+        K::ForLoop,
+        K::WhileLoop,
+        K::DoWhileLoop,
+        K::CaseBranch,
+        K::LogicalOperator,
+        K::Ternary,
+        K::OptionalChain,
+        K::Catch,
+    ] {
+        let key = format!("{kind:?}");
+        assert!(
+            seen.get(&key).copied().unwrap_or(0) > 0,
+            "grammar never produced a {key} contributor across 600 programs; \
+             coverage seen: {seen:?}"
+        );
+    }
+}

--- a/crates/crap4ts/tests/walker_smoke.rs
+++ b/crates/crap4ts/tests/walker_smoke.rs
@@ -53,6 +53,15 @@ const EXAMPLE_CJS: &str = include_str!("fixtures/ts-fixtures/example.cjs");
 const CLASS_FIELD_ARROWS_TSX: &str = include_str!("fixtures/ts-fixtures/class-field-arrows.tsx");
 const STATIC_BLOCK_TS: &str = include_str!("fixtures/ts-fixtures/static-block.ts");
 
+// #200 + #205: walker traversal coverage-gap fixtures.
+const COMPUTED_OBJECT_KEY_TS: &str = include_str!("fixtures/ts-fixtures/computed-object-key.ts");
+const NAMESPACE_TS: &str = include_str!("fixtures/ts-fixtures/namespace.ts");
+const ASSIGNMENT_COMPUTED_LHS_TS: &str =
+    include_str!("fixtures/ts-fixtures/assignment-computed-lhs.ts");
+const UPDATE_COMPUTED_OPERAND_TS: &str =
+    include_str!("fixtures/ts-fixtures/update-computed-operand.ts");
+const COMPUTED_CLASS_KEY_TS: &str = include_str!("fixtures/ts-fixtures/computed-class-key.ts");
+
 fn extract(source: &str, file_path: &str) -> Vec<FunctionComplexity> {
     let walker = OxcWalker::new();
     walker
@@ -635,4 +644,153 @@ fn static_block_is_discovered_as_synthetic_static_init_function() {
         .filter(|c| c.kind == ContributorKind::IfBranch)
         .count();
     assert_eq!(ifs, 1, "expected one IfBranch in the static block body");
+}
+
+// ── #200 + #205 — Walker traversal coverage gaps ──────────────────────
+//
+// Each fixture isolates one previously-uncovered traversal path so the
+// assertions stay surgical: exact CC, exact ContributorKind, exact
+// line, exact function set (no leakage, no double-count). Mirrors the
+// W2.1 smoke-test rigor above.
+
+#[test]
+fn computed_object_key_decision_point_charges_enclosing_function() {
+    // #200 item 1: `{ [a && b]: 1, ...rest }` — the `&&` in the
+    // computed key is a LogicalOperator that must charge `build`.
+    // The spread property must NOT mint any contributor.
+    let fns = extract(COMPUTED_OBJECT_KEY_TS, "computed-object-key.ts");
+    assert_eq!(fns.len(), 1, "expected exactly one function (build)");
+    let f = find_fn(&fns, "build");
+    assert_eq!(
+        f.complexity, 2,
+        "the && inside the computed key adds exactly one decision point"
+    );
+    assert_eq!(f.contributors.len(), 1, "spread must not add a contributor");
+    let c = &f.contributors[0];
+    assert_eq!(c.kind, ContributorKind::LogicalOperator);
+    assert_eq!(c.increment, 1);
+    // `[a && b]: 1` is on line 7 of the fixture (1-based).
+    assert_eq!(c.line, 7, "contributor points at the computed-key line");
+}
+
+#[test]
+fn namespace_nested_function_is_discovered_as_separate_site() {
+    // #200 item 2: `namespace Foo { export function bar() { if … } }`
+    // — `bar` is its own FunctionComplexity; its `if` charges `bar`,
+    // not module scope. The trailing declaration-only
+    // `declare module "side-effect-only";` (body: None) must be a
+    // clean no-op (no panic, no extra function).
+    let fns = extract(NAMESPACE_TS, "namespace.ts");
+    let names: Vec<_> = fns
+        .iter()
+        .map(|f| f.identity.qualified_name.clone())
+        .collect();
+    assert_eq!(
+        fns.len(),
+        1,
+        "expected exactly one function (Foo.bar); got names: {names:?}"
+    );
+    let bar = find_fn(&fns, "bar");
+    assert_eq!(bar.complexity, 2, "bar's `if` adds one decision point");
+    assert_eq!(bar.contributors.len(), 1);
+    assert_eq!(bar.contributors[0].kind, ContributorKind::IfBranch);
+    // The `if` is on line 6 of the fixture (1-based).
+    assert_eq!(bar.contributors[0].line, 6);
+}
+
+#[test]
+fn assignment_computed_lhs_iife_is_discovered() {
+    // #200 item 3: `target[(() => { if … })()] = 1` — the IIFE arrow
+    // in the index expression is its own FunctionComplexity (CC 2 from
+    // its own `if`); `assign` itself stays CC 1 (the `if` must not
+    // bleed into the enclosing function).
+    let fns = extract(ASSIGNMENT_COMPUTED_LHS_TS, "assignment-computed-lhs.ts");
+    let names: Vec<_> = fns
+        .iter()
+        .map(|f| f.identity.qualified_name.clone())
+        .collect();
+    assert_eq!(
+        fns.len(),
+        2,
+        "expected assign + the IIFE arrow; got names: {names:?}"
+    );
+    let assign = find_fn(&fns, "assign");
+    assert_eq!(
+        assign.complexity, 1,
+        "the nested IIFE's `if` must NOT bleed into assign"
+    );
+    assert!(
+        assign.contributors.is_empty(),
+        "assign has no decision points of its own; got {:?}",
+        assign.contributors
+    );
+    let arrow = find_fn(&fns, "<arrow>");
+    assert_eq!(
+        arrow.complexity, 2,
+        "the IIFE arrow's own `if` adds one decision point"
+    );
+    assert_eq!(arrow.contributors.len(), 1);
+    assert_eq!(arrow.contributors[0].kind, ContributorKind::IfBranch);
+}
+
+#[test]
+fn update_expression_computed_operand_iife_is_discovered() {
+    // #200 item 4: `counters[(() => { if … })()]++` — the IIFE arrow
+    // in the operand's index expression is its own FunctionComplexity;
+    // `bump` stays CC 1.
+    let fns = extract(UPDATE_COMPUTED_OPERAND_TS, "update-computed-operand.ts");
+    let names: Vec<_> = fns
+        .iter()
+        .map(|f| f.identity.qualified_name.clone())
+        .collect();
+    assert_eq!(
+        fns.len(),
+        2,
+        "expected bump + the IIFE arrow; got names: {names:?}"
+    );
+    let bump = find_fn(&fns, "bump");
+    assert_eq!(
+        bump.complexity, 1,
+        "the nested IIFE's `if` must NOT bleed into bump"
+    );
+    assert!(bump.contributors.is_empty());
+    let arrow = find_fn(&fns, "<arrow>");
+    assert_eq!(arrow.complexity, 2, "the IIFE arrow's own `if`");
+    assert_eq!(arrow.contributors.len(), 1);
+    assert_eq!(arrow.contributors[0].kind, ContributorKind::IfBranch);
+}
+
+#[test]
+fn computed_class_key_iife_is_discovered() {
+    // #205 (class side): `class Widget { [(() => "x")()]: number = 0 }`
+    // — the IIFE arrow in the computed class-property key is its own
+    // FunctionComplexity (CC 1, no decision points), separate from the
+    // class's regular method `Widget.regular` (CC 2 from its `if`).
+    let fns = extract(COMPUTED_CLASS_KEY_TS, "computed-class-key.ts");
+    let names: Vec<_> = fns
+        .iter()
+        .map(|f| f.identity.qualified_name.clone())
+        .collect();
+    assert_eq!(
+        fns.len(),
+        2,
+        "expected Widget.regular + the computed-key IIFE arrow; got names: {names:?}"
+    );
+    let arrow = find_fn(&fns, "<arrow>");
+    assert_eq!(
+        arrow.complexity, 1,
+        "the computed-key IIFE arrow has no decision points"
+    );
+    assert!(
+        arrow.contributors.is_empty(),
+        "arrow has no contributors; got {:?}",
+        arrow.contributors
+    );
+    let regular = find_fn(&fns, "Widget.regular");
+    assert_eq!(
+        regular.complexity, 2,
+        "Widget.regular's `if` adds one decision point"
+    );
+    assert_eq!(regular.contributors.len(), 1);
+    assert_eq!(regular.contributors[0].kind, ContributorKind::IfBranch);
 }

--- a/crates/crap4ts/tests/walker_smoke.rs
+++ b/crates/crap4ts/tests/walker_smoke.rs
@@ -61,6 +61,11 @@ const ASSIGNMENT_COMPUTED_LHS_TS: &str =
 const UPDATE_COMPUTED_OPERAND_TS: &str =
     include_str!("fixtures/ts-fixtures/update-computed-operand.ts");
 const COMPUTED_CLASS_KEY_TS: &str = include_str!("fixtures/ts-fixtures/computed-class-key.ts");
+// gemini PR #220 review: static-member object recursion (assignment + update).
+const ASSIGNMENT_STATIC_MEMBER_OBJECT_TS: &str =
+    include_str!("fixtures/ts-fixtures/assignment-static-member-object.ts");
+const UPDATE_STATIC_MEMBER_OBJECT_TS: &str =
+    include_str!("fixtures/ts-fixtures/update-static-member-object.ts");
 
 fn extract(source: &str, file_path: &str) -> Vec<FunctionComplexity> {
     let walker = OxcWalker::new();
@@ -685,10 +690,16 @@ fn namespace_nested_function_is_discovered_as_separate_site() {
         .iter()
         .map(|f| f.identity.qualified_name.clone())
         .collect();
+    // The walker records the BARE local name `bar` here, not a
+    // namespace-qualified `Foo.bar` (contrast class methods, which
+    // qualify as `C.m`). #200 item 2's AC only requires `bar` be
+    // discovered as a separate FunctionComplexity, which it is.
+    // Namespace-qualified naming is a tracked enhancement:
+    // tracked: crap-rs#221 — namespace-qualified function names
     assert_eq!(
         fns.len(),
         1,
-        "expected exactly one function (Foo.bar); got names: {names:?}"
+        "expected exactly one function (local name `bar`); got names: {names:?}"
     );
     let bar = find_fn(&fns, "bar");
     assert_eq!(bar.complexity, 2, "bar's `if` adds one decision point");
@@ -752,6 +763,70 @@ fn update_expression_computed_operand_iife_is_discovered() {
     assert_eq!(
         bump.complexity, 1,
         "the nested IIFE's `if` must NOT bleed into bump"
+    );
+    assert!(bump.contributors.is_empty());
+    let arrow = find_fn(&fns, "<arrow>");
+    assert_eq!(arrow.complexity, 2, "the IIFE arrow's own `if`");
+    assert_eq!(arrow.contributors.len(), 1);
+    assert_eq!(arrow.contributors[0].kind, ContributorKind::IfBranch);
+}
+
+#[test]
+fn assignment_static_member_object_iife_is_discovered() {
+    // gemini PR #220 review: `(() => { if … })().prop = 1` — the IIFE
+    // arrow is the *object* of a STATIC-member assignment LHS. It must
+    // be discovered as its own FunctionComplexity (CC 2 from its own
+    // `if`); `assignStatic` stays CC 1 (the arrow's `if` must not
+    // bleed). Pre-fix this whole LHS was dropped (only the computed
+    // case recursed).
+    let fns = extract(
+        ASSIGNMENT_STATIC_MEMBER_OBJECT_TS,
+        "assignment-static-member-object.ts",
+    );
+    let names: Vec<_> = fns
+        .iter()
+        .map(|f| f.identity.qualified_name.clone())
+        .collect();
+    assert_eq!(
+        fns.len(),
+        2,
+        "expected assignStatic + the IIFE arrow; got names: {names:?}"
+    );
+    let assign = find_fn(&fns, "assignStatic");
+    assert_eq!(
+        assign.complexity, 1,
+        "the static-member-object IIFE's `if` must NOT bleed into assignStatic"
+    );
+    assert!(assign.contributors.is_empty());
+    let arrow = find_fn(&fns, "<arrow>");
+    assert_eq!(arrow.complexity, 2, "the IIFE arrow's own `if`");
+    assert_eq!(arrow.contributors.len(), 1);
+    assert_eq!(arrow.contributors[0].kind, ContributorKind::IfBranch);
+}
+
+#[test]
+fn update_static_member_object_iife_is_discovered() {
+    // gemini PR #220 review: `(() => { if … })().prop++` — the IIFE
+    // arrow is the *object* of a STATIC-member UpdateExpression
+    // operand. Same contract as the assignment case: arrow is its own
+    // CC-2 site; `bumpStatic` stays CC 1.
+    let fns = extract(
+        UPDATE_STATIC_MEMBER_OBJECT_TS,
+        "update-static-member-object.ts",
+    );
+    let names: Vec<_> = fns
+        .iter()
+        .map(|f| f.identity.qualified_name.clone())
+        .collect();
+    assert_eq!(
+        fns.len(),
+        2,
+        "expected bumpStatic + the IIFE arrow; got names: {names:?}"
+    );
+    let bump = find_fn(&fns, "bumpStatic");
+    assert_eq!(
+        bump.complexity, 1,
+        "the static-member-object IIFE's `if` must NOT bleed into bumpStatic"
     );
     assert!(bump.contributors.is_empty());
     let arrow = find_fn(&fns, "<arrow>");


### PR DESCRIPTION
## Summary

Interstitial walker-correctness + walker-quality-gate bundle (Cluster W
of the `crap-rs/20260513-typescript-adapter` pipeline, epic #173) — one
PR closing four issues against the oxc walker
(`crates/crap4ts/src/adapters/walker/mod.rs`) and its test/CI surface.
The cluster is **self-verifying**: #207's proptest + #209's mutation
surface are the independent-axis verification for #200/#205's traversal
code.

Closes #200
Closes #205
Closes #207
Closes #209

## What shipped per issue

**#200 — walker traversal coverage gaps (4 arms).**
1. Computed object property keys (`{ [a && b]: 1 }`) — `visit_object_expression` recurses `ObjectProperty.key` when `p.computed`, via the `inherit_variants!`-generated `PropertyKey::as_expression` downcast.
2. `TSModuleDeclaration` (TS namespaces) — new `visit_statement` arm + `visit_ts_module_declaration` helper walking `TSModuleBlock.body` and recursing nested `TSModuleDeclaration` (dotted `namespace A.B`). `body: None` (`declare module "x";`) is a clean no-op.
3. `AssignmentExpression` computed-member LHS (`x[foo()] = 1`) — the pre-#200 arm discarded `a.left` entirely; now recurses `AssignmentTarget::ComputedMemberExpression` object + index before the RHS.
4. `UpdateExpression` computed-member operand (`x[foo()]++`) — new `visit_expression` arm; the whole `UpdateExpression` was previously dropped at the `_ => {}` fallthrough; matches `SimpleAssignmentTarget::ComputedMemberExpression`.

Out-of-scope items left untouched as specified: no `WithStatement` arm, no `byte_to_line` perf rework, no CJS `module.exports` LHS-name fix.

**#205 — recurse into computed class/object property keys.** Disposition (a) recurse, chosen for consistency with #200 item 1 (object side). `visit_property_definition` recurses a computed `PropertyDefinition.key` through a throwaway sink (the class element is its own root), placed BEFORE the early value-None return so `class Foo { [k()]; }` is still walked.

**#207 — walker proptest suite.** `crates/crap4ts/tests/walker_proptest.rs`: a constrained AST grammar generating valid TS source across every walker construct (simple/nested functions, class methods + computed-key fields + static blocks, namespaces, all 11 decision-point kinds, JSX conditionals, 12 expression-wrapper contexts) over all six file extensions, asserting **7 invariants** (the 6 from #207 AC + a 7th `contributor.nesting`-depth oracle added to mechanically kill the `nesting.map(|n| n + 1)` arithmetic mutant class #209 surfaced). The grammar carries its own independent oracle (`expected_body_holder_complexity`, `expected_nestings`, `nested_fn_count`) so invariants 3/4/7 are checked against a count the walker never computes — a miscounting walker is caught even when its internal `1 + sum` arithmetic is self-consistent. `proptest` added to crap4ts's existing `[dev-dependencies]`.

**#209 — mutation surface + AGENTS.md.** `.github/workflows/ci.yml` `mutants:` job extended with a parallel walker step; AGENTS.md "Mutation testing" section rewritten for the dual-file surface.

## Self-verifying rationale (the #218-mask this avoids)

#218 shipped a walker code path that "looked right" and passed every hand-picked fixture its author chose, but was wrong on inputs nobody hand-wrote — because nothing exercised it on *generated* inputs. This cluster bundles the fix (#200/#205) WITH its independent-axis verification (#207 proptest over a generated grammar that specifically emits computed keys + namespaces; #209 mutation testing that proves the test suite actually kills the relevant mutants). "My code looks right" is explicitly not the verification — the proptest invariants over generated inputs and the mutant-kill evidence are.

## Verified oxc 0.129 AST API

Primary-source-verified against the vendored `oxc_ast-0.129.0` crate (Context7 only had high-level docs). Confirmed names:

| Construct | Verified 0.129 API |
|---|---|
| computed object key | `ObjectProperty.computed: bool`, `ObjectProperty.key: PropertyKey`, `PropertyKey::as_expression()` (via `inherit_variants! { @inherit Expression }`) |
| computed class key | `PropertyDefinition.computed: bool`, `PropertyDefinition.key: PropertyKey` |
| TS namespace | `Statement::TSModuleDeclaration(Box<TSModuleDeclaration>)`; `TSModuleDeclaration.body: Option<TSModuleDeclarationBody>`; `TSModuleDeclarationBody::{TSModuleBlock(Box<TSModuleBlock>), TSModuleDeclaration(Box<…>)}`; `TSModuleBlock.body: Vec<Statement>` |
| assignment LHS | `AssignmentExpression.left: AssignmentTarget`; `AssignmentTarget::ComputedMemberExpression(Box<ComputedMemberExpression>)` (flattened in via `inherit_variants!` from `MemberExpression`; confirmed valid by oxc's own generated `derive_clone_in.rs`); `ComputedMemberExpression.{object, expression}` |
| update operand | `UpdateExpression.argument: SimpleAssignmentTarget`; `SimpleAssignmentTarget::ComputedMemberExpression(...)` (same `inherit_variants!` flatten) |
| optional chain | `Expression::ChainExpression(Box<ChainExpression>)` (unchanged, pre-existing) |

Historical-rename note: `AssignmentTarget`'s computed-member variant is NOT a dedicated `AssignmentTarget::Computed*` — it is the `MemberExpression::ComputedMemberExpression` variant flattened in by the `inherit_variants!` macro. The pattern `AssignmentTarget::ComputedMemberExpression(m)` is valid and verified.

## Surviving-mutant disposition

`cargo mutants --package crap4ts --file crates/crap4ts/src/adapters/walker/mod.rs` enumerates **157 mutants**. The crap-rs#207 proptest suite (with the ExprWrap grammar + the 7th nesting-depth invariant) kills the two large survivor classes that a pre-#207 run leaves:

- **Nesting-arithmetic class** (`replace + with *` / `delete nesting bump` in `visit_for`/`visit_for_in`/`visit_for_of`/`visit_while`/`visit_do_while`/`visit_if`/`visit_switch_case`) → **killed** by `walker_nesting_depth_matches_oracle` (invariant 7), which checks every `contributor.nesting_depth` against an independent grammar oracle the walker never computes.
- **Expression-recursion-arm class** (`delete match arm Expression::{Await,Array,Sequence,Unary,TSAs,TSSatisfies,TSNonNull,Template,TaggedTemplate,ComputedMember,Conditional,Import,...}`) → **killed** by the `Stmt::ExprWrap` grammar variant (12 `WrapKind` contexts) — each routes a discoverable IIFE through a distinct arm, so deleting the arm drops it from the discovered-function set and `walker_nested_function_isolation` catches it (empirically verified per-arm via direct test).

Targeted verification run (30 high-survivor-density mutants, `-j 4`): **26 CAUGHT, 4 MISSED, 0 timeout, 0 unviable**.

The **4 residual survivors** are a single root cause — the proptest grammar doesn't economically generate the construct that makes the arm load-bearing — and the walker is **verified correct** in every case (it discovers the nested function). They are excluded-with-tracking, not filed as `type:bug`, per `~/.claude/rules/exclusions.md`:

| Surviving mutant | Walker correct? | Disposition |
|---|---|---|
| `walker/mod.rs:221` `replace visit_export_default with ()` | ✅ `export default (()=>{fn})()` discovers the fn | `.cargo/mutants.toml` `exclude_re` → `tracked: crap-rs#219` |
| `walker/mod.rs:446` `delete arm Statement::ClassDeclaration in visit_statement` | ✅ `function o(){ class C{m(){}} }` discovers `C.m` | `exclude_re` → `tracked: crap-rs#219` |
| `walker/mod.rs:471` `delete arm Statement::LabeledStatement in visit_statement` | ✅ `lbl: { function inner(){} }` discovers `inner` | `exclude_re` → `tracked: crap-rs#219` |
| `walker/mod.rs:472` `delete arm Statement::ThrowStatement in visit_statement` | ✅ `throw (()=>{fn})()` discovers the fn | `exclude_re` → `tracked: crap-rs#219` |

**Coverage-boundary honesty:** the targeted run covered the structural-arm + nesting-arithmetic survivor classes (the two large ones). The `byte_to_line_col` **column**-arithmetic mutants (`== with !=`, `+ with -`/`*`, `- with +` on the column computation, ~5 mutants) were **not specifically verified** and may survive — no proptest invariant asserts column correctness (invariant 2 checks `contributor.line ∈ [start,end]`; nothing checks `column`). This is not papered over: #219's scope is widened to also add a column-correctness invariant, and the CI mutation gate still runs the full surface every PR — whatever it surfaces is captured by the `exclude_re`/`tracked:` discipline already in place.

**Filed sub-issue: #219** (`type:chore`, `priority:soon`, sub-issue of epic #173) — extend the proptest grammar to cover the 4 structural positions AND add a `byte_to_line_col` column-correctness invariant, then delete the `exclude_re` lines. Opened BEFORE the exclusions landed; restoration condition documented in the issue and inline in `.cargo/mutants.toml`. After exclusions: `cargo mutants --list` shows 153 mutants (157 − 4), the 4 above absent. **Zero surviving mutants are unaccounted-for; zero are walker correctness bugs.**

## Wire-snapshot drift

**No drift.** Both `wire_envelope_crap4rs` and `wire_envelope_crap4ts` snapshot tests pass byte-identical after Commit 1 (verified before Commit 2). As predicted: the W1.1 wire fixtures (`simple.ts`/`arrow.ts`/`Button.tsx`/`map.ts`/`mixed.ts`) use no computed keys/namespaces/computed-member LHS, so the new traversal arms discover no additional functions there. No `cargo insta accept` was run.

## Plan-of-record deviations

1. **`[dev-dependencies]` already existed** in `crates/crap4ts/Cargo.toml` — the brief said no section existed and to create one. `proptest` appended to the existing section.
2. **AGENTS.md location** — the brief referenced `crates/crap4rs/AGENTS.md`; the "Mutation testing" section actually lives in the repo-root `AGENTS.md` (imported by CLAUDE.md via `@AGENTS.md`). Edited there.
3. **Wire-snapshot test filter** — the brief's `cargo nextest run -E 'test(wire_envelope)'` matches nothing; the test name is `envelope` in binaries `wire_envelope_crap4rs`/`wire_envelope_crap4ts`. Used `-E 'binary(wire_envelope_crap4rs) + binary(wire_envelope_crap4ts)'`.
4. **A 7th proptest invariant** beyond #207's six — `walker_nesting_depth_matches_oracle` — was added because #209's mutation run surfaced that the `nesting.map(|n| n + 1)` arithmetic mutant class had zero test coverage. This is the self-verifying cluster working as designed (#209 drove a #207 strengthening); folded into the #209 commit.
5. **CI walker mutants step uses `-j 4` copy mode, not `--in-place`** (asymmetric vs the view.rs step). 157 walker mutants × single-worker `--in-place` ≈ 1 h wall-clock — the #209 ≤8-min AC is **not meetable** by single-worker in-place on a file this size. `-j 4` copy mode (supported by the existing `.cargo/mutants.toml` `copy_target = true`) is the mitigation; the ≤8-min budget remains an honest open concern documented in AGENTS.md, not silently met.

## Test plan

- [ ] `cargo build --workspace` green
- [ ] `cargo nextest run --workspace --all-targets` green (1043 tests)
- [ ] `cargo +1.93 check --workspace --all-targets` green (MSRV)
- [ ] `cargo fmt --check && cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] `cargo doc --workspace --no-deps` (`-D warnings`) clean
- [ ] `cargo deny check` clean
- [ ] AST-purity grep clean on `crates/crap-core/src/`
- [ ] Both wire snapshots byte-identical (no drift)
- [ ] Reviewer reads proptest invariants for correctness + surviving-mutant disposition for legitimacy (independent-axis review, not a gate re-run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced TypeScript analysis to support computed property keys, namespace declarations, and computed member expressions in assignments and updates.

* **Tests**
  * Added comprehensive test fixtures and property-based test suite to validate walker behavior across additional TypeScript constructs.

* **Chores**
  * Updated CI pipeline and documentation to include expanded mutation testing coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/breezy-bays-labs/crap-rs/pull/220?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->