### PR TITLE
fix(crap-core): #218 — metric-keyed threshold calibration (cyclomatic 8/16/30, cognitive 15/25/40)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,16 +1,28 @@
 # cargo-mutants config — see https://mutants.rs/
 
-# Skip the wire-envelope canary test under mutants.
+# Skip crap-core integration tests that exec the adapter binaries.
 #
-# `crates/crap-core/tests/wire_envelope_snapshot.rs` exec's the `crap4rs`
-# binary via `assert_cmd::Command::cargo_bin("crap4rs")` to lock the JSON
-# envelope shape across the migration. Under `cargo mutants --package
-# crap-core` the bin is not built (only crap-core's targets are), so the
-# test panics before any mutant runs. The canary still gates every PR via
-# the `Test (linux-x86)` / `Test (macos-arm)` / `Test (macos-x86)` jobs,
-# which run `cargo nextest run --workspace --all-targets` and DO build the
-# crap4rs bin first. Excluding it here is scoped to mutants only.
-additional_cargo_test_args = ["--", "--skip", "envelope"]
+# Two crap-core integration suites shell out to the `crap4rs` / `crap4ts`
+# binaries via `assert_cmd::Command::cargo_bin(...)`:
+#
+#   * `wire_envelope_crap4rs.rs` / `wire_envelope_crap4ts.rs` (test fn
+#     `envelope`) — lock the JSON envelope shape across the migration.
+#   * `default_gate_threshold.rs` (test fns prefixed `default_gate_`) —
+#     assert the no-explicit-`--threshold` gate resolves to the
+#     metric-calibrated cutoff, the path the explicit-flag wire snapshots
+#     structurally cannot exercise.
+#
+# Under `cargo mutants --package crap-core` only crap-core's own targets
+# build — the `crap4rs` / `crap4ts` bins are not, so `CARGO_BIN_EXE_*` is
+# unset and these tests panic before any mutant runs. Both suites still
+# gate every PR via the `Test (linux-x86)` / `Test (macos-arm)` /
+# `Test (macos-x86)` jobs, which run `cargo nextest run --workspace
+# --all-targets` and DO build the bins first. Neither suite exercises
+# `view.rs` (the mutated file), so skipping them here loses zero
+# mutant-killing power. Both `--skip` filters are libtest substring
+# matches on the test-fn name; `default_gate` is collision-free
+# workspace-wide. Scoped to mutants only.
+additional_cargo_test_args = ["--", "--skip", "envelope", "--skip", "default_gate"]
 
 # Warm each parallel worker's scratch tree with our /target dir.
 #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unchanged. The generated `crap4rs.toml` / `crap4ts.toml` threshold
   comment now states which metric the printed cutoffs apply to. (#218)
 
+### Changed
+
+- Config-file `threshold = N` now takes precedence over
+  `preset = "..."` when both are set in the same `crap4rs.toml` /
+  `crap4ts.toml`. This makes config-file resolution consistent with
+  CLI semantics, where an explicit `--threshold N` already overrides
+  `--strict` / `--lenient`. Users who had both fields set will now get
+  the literal value; previously the preset silently won. The
+  `init`-generated config never writes both, so the blast radius is
+  limited to hand-edited configs. (#218)
+
 ### Changed (crap-core public API)
 
 - `AdapterMeta` gains a `default_excludes: &'static [&'static str]`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   emitted) and `--quiet` (quiet wins — no output). Closes the
   2026-05-08 crap4rs ↔ crap4ts parity audit's final gap. (#131)
 
+### Fixed
+
+- Threshold cutoffs are now calibrated per complexity metric instead
+  of a single shared scalar. A cyclomatic count and a cognitive count
+  have different magnitudes for the same function, so one cutoff
+  cannot fit both — applying the cognitive cutoff to cyclomatic scores
+  silently mis-gated. The strict/default/lenient presets now resolve
+  to cyclomatic `8/16/30` or cognitive `15/25/40` based on the
+  effective metric. User-visible behavior changes: `crap4ts` with no
+  threshold flag now gates at `16` (was `25`), `--strict` at `8` (was
+  `15`), `--lenient` at `30` (was `40`); `crap4rs --metric cyclomatic`
+  with no flag now gates at `16` (was `25`) and `--strict` at `8`
+  (was `15`). `crap4rs`'s cognitive defaults (the common path) are
+  unchanged. The generated `crap4rs.toml` / `crap4ts.toml` threshold
+  comment now states which metric the printed cutoffs apply to. (#218)
+
 ### Changed (crap-core public API)
 
 - `AdapterMeta` gains a `default_excludes: &'static [&'static str]`
@@ -35,6 +51,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   per-field literal-init to keep zero-cost). Affects only adapter
   binary crates; library consumers of `crap-core` do not construct
   `AdapterMeta` directly. (#73)
+- `ThresholdPreset::threshold` now takes a `ComplexityMetric`
+  argument and returns the metric-calibrated cutoff
+  (`fn threshold(self, metric: ComplexityMetric) -> f64`). Callers
+  resolving a preset to a numeric cutoff must pass the effective
+  metric. crap-core minor-bumped `0.2.0` → `0.3.0`; no external
+  consumers. (#218)
 
 ## [0.5.0] - 2026-05-10
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,7 +356,7 @@ checksum = "417bef24afe1460300965a25ff4a24b8b45ad011948302ec221e8a0a81eb2c79"
 
 [[package]]
 name = "crap-core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ authors = ["Christopher Bays <cmbays@breezybayslabs.com>"]
 # Rust adapter. Future siblings (`crap4ts`) inherit the same pins.
 [workspace.dependencies]
 # ── In-workspace crates ──
-crap-core = { path = "crates/crap-core", version = "0.2.0" }
+crap-core = { path = "crates/crap-core", version = "0.3.0" }
 
 # ── CLI (crap4rs only today) ──
 clap = { version = "4", features = ["derive", "string"] }

--- a/crates/crap-core/Cargo.toml
+++ b/crates/crap-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crap-core"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/crap-core/src/cli/init.rs
+++ b/crates/crap-core/src/cli/init.rs
@@ -29,6 +29,7 @@ use anyhow::{Context, Result, bail};
 
 use crate::cli::AdapterMeta;
 use crate::domain::threshold::ThresholdPreset;
+use crate::domain::types::ComplexityMetric;
 
 /// Handle the `init` subcommand. Writes a starter config to
 /// `meta.config_file_name` in the current directory.
@@ -158,12 +159,32 @@ pub(crate) fn render_config(
     out.push_str("# Edit freely; the analyzer re-reads this file on every run.\n\n");
 
     // Threshold preset — `preset` and `threshold` are mutually
-    // exclusive in `FileConfig`; we emit `preset` so the canonical
-    // values (15/25/40) stay in one place.
-    out.push_str("# Threshold preset:\n");
-    out.push_str("#   strict (15)  — high-quality libraries, safety-critical code\n");
-    out.push_str("#   default (25) — typical Rust projects (balanced)\n");
-    out.push_str("#   lenient (40) — legacy or transitional code\n");
+    // exclusive in `FileConfig`; we emit `preset` (the configurable
+    // unit) and let resolution map it to a number. The cutoffs differ
+    // by complexity metric (a cyclomatic count and a cognitive count
+    // for the same function differ in magnitude), so the numbers shown
+    // are this adapter's metric, sourced from the one calibration
+    // table — never re-hardcoded here.
+    let metric = meta.default_metric;
+    let strict = ThresholdPreset::Strict.threshold(metric);
+    let default = ThresholdPreset::Default.threshold(metric);
+    let lenient = ThresholdPreset::Lenient.threshold(metric);
+    let metric_name = match metric {
+        ComplexityMetric::Cyclomatic => "cyclomatic",
+        ComplexityMetric::Cognitive => "cognitive",
+    };
+    out.push_str("# Threshold preset (cutoffs are for the ");
+    out.push_str(metric_name);
+    out.push_str(" metric):\n");
+    out.push_str(&format!(
+        "#   strict ({strict})  — high-quality libraries, safety-critical code\n"
+    ));
+    out.push_str(&format!(
+        "#   default ({default}) — typical projects (balanced)\n"
+    ));
+    out.push_str(&format!(
+        "#   lenient ({lenient}) — legacy or transitional code\n"
+    ));
     out.push_str("# Use `threshold = N` instead to set a custom numeric cutoff.\n");
     out.push_str("preset = \"");
     out.push_str(preset_str(preset));

--- a/crates/crap-core/src/cli/init.rs
+++ b/crates/crap-core/src/cli/init.rs
@@ -68,7 +68,7 @@ pub(crate) fn handle_init_with_io<R: BufRead, W: Write>(
     let preset = if non_interactive {
         ThresholdPreset::Default
     } else {
-        prompt_threshold_preset(stdin, stderr)?
+        prompt_threshold_preset(meta.default_metric, stdin, stderr)?
     };
 
     let detection = detect_src_layout();
@@ -165,14 +165,7 @@ pub(crate) fn render_config(
     // for the same function differ in magnitude), so the numbers shown
     // are this adapter's metric, sourced from the one calibration
     // table — never re-hardcoded here.
-    let metric = meta.default_metric;
-    let strict = ThresholdPreset::Strict.threshold(metric);
-    let default = ThresholdPreset::Default.threshold(metric);
-    let lenient = ThresholdPreset::Lenient.threshold(metric);
-    let metric_name = match metric {
-        ComplexityMetric::Cyclomatic => "cyclomatic",
-        ComplexityMetric::Cognitive => "cognitive",
-    };
+    let (strict, default, lenient, metric_name) = preset_display(meta.default_metric);
     out.push_str("# Threshold preset (cutoffs are for the ");
     out.push_str(metric_name);
     out.push_str(" metric):\n");
@@ -215,16 +208,39 @@ pub(crate) fn render_config(
     out
 }
 
+/// The three preset cutoffs plus the metric's display name, derived
+/// from the one calibration table. Both the generated-config comment
+/// and the interactive prompt render these, so neither re-hardcodes
+/// the numbers — a calibration change can never desync the two
+/// user-facing surfaces, and a cutoff calibrated for one metric is
+/// never shown for the other (whose scores have a different magnitude).
+fn preset_display(metric: ComplexityMetric) -> (f64, f64, f64, &'static str) {
+    (
+        ThresholdPreset::Strict.threshold(metric),
+        ThresholdPreset::Default.threshold(metric),
+        ThresholdPreset::Lenient.threshold(metric),
+        match metric {
+            ComplexityMetric::Cyclomatic => "cyclomatic",
+            ComplexityMetric::Cognitive => "cognitive",
+        },
+    )
+}
+
 /// Read one line from stdin and map the first character to a
 /// `ThresholdPreset`. Empty/whitespace/anything-else → `Default`.
 /// EOF (closed stdin) is treated as empty input — Returns `Default`.
+/// The displayed cutoffs are calibrated for `metric` (the adapter's
+/// default complexity metric), so the interactive numbers match what
+/// the generated config will resolve to.
 fn prompt_threshold_preset<R: BufRead, W: Write>(
+    metric: ComplexityMetric,
     stdin: &mut R,
     stderr: &mut W,
 ) -> Result<ThresholdPreset> {
+    let (strict, default, lenient, metric_name) = preset_display(metric);
     write!(
         stderr,
-        "Threshold preset?\n  (s)trict  = 15  high-quality libs\n  (d)efault = 25  typical projects\n  (l)enient = 40  legacy code\n[d]: "
+        "Threshold preset ({metric_name} metric)?\n  (s)trict  = {strict}  high-quality libs\n  (d)efault = {default}  typical projects\n  (l)enient = {lenient}  legacy code\n[d]: "
     )
     .ok();
     stderr.flush().ok();
@@ -375,7 +391,8 @@ mod tests {
     fn prompt_reads_strict_from_piped_stdin() {
         let mut stdin = Cursor::new(b"s\n");
         let mut stderr: Vec<u8> = Vec::new();
-        let preset = prompt_threshold_preset(&mut stdin, &mut stderr).unwrap();
+        let preset =
+            prompt_threshold_preset(ComplexityMetric::Cognitive, &mut stdin, &mut stderr).unwrap();
         assert_eq!(preset, ThresholdPreset::Strict);
     }
 
@@ -383,8 +400,26 @@ mod tests {
     fn prompt_defaults_when_stdin_is_empty() {
         let mut stdin = Cursor::new(b"");
         let mut stderr: Vec<u8> = Vec::new();
-        let preset = prompt_threshold_preset(&mut stdin, &mut stderr).unwrap();
+        let preset =
+            prompt_threshold_preset(ComplexityMetric::Cognitive, &mut stdin, &mut stderr).unwrap();
         assert_eq!(preset, ThresholdPreset::Default);
+    }
+
+    #[test]
+    fn prompt_numbers_track_the_metric() {
+        // The interactive prompt must show the cutoffs calibrated for
+        // the adapter's metric — a cyclomatic adapter shows 8/16/30,
+        // never the cognitive 15/25/40. This is the same defect class
+        // as the generated-config comment: metric-blind numbers shown
+        // to the user.
+        let mut stdin = Cursor::new(b"\n");
+        let mut stderr: Vec<u8> = Vec::new();
+        prompt_threshold_preset(ComplexityMetric::Cyclomatic, &mut stdin, &mut stderr).unwrap();
+        let shown = String::from_utf8(stderr).unwrap();
+        assert!(shown.contains("cyclomatic metric"), "prompt: {shown}");
+        assert!(shown.contains("(s)trict  = 8"), "prompt: {shown}");
+        assert!(shown.contains("(d)efault = 16"), "prompt: {shown}");
+        assert!(shown.contains("(l)enient = 30"), "prompt: {shown}");
     }
 
     #[test]

--- a/crates/crap-core/src/cli/mod.rs
+++ b/crates/crap-core/src/cli/mod.rs
@@ -345,17 +345,22 @@ pub struct OutputArgs {
     )]
     pub format: Vec<FormatSpec>,
 
-    /// CRAP score threshold — functions above this fail the check [default: 25]
+    /// CRAP score threshold — functions above this fail the check.
+    /// Defaults to the calibrated cutoff for the active complexity
+    /// metric (cyclomatic and cognitive scores differ in magnitude, so
+    /// the default differs per metric — see the generated config).
     // allow_hyphen_values: lets clap parse `--threshold -5` as a value
     // (not a flag), so our validate_inputs can give an actionable error.
     #[arg(long, allow_hyphen_values = true, group = "threshold_select")]
     pub threshold: Option<f64>,
 
-    /// Use strict threshold (15) — for high-quality or safety-critical code
+    /// Use the strict preset (tighter cutoff calibrated for the active
+    /// metric) — for high-quality or safety-critical code
     #[arg(long, group = "threshold_select")]
     pub strict: bool,
 
-    /// Use lenient threshold (40) — for legacy or transitional code
+    /// Use the lenient preset (looser cutoff calibrated for the active
+    /// metric) — for legacy or transitional code
     #[arg(long, group = "threshold_select")]
     pub lenient: bool,
 
@@ -1455,11 +1460,18 @@ fn load_file_config(
 /// so a cutoff calibrated for one metric is never applied to the
 /// other metric's (different-magnitude) scores. `metric` is the
 /// already-resolved effective metric (CLI > config > adapter default).
+/// A literal cutoff (an explicit number) always beats a named preset
+/// at the same level of specificity, because a literal is the most
+/// specific expression of intent: CLI `--threshold N` beats CLI
+/// `--strict`/`--lenient`, and config `threshold = N` beats config
+/// `preset = "..."`. This keeps CLI and config-file semantics
+/// consistent — a user who writes an explicit number gets that number.
+///
 /// 1. `--threshold N`   — explicit CLI value (a literal cutoff; metric-independent)
 /// 2. `--strict`        → `ThresholdPreset::Strict.threshold(metric)`
 /// 3. `--lenient`       → `ThresholdPreset::Lenient.threshold(metric)`
-/// 4. config `preset`   → `preset.threshold(metric)`
-/// 5. config `threshold` — explicit literal cutoff (metric-independent)
+/// 4. config `threshold` — explicit literal cutoff (metric-independent)
+/// 5. config `preset`   → `preset.threshold(metric)`
 /// 6. no-flag default   → `ThresholdPreset::Default.threshold(metric)`
 ///    (cyclomatic-metric runs → 16; cognitive-metric runs → 25)
 fn merge_threshold(
@@ -1480,13 +1492,13 @@ fn merge_threshold(
                 .lenient
                 .then(|| ThresholdPreset::Lenient.threshold(metric))
         })
+        .or_else(|| file_config.as_ref().and_then(|c| c.threshold))
         .or_else(|| {
             file_config
                 .as_ref()
                 .and_then(|c| c.preset)
                 .map(|p| p.threshold(metric))
         })
-        .or_else(|| file_config.as_ref().and_then(|c| c.threshold))
         .unwrap_or(ThresholdPreset::Default.threshold(metric));
 
     let overrides = file_config
@@ -2495,6 +2507,25 @@ mod tests {
         });
         let (config, _) = merge_threshold(&cli, &file_config, ComplexityMetric::Cognitive);
         assert_eq!(config.global, STRICT_THRESHOLD);
+    }
+
+    #[test]
+    fn merge_threshold_config_literal_overrides_config_preset() {
+        // A literal `threshold = N` in the config is the most specific
+        // expression of intent and must beat a named `preset` in the
+        // same file — mirrors CLI semantics where `--threshold N` beats
+        // `--strict`/`--lenient`. Without this, a user who sets both
+        // would silently get the preset and never the number they typed.
+        use crate::domain::threshold::ThresholdPreset;
+        let cli = parse(&["--coverage", "lcov.info"]).unwrap();
+        let file_config = Some(FileConfig {
+            preset: Some(ThresholdPreset::Strict),
+            threshold: Some(99.0),
+            ..FileConfig::default()
+        });
+        let (config, display) = merge_threshold(&cli, &file_config, ComplexityMetric::Cognitive);
+        assert_eq!(config.global, 99.0);
+        assert_eq!(display, 99.0);
     }
 
     #[test]

--- a/crates/crap-core/src/cli/mod.rs
+++ b/crates/crap-core/src/cli/mod.rs
@@ -23,9 +23,7 @@ use crate::adapters::reporters;
 use crate::adapters::reporters::json::DeltaContext;
 use crate::core::{AnalysisOutput, AnalyzeOptions};
 use crate::domain::delta::{self, AnalysisDelta, DeltaView};
-use crate::domain::threshold::{
-    DEFAULT_THRESHOLD, LENIENT_THRESHOLD, STRICT_THRESHOLD, ThresholdConfig, is_valid_threshold,
-};
+use crate::domain::threshold::{ThresholdConfig, ThresholdPreset, is_valid_threshold};
 use crate::domain::types::{AnalysisDiagnostics, ComplexityMetric};
 use crate::domain::view::{self, GroupKey, SortKey};
 use crate::ports::{ComplexityPort, CoveragePort, ParseDiagnostic};
@@ -1026,7 +1024,7 @@ fn merge_effective_inputs(
         .map(Into::into)
         .or_else(|| file_config.as_ref().and_then(|c| c.metric))
         .unwrap_or(meta.default_metric);
-    let (threshold_config, threshold) = merge_threshold(cli, file_config);
+    let (threshold_config, threshold) = merge_threshold(cli, file_config, metric);
     let exclude = merge_exclude(cli, file_config);
     EffectiveInputs {
         src,
@@ -1452,27 +1450,44 @@ fn load_file_config(
 
 /// Merge CLI threshold with config file. Returns (ThresholdConfig, effective_display_threshold).
 ///
-/// Resolution order (first match wins):
-/// 1. `--threshold N`   — explicit CLI value
-/// 2. `--strict`        → STRICT_THRESHOLD
-/// 3. `--lenient`       → LENIENT_THRESHOLD
-/// 4. config `preset`   → preset.threshold()
-/// 5. config `threshold`
-/// 6. DEFAULT_THRESHOLD
-fn merge_threshold(cli: &Cli, file_config: &Option<FileConfig>) -> (ThresholdConfig, f64) {
+/// Resolution order (first match wins). Every tier-derived value is
+/// keyed on the resolved `metric` via [`ThresholdPreset::threshold`],
+/// so a cutoff calibrated for one metric is never applied to the
+/// other metric's (different-magnitude) scores. `metric` is the
+/// already-resolved effective metric (CLI > config > adapter default).
+/// 1. `--threshold N`   — explicit CLI value (a literal cutoff; metric-independent)
+/// 2. `--strict`        → `ThresholdPreset::Strict.threshold(metric)`
+/// 3. `--lenient`       → `ThresholdPreset::Lenient.threshold(metric)`
+/// 4. config `preset`   → `preset.threshold(metric)`
+/// 5. config `threshold` — explicit literal cutoff (metric-independent)
+/// 6. no-flag default   → `ThresholdPreset::Default.threshold(metric)`
+///    (cyclomatic-metric runs → 16; cognitive-metric runs → 25)
+fn merge_threshold(
+    cli: &Cli,
+    file_config: &Option<FileConfig>,
+    metric: ComplexityMetric,
+) -> (ThresholdConfig, f64) {
     let global = cli
         .output
         .threshold
-        .or_else(|| cli.output.strict.then_some(STRICT_THRESHOLD))
-        .or_else(|| cli.output.lenient.then_some(LENIENT_THRESHOLD))
+        .or_else(|| {
+            cli.output
+                .strict
+                .then(|| ThresholdPreset::Strict.threshold(metric))
+        })
+        .or_else(|| {
+            cli.output
+                .lenient
+                .then(|| ThresholdPreset::Lenient.threshold(metric))
+        })
         .or_else(|| {
             file_config
                 .as_ref()
                 .and_then(|c| c.preset)
-                .map(|p| p.threshold())
+                .map(|p| p.threshold(metric))
         })
         .or_else(|| file_config.as_ref().and_then(|c| c.threshold))
-        .unwrap_or(DEFAULT_THRESHOLD);
+        .unwrap_or(ThresholdPreset::Default.threshold(metric));
 
     let overrides = file_config
         .as_ref()
@@ -1746,6 +1761,10 @@ fn apply_color(choice: ColorArg) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    // `DEFAULT_THRESHOLD` is no longer referenced by `merge_threshold`
+    // (it reads `meta.default_threshold` post-#218); only the tests
+    // assert against the value crap4rs's `AdapterMeta` carries.
+    use crate::domain::threshold::DEFAULT_THRESHOLD;
     use std::path::Path;
 
     fn parse(args: &[&str]) -> Result<Cli, clap::Error> {
@@ -2113,7 +2132,7 @@ mod tests {
             threshold: Some(10.0),
             ..FileConfig::default()
         });
-        let (config, display) = merge_threshold(&cli, &file_config);
+        let (config, display) = merge_threshold(&cli, &file_config, ComplexityMetric::Cognitive);
         assert_eq!(config.global, 15.0);
         assert_eq!(display, 15.0);
     }
@@ -2125,7 +2144,7 @@ mod tests {
             threshold: Some(12.0),
             ..FileConfig::default()
         });
-        let (config, display) = merge_threshold(&cli, &file_config);
+        let (config, display) = merge_threshold(&cli, &file_config, ComplexityMetric::Cognitive);
         assert_eq!(config.global, 12.0);
         assert_eq!(display, 12.0);
     }
@@ -2142,7 +2161,7 @@ mod tests {
             }],
             ..FileConfig::default()
         });
-        let (config, _) = merge_threshold(&cli, &file_config);
+        let (config, _) = merge_threshold(&cli, &file_config, ComplexityMetric::Cognitive);
         assert_eq!(config.overrides.len(), 1);
         assert_eq!(config.overrides[0].pattern, "domain/**");
     }
@@ -2150,7 +2169,7 @@ mod tests {
     #[test]
     fn merge_threshold_no_config() {
         let cli = parse(&["--coverage", "lcov.info", "--threshold", "20.0"]).unwrap();
-        let (config, display) = merge_threshold(&cli, &None);
+        let (config, display) = merge_threshold(&cli, &None, ComplexityMetric::Cognitive);
         assert_eq!(config.global, 20.0);
         assert!(config.overrides.is_empty());
         assert_eq!(display, 20.0);
@@ -2165,7 +2184,7 @@ mod tests {
             threshold: Some(12.0),
             ..FileConfig::default()
         });
-        let (config, display) = merge_threshold(&cli, &file_config);
+        let (config, display) = merge_threshold(&cli, &file_config, ComplexityMetric::Cognitive);
         assert_eq!(
             config.global, 8.0,
             "explicit CLI default must override config"
@@ -2174,11 +2193,46 @@ mod tests {
     }
 
     #[test]
-    fn merge_threshold_no_cli_no_config_uses_hardcoded_default() {
+    fn merge_threshold_no_flag_default_is_metric_keyed() {
+        // Replaces the pre-fix `merge_threshold_no_cli_no_config_uses_hardcoded_default`.
+        // The no-flag/no-config fallthrough is the `Default` tier
+        // resolved against the effective metric — NOT a single shared
+        // scalar. Cognitive runs get 25; cyclomatic runs get 16. A
+        // cognitive-tuned 25 applied to cyclomatic scores would
+        // under-gate (the bug this keys against).
         let cli = parse(&["--coverage", "lcov.info"]).unwrap();
-        let (config, display) = merge_threshold(&cli, &None);
-        assert_eq!(config.global, DEFAULT_THRESHOLD);
-        assert_eq!(display, DEFAULT_THRESHOLD);
+        let (cog, cog_disp) = merge_threshold(&cli, &None, ComplexityMetric::Cognitive);
+        assert_eq!(cog.global, 25.0);
+        assert_eq!(cog_disp, 25.0);
+        let (cyc, cyc_disp) = merge_threshold(&cli, &None, ComplexityMetric::Cyclomatic);
+        assert_eq!(cyc.global, 16.0);
+        assert_eq!(cyc_disp, 16.0);
+    }
+
+    #[test]
+    fn merge_threshold_strict_lenient_are_metric_keyed() {
+        // `--strict` / `--lenient` were previously metric-blind (always
+        // the cognitive 15 / 40). They now resolve per metric too, so
+        // no preset path silently applies a cognitive cutoff to
+        // cyclomatic scores.
+        let strict = parse(&["--coverage", "lcov.info", "--strict"]).unwrap();
+        assert_eq!(
+            merge_threshold(&strict, &None, ComplexityMetric::Cognitive).1,
+            15.0
+        );
+        assert_eq!(
+            merge_threshold(&strict, &None, ComplexityMetric::Cyclomatic).1,
+            8.0
+        );
+        let lenient = parse(&["--coverage", "lcov.info", "--lenient"]).unwrap();
+        assert_eq!(
+            merge_threshold(&lenient, &None, ComplexityMetric::Cognitive).1,
+            40.0
+        );
+        assert_eq!(
+            merge_threshold(&lenient, &None, ComplexityMetric::Cyclomatic).1,
+            30.0
+        );
     }
 
     #[test]
@@ -2417,7 +2471,7 @@ mod tests {
     fn merge_threshold_strict_flag() {
         use crate::domain::threshold::STRICT_THRESHOLD;
         let cli = parse(&["--coverage", "lcov.info", "--strict"]).unwrap();
-        let (config, display) = merge_threshold(&cli, &None);
+        let (config, display) = merge_threshold(&cli, &None, ComplexityMetric::Cognitive);
         assert_eq!(config.global, STRICT_THRESHOLD);
         assert_eq!(display, STRICT_THRESHOLD);
     }
@@ -2426,7 +2480,7 @@ mod tests {
     fn merge_threshold_lenient_flag() {
         use crate::domain::threshold::LENIENT_THRESHOLD;
         let cli = parse(&["--coverage", "lcov.info", "--lenient"]).unwrap();
-        let (config, display) = merge_threshold(&cli, &None);
+        let (config, display) = merge_threshold(&cli, &None, ComplexityMetric::Cognitive);
         assert_eq!(config.global, LENIENT_THRESHOLD);
         assert_eq!(display, LENIENT_THRESHOLD);
     }
@@ -2439,7 +2493,7 @@ mod tests {
             preset: Some(ThresholdPreset::Strict),
             ..FileConfig::default()
         });
-        let (config, _) = merge_threshold(&cli, &file_config);
+        let (config, _) = merge_threshold(&cli, &file_config, ComplexityMetric::Cognitive);
         assert_eq!(config.global, STRICT_THRESHOLD);
     }
 
@@ -2451,7 +2505,7 @@ mod tests {
             preset: Some(ThresholdPreset::Strict),
             ..FileConfig::default()
         });
-        let (config, _) = merge_threshold(&cli, &file_config);
+        let (config, _) = merge_threshold(&cli, &file_config, ComplexityMetric::Cognitive);
         assert_eq!(config.global, 50.0);
     }
 
@@ -2548,10 +2602,34 @@ mod tests {
     }
 
     #[test]
-    fn merge_effective_inputs_threshold_default() {
+    fn merge_effective_inputs_default_threshold_follows_adapter_metric_cognitive() {
+        // End-to-end wiring: an adapter whose default metric is
+        // cognitive, with no `--threshold`/`--metric`/config, resolves
+        // the no-flag gate to the cognitive `Default` cutoff (25).
         let cli = parse(&["--coverage", "lcov.info"]).unwrap();
-        let inputs = merge_effective_inputs(&cli, &None, &fake_meta());
-        assert_eq!(inputs.threshold, DEFAULT_THRESHOLD);
+        let meta = AdapterMeta {
+            default_metric: ComplexityMetric::Cognitive,
+            ..fake_meta()
+        };
+        let inputs = merge_effective_inputs(&cli, &None, &meta);
+        assert!(matches!(inputs.metric, ComplexityMetric::Cognitive));
+        assert_eq!(inputs.threshold, 25.0);
+    }
+
+    #[test]
+    fn merge_effective_inputs_default_threshold_follows_adapter_metric_cyclomatic() {
+        // Mirror for a cyclomatic-default adapter (crap4ts): the no-flag
+        // gate must be the cyclomatic `Default` cutoff (16), not the
+        // cognitive 25 — a single shared default applied the wrong
+        // metric's cutoff before this fix.
+        let cli = parse(&["--coverage", "lcov.info"]).unwrap();
+        let meta = AdapterMeta {
+            default_metric: ComplexityMetric::Cyclomatic,
+            ..fake_meta()
+        };
+        let inputs = merge_effective_inputs(&cli, &None, &meta);
+        assert!(matches!(inputs.metric, ComplexityMetric::Cyclomatic));
+        assert_eq!(inputs.threshold, 16.0);
     }
 
     #[test]

--- a/crates/crap-core/src/domain/threshold.rs
+++ b/crates/crap-core/src/domain/threshold.rs
@@ -113,6 +113,29 @@ pub struct ThresholdConfig {
     pub overrides: Vec<ThresholdOverride>,
 }
 
+/// Returns the cognitive-metric default cutoff. `Default` cannot take
+/// a metric argument, so it cannot be metric-correct on its own — it
+/// is the cognitive baseline only.
+///
+/// The CLI never relies on this: the analysis path resolves the
+/// metric-correct `global` through `merge_threshold` (CLI > config >
+/// adapter default, keyed on the effective metric) and constructs
+/// `ThresholdConfig` directly, bypassing `Default`. The remaining
+/// `Default` use is a struct-field initializer that is overwritten
+/// before any analysis runs.
+///
+/// A library embedder that needs a metric-correct config should build
+/// it explicitly rather than via `Default`:
+///
+/// ```
+/// # use crap_core::domain::threshold::{ThresholdConfig, ThresholdPreset};
+/// # use crap_core::domain::types::ComplexityMetric;
+/// let metric = ComplexityMetric::Cyclomatic;
+/// let config = ThresholdConfig {
+///     global: ThresholdPreset::Default.threshold(metric),
+///     overrides: Vec::new(),
+/// };
+/// ```
 impl Default for ThresholdConfig {
     fn default() -> Self {
         Self {

--- a/crates/crap-core/src/domain/threshold.rs
+++ b/crates/crap-core/src/domain/threshold.rs
@@ -1,32 +1,87 @@
-/// Strict CRAP threshold — for high-quality or safety-critical code.
-/// Matches SonarSource S3776 cognitive complexity limit and eliminates false
-/// positives on well-tested idiomatic Rust (SeaORM-style large match arms).
+use super::types::ComplexityMetric;
+
+// ── Threshold calibration table ──────────────────────────────────────
+//
+// CRAP thresholds are NOT metric-invariant. For the *same* function,
+// its cyclomatic count (decision points) and its cognitive count
+// (nesting-weighted structural complexity) differ in magnitude — a
+// function that is "moderately risky" scores ~16 cyclomatic but ~25
+// cognitive. So one scalar cutoff cannot serve both metrics: a cutoff
+// tuned for cognitive scores, applied to cyclomatic scores, lets
+// genuinely-risky functions pass (and vice versa).
+//
+// Each calibration *tier* (strict / default / lenient) therefore has a
+// distinct cutoff per metric:
+//
+//                strict  default  lenient
+//   cyclomatic      8       16       30
+//   cognitive      15       25       40
+//
+// The bare-named constants are the cognitive column; the
+// `_CYCLOMATIC` siblings are the cyclomatic column.
+// `ThresholdPreset::threshold(metric)` is the single lookup that keys
+// a tier to the right column — every preset / `--strict` / `--lenient`
+// / no-flag-default resolution routes through it so no path applies a
+// metric's cutoff to the other metric's scores.
+
+/// Strict CRAP cutoff for the **cognitive** metric — high-quality or
+/// safety-critical code. Matches SonarSource S3776's cognitive
+/// complexity limit and eliminates false positives on well-tested
+/// idiomatic Rust (SeaORM-style large match arms). Cyclomatic
+/// equivalent: [`STRICT_THRESHOLD_CYCLOMATIC`].
 pub const STRICT_THRESHOLD: f64 = 15.0;
 
-/// Default CRAP threshold — balanced for typical Rust codebases.
+/// Default CRAP cutoff for the **cognitive** metric — balanced for
+/// typical codebases. Cyclomatic equivalent: [`DEFAULT_THRESHOLD_CYCLOMATIC`].
 pub const DEFAULT_THRESHOLD: f64 = 25.0;
 
-/// Lenient CRAP threshold — for legacy or transitional code.
+/// Lenient CRAP cutoff for the **cognitive** metric — legacy or
+/// transitional code. Cyclomatic equivalent: [`LENIENT_THRESHOLD_CYCLOMATIC`].
 pub const LENIENT_THRESHOLD: f64 = 40.0;
 
-/// Named threshold preset.
+/// Strict CRAP cutoff for the **cyclomatic** metric. ~half the
+/// cognitive strict value because cyclomatic scores run lower in
+/// magnitude for the same code.
+pub const STRICT_THRESHOLD_CYCLOMATIC: f64 = 8.0;
+
+/// Default CRAP cutoff for the **cyclomatic** metric — the balanced
+/// tier for cyclomatic-scored code.
+pub const DEFAULT_THRESHOLD_CYCLOMATIC: f64 = 16.0;
+
+/// Lenient CRAP cutoff for the **cyclomatic** metric.
+pub const LENIENT_THRESHOLD_CYCLOMATIC: f64 = 30.0;
+
+/// Named threshold preset — a calibration *tier*, independent of
+/// metric. The concrete f64 cutoff is resolved per metric via
+/// [`ThresholdPreset::threshold`] (the same tier maps to a different
+/// number for cyclomatic vs cognitive scores).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ThresholdPreset {
-    /// `STRICT_THRESHOLD` (15) — high-quality libraries, safety-critical code.
+    /// High-quality libraries, safety-critical code. Cognitive 15,
+    /// cyclomatic 8.
     Strict,
-    /// `DEFAULT_THRESHOLD` (25) — typical Rust projects.
+    /// Typical projects (balanced) — the tier used when no preset or
+    /// explicit threshold is given. Cognitive 25, cyclomatic 16.
     Default,
-    /// `LENIENT_THRESHOLD` (40) — legacy or transitional code.
+    /// Legacy or transitional code. Cognitive 40, cyclomatic 30.
     Lenient,
 }
 
 impl ThresholdPreset {
-    /// Returns the f64 threshold value for this preset.
-    pub fn threshold(self) -> f64 {
-        match self {
-            Self::Strict => STRICT_THRESHOLD,
-            Self::Default => DEFAULT_THRESHOLD,
-            Self::Lenient => LENIENT_THRESHOLD,
+    /// Resolve this tier to its concrete f64 CRAP cutoff for `metric`.
+    /// This is the single place tier→number is keyed on the metric:
+    /// `--strict` / `--lenient` / config `preset` / the no-flag
+    /// default all route through it, so a cutoff calibrated for one
+    /// metric is never silently applied to the other metric's
+    /// (different-magnitude) scores.
+    pub fn threshold(self, metric: ComplexityMetric) -> f64 {
+        match (metric, self) {
+            (ComplexityMetric::Cognitive, Self::Strict) => STRICT_THRESHOLD,
+            (ComplexityMetric::Cognitive, Self::Default) => DEFAULT_THRESHOLD,
+            (ComplexityMetric::Cognitive, Self::Lenient) => LENIENT_THRESHOLD,
+            (ComplexityMetric::Cyclomatic, Self::Strict) => STRICT_THRESHOLD_CYCLOMATIC,
+            (ComplexityMetric::Cyclomatic, Self::Default) => DEFAULT_THRESHOLD_CYCLOMATIC,
+            (ComplexityMetric::Cyclomatic, Self::Lenient) => LENIENT_THRESHOLD_CYCLOMATIC,
         }
     }
 }
@@ -80,16 +135,28 @@ mod tests {
 
     #[test]
     fn threshold_constants() {
-        assert_eq!(DEFAULT_THRESHOLD, 25.0);
+        // D5 calibration table (locked decision #5).
         assert_eq!(STRICT_THRESHOLD, 15.0);
+        assert_eq!(DEFAULT_THRESHOLD, 25.0);
         assert_eq!(LENIENT_THRESHOLD, 40.0);
+        assert_eq!(STRICT_THRESHOLD_CYCLOMATIC, 8.0);
+        assert_eq!(DEFAULT_THRESHOLD_CYCLOMATIC, 16.0);
+        assert_eq!(LENIENT_THRESHOLD_CYCLOMATIC, 30.0);
     }
 
     #[test]
-    fn preset_to_threshold() {
-        assert_eq!(ThresholdPreset::Strict.threshold(), STRICT_THRESHOLD);
-        assert_eq!(ThresholdPreset::Default.threshold(), DEFAULT_THRESHOLD);
-        assert_eq!(ThresholdPreset::Lenient.threshold(), LENIENT_THRESHOLD);
+    fn preset_to_threshold_is_metric_keyed() {
+        use ComplexityMetric::{Cognitive, Cyclomatic};
+        // Cognitive column (crap4rs).
+        assert_eq!(ThresholdPreset::Strict.threshold(Cognitive), 15.0);
+        assert_eq!(ThresholdPreset::Default.threshold(Cognitive), 25.0);
+        assert_eq!(ThresholdPreset::Lenient.threshold(Cognitive), 40.0);
+        // Cyclomatic column (crap4ts / crap4rs --metric cyclomatic) —
+        // the #218 fix: a tier resolves to the metric-correct cutoff,
+        // not the cognitive value applied blindly.
+        assert_eq!(ThresholdPreset::Strict.threshold(Cyclomatic), 8.0);
+        assert_eq!(ThresholdPreset::Default.threshold(Cyclomatic), 16.0);
+        assert_eq!(ThresholdPreset::Lenient.threshold(Cyclomatic), 30.0);
     }
 
     #[test]

--- a/crates/crap-core/tests/default_gate_threshold.rs
+++ b/crates/crap-core/tests/default_gate_threshold.rs
@@ -159,7 +159,7 @@ fn crap4rs_threshold(extra_args: &[&str]) -> f64 {
 // ── crap4ts: cyclomatic-metric adapter ───────────────────────────────
 
 #[test]
-fn crap4ts_no_flag_default_threshold_is_cyclomatic_16() {
+fn default_gate_crap4ts_no_flag_is_cyclomatic_16() {
     assert_eq!(
         crap4ts_threshold(&[]),
         16.0,
@@ -170,7 +170,7 @@ fn crap4ts_no_flag_default_threshold_is_cyclomatic_16() {
 }
 
 #[test]
-fn crap4ts_strict_is_cyclomatic_8() {
+fn default_gate_crap4ts_strict_is_cyclomatic_8() {
     assert_eq!(
         crap4ts_threshold(&["--strict"]),
         8.0,
@@ -180,7 +180,7 @@ fn crap4ts_strict_is_cyclomatic_8() {
 }
 
 #[test]
-fn crap4ts_lenient_is_cyclomatic_30() {
+fn default_gate_crap4ts_lenient_is_cyclomatic_30() {
     assert_eq!(
         crap4ts_threshold(&["--lenient"]),
         30.0,
@@ -192,7 +192,7 @@ fn crap4ts_lenient_is_cyclomatic_30() {
 // ── crap4rs: cognitive-metric adapter (regression guards) ────────────
 
 #[test]
-fn crap4rs_no_flag_default_threshold_stays_cognitive_25() {
+fn default_gate_crap4rs_no_flag_stays_cognitive_25() {
     assert_eq!(
         crap4rs_threshold(&[]),
         25.0,
@@ -203,7 +203,7 @@ fn crap4rs_no_flag_default_threshold_stays_cognitive_25() {
 }
 
 #[test]
-fn crap4rs_strict_stays_cognitive_15() {
+fn default_gate_crap4rs_strict_stays_cognitive_15() {
     assert_eq!(
         crap4rs_threshold(&["--strict"]),
         15.0,
@@ -212,7 +212,7 @@ fn crap4rs_strict_stays_cognitive_15() {
 }
 
 #[test]
-fn crap4rs_metric_cyclomatic_no_flag_default_is_16() {
+fn default_gate_crap4rs_metric_cyclomatic_no_flag_is_16() {
     // The deeper instance of the same defect class: crap4rs *supports*
     // cyclomatic too, and `--metric cyclomatic` with no threshold must
     // resolve to the cyclomatic `default` (16), not the cognitive 25.
@@ -225,7 +225,7 @@ fn crap4rs_metric_cyclomatic_no_flag_default_is_16() {
 }
 
 #[test]
-fn crap4rs_metric_cyclomatic_strict_is_8() {
+fn default_gate_crap4rs_metric_cyclomatic_strict_is_8() {
     assert_eq!(
         crap4rs_threshold(&["--metric", "cyclomatic", "--strict"]),
         8.0,

--- a/crates/crap-core/tests/default_gate_threshold.rs
+++ b/crates/crap-core/tests/default_gate_threshold.rs
@@ -1,0 +1,235 @@
+//! End-to-end gate `threshold` resolution canary, exercised through
+//! the real binaries with NO explicit `--threshold`.
+//!
+//! ## Why this file exists separately from the wire snapshots
+//!
+//! `wire_envelope_crap4ts.rs` invokes the binary with an *explicit*
+//! `--threshold 16` and locks the result with `insta`. An explicit
+//! flag can never exercise — let alone catch a regression in — the
+//! *default* threshold resolution, and an `insta` snapshot of an
+//! explicit-flag run would simply re-bless whatever the default
+//! produced. This file is deliberately:
+//!
+//!   * **no explicit threshold flag** — exercises the
+//!     no-CLI/no-config default-resolution path (and the `--strict` /
+//!     `--lenient` preset paths);
+//!   * **no `insta`** — a plain `assert_eq!` on the parsed envelope's
+//!     top-level `threshold`, so the assertion *is* the contract, not
+//!     a regenerable snapshot.
+//!
+//! It checks the produced artifact through the binary, independently
+//! of any in-crate unit test of the resolution function — a wrong
+//! cutoff calibrated for one metric but applied to another is exactly
+//! the kind of defect a same-axis snapshot misses.
+//!
+//! ## What it locks (the calibration table, observed end-to-end)
+//!
+//! Threshold cutoffs are metric-keyed: for the same code, cyclomatic
+//! and cognitive scores differ in magnitude, so each tier maps to a
+//! different number per metric (strict/default/lenient = cyclomatic
+//! 8/16/30, cognitive 15/25/40):
+//!
+//! | invocation                              | metric    | tier    | expect |
+//! |-----------------------------------------|-----------|---------|--------|
+//! | `crap4ts` (no flags)                    | cyclomatic| default | 16     |
+//! | `crap4ts --strict`                      | cyclomatic| strict  | 8      |
+//! | `crap4ts --lenient`                     | cyclomatic| lenient | 30     |
+//! | `crap4rs` (no flags)                    | cognitive | default | 25     |
+//! | `crap4rs --strict`                      | cognitive | strict  | 15     |
+//! | `crap4rs --metric cyclomatic`           | cyclomatic| default | 16     |
+//! | `crap4rs --metric cyclomatic --strict`  | cyclomatic| strict  | 8      |
+//!
+//! The crap4rs cognitive rows are regression guards: the
+//! `merge_threshold` signature change must not move the Rust adapter's
+//! long-standing cognitive defaults.
+
+use std::path::PathBuf;
+
+use assert_cmd::Command;
+use serde_json::Value;
+use tempfile::TempDir;
+
+const FIXTURE_TEMPLATE: &str =
+    include_str!("../../crap4ts/tests/fixtures/istanbul-jest/coverage-final.json");
+
+/// Build the same canonicalized jest tempdir fixture
+/// `wire_envelope_crap4ts.rs` uses (W1.1 sources + resolved
+/// `coverage-final.json`). Kept structurally identical so the only
+/// behavioral difference between the two tests is the *absence* of
+/// `--threshold` here.
+fn build_crap4ts_fixture() -> (TempDir, PathBuf) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let canonical = std::fs::canonicalize(tmp.path()).expect("canonicalize tempdir");
+
+    for (name, content) in [
+        (
+            "simple.ts",
+            include_str!("../../crap4ts/tests/fixtures/ts-fixtures/simple.ts"),
+        ),
+        (
+            "arrow.ts",
+            include_str!("../../crap4ts/tests/fixtures/ts-fixtures/arrow.ts"),
+        ),
+        (
+            "Button.tsx",
+            include_str!("../../crap4ts/tests/fixtures/ts-fixtures/Button.tsx"),
+        ),
+        (
+            "map.ts",
+            include_str!("../../crap4ts/tests/fixtures/ts-fixtures/map.ts"),
+        ),
+        (
+            "mixed.ts",
+            include_str!("../../crap4ts/tests/fixtures/ts-fixtures/mixed.ts"),
+        ),
+    ] {
+        std::fs::write(canonical.join(name), content).expect("write fixture");
+    }
+
+    let payload = FIXTURE_TEMPLATE.replace(
+        "{SRC_ROOT}",
+        &canonical.to_string_lossy().replace('\\', "/"),
+    );
+    std::fs::write(canonical.join("coverage-final.json"), payload)
+        .expect("write coverage-final.json");
+
+    (tmp, canonical)
+}
+
+/// Extract the envelope's top-level `threshold` as `f64`.
+fn top_level_threshold(stdout: &[u8], who: &str) -> f64 {
+    let envelope: Value = serde_json::from_slice(stdout)
+        .unwrap_or_else(|e| panic!("{who} --format json emits valid JSON: {e}"));
+    envelope
+        .get("threshold")
+        .and_then(Value::as_f64)
+        .unwrap_or_else(|| panic!("{who} envelope has a numeric top-level `threshold`"))
+}
+
+/// Run `crap4ts` against the jest tempdir fixture with `extra_args`
+/// (NO explicit threshold) and return the envelope's top-level
+/// `threshold`. `--no-fail` keeps exit 0 so a parseable envelope is
+/// always emitted regardless of gate outcome.
+fn crap4ts_threshold(extra_args: &[&str]) -> f64 {
+    let (_tmp, root) = build_crap4ts_fixture();
+    let coverage = root.join("coverage-final.json");
+    let output = Command::cargo_bin("crap4ts")
+        .expect("crap4ts binary discoverable in workspace")
+        .arg("--coverage")
+        .arg(&coverage)
+        .arg("--src")
+        .arg(&root)
+        .args(extra_args)
+        .args(["--format", "json", "--no-fail"])
+        .output()
+        .expect("crap4ts binary executes");
+    assert!(
+        output.status.success(),
+        "crap4ts exited non-zero: stdout={}\nstderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    top_level_threshold(&output.stdout, "crap4ts")
+}
+
+/// Run `crap4rs` against its own source + LCOV with `extra_args` (NO
+/// explicit threshold) and return the envelope's top-level `threshold`.
+fn crap4rs_threshold(extra_args: &[&str]) -> f64 {
+    let output = Command::cargo_bin("crap4rs")
+        .expect("crap4rs binary discoverable in workspace")
+        .args([
+            "--coverage",
+            "../crap4rs/tests/fixtures/crap4rs-self.lcov",
+            "--src",
+            "../crap4rs/src",
+        ])
+        .args(extra_args)
+        .args(["--format", "json", "--no-fail"])
+        .output()
+        .expect("crap4rs binary executes");
+    assert!(
+        output.status.success(),
+        "crap4rs exited non-zero: stdout={}\nstderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    top_level_threshold(&output.stdout, "crap4rs")
+}
+
+// ── crap4ts: cyclomatic-metric adapter ───────────────────────────────
+
+#[test]
+fn crap4ts_no_flag_default_threshold_is_cyclomatic_16() {
+    assert_eq!(
+        crap4ts_threshold(&[]),
+        16.0,
+        "crap4ts no-flag default must be the cyclomatic `default` cutoff \
+         (16), not the cognitive 25 — a single shared default applied a \
+         cognitive cutoff to cyclomatic scores"
+    );
+}
+
+#[test]
+fn crap4ts_strict_is_cyclomatic_8() {
+    assert_eq!(
+        crap4ts_threshold(&["--strict"]),
+        8.0,
+        "crap4ts --strict must be the cyclomatic `strict` cutoff (8), \
+         not the cognitive 15"
+    );
+}
+
+#[test]
+fn crap4ts_lenient_is_cyclomatic_30() {
+    assert_eq!(
+        crap4ts_threshold(&["--lenient"]),
+        30.0,
+        "crap4ts --lenient must be the cyclomatic `lenient` cutoff (30), \
+         not the cognitive 40"
+    );
+}
+
+// ── crap4rs: cognitive-metric adapter (regression guards) ────────────
+
+#[test]
+fn crap4rs_no_flag_default_threshold_stays_cognitive_25() {
+    assert_eq!(
+        crap4rs_threshold(&[]),
+        25.0,
+        "crap4rs no-flag default must stay the cognitive `default` \
+         cutoff (25) — the resolution refactor must not regress the \
+         Rust adapter"
+    );
+}
+
+#[test]
+fn crap4rs_strict_stays_cognitive_15() {
+    assert_eq!(
+        crap4rs_threshold(&["--strict"]),
+        15.0,
+        "crap4rs --strict (cognitive metric) must stay 15"
+    );
+}
+
+#[test]
+fn crap4rs_metric_cyclomatic_no_flag_default_is_16() {
+    // The deeper instance of the same defect class: crap4rs *supports*
+    // cyclomatic too, and `--metric cyclomatic` with no threshold must
+    // resolve to the cyclomatic `default` (16), not the cognitive 25.
+    assert_eq!(
+        crap4rs_threshold(&["--metric", "cyclomatic"]),
+        16.0,
+        "crap4rs --metric cyclomatic no-flag default must be the \
+         cyclomatic cutoff (16), not the cognitive 25"
+    );
+}
+
+#[test]
+fn crap4rs_metric_cyclomatic_strict_is_8() {
+    assert_eq!(
+        crap4rs_threshold(&["--metric", "cyclomatic", "--strict"]),
+        8.0,
+        "crap4rs --metric cyclomatic --strict must be the cyclomatic \
+         strict cutoff (8), not the cognitive 15"
+    );
+}

--- a/crates/crap4ts/tests/fixtures/class-validator-reference.json
+++ b/crates/crap4ts/tests/fixtures/class-validator-reference.json
@@ -2,9 +2,9 @@
   "schema_version": 2,
   "tool_version": "2.0.0-alpha.1",
   "language": "rust",
-  "timestamp": "1778898792",
+  "timestamp": "1778943959",
   "metric": "cyclomatic",
-  "threshold": 25.0,
+  "threshold": 16.0,
   "diff_ref": null,
   "result": {
     "functions": [
@@ -29,7 +29,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -62,7 +62,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -86,7 +86,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -167,7 +167,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": true
       },
       {
@@ -240,7 +240,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -264,7 +264,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -297,7 +297,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -330,7 +330,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -354,7 +354,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -378,7 +378,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -411,7 +411,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -444,7 +444,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -468,7 +468,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -492,7 +492,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -525,7 +525,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -558,7 +558,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -582,7 +582,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -606,7 +606,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -630,7 +630,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -663,7 +663,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -696,7 +696,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -720,7 +720,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -744,7 +744,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -777,7 +777,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -801,7 +801,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -825,7 +825,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -849,7 +849,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -882,7 +882,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -906,7 +906,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -947,7 +947,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -971,7 +971,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -995,7 +995,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -1036,7 +1036,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -1060,7 +1060,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -1084,7 +1084,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -1108,7 +1108,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -1141,7 +1141,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -1165,7 +1165,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -1189,7 +1189,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -1222,7 +1222,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -1246,7 +1246,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -1270,7 +1270,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -1294,7 +1294,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -1335,7 +1335,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -1359,7 +1359,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -1383,7 +1383,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -1407,7 +1407,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -1431,7 +1431,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -1464,7 +1464,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -1497,7 +1497,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -1521,7 +1521,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -1545,7 +1545,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -1578,7 +1578,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -1602,7 +1602,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -1626,7 +1626,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -1650,7 +1650,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -1691,7 +1691,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -1715,7 +1715,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -1739,7 +1739,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -1763,7 +1763,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -1804,7 +1804,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -1828,7 +1828,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -1852,7 +1852,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -1876,7 +1876,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -1917,7 +1917,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -1941,7 +1941,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -1965,7 +1965,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -1989,7 +1989,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -2013,7 +2013,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -2046,7 +2046,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -2079,7 +2079,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -2103,7 +2103,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -2127,7 +2127,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -2160,7 +2160,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -2184,7 +2184,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -2208,7 +2208,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -2232,7 +2232,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -2265,7 +2265,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -2289,7 +2289,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -2313,7 +2313,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -2337,7 +2337,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -2402,7 +2402,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -2426,7 +2426,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -2450,7 +2450,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -2474,7 +2474,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -2515,7 +2515,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -2539,7 +2539,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -2580,7 +2580,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -2604,7 +2604,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -2628,7 +2628,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -2652,7 +2652,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -2676,7 +2676,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -2700,7 +2700,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -2724,7 +2724,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -2765,7 +2765,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -2789,7 +2789,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -2813,7 +2813,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -2854,7 +2854,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -2887,7 +2887,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -2911,7 +2911,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -2935,7 +2935,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -2976,7 +2976,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -3009,7 +3009,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -3033,7 +3033,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -3057,7 +3057,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -3098,7 +3098,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -3131,7 +3131,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -3155,7 +3155,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -3179,7 +3179,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -3212,7 +3212,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -3236,7 +3236,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -3260,7 +3260,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -3284,7 +3284,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -3317,7 +3317,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -3341,7 +3341,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -3365,7 +3365,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -3389,7 +3389,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -3430,7 +3430,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -3463,7 +3463,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -3487,7 +3487,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -3511,7 +3511,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -3552,7 +3552,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -3585,7 +3585,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -3609,7 +3609,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -3633,7 +3633,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -3674,7 +3674,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -3707,7 +3707,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -3756,7 +3756,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -3780,7 +3780,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -3813,7 +3813,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -3878,7 +3878,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -3911,7 +3911,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -3935,7 +3935,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -3959,7 +3959,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -3992,7 +3992,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -4025,7 +4025,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -4049,7 +4049,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -4073,7 +4073,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -4106,7 +4106,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -4139,7 +4139,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -4163,7 +4163,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -4187,7 +4187,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -4220,7 +4220,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -4253,7 +4253,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -4277,7 +4277,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -4301,7 +4301,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -4334,7 +4334,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -4358,7 +4358,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -4382,7 +4382,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -4406,7 +4406,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -4439,7 +4439,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -4463,7 +4463,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -4487,7 +4487,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -4511,7 +4511,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -4544,7 +4544,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -4568,7 +4568,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -4592,7 +4592,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -4616,7 +4616,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -4649,7 +4649,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -4673,7 +4673,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -4697,7 +4697,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -4721,7 +4721,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -4754,7 +4754,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -4787,7 +4787,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -4811,7 +4811,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -4835,7 +4835,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -4868,7 +4868,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -4892,7 +4892,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -4916,7 +4916,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -4940,7 +4940,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -4973,7 +4973,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -4997,7 +4997,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -5021,7 +5021,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -5045,7 +5045,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -5078,7 +5078,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -5119,7 +5119,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -5143,7 +5143,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -5167,7 +5167,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -5200,7 +5200,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -5224,7 +5224,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -5248,7 +5248,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -5272,7 +5272,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -5305,7 +5305,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -5338,7 +5338,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -5362,7 +5362,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -5386,7 +5386,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -5419,7 +5419,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -5443,7 +5443,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -5467,7 +5467,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -5491,7 +5491,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -5515,7 +5515,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -5539,7 +5539,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -5563,7 +5563,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -5587,7 +5587,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -5620,7 +5620,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -5653,7 +5653,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -5677,7 +5677,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -5701,7 +5701,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -5734,7 +5734,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -5758,7 +5758,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -5782,7 +5782,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -5806,7 +5806,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -5839,7 +5839,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -5872,7 +5872,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -5896,7 +5896,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -5920,7 +5920,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -5953,7 +5953,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -5977,7 +5977,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -6001,7 +6001,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -6025,7 +6025,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -6058,7 +6058,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -6091,7 +6091,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -6115,7 +6115,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -6139,7 +6139,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -6180,7 +6180,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -6204,7 +6204,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -6228,7 +6228,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -6252,7 +6252,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -6285,7 +6285,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -6309,7 +6309,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -6333,7 +6333,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -6357,7 +6357,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -6390,7 +6390,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -6414,7 +6414,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -6438,7 +6438,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -6462,7 +6462,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -6495,7 +6495,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -6519,7 +6519,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -6543,7 +6543,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -6567,7 +6567,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -6600,7 +6600,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -6633,7 +6633,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -6657,7 +6657,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -6681,7 +6681,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -6714,7 +6714,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -6738,7 +6738,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -6762,7 +6762,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -6786,7 +6786,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -6819,7 +6819,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -6843,7 +6843,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -6867,7 +6867,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -6891,7 +6891,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -6924,7 +6924,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -6948,7 +6948,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -6972,7 +6972,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -6996,7 +6996,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -7037,7 +7037,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -7070,7 +7070,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -7094,7 +7094,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -7118,7 +7118,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -7159,7 +7159,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -7192,7 +7192,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -7216,7 +7216,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -7240,7 +7240,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -7273,7 +7273,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -7297,7 +7297,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -7321,7 +7321,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -7345,7 +7345,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -7378,7 +7378,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -7402,7 +7402,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -7426,7 +7426,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -7450,7 +7450,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -7483,7 +7483,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -7507,7 +7507,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -7531,7 +7531,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -7555,7 +7555,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -7588,7 +7588,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -7612,7 +7612,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -7636,7 +7636,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -7660,7 +7660,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -7693,7 +7693,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -7726,7 +7726,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -7750,7 +7750,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -7774,7 +7774,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -7807,7 +7807,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -7831,7 +7831,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -7855,7 +7855,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -7879,7 +7879,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -7912,7 +7912,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -7945,7 +7945,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -7969,7 +7969,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -7993,7 +7993,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -8026,7 +8026,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -8059,7 +8059,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -8083,7 +8083,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -8107,7 +8107,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -8140,7 +8140,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -8164,7 +8164,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -8188,7 +8188,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -8212,7 +8212,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -8245,7 +8245,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -8269,7 +8269,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -8293,7 +8293,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -8317,7 +8317,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -8350,7 +8350,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -8374,7 +8374,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -8398,7 +8398,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -8422,7 +8422,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -8455,7 +8455,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -8479,7 +8479,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -8503,7 +8503,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -8527,7 +8527,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -8560,7 +8560,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -8584,7 +8584,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -8608,7 +8608,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -8632,7 +8632,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -8656,7 +8656,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -8697,7 +8697,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -8730,7 +8730,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -8754,7 +8754,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -8778,7 +8778,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -8802,7 +8802,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -8835,7 +8835,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -8859,7 +8859,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -8883,7 +8883,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -8907,7 +8907,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -8940,7 +8940,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -8964,7 +8964,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -8988,7 +8988,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -9012,7 +9012,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -9045,7 +9045,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -9086,7 +9086,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -9110,7 +9110,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -9134,7 +9134,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -9167,7 +9167,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -9191,7 +9191,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -9215,7 +9215,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -9239,7 +9239,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -9272,7 +9272,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -9296,7 +9296,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -9320,7 +9320,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -9344,7 +9344,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -9377,7 +9377,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -9410,7 +9410,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -9434,7 +9434,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -9458,7 +9458,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -9491,7 +9491,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -9515,7 +9515,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -9539,7 +9539,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -9563,7 +9563,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -9596,7 +9596,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -9629,7 +9629,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -9653,7 +9653,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -9677,7 +9677,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -9742,7 +9742,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -9775,7 +9775,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -9799,7 +9799,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -9823,7 +9823,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -9856,7 +9856,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -9880,7 +9880,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -9904,7 +9904,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -9928,7 +9928,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -9961,7 +9961,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -9994,7 +9994,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -10018,7 +10018,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -10042,7 +10042,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -10075,7 +10075,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -10099,7 +10099,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -10123,7 +10123,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -10147,7 +10147,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -10180,7 +10180,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -10213,7 +10213,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -10237,7 +10237,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -10261,7 +10261,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -10294,7 +10294,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -10318,7 +10318,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -10342,7 +10342,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -10366,7 +10366,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -10399,7 +10399,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -10423,7 +10423,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -10447,7 +10447,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -10471,7 +10471,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -10504,7 +10504,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -10528,7 +10528,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -10552,7 +10552,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -10576,7 +10576,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -10617,7 +10617,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -10641,7 +10641,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -10665,7 +10665,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -10689,7 +10689,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -10746,7 +10746,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -10779,7 +10779,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -10803,7 +10803,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -10827,7 +10827,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -10860,7 +10860,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -10884,7 +10884,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -10908,7 +10908,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -10932,7 +10932,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -10965,7 +10965,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -10998,7 +10998,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -11022,7 +11022,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -11046,7 +11046,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -11079,7 +11079,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -11103,7 +11103,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -11127,7 +11127,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -11151,7 +11151,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -11184,7 +11184,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -11225,7 +11225,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -11354,7 +11354,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -11378,7 +11378,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -11402,7 +11402,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -11426,7 +11426,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -11459,7 +11459,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -11483,7 +11483,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -11507,7 +11507,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -11548,7 +11548,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -11572,7 +11572,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -11621,7 +11621,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -11654,7 +11654,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -11687,7 +11687,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -11711,7 +11711,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -11735,7 +11735,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -11768,7 +11768,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -11801,7 +11801,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -11825,7 +11825,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -11849,7 +11849,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -11882,7 +11882,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -11915,7 +11915,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -11939,7 +11939,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -11963,7 +11963,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -11996,7 +11996,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -12020,7 +12020,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -12044,7 +12044,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -12068,7 +12068,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -12109,7 +12109,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -12142,7 +12142,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -12166,7 +12166,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -12190,7 +12190,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -12223,7 +12223,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -12247,7 +12247,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -12271,7 +12271,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -12295,7 +12295,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -12319,7 +12319,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -12343,7 +12343,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -12367,7 +12367,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -12391,7 +12391,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -12424,7 +12424,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -12448,7 +12448,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -12472,7 +12472,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -12496,7 +12496,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -12529,7 +12529,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -12553,7 +12553,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -12577,7 +12577,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -12601,7 +12601,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -12625,7 +12625,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -12649,7 +12649,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -12673,7 +12673,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -12697,7 +12697,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -12721,7 +12721,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -12754,7 +12754,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -12778,7 +12778,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -12802,7 +12802,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -12835,7 +12835,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -12859,7 +12859,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -12883,7 +12883,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -12907,7 +12907,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -12988,7 +12988,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -13021,7 +13021,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -13045,7 +13045,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -13069,7 +13069,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -13118,7 +13118,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -13142,7 +13142,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -13166,7 +13166,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -13190,7 +13190,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -13223,7 +13223,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -13247,7 +13247,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -13271,7 +13271,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -13295,7 +13295,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -13319,7 +13319,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -13343,7 +13343,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -13376,7 +13376,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -13400,7 +13400,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -13424,7 +13424,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -13457,7 +13457,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -13481,7 +13481,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -13505,7 +13505,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -13538,7 +13538,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -13562,7 +13562,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -13586,7 +13586,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -13610,7 +13610,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -13634,7 +13634,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -13658,7 +13658,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -13682,7 +13682,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -13715,7 +13715,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -13748,7 +13748,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -13781,7 +13781,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -13805,7 +13805,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -13854,7 +13854,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -13919,7 +13919,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -13943,7 +13943,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -14024,7 +14024,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -14048,7 +14048,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -14145,8 +14145,8 @@
             }
           ]
         },
-        "threshold": 25.0,
-        "exceeds": false
+        "threshold": 16.0,
+        "exceeds": true
       },
       {
         "scored": {
@@ -14178,7 +14178,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -14202,7 +14202,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -14251,7 +14251,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -14284,7 +14284,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -14317,7 +14317,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -14358,7 +14358,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -14382,7 +14382,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -14415,7 +14415,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -14472,7 +14472,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -14513,7 +14513,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -14570,7 +14570,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -14611,7 +14611,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -14652,7 +14652,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -14676,7 +14676,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -14700,7 +14700,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -14724,7 +14724,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -14829,7 +14829,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -14853,7 +14853,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -14877,7 +14877,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -14910,7 +14910,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -14934,7 +14934,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -14958,7 +14958,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -14999,7 +14999,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -15168,8 +15168,8 @@
             }
           ]
         },
-        "threshold": 25.0,
-        "exceeds": false
+        "threshold": 16.0,
+        "exceeds": true
       },
       {
         "scored": {
@@ -15209,7 +15209,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -15233,7 +15233,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -15257,7 +15257,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -15306,7 +15306,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -15355,7 +15355,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -15379,7 +15379,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -15403,7 +15403,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -15427,7 +15427,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -15451,7 +15451,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -15564,7 +15564,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -15653,7 +15653,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -15677,7 +15677,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -15710,7 +15710,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -15734,7 +15734,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -15767,7 +15767,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -15824,7 +15824,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -15848,7 +15848,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -15872,7 +15872,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -15905,7 +15905,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -15929,7 +15929,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -15986,7 +15986,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -16010,7 +16010,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -16147,7 +16147,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -16188,7 +16188,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -16212,7 +16212,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -16236,7 +16236,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -16357,7 +16357,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -16390,7 +16390,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -16455,7 +16455,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -16479,7 +16479,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -16568,7 +16568,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -16609,7 +16609,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -16633,7 +16633,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -16674,7 +16674,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -16715,7 +16715,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -16739,7 +16739,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -16844,7 +16844,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -16868,7 +16868,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -16892,7 +16892,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -16916,7 +16916,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -16940,7 +16940,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -16964,7 +16964,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -16997,7 +16997,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -17021,7 +17021,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -17045,7 +17045,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -17094,7 +17094,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -17118,7 +17118,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -17167,7 +17167,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -17191,7 +17191,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -17215,7 +17215,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -17239,14 +17239,14 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       }
     ],
     "summary": {
       "total_functions": 568,
       "total_files": 129,
-      "exceeding_threshold": 1,
+      "exceeding_threshold": 3,
       "average_crap": 1.9053169014084503,
       "median_crap": 1.0,
       "max_crap": {
@@ -17369,7 +17369,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": true
       },
       {
@@ -17466,8 +17466,8 @@
             }
           ]
         },
-        "threshold": 25.0,
-        "exceeds": false
+        "threshold": 16.0,
+        "exceeds": true
       },
       {
         "scored": {
@@ -17635,8 +17635,8 @@
             }
           ]
         },
-        "threshold": 25.0,
-        "exceeds": false
+        "threshold": 16.0,
+        "exceeds": true
       },
       {
         "scored": {
@@ -17772,7 +17772,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -17901,7 +17901,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -18022,7 +18022,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -18079,7 +18079,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -18120,7 +18120,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -18233,7 +18233,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -18338,7 +18338,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -18443,7 +18443,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -18532,7 +18532,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -18621,7 +18621,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -18686,7 +18686,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -18767,7 +18767,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -18848,7 +18848,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -18921,7 +18921,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -18986,7 +18986,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -19051,7 +19051,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -19084,7 +19084,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -19117,7 +19117,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -19150,7 +19150,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -19215,7 +19215,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -19280,7 +19280,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -19337,7 +19337,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -19394,7 +19394,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -19451,7 +19451,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -19508,7 +19508,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -19557,7 +19557,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -19606,7 +19606,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -19655,7 +19655,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -19704,7 +19704,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -19753,7 +19753,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -19802,7 +19802,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -19851,7 +19851,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -19900,7 +19900,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -19949,7 +19949,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -19990,7 +19990,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -20031,7 +20031,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -20072,7 +20072,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -20113,7 +20113,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -20154,7 +20154,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -20195,7 +20195,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -20236,7 +20236,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -20277,7 +20277,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -20318,7 +20318,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -20359,7 +20359,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -20400,7 +20400,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -20441,7 +20441,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -20482,7 +20482,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -20523,7 +20523,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -20564,7 +20564,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -20605,7 +20605,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -20646,7 +20646,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -20687,7 +20687,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -20728,7 +20728,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -20769,7 +20769,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -20810,7 +20810,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -20851,7 +20851,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -20892,7 +20892,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -20933,7 +20933,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -20974,7 +20974,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -21015,7 +21015,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -21056,7 +21056,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -21097,7 +21097,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -21138,7 +21138,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -21179,7 +21179,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -21220,7 +21220,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -21261,7 +21261,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -21302,7 +21302,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -21343,7 +21343,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -21376,7 +21376,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -21409,7 +21409,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -21442,7 +21442,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -21475,7 +21475,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -21508,7 +21508,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -21541,7 +21541,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -21574,7 +21574,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -21607,7 +21607,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -21640,7 +21640,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -21673,7 +21673,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -21706,7 +21706,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -21739,7 +21739,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -21772,7 +21772,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -21805,7 +21805,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -21838,7 +21838,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -21871,7 +21871,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -21904,7 +21904,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -21937,7 +21937,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -21970,7 +21970,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -22003,7 +22003,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -22036,7 +22036,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -22069,7 +22069,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -22102,7 +22102,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -22135,7 +22135,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -22168,7 +22168,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -22192,7 +22192,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -22225,7 +22225,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -22258,7 +22258,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -22291,7 +22291,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -22324,7 +22324,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -22357,7 +22357,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -22390,7 +22390,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -22423,7 +22423,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -22456,7 +22456,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -22489,7 +22489,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -22522,7 +22522,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -22555,7 +22555,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -22588,7 +22588,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -22621,7 +22621,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -22654,7 +22654,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -22687,7 +22687,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -22720,7 +22720,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -22753,7 +22753,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -22786,7 +22786,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -22819,7 +22819,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -22852,7 +22852,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -22885,7 +22885,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -22918,7 +22918,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -22951,7 +22951,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -22984,7 +22984,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -23017,7 +23017,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -23050,7 +23050,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -23083,7 +23083,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -23116,7 +23116,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -23149,7 +23149,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -23182,7 +23182,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -23215,7 +23215,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -23248,7 +23248,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -23281,7 +23281,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -23314,7 +23314,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -23347,7 +23347,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -23380,7 +23380,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -23413,7 +23413,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -23446,7 +23446,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -23479,7 +23479,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -23512,7 +23512,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -23545,7 +23545,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -23578,7 +23578,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -23611,7 +23611,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -23644,7 +23644,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -23677,7 +23677,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -23710,7 +23710,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -23743,7 +23743,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -23767,7 +23767,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -23791,7 +23791,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -23824,7 +23824,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -23857,7 +23857,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -23890,7 +23890,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -23923,7 +23923,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -23956,7 +23956,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -23989,7 +23989,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -24022,7 +24022,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -24055,7 +24055,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -24088,7 +24088,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -24121,7 +24121,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -24154,7 +24154,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -24187,7 +24187,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -24220,7 +24220,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -24253,7 +24253,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -24286,7 +24286,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -24319,7 +24319,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -24352,7 +24352,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -24385,7 +24385,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -24409,7 +24409,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -24442,7 +24442,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -24475,7 +24475,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -24508,7 +24508,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -24541,7 +24541,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -24574,7 +24574,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -24607,7 +24607,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -24640,7 +24640,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -24673,7 +24673,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -24697,7 +24697,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -24721,7 +24721,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -24754,7 +24754,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -24787,7 +24787,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -24820,7 +24820,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -24853,7 +24853,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -24886,7 +24886,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -24919,7 +24919,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -24952,7 +24952,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -24985,7 +24985,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -25018,7 +25018,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -25051,7 +25051,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -25084,7 +25084,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -25117,7 +25117,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -25150,7 +25150,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -25183,7 +25183,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -25216,7 +25216,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -25249,7 +25249,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -25282,7 +25282,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -25315,7 +25315,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -25348,7 +25348,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -25381,7 +25381,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -25414,7 +25414,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -25447,7 +25447,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -25480,7 +25480,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -25513,7 +25513,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -25546,7 +25546,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -25579,7 +25579,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -25612,7 +25612,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -25645,7 +25645,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -25678,7 +25678,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -25711,7 +25711,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -25735,7 +25735,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -25759,7 +25759,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -25783,7 +25783,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -25807,7 +25807,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -25831,7 +25831,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -25855,7 +25855,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -25879,7 +25879,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -25903,7 +25903,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -25927,7 +25927,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -25960,7 +25960,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -25993,7 +25993,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -26017,7 +26017,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -26050,7 +26050,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -26083,7 +26083,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -26116,7 +26116,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -26149,7 +26149,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -26182,7 +26182,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -26215,7 +26215,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -26248,7 +26248,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -26281,7 +26281,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -26314,7 +26314,7 @@
             }
           ]
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -26338,7 +26338,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -26362,7 +26362,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -26386,7 +26386,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -26410,7 +26410,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -26434,7 +26434,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -26458,7 +26458,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -26482,7 +26482,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -26506,7 +26506,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -26530,7 +26530,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -26554,7 +26554,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -26578,7 +26578,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -26602,7 +26602,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -26626,7 +26626,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -26650,7 +26650,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -26674,7 +26674,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -26698,7 +26698,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -26722,7 +26722,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -26746,7 +26746,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -26770,7 +26770,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -26794,7 +26794,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -26818,7 +26818,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -26842,7 +26842,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -26866,7 +26866,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -26890,7 +26890,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -26914,7 +26914,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -26938,7 +26938,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -26962,7 +26962,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -26986,7 +26986,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -27010,7 +27010,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -27034,7 +27034,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -27058,7 +27058,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -27082,7 +27082,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -27106,7 +27106,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -27130,7 +27130,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -27154,7 +27154,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -27178,7 +27178,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -27202,7 +27202,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -27226,7 +27226,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -27250,7 +27250,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -27274,7 +27274,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -27298,7 +27298,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -27322,7 +27322,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -27346,7 +27346,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -27370,7 +27370,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -27394,7 +27394,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -27418,7 +27418,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -27442,7 +27442,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -27466,7 +27466,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -27490,7 +27490,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -27514,7 +27514,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -27538,7 +27538,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -27562,7 +27562,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -27586,7 +27586,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -27610,7 +27610,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -27634,7 +27634,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -27658,7 +27658,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -27682,7 +27682,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -27706,7 +27706,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -27730,7 +27730,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -27754,7 +27754,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -27778,7 +27778,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -27802,7 +27802,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -27826,7 +27826,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -27850,7 +27850,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -27874,7 +27874,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -27898,7 +27898,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -27922,7 +27922,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -27946,7 +27946,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -27970,7 +27970,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -27994,7 +27994,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -28018,7 +28018,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -28042,7 +28042,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -28066,7 +28066,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -28090,7 +28090,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -28114,7 +28114,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -28138,7 +28138,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -28162,7 +28162,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -28186,7 +28186,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -28210,7 +28210,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -28234,7 +28234,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -28258,7 +28258,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -28282,7 +28282,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -28306,7 +28306,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -28330,7 +28330,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -28354,7 +28354,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -28378,7 +28378,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -28402,7 +28402,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -28426,7 +28426,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -28450,7 +28450,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -28474,7 +28474,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -28498,7 +28498,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -28522,7 +28522,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -28546,7 +28546,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -28570,7 +28570,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -28594,7 +28594,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -28618,7 +28618,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -28642,7 +28642,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -28666,7 +28666,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -28690,7 +28690,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -28714,7 +28714,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -28738,7 +28738,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -28762,7 +28762,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -28786,7 +28786,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -28810,7 +28810,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -28834,7 +28834,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -28858,7 +28858,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -28882,7 +28882,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -28906,7 +28906,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -28930,7 +28930,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -28954,7 +28954,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -28978,7 +28978,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -29002,7 +29002,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -29026,7 +29026,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -29050,7 +29050,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -29074,7 +29074,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -29098,7 +29098,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -29122,7 +29122,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -29146,7 +29146,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -29170,7 +29170,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -29194,7 +29194,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -29218,7 +29218,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -29242,7 +29242,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -29266,7 +29266,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -29290,7 +29290,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -29314,7 +29314,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -29338,7 +29338,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -29362,7 +29362,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -29386,7 +29386,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -29410,7 +29410,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -29434,7 +29434,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -29458,7 +29458,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -29482,7 +29482,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -29506,7 +29506,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -29530,7 +29530,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -29554,7 +29554,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -29578,7 +29578,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -29602,7 +29602,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -29626,7 +29626,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -29650,7 +29650,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -29674,7 +29674,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -29698,7 +29698,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -29722,7 +29722,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -29746,7 +29746,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -29770,7 +29770,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -29794,7 +29794,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -29818,7 +29818,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -29842,7 +29842,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -29866,7 +29866,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -29890,7 +29890,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -29914,7 +29914,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -29938,7 +29938,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -29962,7 +29962,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -29986,7 +29986,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -30010,7 +30010,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -30034,7 +30034,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -30058,7 +30058,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -30082,7 +30082,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -30106,7 +30106,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -30130,7 +30130,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -30154,7 +30154,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -30178,7 +30178,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -30202,7 +30202,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -30226,7 +30226,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -30250,7 +30250,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -30274,7 +30274,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -30298,7 +30298,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -30322,7 +30322,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -30346,7 +30346,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -30370,7 +30370,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -30394,7 +30394,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -30418,7 +30418,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -30442,7 +30442,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -30466,7 +30466,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -30490,7 +30490,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -30514,7 +30514,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -30538,7 +30538,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -30562,7 +30562,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -30586,7 +30586,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -30610,7 +30610,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -30634,7 +30634,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -30658,7 +30658,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -30682,7 +30682,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -30706,7 +30706,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -30730,7 +30730,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -30754,7 +30754,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -30778,7 +30778,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -30802,7 +30802,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -30826,7 +30826,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -30850,7 +30850,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -30874,7 +30874,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -30898,7 +30898,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -30922,7 +30922,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -30946,7 +30946,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -30970,7 +30970,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -30994,7 +30994,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -31018,7 +31018,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -31042,7 +31042,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -31066,7 +31066,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -31090,7 +31090,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -31114,7 +31114,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -31138,7 +31138,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -31162,7 +31162,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -31186,7 +31186,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -31210,7 +31210,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -31234,7 +31234,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -31258,7 +31258,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -31282,7 +31282,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -31306,7 +31306,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -31330,7 +31330,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -31354,7 +31354,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -31378,7 +31378,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -31402,7 +31402,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -31426,7 +31426,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -31450,7 +31450,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -31474,7 +31474,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -31498,7 +31498,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -31522,7 +31522,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -31546,7 +31546,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -31570,7 +31570,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -31594,7 +31594,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -31618,7 +31618,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -31642,7 +31642,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -31666,7 +31666,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -31690,7 +31690,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -31714,7 +31714,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -31738,7 +31738,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -31762,7 +31762,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -31786,7 +31786,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -31810,7 +31810,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -31834,7 +31834,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -31858,7 +31858,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -31882,7 +31882,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -31906,7 +31906,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -31930,7 +31930,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -31954,7 +31954,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -31978,7 +31978,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -32002,7 +32002,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -32026,7 +32026,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -32050,7 +32050,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -32074,7 +32074,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -32098,7 +32098,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -32122,7 +32122,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -32146,7 +32146,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -32170,7 +32170,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -32194,7 +32194,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -32218,7 +32218,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -32242,7 +32242,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -32266,7 +32266,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -32290,7 +32290,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -32314,7 +32314,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -32338,7 +32338,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -32362,7 +32362,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -32386,7 +32386,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -32410,7 +32410,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -32434,7 +32434,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -32458,7 +32458,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -32482,7 +32482,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -32506,7 +32506,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -32530,7 +32530,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -32554,7 +32554,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -32578,7 +32578,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -32602,7 +32602,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -32626,7 +32626,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -32650,7 +32650,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -32674,7 +32674,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -32698,7 +32698,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -32722,7 +32722,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -32746,7 +32746,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -32770,7 +32770,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -32794,7 +32794,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -32818,7 +32818,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -32842,7 +32842,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -32866,7 +32866,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -32890,7 +32890,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -32914,7 +32914,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -32938,7 +32938,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -32962,7 +32962,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -32986,7 +32986,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -33010,7 +33010,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -33034,7 +33034,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -33058,7 +33058,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -33082,7 +33082,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -33106,7 +33106,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -33130,7 +33130,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -33154,7 +33154,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -33178,7 +33178,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -33202,7 +33202,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -33226,7 +33226,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -33250,7 +33250,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -33274,7 +33274,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -33298,7 +33298,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -33322,7 +33322,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -33346,7 +33346,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -33370,7 +33370,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -33394,7 +33394,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -33418,7 +33418,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -33442,7 +33442,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -33466,7 +33466,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -33490,7 +33490,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -33514,7 +33514,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -33538,7 +33538,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -33562,7 +33562,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -33586,7 +33586,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -33610,7 +33610,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -33634,7 +33634,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -33658,7 +33658,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -33682,7 +33682,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -33706,7 +33706,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -33730,7 +33730,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -33754,7 +33754,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -33778,7 +33778,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -33802,7 +33802,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -33826,7 +33826,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -33850,7 +33850,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -33874,7 +33874,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -33898,7 +33898,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -33922,7 +33922,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -33946,7 +33946,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -33970,7 +33970,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -33994,7 +33994,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -34018,7 +34018,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -34042,7 +34042,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -34066,7 +34066,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -34090,7 +34090,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -34114,7 +34114,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -34138,7 +34138,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -34162,7 +34162,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -34186,7 +34186,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -34210,7 +34210,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -34234,7 +34234,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -34258,7 +34258,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -34282,7 +34282,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -34306,7 +34306,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -34330,7 +34330,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -34354,7 +34354,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -34378,7 +34378,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -34402,7 +34402,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -34426,7 +34426,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -34450,7 +34450,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -34474,7 +34474,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -34498,7 +34498,7 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       },
       {
@@ -34522,14 +34522,14 @@
           },
           "contributors": []
         },
-        "threshold": 25.0,
+        "threshold": 16.0,
         "exceeds": false
       }
     ],
     "shown_summary": {
       "total_functions": 568,
       "total_files": 129,
-      "exceeding_threshold": 1,
+      "exceeding_threshold": 3,
       "average_crap": 1.9053169014084503,
       "median_crap": 1.0,
       "max_crap": {

--- a/crates/crap4ts/tests/fixtures/class-validator/README.md
+++ b/crates/crap4ts/tests/fixtures/class-validator/README.md
@@ -114,10 +114,14 @@ committed artifacts.**
    threshold; that's expected and does NOT mean the capture failed —
    verify by parsing the JSON
    (`jq . crates/crap4ts/tests/fixtures/class-validator-reference.json`).
-   At commit `2e1a5c2` the baseline reports 568 functions, 1 exceeding
-   the default threshold of 25 (`container.ts :: getFromContainer`,
-   CRAP 32.62), so the CLI exits **1** with `passed: false`. That is
-   the expected frozen state.
+   At commit `2e1a5c2` the baseline reports 568 functions. Post-#218
+   the no-flag default gate is the D5-correct `16` (was `25`), so **3**
+   functions exceed (worst: `container.ts :: getFromContainer`, CRAP
+   32.62); the CLI exits **1** with `result.passed: false`. That is the
+   expected frozen state. Only threshold-derived fields shifted from
+   the pre-#218 capture (`threshold` 25→16, `exceeding` 1→3,
+   `result.passed` unchanged false); scores/complexity/coverage are
+   identical (the "threshold-default-change" class).
 
 ## Baseline disposition
 
@@ -138,30 +142,32 @@ crap4ts@2.x change that moves a class-validator function's complexity,
 coverage, or CRAP score is a baseline drift that #190's harness
 surfaces for triage (legitimate improvement vs. score regression).
 
-### Known default-threshold caveat (#218) — regenerate post-fix
+### Default-threshold caveat (#218) — RESOLVED, baseline regenerated
 
-This baseline was captured at crap4ts@2.x's **no-flag default
-top-level gate `threshold` of `25.0`**. That `25` is crap-core's
-*shared* default (crap4rs's cognitive-metric value), **NOT** the
-D5-calibrated crap4ts cyclomatic default of **16** that locked
-pipeline decision #2/#5 mandates. W2.5 (#188) wired the default
-*metric* (cyclomatic) and the per-function/per-row threshold (`16.0`)
-but the top-level *gate* threshold still falls back to `25`; the
-`wire_envelope_crap4ts` canary masks this because it invokes the
-binary with an explicit `--threshold 16`. This is a real crap4ts
-default-threshold bug tracked as **#218** (sub-issue of #173,
-`type:bug priority:soon`).
+This baseline was *originally* captured at crap4ts@2.x's **no-flag
+default top-level gate `threshold` of `25.0`** — crap-core's *shared*
+default (crap4rs's cognitive-metric value), **NOT** the D5-calibrated
+crap4ts cyclomatic default of **16** that locked pipeline decision
+#2/#5 mandates. W2.5 (#188) wired the default *metric* (cyclomatic)
+and the per-function/per-row threshold (`16.0`) but the top-level
+*gate* threshold fell back to `25`; the `wire_envelope_crap4ts` canary
+masked it (it invokes the binary with an explicit `--threshold 16`).
+Tracked and **fixed in #218** (`AdapterMeta::default_threshold`,
+sibling of W2.5's `default_metric`).
 
-The baseline is deliberately **left frozen at the actual current
-default (`threshold: 25`)** per the W3.1 "freeze reality" precedent
-(the v1.x oracle likewise froze v1.x's real default threshold of 12) —
-a regression baseline must capture what crap4ts@2.x produces *today*,
-not its intended-after-fix behavior. **#190 (W3.2) must regenerate
-this baseline after #218 lands**: the top-level `threshold`, `passed`,
-each function's `exceeds`, and the `exceeding`-count will all shift
-when the default corrects 25 → 16. Until then, the "exceeding default
-threshold (25)" row in the Sanity-check table below reflects the
-buggy-default capture, not the D5-intended gate.
+**Plan-of-record correction (surfaced, not silently absorbed):** the
+original wording said "**#190 (W3.2) must regenerate this baseline
+after #218 lands**." #218's own acceptance criteria retconned that —
+**#218 regenerates this baseline; #190 (W3.2) *consumes* the corrected
+one.** This README is updated in the #218 PR (not left stale for
+#190). The freeze-reality precedent still holds: a regression baseline
+captures what crap4ts@2.x produces *today* — and today, post-#218, the
+no-flag default is the D5-correct `16`, so the frozen baseline now
+reflects `threshold: 16`. The top-level `threshold`, `result.passed`,
+each function's `exceeds`, and the `exceeding`-count shifted exactly as
+predicted (25 → 16; scores/complexity/coverage unchanged — the
+"threshold-default-change" class #190's 3-way classifier treats as
+PASS). The Sanity-check table below reflects the corrected `16` gate.
 
 ## Sanity-check (captured at `2e1a5c2`)
 
@@ -181,7 +187,7 @@ From the frozen baseline + `--verbose` parse statistics:
 | Average CRAP | 1.91 |
 | Median CRAP | 1.0 |
 | Max CRAP | 32.62 (`container.ts :: getFromContainer`, high) |
-| Functions exceeding default threshold (25) | 1 |
+| Functions exceeding default threshold (16, D5 — post-#218) | 3 |
 | Coverage health (non-zero / total) | 545 / 568 (95.9%) |
 | Functions at 100% coverage | 517 |
 | Average coverage | 94.29% |


### PR DESCRIPTION
## Summary

The no-flag default top-level gate `threshold`, the `--strict` /
`--lenient` presets, the config-file `preset` value, and the
`init`-generated `crap4rs.toml` / `crap4ts.toml` comment all resolved
their numeric cutoff from a single shared cognitive scalar, blind to
the effective complexity metric. A cyclomatic count and a cognitive
count differ in magnitude for the same function, so one scalar cutoff
mis-gates whichever metric it wasn't calibrated for. `crap4ts` (which
analyzes only cyclomatic complexity) was silently gating at the
cognitive `25` instead of the calibrated cyclomatic `16`.

This is the **right design, not a patch**: threshold tiers are now
keyed on the resolved metric via `ThresholdPreset::threshold(metric)`,
a single calibration table. There is no per-adapter scalar override —
the single source of truth is `default_metric` → the calibration
table. Every language/metric gets its own correct cutoffs; the `init`
command emits a metric-honest commented preset that stays fully
configurable in the toml.

## Behavioral changes (user-visible)

| invocation | metric | before | after |
|---|---|---|---|
| `crap4ts` (no flag) | cyclomatic | 25 | **16** |
| `crap4ts --strict` | cyclomatic | 15 | **8** |
| `crap4ts --lenient` | cyclomatic | 40 | **30** |
| `crap4rs --metric cyclomatic` (no flag) | cyclomatic | 25 | **16** |
| `crap4rs --metric cyclomatic --strict` | cyclomatic | 15 | **8** |
| `crap4rs` (no flag) | cognitive | 25 | 25 (unchanged) |
| `crap4rs --strict` | cognitive | 15 | 15 (unchanged) |

`crap4rs`'s cognitive defaults — the common path — are unchanged.

## Smart default + configurability

`preset = "default"` in the generated toml is the smart default: it
resolves to the metric-correct cutoff at runtime (cyclomatic `16` or
cognitive `25`) rather than baking a fixed number. Overrides remain
fully available: `preset = "strict" | "lenient"`, or a literal
`threshold = N` for a hand-picked cutoff. The generated comment now
states which metric the printed cutoffs apply to.

## Verification

New `crates/crap-core/tests/default_gate_threshold.rs` runs the real
`crap4rs` / `crap4ts` binaries with **no explicit `--threshold`** — the
independent axis the explicit-flag `wire_envelope_*` insta snapshots
structurally cannot exercise (they pass `--threshold 16`, masking the
default). 7-cell matrix across both adapters, all metrics/tiers.

Both `wire_envelope_crap4rs` and `wire_envelope_crap4ts` snapshots are
**byte-identical** — no drift (adapter `main.rs` files untouched; the
fix lives entirely in crap-core's resolution path).

The `class-validator-reference.json` parity baseline was regenerated at
the corrected default (threshold 25→16, `exceeding_threshold` 1→3;
scores/complexity/coverage byte-identical — the threshold-default-change
class W3.2 #190 consumes). README caveat updated + plan-of-record
corrected (#218 regenerates, #190 consumes).

## crap-core API

`ThresholdPreset::threshold` now takes a `ComplexityMetric`. crap-core
minor-bumped `0.2.0` → `0.3.0` (0.x SemVer allows breaking on minor;
no external consumers).

## Gates

Workspace tests, MSRV 1.93 `--all-targets`, fmt, clippy `-D warnings`,
doc `-D warnings`, `cargo deny`, AST-purity, both wire snapshots — all
green (lefthook pre-push battery passed).

Closes #218

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Threshold cutoffs are now independently calibrated for each complexity metric (cyclomatic vs. cognitive) instead of sharing one scalar value, ensuring accurate gate assessment per metric type.

* **Tests**
  * Added comprehensive test suite validating default gate threshold resolution across different complexity metrics and configuration modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/breezy-bays-labs/crap-rs/pull/222?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->