### PR TITLE
test(crap4ts): #214 — Istanbul producer fixture matrix + null-tolerance hardening

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -8,9 +8,18 @@ reviews:
   # CodeRabbit/gemini from reviewing snapshot source as if it were ours
   # (recurred on PR #213 — 6 false suggestions on the crap4ts-v1 snapshot;
   # W3.1-deferred follow-up, landed with the class-validator second oracle #208).
+  # The producer-matrix corpus (#214) is the same case: captured-real
+  # Istanbul output from jest/vitest/nyc/c8, byte-faithful except a
+  # {SRC_ROOT} path substitution — reviewing it as our code is noise.
+  # istanbul-c8/ is a wholly-captured directory; coverage-real-*.json
+  # are the captured files added beside the synthetic fixtures in the
+  # pre-existing istanbul-{jest,vitest,nyc}/ dirs (the glob suppresses
+  # only those, not the reviewed synthetic fixtures there).
   path_filters:
     - "!crates/crap4ts/tests/fixtures/crap4ts-v1/**"
     - "!crates/crap4ts/tests/fixtures/class-validator/**"
+    - "!crates/crap4ts/tests/fixtures/istanbul-c8/**"
+    - "!crates/crap4ts/tests/fixtures/**/coverage-real-*.json"
   path_instructions:
     - path: "src/domain/**"
       instructions: "Domain layer must be pure — no external crate imports, no I/O, no Rust-language-specific assumptions. These modules are destined for crap-core extraction."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the literal value; previously the preset silently won. The
   `init`-generated config never writes both, so the blast radius is
   limited to hand-edited configs. (#218)
+- crap4ts's Istanbul `coverage-final.json` parser now models only the
+  fields it actually consumes (`path`, `s`, `statementMap.start.line`,
+  `b`, `branchMap`). Unconsumed fields (`f`/`fnMap`, statement/branch
+  `end` positions, `column`, branch `type`) are no longer deserialized,
+  so emitter-side `null` or shape drift in those fields can no longer
+  abort the whole-file parse. Forward-looking: every captured jest 29 /
+  vitest-istanbul 4 / nyc 17 / c8 10 fixture already parsed cleanly, so
+  no current producer triggered this; the change removes a latent
+  whole-file-bail vector and locks the four producers as regression
+  fixtures. (#214)
 
 ### Changed (crap-core public API)
 

--- a/crates/crap4ts/src/adapters/coverage/mod.rs
+++ b/crates/crap4ts/src/adapters/coverage/mod.rs
@@ -29,11 +29,28 @@
 //!   detected top-level keys. `MissingField` covers entries that
 //!   have `s` records but an empty `statementMap` (or vice versa).
 //!
-//! ## Decision points (locked)
+//! ## Schema minimalism (only model what is consumed)
 //!
-//! - **No `f`/`fnMap` backfill** — W1.1 discovery 5a–5d empirically
-//!   showed `s`/`statementMap` data is sufficient for arrow-function
-//!   coverage (CLAUDE.md locked decision #13).
+//! The internal deserialization types model **only** the fields the
+//! parser actually reads (`path`, `s`, `statementMap.start.line`, `b`,
+//! `branchMap.loc.start.line`, `branchMap.line`). Fields a producer
+//! emits but the parser never consults (`f`/`fnMap`, the `end` side of
+//! every span, a branch's `type`) are deliberately **not** modelled —
+//! serde drops unknown fields, so they are tolerated for free.
+//!
+//! This is not just tidiness: it shrinks the whole-file failure
+//! surface. serde aborts the entire flat-shape parse the instant any
+//! *modelled, required* field has the wrong type (e.g. `"type": null`,
+//! `"name": null`, `"end": {}`), and that abort happens **before** any
+//! per-entry diagnostic can fire — the file produces zero coverage and
+//! zero diagnostics, the worst possible outcome. Empirically, jest,
+//! `@vitest/coverage-istanbul@4`, nyc, and `c8 --reporter=json` all
+//! emit concrete values for the fields we *do* model, but they vary
+//! freely in the fields we don't (anonymous `fnMap` names, generic
+//! branch `type`, `column: null`, empty `{}` position objects). Not
+//! modelling the unconsumed fields means that variance — present or
+//! future — can never bail the parse.
+//!
 //! - **`ParseOutput.branches` is internal** — `crap-core::core::analyze`
 //!   lowers branch data into per-function `branch_coverage:
 //!   Option<CoverageRatio>` records, but the JSON envelope only
@@ -248,95 +265,57 @@ struct IstanbulCoverageFile {
     /// `statement_id` → execution count.
     #[serde(default)]
     s: HashMap<String, u64>,
-    /// `statement_id` → `{ start: {line, column}, end: {line, column} }`.
+    /// `statement_id` → statement location. Only `start.line` is read
+    /// (the line-coverage join key).
     #[serde(default)]
     statement_map: HashMap<String, StatementLoc>,
-    /// W2.3 (now consumed): `branch_id` → `[hit count per branch arm]`.
-    /// Each branchId maps to a `Vec<u64>` of arm-level hit counts; the
-    /// parser fans these into one `BranchCoverage` row per arm at the
-    /// associated `branchMap[id]` start line.
+    /// `branch_id` → per-arm hit counts. Each branchId maps to a
+    /// `Vec<u64>` of arm-level counts; the parser fans these into one
+    /// `BranchCoverage` row per arm at the branching site's line.
     #[serde(default)]
     b: HashMap<String, Vec<u64>>,
-    /// W2.3 (now consumed): `branch_id` → branch location. See `b`
-    /// above.
+    /// `branch_id` → branch location. See `b` above.
     #[serde(default)]
     branch_map: HashMap<String, BranchLoc>,
-    /// `function_id` → execution count. Locked decision #13: NOT
-    /// consumed — W1.1 discovery 5a–5d showed `s`/`statementMap` is
-    /// sufficient for arrow-function coverage. Field kept for forward
-    /// compatibility (and to keep test fixtures faithful to real
-    /// emitter output) so future inclusion is consumer-side only.
-    #[serde(default)]
-    #[allow(dead_code)]
-    f: HashMap<String, u64>,
-    /// `function_id` → function metadata. See `f` above; not consumed
-    /// in v2.0.0.
-    #[serde(default)]
-    #[allow(dead_code)]
-    fn_map: HashMap<String, FnLoc>,
+    // `f`/`fnMap` (function exec counts + metadata) are intentionally
+    // not modelled: line coverage from `s`/`statementMap` is sufficient
+    // for every function shape (including arrow functions), so the
+    // parser never reads them. serde drops them as unknown fields.
+    // Modelling `fnMap` would re-introduce a whole-file bail vector —
+    // its `name` is `null` for anonymous functions in some producers.
 }
 
-/// Range location for a statement (or function decl/body). `start`
-/// and `end` carry 1-based line numbers + 0-based columns.
+/// A span location. Istanbul carries `{ start, end }`, but only
+/// `start.line` is the line-coverage join key, so `end` (and the
+/// column on either side) is not modelled — see the module-level
+/// "Schema minimalism" note. serde ignores the unmodelled `end`.
 #[derive(Debug, Deserialize)]
 struct StatementLoc {
     start: Position,
-    #[allow(dead_code)]
-    end: Position,
 }
 
-/// 1-based line + 0-based column. Matches Istanbul's emitter
-/// convention; downstream `LineCoverage.line` is 1-based `usize`.
-///
-/// `column` is `Option<u32>` because `@vitest/coverage-istanbul` (and
-/// possibly other producers) emit `"column": null` on the `end` side of
-/// every span, signalling "unknown column" — the underlying V8
-/// inspector data they transform doesn't always have a precise
-/// end-column. crap4ts line-range matching is line-only, so the
-/// column value is advisory and never consulted; accepting `null` is
-/// semantically a no-op. Surfaced by W3.1's crap4ts@1.x corpus
-/// capture (#189) where 1,943 of 4,696 columns were null; tracked
-/// fix: #211.
+/// The 1-based source line of a span's start — the only positional
+/// datum the line-coverage join consumes. Istanbul also emits a
+/// `column` here (and a whole `end` position), sometimes `null` or an
+/// empty `{}` object depending on the producer; none of that is
+/// modelled because none of it is read, so its variance can never
+/// fail the parse.
 #[derive(Debug, Deserialize)]
 struct Position {
     line: u32,
-    #[allow(dead_code)]
-    column: Option<u32>,
 }
 
-/// W2.3 branch metadata. `kind` (e.g. `"if"`, `"switch"`, `"cond-expr"`)
-/// is carried but not consumed by the parser — line attribution joins
-/// only on the `loc.start.line` value (or the optional emitter-set
-/// `line` field when present, which some emitters use as the
-/// branching-site line independent of `loc`).
+/// Branch location. Only the branching-site line is consumed: the
+/// emitter-set `line` when present (some emitters pin it to the
+/// branching keyword's line while `loc` spans both arms), else
+/// `loc.start.line`. Istanbul's branch `type` and `locations[]` are
+/// not modelled — unread, and `type` is `null` / `locations[]` holds
+/// empty `{}` objects in some producers' output.
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
 struct BranchLoc {
     loc: StatementLoc,
-    /// Istanbul branch kind (`if`, `switch`, `cond-expr`, `default-arg`,
-    /// `binary-expr`, etc.). Kept for downstream display only; not
-    /// consumed by the line-range join.
-    #[serde(rename = "type")]
-    #[allow(dead_code)]
-    kind: String,
-    /// Optional emitter-set branching-site line. When present, takes
-    /// precedence over `loc.start.line` for line attribution (some
-    /// emitters set `loc` to a wide span covering both arms but pin
-    /// `line` to the branching keyword's line).
-    #[serde(default)]
-    line: Option<u32>,
-}
-
-/// W2.3 fallback: function metadata. Declared minimal here for the
-/// same reason as `BranchLoc`; `name` + `decl` + `loc` + `line` is the
-/// minimum surface needed if `f`/`fnMap` later backfills arrow
-/// coverage that `s`/`statementMap` undercounts.
-#[derive(Debug, Deserialize)]
-#[allow(dead_code)]
-struct FnLoc {
-    name: String,
-    decl: StatementLoc,
-    loc: StatementLoc,
+    /// Optional emitter-set branching-site line; takes precedence over
+    /// `loc.start.line` when present.
     #[serde(default)]
     line: Option<u32>,
 }

--- a/crates/crap4ts/tests/fixtures/istanbul-c8/README.md
+++ b/crates/crap4ts/tests/fixtures/istanbul-c8/README.md
@@ -1,0 +1,60 @@
+# istanbul-c8 fixtures
+
+Istanbul `coverage-final.json` payloads from **c8** (`--reporter=json`).
+
+| File | Origin |
+|---|---|
+| `coverage-real-c8.json` | **Captured-real** from c8 10 (+ tsx, `node:test`). |
+
+This directory is wholly captured (no synthetic fixture). Paths use the
+`{SRC_ROOT}` placeholder; smoke tests substitute a canonical tempdir
+root.
+
+## Discovery resolved: c8 does emit Istanbul shape
+
+c8 is a native V8-coverage tool, but it converts V8 coverage into an
+Istanbul `CoverageMap` and its `json` reporter writes a
+`coverage-final.json` in the flat Istanbul shape the parser's arm 1
+already consumes — `statementMap` / `fnMap` / `branchMap` / `s` / `b` /
+`f` / `path`, plus one **extra per-entry `all` field** and a generic
+`type: "branch"` on every `branchMap` entry (c8 does not classify
+`if`/`cond-expr`/`switch`). `fnMap` names are concrete transpiled
+helper names (e.g. `__name`, `__export`), not `(anonymous_N)`. None of
+`all`, branch `type`, or `fnMap` is modelled, so the parse is
+unaffected. The canonical flag is `--reporter=json` (verified against
+c8 10.x).
+
+## `coverage-real-c8.json` — captured state
+
+- **Captured on**: 2026-05-17
+- **Source**: `tests/fixtures/ts-fixtures/producer-sample.ts` as `src/sample.ts`
+- **Toolchain**:
+  - node: `v25.9.0`
+  - c8: `10.1.3`
+  - tsx: `4.22.1`
+  - typescript: `5.9.3`
+
+## Capture procedure
+
+1. Scaffold (`package.json` devDeps `c8@^10.1.3`, `tsx@^4.19.2`,
+   `typescript@^5.4.5`):
+
+   ```bash
+   mkdir -p c8/src && cp producer-sample.ts c8/src/sample.ts
+   # add a sample.test.ts using node:test + node:assert
+   cd c8 && npm install
+   ```
+
+2. Run coverage (c8 wraps the node process, sets `NODE_V8_COVERAGE`,
+   converts V8 → Istanbul):
+
+   ```bash
+   npx c8 --reporter=json --src=src \
+     --include='src/**/*.ts' --exclude='src/**/*.test.ts' \
+     --reports-dir=coverage \
+     node --import tsx --test src/sample.test.ts
+   # writes coverage/coverage-final.json (Istanbul shape)
+   ```
+
+3. Substitute the absolute `.../src` prefix with `{SRC_ROOT}` and copy
+   in as `coverage-real-c8.json`.

--- a/crates/crap4ts/tests/fixtures/istanbul-c8/coverage-real-c8.json
+++ b/crates/crap4ts/tests/fixtures/istanbul-c8/coverage-real-c8.json
@@ -1,0 +1,911 @@
+{
+  "{SRC_ROOT}/sample.ts": {
+    "path": "{SRC_ROOT}/sample.ts",
+    "all": false,
+    "statementMap": {
+      "0": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 45
+        }
+      },
+      "1": {
+        "start": {
+          "line": 2,
+          "column": 0
+        },
+        "end": {
+          "line": 2,
+          "column": 14
+        }
+      },
+      "2": {
+        "start": {
+          "line": 3,
+          "column": 0
+        },
+        "end": {
+          "line": 3,
+          "column": 22
+        }
+      },
+      "3": {
+        "start": {
+          "line": 4,
+          "column": 0
+        },
+        "end": {
+          "line": 4,
+          "column": 3
+        }
+      },
+      "4": {
+        "start": {
+          "line": 5,
+          "column": 0
+        },
+        "end": {
+          "line": 5,
+          "column": 39
+        }
+      },
+      "5": {
+        "start": {
+          "line": 6,
+          "column": 0
+        },
+        "end": {
+          "line": 6,
+          "column": 1
+        }
+      },
+      "6": {
+        "start": {
+          "line": 7,
+          "column": 0
+        },
+        "end": {
+          "line": 7,
+          "column": 0
+        }
+      },
+      "7": {
+        "start": {
+          "line": 8,
+          "column": 0
+        },
+        "end": {
+          "line": 8,
+          "column": 51
+        }
+      },
+      "8": {
+        "start": {
+          "line": 9,
+          "column": 0
+        },
+        "end": {
+          "line": 9,
+          "column": 0
+        }
+      },
+      "9": {
+        "start": {
+          "line": 10,
+          "column": 0
+        },
+        "end": {
+          "line": 10,
+          "column": 51
+        }
+      },
+      "10": {
+        "start": {
+          "line": 11,
+          "column": 0
+        },
+        "end": {
+          "line": 11,
+          "column": 0
+        }
+      },
+      "11": {
+        "start": {
+          "line": 12,
+          "column": 0
+        },
+        "end": {
+          "line": 12,
+          "column": 47
+        }
+      },
+      "12": {
+        "start": {
+          "line": 13,
+          "column": 0
+        },
+        "end": {
+          "line": 13,
+          "column": 22
+        }
+      },
+      "13": {
+        "start": {
+          "line": 14,
+          "column": 0
+        },
+        "end": {
+          "line": 14,
+          "column": 1
+        }
+      }
+    },
+    "s": {
+      "0": 1,
+      "1": 1,
+      "2": 0,
+      "3": 0,
+      "4": 1,
+      "5": 1,
+      "6": 1,
+      "7": 1,
+      "8": 1,
+      "9": 1,
+      "10": 1,
+      "11": 1,
+      "12": 0,
+      "13": 0
+    },
+    "branchMap": {
+      "0": {
+        "type": "branch",
+        "line": 12,
+        "loc": {
+          "start": {
+            "line": 12,
+            "column": 16
+          },
+          "end": {
+            "line": 12,
+            "column": 23
+          }
+        },
+        "locations": [
+          {
+            "start": {
+              "line": 12,
+              "column": 16
+            },
+            "end": {
+              "line": 12,
+              "column": 23
+            }
+          }
+        ]
+      },
+      "1": {
+        "type": "branch",
+        "line": 1,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 7
+          }
+        },
+        "locations": [
+          {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 7
+            }
+          }
+        ]
+      },
+      "2": {
+        "type": "branch",
+        "line": 1,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 7
+          }
+        },
+        "locations": [
+          {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 7
+            }
+          }
+        ]
+      },
+      "3": {
+        "type": "branch",
+        "line": 1,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 7
+          }
+        },
+        "locations": [
+          {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 7
+            }
+          }
+        ]
+      },
+      "4": {
+        "type": "branch",
+        "line": 1,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 7
+          }
+        },
+        "locations": [
+          {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 7
+            }
+          }
+        ]
+      },
+      "5": {
+        "type": "branch",
+        "line": 1,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 7
+          }
+        },
+        "locations": [
+          {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 7
+            }
+          }
+        ]
+      },
+      "6": {
+        "type": "branch",
+        "line": 1,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 7
+          }
+        },
+        "locations": [
+          {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 7
+            }
+          }
+        ]
+      },
+      "7": {
+        "type": "branch",
+        "line": 1,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 7
+          }
+        },
+        "locations": [
+          {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 7
+            }
+          }
+        ]
+      },
+      "8": {
+        "type": "branch",
+        "line": 1,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 7
+          }
+        },
+        "locations": [
+          {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 7
+            }
+          }
+        ]
+      },
+      "9": {
+        "type": "branch",
+        "line": 1,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 7
+          }
+        },
+        "locations": [
+          {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 7
+            }
+          }
+        ]
+      },
+      "10": {
+        "type": "branch",
+        "line": 1,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 7
+          }
+        },
+        "locations": [
+          {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 7
+            }
+          }
+        ]
+      },
+      "11": {
+        "type": "branch",
+        "line": 1,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 7
+          },
+          "end": {
+            "line": 6,
+            "column": 1
+          }
+        },
+        "locations": [
+          {
+            "start": {
+              "line": 1,
+              "column": 7
+            },
+            "end": {
+              "line": 6,
+              "column": 1
+            }
+          }
+        ]
+      },
+      "12": {
+        "type": "branch",
+        "line": 2,
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 13
+          },
+          "end": {
+            "line": 4,
+            "column": 3
+          }
+        },
+        "locations": [
+          {
+            "start": {
+              "line": 2,
+              "column": 13
+            },
+            "end": {
+              "line": 4,
+              "column": 3
+            }
+          }
+        ]
+      },
+      "13": {
+        "type": "branch",
+        "line": 5,
+        "loc": {
+          "start": {
+            "line": 5,
+            "column": 15
+          },
+          "end": {
+            "line": 5,
+            "column": 28
+          }
+        },
+        "locations": [
+          {
+            "start": {
+              "line": 5,
+              "column": 15
+            },
+            "end": {
+              "line": 5,
+              "column": 28
+            }
+          }
+        ]
+      },
+      "14": {
+        "type": "branch",
+        "line": 8,
+        "loc": {
+          "start": {
+            "line": 8,
+            "column": 23
+          },
+          "end": {
+            "line": 8,
+            "column": 51
+          }
+        },
+        "locations": [
+          {
+            "start": {
+              "line": 8,
+              "column": 23
+            },
+            "end": {
+              "line": 8,
+              "column": 51
+            }
+          }
+        ]
+      },
+      "15": {
+        "type": "branch",
+        "line": 10,
+        "loc": {
+          "start": {
+            "line": 10,
+            "column": 38
+          },
+          "end": {
+            "line": 10,
+            "column": 49
+          }
+        },
+        "locations": [
+          {
+            "start": {
+              "line": 10,
+              "column": 38
+            },
+            "end": {
+              "line": 10,
+              "column": 49
+            }
+          }
+        ]
+      }
+    },
+    "b": {
+      "0": [
+        0
+      ],
+      "1": [
+        3
+      ],
+      "2": [
+        1
+      ],
+      "3": [
+        4
+      ],
+      "4": [
+        1
+      ],
+      "5": [
+        0
+      ],
+      "6": [
+        4
+      ],
+      "7": [
+        2
+      ],
+      "8": [
+        1
+      ],
+      "9": [
+        1
+      ],
+      "10": [
+        1
+      ],
+      "11": [
+        1
+      ],
+      "12": [
+        0
+      ],
+      "13": [
+        0
+      ],
+      "14": [
+        1
+      ],
+      "15": [
+        3
+      ]
+    },
+    "fnMap": {
+      "0": {
+        "name": "__name",
+        "decl": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 7
+          }
+        },
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 7
+          }
+        },
+        "line": 1
+      },
+      "1": {
+        "name": "__export",
+        "decl": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 7
+          }
+        },
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 7
+          }
+        },
+        "line": 1
+      },
+      "2": {
+        "name": "__copyProps",
+        "decl": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 7
+          }
+        },
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 7
+          }
+        },
+        "line": 1
+      },
+      "3": {
+        "name": "get",
+        "decl": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 7
+          }
+        },
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 7
+          }
+        },
+        "line": 1
+      },
+      "4": {
+        "name": "__toCommonJS",
+        "decl": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 7
+          }
+        },
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 7
+          }
+        },
+        "line": 1
+      },
+      "5": {
+        "name": "classify",
+        "decl": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 7
+          }
+        },
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 7
+          }
+        },
+        "line": 1
+      },
+      "6": {
+        "name": "double",
+        "decl": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 7
+          }
+        },
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 7
+          }
+        },
+        "line": 1
+      },
+      "7": {
+        "name": "squares",
+        "decl": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 7
+          }
+        },
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 7
+          }
+        },
+        "line": 1
+      },
+      "8": {
+        "name": "unused",
+        "decl": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 7
+          }
+        },
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 7
+          }
+        },
+        "line": 1
+      },
+      "9": {
+        "name": "classify",
+        "decl": {
+          "start": {
+            "line": 1,
+            "column": 7
+          },
+          "end": {
+            "line": 6,
+            "column": 1
+          }
+        },
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 7
+          },
+          "end": {
+            "line": 6,
+            "column": 1
+          }
+        },
+        "line": 1
+      },
+      "10": {
+        "name": "unused",
+        "decl": {
+          "start": {
+            "line": 12,
+            "column": 7
+          },
+          "end": {
+            "line": 14,
+            "column": 1
+          }
+        },
+        "loc": {
+          "start": {
+            "line": 12,
+            "column": 7
+          },
+          "end": {
+            "line": 14,
+            "column": 1
+          }
+        },
+        "line": 12
+      }
+    },
+    "f": {
+      "0": 3,
+      "1": 1,
+      "2": 1,
+      "3": 2,
+      "4": 1,
+      "5": 1,
+      "6": 1,
+      "7": 0,
+      "8": 0,
+      "9": 1,
+      "10": 0
+    }
+  }
+}

--- a/crates/crap4ts/tests/fixtures/istanbul-jest/README.md
+++ b/crates/crap4ts/tests/fixtures/istanbul-jest/README.md
@@ -1,0 +1,57 @@
+# istanbul-jest fixtures
+
+Istanbul `coverage-final.json` payloads in **jest** shape.
+
+| File | Origin |
+|---|---|
+| `coverage-final.json` | Synthetic (hand-authored), 5-file jest-flat shape — the W1.1 happy-path corpus. |
+| `coverage-with-branches.json` | Synthetic, branch-coverage corpus (`b` + `branchMap`). |
+| `coverage-real-jest29.json` | **Captured-real** from jest 29 via `ts-jest`. |
+
+Paths use the `{SRC_ROOT}` placeholder; smoke tests substitute a
+canonical tempdir root (see `tests/istanbul_smoke.rs`).
+
+## `coverage-real-jest29.json` — captured state
+
+- **Captured on**: 2026-05-17
+- **Source**: `tests/fixtures/ts-fixtures/producer-sample.ts` (one file:
+  statements + an `if` + a ternary + an inline anonymous arrow +
+  an uncovered function), copied in as `src/sample.ts`
+- **Toolchain**:
+  - node: `v25.9.0`
+  - jest: `29.7.0`
+  - ts-jest: `29.4.9`
+  - typescript: `5.9.3`
+
+### Observed shape
+
+- `fnMap` names for the inline arrow are synthesized `(anonymous_N)`
+  (babel-plugin-istanbul), **never `null`**.
+- `branchMap` `type` is concrete (`if`, `cond-expr`); no null columns.
+
+## Capture procedure
+
+Reproducible from a throwaway scaffold. Only the machine-absolute
+source dir is rewritten to `{SRC_ROOT}`; the payload is otherwise
+byte-faithful.
+
+1. Scaffold (`package.json` devDeps `jest@^29.7.0`, `ts-jest@^29.1.2`,
+   `typescript@^5.4.5`, `@types/jest@^29.5.12`; `jest.config.js` with
+   `preset: "ts-jest"`, `rootDir: "src"`,
+   `collectCoverageFrom: ["**/*.ts", "!**/*.test.ts"]`):
+
+   ```bash
+   mkdir -p jest/src && cp producer-sample.ts jest/src/sample.ts
+   # add a sample.test.ts that imports + exercises classify(5) and double(3)
+   cd jest && npm install
+   ```
+
+2. Run coverage:
+
+   ```bash
+   npx jest --coverage --coverageReporters=json --ci
+   # writes src/coverage/coverage-final.json (rootDir-relative)
+   ```
+
+3. Substitute the absolute `.../src` prefix with `{SRC_ROOT}` and copy
+   into this directory as `coverage-real-jest29.json`.

--- a/crates/crap4ts/tests/fixtures/istanbul-jest/coverage-real-jest29.json
+++ b/crates/crap4ts/tests/fixtures/istanbul-jest/coverage-real-jest29.json
@@ -1,0 +1,340 @@
+{
+  "{SRC_ROOT}/sample.ts": {
+    "path": "{SRC_ROOT}/sample.ts",
+    "statementMap": {
+      "0": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 16
+        }
+      },
+      "1": {
+        "start": {
+          "line": 12,
+          "column": 0
+        },
+        "end": {
+          "line": 12,
+          "column": 16
+        }
+      },
+      "2": {
+        "start": {
+          "line": 2,
+          "column": 2
+        },
+        "end": {
+          "line": 4,
+          "column": 3
+        }
+      },
+      "3": {
+        "start": {
+          "line": 3,
+          "column": 4
+        },
+        "end": {
+          "line": 3,
+          "column": 22
+        }
+      },
+      "4": {
+        "start": {
+          "line": 5,
+          "column": 2
+        },
+        "end": {
+          "line": 5,
+          "column": 39
+        }
+      },
+      "5": {
+        "start": {
+          "line": 8,
+          "column": 22
+        },
+        "end": {
+          "line": 8,
+          "column": 50
+        }
+      },
+      "6": {
+        "start": {
+          "line": 8,
+          "column": 45
+        },
+        "end": {
+          "line": 8,
+          "column": 50
+        }
+      },
+      "7": {
+        "start": {
+          "line": 8,
+          "column": 13
+        },
+        "end": {
+          "line": 8,
+          "column": 22
+        }
+      },
+      "8": {
+        "start": {
+          "line": 10,
+          "column": 13
+        },
+        "end": {
+          "line": 10,
+          "column": 51
+        }
+      },
+      "9": {
+        "start": {
+          "line": 10,
+          "column": 44
+        },
+        "end": {
+          "line": 10,
+          "column": 49
+        }
+      },
+      "10": {
+        "start": {
+          "line": 13,
+          "column": 2
+        },
+        "end": {
+          "line": 13,
+          "column": 22
+        }
+      }
+    },
+    "fnMap": {
+      "0": {
+        "name": "classify",
+        "decl": {
+          "start": {
+            "line": 1,
+            "column": 16
+          },
+          "end": {
+            "line": 1,
+            "column": 24
+          }
+        },
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 34
+          },
+          "end": {
+            "line": 6,
+            "column": 1
+          }
+        }
+      },
+      "1": {
+        "name": "(anonymous_1)",
+        "decl": {
+          "start": {
+            "line": 8,
+            "column": 22
+          },
+          "end": {
+            "line": 8,
+            "column": 23
+          }
+        },
+        "loc": {
+          "start": {
+            "line": 8,
+            "column": 45
+          },
+          "end": {
+            "line": 8,
+            "column": 50
+          }
+        }
+      },
+      "2": {
+        "name": "(anonymous_2)",
+        "decl": {
+          "start": {
+            "line": 10,
+            "column": 37
+          },
+          "end": {
+            "line": 10,
+            "column": 38
+          }
+        },
+        "loc": {
+          "start": {
+            "line": 10,
+            "column": 44
+          },
+          "end": {
+            "line": 10,
+            "column": 49
+          }
+        }
+      },
+      "3": {
+        "name": "unused",
+        "decl": {
+          "start": {
+            "line": 12,
+            "column": 16
+          },
+          "end": {
+            "line": 12,
+            "column": 22
+          }
+        },
+        "loc": {
+          "start": {
+            "line": 12,
+            "column": 36
+          },
+          "end": {
+            "line": 14,
+            "column": 1
+          }
+        }
+      }
+    },
+    "branchMap": {
+      "0": {
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 2
+          },
+          "end": {
+            "line": 4,
+            "column": 3
+          }
+        },
+        "type": "if",
+        "locations": [
+          {
+            "start": {
+              "line": 2,
+              "column": 2
+            },
+            "end": {
+              "line": 4,
+              "column": 3
+            }
+          }
+        ]
+      },
+      "1": {
+        "loc": {
+          "start": {
+            "line": 5,
+            "column": 9
+          },
+          "end": {
+            "line": 5,
+            "column": 38
+          }
+        },
+        "type": "cond-expr",
+        "locations": [
+          {
+            "start": {
+              "line": 5,
+              "column": 19
+            },
+            "end": {
+              "line": 5,
+              "column": 25
+            }
+          },
+          {
+            "start": {
+              "line": 5,
+              "column": 28
+            },
+            "end": {
+              "line": 5,
+              "column": 38
+            }
+          }
+        ]
+      },
+      "2": {
+        "loc": {
+          "start": {
+            "line": 13,
+            "column": 9
+          },
+          "end": {
+            "line": 13,
+            "column": 21
+          }
+        },
+        "type": "cond-expr",
+        "locations": [
+          {
+            "start": {
+              "line": 13,
+              "column": 16
+            },
+            "end": {
+              "line": 13,
+              "column": 17
+            }
+          },
+          {
+            "start": {
+              "line": 13,
+              "column": 20
+            },
+            "end": {
+              "line": 13,
+              "column": 21
+            }
+          }
+        ]
+      }
+    },
+    "s": {
+      "0": 1,
+      "1": 1,
+      "2": 1,
+      "3": 0,
+      "4": 1,
+      "5": 1,
+      "6": 1,
+      "7": 1,
+      "8": 1,
+      "9": 3,
+      "10": 0
+    },
+    "f": {
+      "0": 1,
+      "1": 1,
+      "2": 3,
+      "3": 0
+    },
+    "b": {
+      "0": [
+        0
+      ],
+      "1": [
+        0,
+        1
+      ],
+      "2": [
+        0,
+        0
+      ]
+    }
+  }
+}

--- a/crates/crap4ts/tests/fixtures/istanbul-nyc/README.md
+++ b/crates/crap4ts/tests/fixtures/istanbul-nyc/README.md
@@ -1,0 +1,53 @@
+# istanbul-nyc fixtures
+
+Istanbul `coverage-final.json` payloads in **nyc** shape.
+
+| File | Origin |
+|---|---|
+| `coverage-final.json` | Synthetic, 3-file nyc-flat shape (absolute paths). |
+| `coverage-real-nyc17.json` | **Captured-real** from nyc 17 (+ tsx, `node:test`). |
+
+Paths use the `{SRC_ROOT}` placeholder; smoke tests substitute a
+canonical tempdir root.
+
+## `coverage-real-nyc17.json` — captured state
+
+- **Captured on**: 2026-05-17
+- **Source**: `tests/fixtures/ts-fixtures/producer-sample.ts` as `src/sample.ts`
+- **Toolchain**:
+  - node: `v25.9.0`
+  - nyc: `17.1.0`
+  - tsx: `4.22.1`
+  - typescript: `5.9.3`
+
+### Observed shape
+
+nyc instruments TS via the `tsx` loader and source-map remapping; the
+remap path emits `"column": null` on some spans. nyc also surfaces
+extra `binary-expr` branch types from transpiled helpers and extra
+synthesized `(anonymous_N)` fnMap entries. None of `column`, branch
+`type`, or `fnMap` is modelled, so the parse is unaffected.
+
+## Capture procedure
+
+1. Scaffold (`package.json` devDeps `nyc@^17.1.0`, `tsx@^4.19.2`,
+   `typescript@^5.4.5`; an `nyc` config block with `all: true`,
+   `include: ["src/**/*.ts"]`, `exclude: ["src/**/*.test.ts"]`,
+   `extension: [".ts"]`, `reporter: ["json"]`, `report-dir:
+   "coverage"`):
+
+   ```bash
+   mkdir -p nyc/src && cp producer-sample.ts nyc/src/sample.ts
+   # add a sample.test.ts using node:test + node:assert
+   cd nyc && npm install
+   ```
+
+2. Run coverage:
+
+   ```bash
+   npx nyc node --import tsx --test src/sample.test.ts
+   # writes coverage/coverage-final.json
+   ```
+
+3. Substitute the absolute `.../src` prefix with `{SRC_ROOT}` and copy
+   in as `coverage-real-nyc17.json`.

--- a/crates/crap4ts/tests/fixtures/istanbul-nyc/coverage-real-nyc17.json
+++ b/crates/crap4ts/tests/fixtures/istanbul-nyc/coverage-real-nyc17.json
@@ -1,0 +1,520 @@
+{
+  "{SRC_ROOT}/sample.ts": {
+    "path": "{SRC_ROOT}/sample.ts",
+    "statementMap": {
+      "0": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 7
+        }
+      },
+      "1": {
+        "start": {
+          "line": 2,
+          "column": 2
+        },
+        "end": {
+          "line": 4,
+          "column": null
+        }
+      },
+      "2": {
+        "start": {
+          "line": 3,
+          "column": 4
+        },
+        "end": {
+          "line": 3,
+          "column": null
+        }
+      },
+      "3": {
+        "start": {
+          "line": 5,
+          "column": 2
+        },
+        "end": {
+          "line": 5,
+          "column": null
+        }
+      },
+      "4": {
+        "start": {
+          "line": 1,
+          "column": 16
+        },
+        "end": {
+          "line": 1,
+          "column": 25
+        }
+      },
+      "5": {
+        "start": {
+          "line": 8,
+          "column": 22
+        },
+        "end": {
+          "line": 8,
+          "column": 23
+        }
+      },
+      "6": {
+        "start": {
+          "line": 8,
+          "column": 45
+        },
+        "end": {
+          "line": 8,
+          "column": null
+        }
+      },
+      "7": {
+        "start": {
+          "line": 10,
+          "column": 23
+        },
+        "end": {
+          "line": 10,
+          "column": null
+        }
+      },
+      "8": {
+        "start": {
+          "line": 10,
+          "column": 44
+        },
+        "end": {
+          "line": 10,
+          "column": 49
+        }
+      },
+      "9": {
+        "start": {
+          "line": 13,
+          "column": 2
+        },
+        "end": {
+          "line": 13,
+          "column": null
+        }
+      },
+      "10": {
+        "start": {
+          "line": 12,
+          "column": 16
+        },
+        "end": {
+          "line": 12,
+          "column": 23
+        }
+      }
+    },
+    "fnMap": {
+      "0": {
+        "name": "(anonymous_1)",
+        "decl": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 7
+          }
+        },
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 7
+          }
+        }
+      },
+      "1": {
+        "name": "classify",
+        "decl": {
+          "start": {
+            "line": 1,
+            "column": 16
+          },
+          "end": {
+            "line": 1,
+            "column": 25
+          }
+        },
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 44
+          },
+          "end": {
+            "line": 6,
+            "column": null
+          }
+        }
+      },
+      "2": {
+        "name": "(anonymous_11)",
+        "decl": {
+          "start": {
+            "line": 8,
+            "column": 23
+          },
+          "end": {
+            "line": 8,
+            "column": 45
+          }
+        },
+        "loc": {
+          "start": {
+            "line": 8,
+            "column": 45
+          },
+          "end": {
+            "line": 8,
+            "column": null
+          }
+        }
+      },
+      "3": {
+        "name": "(anonymous_12)",
+        "decl": {
+          "start": {
+            "line": 10,
+            "column": 38
+          },
+          "end": {
+            "line": 10,
+            "column": 44
+          }
+        },
+        "loc": {
+          "start": {
+            "line": 10,
+            "column": 44
+          },
+          "end": {
+            "line": 10,
+            "column": 49
+          }
+        }
+      },
+      "4": {
+        "name": "unused",
+        "decl": {
+          "start": {
+            "line": 12,
+            "column": 16
+          },
+          "end": {
+            "line": 12,
+            "column": 23
+          }
+        },
+        "loc": {
+          "start": {
+            "line": 12,
+            "column": 46
+          },
+          "end": {
+            "line": 14,
+            "column": null
+          }
+        }
+      }
+    },
+    "branchMap": {
+      "0": {
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 7
+          }
+        },
+        "type": "if",
+        "locations": [
+          {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 7
+            }
+          }
+        ]
+      },
+      "1": {
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 7
+          }
+        },
+        "type": "binary-expr",
+        "locations": [
+          {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 7
+            }
+          },
+          {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 7
+            }
+          },
+          {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 7
+            }
+          }
+        ]
+      },
+      "2": {
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 7
+          }
+        },
+        "type": "binary-expr",
+        "locations": [
+          {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 7
+            }
+          },
+          {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 7
+            }
+          }
+        ]
+      },
+      "3": {
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 2
+          },
+          "end": {
+            "line": 4,
+            "column": null
+          }
+        },
+        "type": "if",
+        "locations": [
+          {
+            "start": {
+              "line": 2,
+              "column": 2
+            },
+            "end": {
+              "line": 4,
+              "column": null
+            }
+          }
+        ]
+      },
+      "4": {
+        "loc": {
+          "start": {
+            "line": 5,
+            "column": 9
+          },
+          "end": {
+            "line": 5,
+            "column": null
+          }
+        },
+        "type": "cond-expr",
+        "locations": [
+          {
+            "start": {
+              "line": 5,
+              "column": 19
+            },
+            "end": {
+              "line": 5,
+              "column": 28
+            }
+          },
+          {
+            "start": {
+              "line": 5,
+              "column": 28
+            },
+            "end": {
+              "line": 5,
+              "column": null
+            }
+          }
+        ]
+      },
+      "5": {
+        "loc": {
+          "start": {
+            "line": 13,
+            "column": 9
+          },
+          "end": {
+            "line": 13,
+            "column": null
+          }
+        },
+        "type": "cond-expr",
+        "locations": [
+          {
+            "start": {
+              "line": 13,
+              "column": 16
+            },
+            "end": {
+              "line": 13,
+              "column": 20
+            }
+          },
+          {
+            "start": {
+              "line": 13,
+              "column": 20
+            },
+            "end": {
+              "line": 13,
+              "column": null
+            }
+          }
+        ]
+      },
+      "6": {
+        "loc": {
+          "start": {
+            "line": 12,
+            "column": 16
+          },
+          "end": {
+            "line": 12,
+            "column": 23
+          }
+        },
+        "type": "binary-expr",
+        "locations": [
+          {
+            "start": {
+              "line": 12,
+              "column": 16
+            },
+            "end": {
+              "line": 12,
+              "column": 23
+            }
+          },
+          {
+            "start": {
+              "line": 12,
+              "column": 16
+            },
+            "end": {
+              "line": 12,
+              "column": 23
+            }
+          }
+        ]
+      }
+    },
+    "s": {
+      "0": 35,
+      "1": 1,
+      "2": 0,
+      "3": 1,
+      "4": 1,
+      "5": 1,
+      "6": 1,
+      "7": 1,
+      "8": 3,
+      "9": 0,
+      "10": 2
+    },
+    "f": {
+      "0": 10,
+      "1": 1,
+      "2": 1,
+      "3": 3,
+      "4": 0
+    },
+    "b": {
+      "0": [
+        5
+      ],
+      "1": [
+        1,
+        1,
+        0
+      ],
+      "2": [
+        8,
+        8
+      ],
+      "3": [
+        0
+      ],
+      "4": [
+        0,
+        1
+      ],
+      "5": [
+        0,
+        0
+      ],
+      "6": [
+        1,
+        0
+      ]
+    }
+  }
+}

--- a/crates/crap4ts/tests/fixtures/istanbul-vitest/README.md
+++ b/crates/crap4ts/tests/fixtures/istanbul-vitest/README.md
@@ -1,0 +1,56 @@
+# istanbul-vitest fixtures
+
+Istanbul `coverage-final.json` payloads in **vitest** (`@vitest/coverage-istanbul`) shape.
+
+| File | Origin |
+|---|---|
+| `coverage-final.json` | Synthetic, 3-file vitest-flat shape with emitter metadata. |
+| `coverage-with-null-columns.json` | Derived from the W3.1 crap4ts@1.x corpus — the original `column: null` regression corpus. |
+| `coverage-real-vitest4.json` | **Captured-real** from `@vitest/coverage-istanbul@4`. |
+
+Paths use the `{SRC_ROOT}` placeholder; smoke tests substitute a
+canonical tempdir root.
+
+## `coverage-real-vitest4.json` — captured state
+
+- **Captured on**: 2026-05-17
+- **Source**: `tests/fixtures/ts-fixtures/producer-sample.ts` as `src/sample.ts`
+- **Toolchain**:
+  - node: `v25.9.0`
+  - vitest: `4.1.6`
+  - @vitest/coverage-istanbul: `4.1.6`
+  - typescript: `5.9.3`
+
+### Observed shape — why the 4.x capture matters
+
+The 3.x line emitted `"column": null` on span ends. The 4.x major bump
+did **not** make columns concrete: `coverage-real-vitest4.json` still
+carries `"column": null` on every span end and empty `{"start":{},
+"end":{}}` objects inside `branchMap.locations[]`. The parser models
+neither (only `start.line` is read), so the original deserialization
+bail does not occur. This fixture is the live regression lock that 4.x
+remains tolerated. Inline-arrow `fnMap` names are synthesized
+`(anonymous_N)`.
+
+## Capture procedure
+
+1. Scaffold (`package.json` devDeps `vitest@^4.0.0`,
+   `@vitest/coverage-istanbul@^4.0.0`, `typescript@^5.4.5`;
+   `vitest.config.ts` with `coverage.provider: "istanbul"`,
+   `reporter: ["json"]`, `root: "src"`):
+
+   ```bash
+   mkdir -p vitest/src && cp producer-sample.ts vitest/src/sample.ts
+   # add a sample.test.ts importing vitest's test/expect
+   cd vitest && npm install
+   ```
+
+2. Run coverage:
+
+   ```bash
+   npx vitest run --coverage
+   # writes src/coverage/coverage-final.json
+   ```
+
+3. Substitute the absolute `.../src` prefix with `{SRC_ROOT}` and copy
+   in as `coverage-real-vitest4.json`.

--- a/crates/crap4ts/tests/fixtures/istanbul-vitest/coverage-real-vitest4.json
+++ b/crates/crap4ts/tests/fixtures/istanbul-vitest/coverage-real-vitest4.json
@@ -1,0 +1,312 @@
+{
+  "{SRC_ROOT}/sample.ts": {
+    "path": "{SRC_ROOT}/sample.ts",
+    "statementMap": {
+      "0": {
+        "start": {
+          "line": 2,
+          "column": 2
+        },
+        "end": {
+          "line": 4,
+          "column": null
+        }
+      },
+      "1": {
+        "start": {
+          "line": 3,
+          "column": 4
+        },
+        "end": {
+          "line": 3,
+          "column": null
+        }
+      },
+      "2": {
+        "start": {
+          "line": 5,
+          "column": 2
+        },
+        "end": {
+          "line": 5,
+          "column": null
+        }
+      },
+      "3": {
+        "start": {
+          "line": 8,
+          "column": 13
+        },
+        "end": {
+          "line": 8,
+          "column": null
+        }
+      },
+      "4": {
+        "start": {
+          "line": 8,
+          "column": 45
+        },
+        "end": {
+          "line": 8,
+          "column": null
+        }
+      },
+      "5": {
+        "start": {
+          "line": 10,
+          "column": 23
+        },
+        "end": {
+          "line": 10,
+          "column": null
+        }
+      },
+      "6": {
+        "start": {
+          "line": 10,
+          "column": 44
+        },
+        "end": {
+          "line": 10,
+          "column": 49
+        }
+      },
+      "7": {
+        "start": {
+          "line": 13,
+          "column": 2
+        },
+        "end": {
+          "line": 13,
+          "column": null
+        }
+      }
+    },
+    "fnMap": {
+      "0": {
+        "name": "classify",
+        "decl": {
+          "start": {
+            "line": 1,
+            "column": 16
+          },
+          "end": {
+            "line": 1,
+            "column": 25
+          }
+        },
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 44
+          },
+          "end": {
+            "line": 6,
+            "column": null
+          }
+        }
+      },
+      "1": {
+        "name": "(anonymous_1)",
+        "decl": {
+          "start": {
+            "line": 8,
+            "column": 13
+          },
+          "end": {
+            "line": 8,
+            "column": 23
+          }
+        },
+        "loc": {
+          "start": {
+            "line": 8,
+            "column": 45
+          },
+          "end": {
+            "line": 8,
+            "column": null
+          }
+        }
+      },
+      "2": {
+        "name": "(anonymous_2)",
+        "decl": {
+          "start": {
+            "line": 10,
+            "column": 33
+          },
+          "end": {
+            "line": 10,
+            "column": 38
+          }
+        },
+        "loc": {
+          "start": {
+            "line": 10,
+            "column": 44
+          },
+          "end": {
+            "line": 10,
+            "column": 49
+          }
+        }
+      },
+      "3": {
+        "name": "unused",
+        "decl": {
+          "start": {
+            "line": 12,
+            "column": 16
+          },
+          "end": {
+            "line": 12,
+            "column": 23
+          }
+        },
+        "loc": {
+          "start": {
+            "line": 12,
+            "column": 46
+          },
+          "end": {
+            "line": 14,
+            "column": null
+          }
+        }
+      }
+    },
+    "branchMap": {
+      "0": {
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 2
+          },
+          "end": {
+            "line": 4,
+            "column": null
+          }
+        },
+        "type": "if",
+        "locations": [
+          {
+            "start": {
+              "line": 2,
+              "column": 2
+            },
+            "end": {
+              "line": 4,
+              "column": null
+            }
+          },
+          {
+            "start": {},
+            "end": {}
+          }
+        ]
+      },
+      "1": {
+        "loc": {
+          "start": {
+            "line": 5,
+            "column": 9
+          },
+          "end": {
+            "line": 5,
+            "column": null
+          }
+        },
+        "type": "cond-expr",
+        "locations": [
+          {
+            "start": {
+              "line": 5,
+              "column": 19
+            },
+            "end": {
+              "line": 5,
+              "column": 28
+            }
+          },
+          {
+            "start": {
+              "line": 5,
+              "column": 28
+            },
+            "end": {
+              "line": 5,
+              "column": null
+            }
+          }
+        ]
+      },
+      "2": {
+        "loc": {
+          "start": {
+            "line": 13,
+            "column": 9
+          },
+          "end": {
+            "line": 13,
+            "column": null
+          }
+        },
+        "type": "cond-expr",
+        "locations": [
+          {
+            "start": {
+              "line": 13,
+              "column": 16
+            },
+            "end": {
+              "line": 13,
+              "column": 20
+            }
+          },
+          {
+            "start": {
+              "line": 13,
+              "column": 20
+            },
+            "end": {
+              "line": 13,
+              "column": null
+            }
+          }
+        ]
+      }
+    },
+    "s": {
+      "0": 1,
+      "1": 0,
+      "2": 1,
+      "3": 1,
+      "4": 1,
+      "5": 1,
+      "6": 3,
+      "7": 0
+    },
+    "f": {
+      "0": 1,
+      "1": 1,
+      "2": 3,
+      "3": 0
+    },
+    "b": {
+      "0": [
+        0,
+        1
+      ],
+      "1": [
+        0,
+        1
+      ],
+      "2": [
+        0,
+        0
+      ]
+    }
+  }
+}

--- a/crates/crap4ts/tests/fixtures/ts-fixtures/producer-sample.ts
+++ b/crates/crap4ts/tests/fixtures/ts-fixtures/producer-sample.ts
@@ -1,0 +1,14 @@
+export function classify(n: number): string {
+  if (n < 0) {
+    return "negative";
+  }
+  return n === 0 ? "zero" : "positive";
+}
+
+export const double = (x: number): number => x * 2;
+
+export const squares = [1, 2, 3].map((v) => v * v);
+
+export function unused(flag: boolean): number {
+  return flag ? 1 : 2;
+}

--- a/crates/crap4ts/tests/istanbul_smoke.rs
+++ b/crates/crap4ts/tests/istanbul_smoke.rs
@@ -1067,3 +1067,130 @@ fn fix216_parentdir_traversal_does_not_resolve_outside_effective_src() {
         "secret.ts (outside effective_src) leaked into coverage"
     );
 }
+
+// ─────────────────────────────────────────────────────────────────────
+// #214 — Producer fixture matrix (captured-real Istanbul output)
+//
+// One small fixture captured from each active Istanbul producer in the
+// TypeScript ecosystem, all run against the same `producer-sample.ts`
+// source (statements + an if + a ternary + an inline anonymous arrow +
+// an uncovered function). Producers vary freely in fields the parser
+// does NOT model: jest/vitest/nyc synthesize `(anonymous_N)` fnMap
+// names while c8 uses concrete transpiled-helper names; branch `type`
+// is `if`/`cond-expr`/`binary-expr` for babel-istanbul producers but a
+// generic `"branch"` for c8; `@vitest/coverage-istanbul@4` still emits
+// `"column": null` on span ends plus empty `{}` objects in
+// `branchMap.locations[]`; nyc emits null columns via tsx source-map
+// remapping; c8 adds an extra per-entry `all` field. These tests are
+// the regression net proving every real producer parses with zero
+// diagnostics and well-formed line coverage after the
+// schema-minimalism hardening — none of that variance can bail.
+
+const PRODUCER_JEST: &str = include_str!("fixtures/istanbul-jest/coverage-real-jest29.json");
+const PRODUCER_VITEST4: &str = include_str!("fixtures/istanbul-vitest/coverage-real-vitest4.json");
+const PRODUCER_NYC: &str = include_str!("fixtures/istanbul-nyc/coverage-real-nyc17.json");
+const PRODUCER_C8: &str = include_str!("fixtures/istanbul-c8/coverage-real-c8.json");
+
+/// Write `producer-sample.ts` as `sample.ts` into a canonical tempdir
+/// and substitute `{SRC_ROOT}`, mirroring `build_fixture`.
+fn build_producer_fixture(template: &str) -> (TempDir, PathBuf, String) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let canonical = std::fs::canonicalize(tmp.path()).expect("canonicalize tempdir");
+    write_fixture(
+        &canonical,
+        "sample.ts",
+        include_str!("fixtures/ts-fixtures/producer-sample.ts"),
+    );
+    let payload = template.replace("{SRC_ROOT}", &canonical.to_string_lossy());
+    (tmp, canonical, payload)
+}
+
+/// Shared contract for every captured producer fixture: parses without
+/// bailing, emits zero diagnostics, keys coverage at `sample.ts`, and
+/// the `LineCoverage` rows are well-formed — non-empty, every line
+/// 1-based ≥ 1, ascending (the deterministic order the downstream
+/// line-range join relies on).
+fn assert_producer_well_formed(
+    out: &ParseOutput<crap4ts::parse_diagnostic::IstanbulParseDiagnostic>,
+) {
+    assert!(
+        out.diagnostics.is_empty(),
+        "expected no diagnostics; got {:?}",
+        out.diagnostics
+    );
+    let lines = lines_for(out, "sample.ts");
+    assert!(
+        !lines.is_empty(),
+        "expected non-empty line coverage for sample.ts"
+    );
+    let mut prev = 0usize;
+    for lc in lines {
+        assert!(
+            lc.line >= 1,
+            "LineCoverage.line must be 1-based ≥ 1; got {lines:?}"
+        );
+        assert!(
+            lc.line >= prev,
+            "LineCoverage rows must be ascending by line; {} came after {}",
+            lc.line,
+            prev
+        );
+        prev = lc.line;
+    }
+}
+
+/// jest 29 (`ts-jest` preset, babel-plugin-istanbul). Synthesizes
+/// `(anonymous_N)` for the inline arrow; concrete `if`/`cond-expr`
+/// branch types; no null columns.
+#[test]
+fn producer_jest29_parses_clean() {
+    let (_t, c, p) = build_producer_fixture(PRODUCER_JEST);
+    let out = IstanbulCoverage::new(c)
+        .parse(&p)
+        .expect("jest 29 captured fixture parses");
+    assert_producer_well_formed(&out);
+    assert!(
+        out.branches.is_some(),
+        "jest fixture carries b+branchMap → Some(branches)"
+    );
+}
+
+/// `@vitest/coverage-istanbul@4`. The major bump did NOT make columns
+/// concrete — 4.x still emits `"column": null` on span ends and empty
+/// `{}` objects in `branchMap.locations[]`. Neither is modelled, so
+/// the parse must not bail (the original #211 failure mode).
+#[test]
+fn producer_vitest4_parses_clean_with_null_columns() {
+    let (_t, c, p) = build_producer_fixture(PRODUCER_VITEST4);
+    assert!(
+        p.contains("\"column\": null"),
+        "vitest4 fixture must carry null columns — that is the variance under test"
+    );
+    let out = IstanbulCoverage::new(c)
+        .parse(&p)
+        .expect("vitest 4.x captured fixture parses despite null columns");
+    assert_producer_well_formed(&out);
+}
+
+/// nyc 17 (+ tsx). Emits null columns via tsx source-map remapping and
+/// extra `binary-expr` branch types from transpiled helpers.
+#[test]
+fn producer_nyc17_parses_clean() {
+    let (_t, c, p) = build_producer_fixture(PRODUCER_NYC);
+    let out = IstanbulCoverage::new(c)
+        .parse(&p)
+        .expect("nyc 17 captured fixture parses");
+    assert_producer_well_formed(&out);
+}
+
+/// c8 10 (`--reporter=json`, V8→Istanbul via v8-to-istanbul). Carries
+/// an extra per-entry `all` field and a generic `type: "branch"` on
+/// every branchMap entry — both unmodelled, must not bail.
+#[test]
+fn producer_c8_parses_clean() {
+    let (_t, c, p) = build_producer_fixture(PRODUCER_C8);
+    let out = IstanbulCoverage::new(c)
+        .parse(&p)
+        .expect("c8 captured fixture parses");
+    assert_producer_well_formed(&out);
+}

--- a/crates/crap4ts/tests/istanbul_smoke.rs
+++ b/crates/crap4ts/tests/istanbul_smoke.rs
@@ -1137,6 +1137,28 @@ fn assert_producer_well_formed(
         );
         prev = lc.line;
     }
+    // When the producer emits b+branchMap, the lowered BranchCoverage
+    // rows must share the line-coverage 1-based invariant. A producer
+    // whose branch line came through as 0 (or whose unmodelled
+    // `locations[]` shape silently zeroed it) would mis-join in the
+    // downstream line-range pass — assert the structural floor here so
+    // the producer matrix regression-locks branch data too, not just
+    // line data.
+    if let Some(branches) = &out.branches {
+        let recs = branches
+            .get("sample.ts")
+            .expect("branches keyed at sample.ts when present");
+        assert!(
+            !recs.is_empty(),
+            "branches present for sample.ts must be non-empty"
+        );
+        for bc in recs {
+            assert!(
+                bc.line >= 1,
+                "BranchCoverage.line must be 1-based ≥ 1; got {recs:?}"
+            );
+        }
+    }
 }
 
 /// jest 29 (`ts-jest` preset, babel-plugin-istanbul). Synthesizes


### PR DESCRIPTION
Closes #214

## Summary

Operational follow-up to ADR D16 (Istanbul schema tolerance). Captures one
small real fixture per active Istanbul producer and proactively hardens the
deserialization types so unconsumed-field variance can never bail a parse.

**Honest framing:** all four real producers parse **cleanly today** — the
post-#211 struct already tolerated jest / `@vitest/coverage-istanbul@4` / nyc
/ c8 with zero diagnostics. This PR is **proactive D16 hardening** that shrinks
the whole-file bail surface; the captured fixtures are **regression locks**, not
bug-fix evidence. No producer-side defect was found.

## Discovery findings (all four resolved empirically)

| Question | Finding |
|---|---|
| Does `c8 --reporter=json` emit Istanbul or always V8? | **Istanbul.** c8 converts V8 → Istanbul `CoverageMap`; its `json` reporter writes flat-Istanbul `coverage-final.json` (+ extra per-entry `all`, generic `type: "branch"`). `istanbul-c8/` is viable; no plan deviation. |
| vitest-istanbul 4.x — `column` concrete now vs 3.2.4's `null`? | **Still `null`.** 4.x did not make columns concrete; still emits `"column": null` on span ends + empty `{"start":{},"end":{}}` in `branchMap.locations[]`. The #211 tolerance is still required. |
| jest anonymous-fn `fnMap.name` — `null` or `(anonymous_0)`? | **Synthesized `(anonymous_N)`**, never `null` (babel-plugin-istanbul). Same for vitest + nyc. c8 uses concrete transpiled-helper names. |
| nyc + mocha vs nyc + vitest shape drift? | Primary fixture is **nyc + tsx + `node:test`** (the common modern path). nyc emits null columns via tsx source-map remapping + extra `binary-expr` branch types. |

## Null-tolerance audit (per-field decision table)

Empirical probe: a `null`/empty value in any **modelled, required** field aborts
the *entire* flat-shape parse via serde **before** any per-entry diagnostic can
fire — yielding zero coverage and zero diagnostics (worst mode). Decisions:

| Field | Consumed? | `null`/empty bails today? | Decision | Rationale |
|---|---|---|---|---|
| `IstanbulCoverageFile.path` | yes (normalize_path) | (pathological — not probed) | keep `String` | every producer emits a concrete path |
| `s` / `statement_map` / `b` / `branch_map` | yes | n/a (already `#[serde(default)]`) | unchanged | already permissive |
| `f` | no | — | **drop field** | unconsumed; removing kills the FnLoc bail vector |
| `fn_map` + `FnLoc` struct | no | **yes** (`fnMap.name: null`) | **drop field + struct** | unconsumed; consistent with the no-`f`/`fnMap`-backfill design |
| `StatementLoc.start` | yes (`start.line`) | — | keep | join key |
| `StatementLoc.end` | no | **yes** (`end: {}`) | **drop field** | only `.start.line` is ever read |
| `Position.line: u32` | yes (join key) | yes (`line: null`) | **keep strict** | no producer (jest/vitest4/nyc/c8) emits a null line; making it `Option` would trade a non-existent failure for a silent per-statement skip + complexity. Reversible if a future capture proves otherwise. |
| `Position.column` | no | n/a | **drop field** | unconsumed; line-only matching. Removes the #211 concern structurally (column is no longer modelled at all). |
| `BranchLoc.loc` | yes (`loc.start.line`) | — | keep | branch line attribution |
| `BranchLoc.kind` (`"type"`) | no | **yes** (`type: null`) | **drop field** | biggest blast-radius win — an unread field whose `null` bailed the whole file |
| `BranchLoc.line: Option<u32>` | yes (precedence) | n/a | unchanged | c8 emits it; others absent |

Net: 5 unconsumed fields dropped (`f`, `fn_map`/`FnLoc`, `StatementLoc.end`,
`Position.column`, `BranchLoc.kind`). serde drops them as unknown fields, so
existing synthetic fixtures (which still emit them) parse unchanged.

## Wire-snapshot canary

**No drift.** Both `wire_envelope_crap4rs` and `wire_envelope_crap4ts` are
byte-identical — the drops are internal struct only, no envelope surface.

## Gates

`cargo nextest run --workspace --all-targets` (1061 pass) · `cargo +1.93 check
--workspace --all-targets` · `cargo fmt --check` · `cargo clippy --workspace
--all-targets -- -D warnings` · `cargo doc --workspace --no-deps` · `cargo deny
check` — all green. lefthook pre-push passed.

## Notes

- Producer smoke tests call `IstanbulCoverage::parse` in-crate (no
  `cargo_bin` shelling), so the recurring `.cargo/mutants.toml` skip rule
  does **not** apply to #214.
- `.coderabbit.yaml` filters the wholly-captured `istanbul-c8/` dir and the
  `coverage-real-*.json` files (captured byte-faithful corpus); Gemini has no
  equivalent config — any Gemini findings on these are by-design-rejected with
  a disposition comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive smoke tests validating that the Istanbul coverage parser correctly handles real-world coverage data from Jest, Vitest, NYC, and C8 coverage tools.

* **Documentation**
  * Added detailed documentation for coverage test fixtures, including capture procedures, fixture descriptions, and toolchain metadata.

* **Chores**
  * Updated code review configuration to exclude coverage-related test fixtures from automated review.
  * Optimized coverage parser schema to remove unused fields from deserialization models.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/breezy-bays-labs/crap-rs/pull/223?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->