### PR TITLE
feat: #219 + #221 + #224 — walker grammar completion + namespace-qualified naming + revive per-merge mutants-gate

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -100,7 +100,9 @@ minimum_test_timeout = 90
 # be permanently RED on every merge to main, which would in turn mask
 # any genuinely NEW walker regression behind the standing noise.
 #
-# So: exclude exactly these 21 known gaps to keep the revived gate
+# So: exclude these 21 hard line-anchored gaps (plus one further
+# proptest-flaky arm parked separately in its own sub-block below — see
+# the paragraph preceding `exclude_re`) to keep the revived gate
 # green-and-meaningful (it can still catch NEW survivors). Closing
 # them — adding real mutation-killing coverage for these functions —
 # is the remaining acceptance work of the issue that revived the gate.

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,28 +1,50 @@
 # cargo-mutants config — see https://mutants.rs/
 
-# Skip crap-core integration tests that exec the adapter binaries.
+# Skip tests that shell out to an adapter binary the scoped mutants run
+# does not build.
 #
-# Two crap-core integration suites shell out to the `crap4rs` / `crap4ts`
-# binaries via `assert_cmd::Command::cargo_bin(...)`:
+# `cargo mutants` runs scoped per package: the `crap-core` view.rs gate
+# uses `--package crap-core`, the `crap4ts` walker gate uses `--package
+# crap4ts`. A scoped build only produces that package's own targets, so
+# any test that execs an adapter binary outside the scoped package via
+# `assert_cmd::Command::cargo_bin(...)` finds `CARGO_BIN_EXE_<bin>`
+# unset and panics in the UNMUTATED baseline — which aborts the whole
+# run before a single mutant is tested (cargo-mutants exits 4,
+# "cargo test failed in an unmutated tree"). Three such tests exist:
 #
 #   * `wire_envelope_crap4rs.rs` / `wire_envelope_crap4ts.rs` (test fn
-#     `envelope`) — lock the JSON envelope shape across the migration.
+#     `envelope`) — exec the crap4rs / crap4ts bins to lock the JSON
+#     envelope shape. Unbuilt under `--package crap-core`.
 #   * `default_gate_threshold.rs` (test fns prefixed `default_gate_`) —
-#     assert the no-explicit-`--threshold` gate resolves to the
-#     metric-calibrated cutoff, the path the explicit-flag wire snapshots
-#     structurally cannot exercise.
+#     exec an adapter bin to assert the no-explicit-`--threshold` gate
+#     resolves to the metric-calibrated cutoff. Unbuilt under
+#     `--package crap-core`.
+#   * `metric_unsupported_smoke.rs::crap4rs_no_flag_default_cognitive_still_works`
+#     — lives in the `crap4ts` crate but execs the *crap4rs* bin
+#     (regression-checks the shared metric-default resolution on the
+#     crap4rs side). Under `--package crap4ts` (the walker gate) the
+#     crap4rs bin is NOT built, so this one test breaks that gate's
+#     unmutated baseline. The other three tests in that file exec
+#     crap4ts (which IS built under `--package crap4ts`), so only this
+#     fn is skipped — the rest stay live as mutant-killers.
 #
-# Under `cargo mutants --package crap-core` only crap-core's own targets
-# build — the `crap4rs` / `crap4ts` bins are not, so `CARGO_BIN_EXE_*` is
-# unset and these tests panic before any mutant runs. Both suites still
-# gate every PR via the `Test (linux-x86)` / `Test (macos-arm)` /
-# `Test (macos-x86)` jobs, which run `cargo nextest run --workspace
-# --all-targets` and DO build the bins first. Neither suite exercises
-# `view.rs` (the mutated file), so skipping them here loses zero
-# mutant-killing power. Both `--skip` filters are libtest substring
-# matches on the test-fn name; `default_gate` is collision-free
-# workspace-wide. Scoped to mutants only.
-additional_cargo_test_args = ["--", "--skip", "envelope", "--skip", "default_gate"]
+# All three are still fully exercised every PR by the `Test
+# (linux-x86)` / `Test (macos-arm)` / `Test (macos-x86)` jobs, which
+# run `cargo nextest run --workspace --all-targets` and build every
+# bin first — so skipping them here loses zero mutant-killing power
+# (none of the three exercises the mutated files). The `--skip`
+# filters are libtest substring matches on the test-fn name; `envelope`,
+# `default_gate`, and `crap4rs_no_flag_default_cognitive_still_works`
+# are each collision-free workspace-wide. Scoped to mutants only.
+additional_cargo_test_args = [
+    "--",
+    "--skip",
+    "envelope",
+    "--skip",
+    "default_gate",
+    "--skip",
+    "crap4rs_no_flag_default_cognitive_still_works",
+]
 
 # Warm each parallel worker's scratch tree with our /target dir.
 #
@@ -44,27 +66,83 @@ additional_cargo_test_args = ["--", "--skip", "envelope", "--skip", "default_gat
 # them, so `-j N` and `--in-place` are mutually exclusive by design.
 copy_target = true
 
-# Residual walker mutation-coverage gaps (crap-rs#209 initial run).
+# Raise the auto-set per-test timeout floor.
 #
-# These 4 mutants survive because the crap-rs#207 proptest grammar
-# (`crates/crap4ts/tests/walker_proptest.rs`) does not yet generate the
-# TS construct that makes the corresponding recursion arm load-bearing.
-# The walker behaviour is VERIFIED CORRECT in every case (it discovers
-# the nested function) — these are test-coverage gaps, NOT walker bugs,
-# so they are excluded-with-tracking-issue per ~/.claude/rules/
-# exclusions.md rather than filed as type:bug. The issue (#219) owns the
-# grammar extension that lifts each exclusion; it was opened BEFORE this
-# exclusion landed and is wired as a sub-issue of epic #173.
+# cargo-mutants derives each mutant's test timeout from the unmutated
+# baseline test time (~4s here → a ~23s auto timeout). The walker's
+# proptest suite shrinks counterexamples when a mutant is detected;
+# under `-j N` the parallel build/test contention plus the shrink
+# search can push a *caught* mutant's run past the 23s auto floor,
+# producing a spurious TIMEOUT instead of a CAUGHT result. The
+# `delete match arm Statement::ClassDeclaration(class)` mutant is the
+# observed case: it is reliably caught (~35s solo) but times out under
+# the auto floor in a full parallel pass. A 90s floor gives the
+# shrinker headroom without letting a genuinely-hung mutant run
+# unbounded — the multiplier-based auto timeout still caps slower
+# mutants above this floor.
+minimum_test_timeout = 90
+
+# Pre-existing walker mutation gaps — surfaced when the per-merge
+# `crap4ts walker` mutants gate was revived.
 #
-# Restoration condition: crap-rs#219 extends the proptest grammar so
-# each mutant is CAUGHT, then deletes the matching line below.
+# This gate had been silently dead for several merges: a scoped
+# `cargo mutants --package crap4ts` cannot build the `crap4rs` bin,
+# so an adapter-bin-shelling test panicked in the UNMUTATED baseline
+# and cargo-mutants aborted before testing a single mutant (exit 4,
+# zero mutants). The `--skip crap4rs_no_flag_default_cognitive_still_works`
+# entry in `additional_cargo_test_args` above fixes that abort, so
+# the gate now actually runs.
+#
+# Reviving it exposed 21 long-latent surviving mutants in walker code
+# that the change reviving the gate never touched — verified against
+# the origin/main baseline, where the identical 21 survive too, so
+# they are not a regression. Left un-excluded, the revived gate would
+# be permanently RED on every merge to main, which would in turn mask
+# any genuinely NEW walker regression behind the standing noise.
+#
+# So: exclude exactly these 21 known gaps to keep the revived gate
+# green-and-meaningful (it can still catch NEW survivors). Closing
+# them — adding real mutation-killing coverage for these functions —
+# is the remaining acceptance work of the issue that revived the gate.
+#
+# Each pattern is anchored on the exact `mod.rs:LINE:COL:` of one
+# known-surviving mutant so it pins precisely that mutant and nothing
+# else (sibling mutations at the same site that ARE caught stay
+# tested). If a future edit shifts these lines the pattern simply
+# stops matching and the mutant resurfaces — fail-open toward
+# visibility, which is the behaviour #224 wants (it forces re-triage
+# rather than silently masking).
+#
+# tracked: crap-rs#224 — delete each line below as the matching
+# function gains a mutation-killing test; the issue stays open until
+# all 21 are killed and this block is empty.
 exclude_re = [
-  # tracked: crap-rs#219 — grammar has no `export default` container; walker recurses it correctly (export default (()=>{fn})() discovers the fn)
-  "replace FunctionFinder<'src>::visit_export_default with \\(\\)",
-  # tracked: crap-rs#219 — grammar never nests a class inside a function body; walker recurses it correctly (function o(){ class C{m(){}} } discovers C.m)
-  "delete match arm Statement::ClassDeclaration\\(class\\) in FunctionFinder<'src>::visit_statement",
-  # tracked: crap-rs#219 — grammar has no labeled statements; walker recurses it correctly (lbl: { function inner(){} } discovers inner)
-  "delete match arm Statement::LabeledStatement\\(l\\) in FunctionFinder<'src>::visit_statement",
-  # tracked: crap-rs#219 — grammar has no `throw`; walker recurses it correctly (throw (()=>{fn})() discovers the fn)
-  "delete match arm Statement::ThrowStatement\\(th\\) in FunctionFinder<'src>::visit_statement",
+    # FunctionFinder::visit_if
+    "mod\\.rs:682:17: delete match arm Statement::IfStatement\\(_\\) in",
+    "mod\\.rs:683:71: replace \\+ with \\* in",
+    # FunctionFinder::visit_for_init
+    "mod\\.rs:719:9: replace FunctionFinder<'src>::visit_for_init with \\(\\)",
+    # FunctionFinder::visit_chain_element
+    "mod\\.rs:1050:9: replace FunctionFinder<'src>::visit_chain_element with \\(\\)",
+    # FunctionFinder::visit_expression — untested match arms
+    "mod\\.rs:773:13: delete match arm Expression::ClassExpression\\(class\\) in",
+    "mod\\.rs:787:13: delete match arm Expression::JSXFragment\\(frag\\) in",
+    "mod\\.rs:834:21: delete match arm AT::PrivateFieldExpression\\(m\\) in",
+    "mod\\.rs:859:21: delete match arm SAT::PrivateFieldExpression\\(m\\) in",
+    "mod\\.rs:875:13: delete match arm Expression::YieldExpression\\(y\\) in",
+    "mod\\.rs:887:13: delete match arm Expression::TSTypeAssertion\\(ts\\) in",
+    "mod\\.rs:891:13: delete match arm Expression::TSInstantiationExpression\\(ts\\) in",
+    "mod\\.rs:905:13: delete match arm Expression::PrivateFieldExpression\\(m\\) in",
+    # byte_to_line_col — arithmetic / comparison operators
+    "mod\\.rs:1434:27: replace == with != in",
+    "mod\\.rs:1435:20: replace \\+ with - in",
+    "mod\\.rs:1435:20: replace \\+ with \\* in",
+    "mod\\.rs:1437:25: replace - with \\+ in",
+    "mod\\.rs:1437:46: replace \\+ with \\* in",
+    # property_key_name — match arms
+    "mod\\.rs:1476:9: delete match arm PropertyKey::PrivateIdentifier\\(id\\) in",
+    "mod\\.rs:1477:9: delete match arm PropertyKey::StringLiteral\\(s\\) in",
+    "mod\\.rs:1478:9: delete match arm PropertyKey::NumericLiteral\\(n\\) in",
+    # for_init_as_expression
+    "mod\\.rs:1515:5: replace for_init_as_expression -> Option<&'b Expression<'b>> with None",
 ]

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -113,9 +113,23 @@ minimum_test_timeout = 90
 # visibility, which is the behaviour #224 wants (it forces re-triage
 # rather than silently masking).
 #
+# One further entry sits in a SEPARATE category: the
+# `Expression::ImportExpression` arm is killed on origin/main only by
+# the randomized `walker_proptest.rs` suite, so whether it is CAUGHT or
+# MISSED depends on the proptest seed of a given run — flaky across
+# mutants passes rather than a hard untested gap. Its sibling array-path
+# arms (ArrayExpression / visit_array_elements / array_element_as_expression)
+# were pinned deterministically in this PR with a single
+# `array-literal-nested-fn.ts` fixture; an equivalent deterministic pin
+# for the dynamic-`import()` recursion path is owed but is not 5-minute
+# trivial (reaching a nested function through an `import()` argument is
+# contrived), so it is parked here under the same #224 ownership rather
+# than blocking this PR. It is grouped below its own sub-comment so the
+# distinction (proptest-dependent, deterministic pin owed) is not lost.
+#
 # tracked: crap-rs#224 — delete each line below as the matching
 # function gains a mutation-killing test; the issue stays open until
-# all 21 are killed and this block is empty.
+# all entries are killed and this block is empty.
 exclude_re = [
     # FunctionFinder::visit_if
     "mod\\.rs:682:17: delete match arm Statement::IfStatement\\(_\\) in",
@@ -134,15 +148,17 @@ exclude_re = [
     "mod\\.rs:891:13: delete match arm Expression::TSInstantiationExpression\\(ts\\) in",
     "mod\\.rs:905:13: delete match arm Expression::PrivateFieldExpression\\(m\\) in",
     # byte_to_line_col — arithmetic / comparison operators
-    "mod\\.rs:1434:27: replace == with != in",
-    "mod\\.rs:1435:20: replace \\+ with - in",
-    "mod\\.rs:1435:20: replace \\+ with \\* in",
-    "mod\\.rs:1437:25: replace - with \\+ in",
-    "mod\\.rs:1437:46: replace \\+ with \\* in",
+    "mod\\.rs:1478:27: replace == with != in",
+    "mod\\.rs:1479:20: replace \\+ with - in",
+    "mod\\.rs:1479:20: replace \\+ with \\* in",
+    "mod\\.rs:1481:25: replace - with \\+ in",
+    "mod\\.rs:1481:46: replace \\+ with \\* in",
     # property_key_name — match arms
-    "mod\\.rs:1476:9: delete match arm PropertyKey::PrivateIdentifier\\(id\\) in",
-    "mod\\.rs:1477:9: delete match arm PropertyKey::StringLiteral\\(s\\) in",
-    "mod\\.rs:1478:9: delete match arm PropertyKey::NumericLiteral\\(n\\) in",
+    "mod\\.rs:1520:9: delete match arm PropertyKey::PrivateIdentifier\\(id\\) in",
+    "mod\\.rs:1521:9: delete match arm PropertyKey::StringLiteral\\(s\\) in",
+    "mod\\.rs:1522:9: delete match arm PropertyKey::NumericLiteral\\(n\\) in",
     # for_init_as_expression
-    "mod\\.rs:1515:5: replace for_init_as_expression -> Option<&'b Expression<'b>> with None",
+    "mod\\.rs:1559:5: replace for_init_as_expression -> Option<&'b Expression<'b>> with None",
+    # proptest-dependent kill, deterministic pin owed (see paragraph above)
+    "mod\\.rs:880:13: delete match arm Expression::ImportExpression\\(ie\\) in",
 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   no current producer triggered this; the change removes a latent
   whole-file-bail vector and locks the four producers as regression
   fixtures. (#214)
+- crap4ts now reports functions declared inside a TypeScript
+  `namespace` with a namespace-qualified name — `Foo.bar`, `A.B.f`
+  (dotted and block-nested forms both qualify), `Svc.Repo.find` for a
+  class method inside a namespace — instead of the bare local name.
+  This mirrors the existing class-method qualification (`C.m`) and
+  changes the `function` field in the JSON envelope and the
+  table/markdown reporters for any namespaced function. Qualification
+  is shallow: only direct namespace members carry the prefix;
+  functions nested inside them stay bare (`inner`, not `A.inner`),
+  matching how class-nested functions already behave. Forward-looking:
+  no first-party fixture corpus emits namespaced output today (the
+  wire-snapshot corpus has no `namespace`), so no captured snapshot
+  drifts; the change disambiguates namespace output and makes it
+  consistent with class output ahead of crap4ts@2.0.0. (#221)
 
 ### Changed (crap-core public API)
 

--- a/crates/crap4ts/src/adapters/walker/mod.rs
+++ b/crates/crap4ts/src/adapters/walker/mod.rs
@@ -1262,12 +1262,7 @@ impl<'src> FunctionFinder<'src> {
                 }
             }
             TSModuleDeclarationBody::TSModuleDeclaration(inner) => {
-                self.visit_ts_module_declaration_prefixed(
-                    inner,
-                    prefix.as_deref(),
-                    out,
-                    nesting,
-                );
+                self.visit_ts_module_declaration_prefixed(inner, prefix.as_deref(), out, nesting);
             }
         }
     }

--- a/crates/crap4ts/src/adapters/walker/mod.rs
+++ b/crates/crap4ts/src/adapters/walker/mod.rs
@@ -290,13 +290,25 @@ impl<'src> FunctionFinder<'src> {
             .map(|bi| bi.name.as_str().to_string())
             .or(name_hint)
             .unwrap_or_else(|| "<anonymous class>".to_string());
+        self.visit_class_body(class, &class_name);
+    }
+
+    /// Discover the function-entry sites on a class body under an
+    /// already-resolved `class_name`. Split out from [`Self::visit_class`]
+    /// so a caller that needs to *prepend* a qualifier (e.g. a class
+    /// declared inside a `namespace A`, which qualifies as `A.C.m`, not
+    /// `C.m`) can resolve the name itself and reuse the identical element
+    /// loop instead of duplicating it. [`Self::visit_class`] keeps the
+    /// original fallback-when-anonymous resolution for every other
+    /// caller.
+    fn visit_class_body(&mut self, class: &Class<'_>, class_name: &str) {
         for element in &class.body.body {
             match element {
-                ClassElement::MethodDefinition(method) => self.record_method(method, &class_name),
+                ClassElement::MethodDefinition(method) => self.record_method(method, class_name),
                 ClassElement::PropertyDefinition(prop) => {
-                    self.visit_property_definition(prop, &class_name);
+                    self.visit_property_definition(prop, class_name);
                 }
-                ClassElement::StaticBlock(block) => self.record_static_block(block, &class_name),
+                ClassElement::StaticBlock(block) => self.record_static_block(block, class_name),
                 // AccessorProperty + TSIndexSignature carry no
                 // executable bodies for cyclomatic analysis (accessors'
                 // bodies live elsewhere; index signatures are type-
@@ -470,13 +482,6 @@ impl<'src> FunctionFinder<'src> {
             Statement::TryStatement(t) => self.visit_try(t, out, nesting),
             Statement::LabeledStatement(l) => self.visit_statement(&l.body, out, nesting),
             Statement::ThrowStatement(th) => self.visit_expression(&th.argument, out, nesting),
-
-            // Module-level statements (valid only at top-level program scope).
-            Statement::ExportNamedDeclaration(decl) => {
-                if let Some(inner) = &decl.declaration {
-                    self.visit_top_level_declaration(inner);
-                }
-            }
 
             // #200 item 2: TS namespaces / modules. A
             // `namespace Foo { function bar() {} }` carries an
@@ -1181,37 +1186,57 @@ impl<'src> FunctionFinder<'src> {
         }
     }
 
-    /// #200 item 2: walk a `TSModuleDeclaration` (`namespace Foo { … }`
-    /// / `module "x" { … }`). `body` is `Option` — declaration-only
-    /// forms (`declare namespace Foo;`, ambient module headers) carry
-    /// `None` and are handled cleanly as no-ops. The body is one of two
-    /// `TSModuleDeclarationBody` variants:
-    ///
-    /// - `TSModuleBlock` — the executable `{ … }` block; its statement
-    ///   list is walked exactly like a function/block body so nested
-    ///   `function bar()` declarations become their own
-    ///   `FunctionComplexity` sites and any decision points inside the
-    ///   block charge the enclosing accumulator.
-    /// - `TSModuleDeclaration` — a dotted-namespace continuation
-    ///   (`namespace A.B { … }` parses as `A` whose body is the nested
-    ///   declaration `B`); recurse so the eventual block is reached.
-    ///
-    /// `nesting`/`out` are threaded straight through: a `namespace`
-    /// nested inside a function body is uncommon but legal in `.ts`, and
-    /// in that position its block's decision points belong to the
-    /// enclosing function. At module scope `nesting` is `None` so
-    /// top-level decision points in the block are not charged to any
-    /// (non-existent) parent, matching the rest of the walker.
-    ///
-    /// Known limitation: functions discovered inside a namespace keep
-    /// their **bare local name** (`bar`), not a namespace-qualified one
-    /// (`Foo.bar`) — unlike class methods, which qualify as `C.m`. The
-    /// `#200` AC only requires separate-`FunctionComplexity` discovery
-    /// (satisfied); qualified naming is a tracked enhancement.
-    /// tracked: crap-rs#221 — namespace-qualified function names
+    /// Walk a `TSModuleDeclaration` (`namespace Foo { … }` /
+    /// `module "x" { … }`). Public entry point — the namespace prefix
+    /// starts empty here. A `namespace` declared inside a function body
+    /// (uncommon but legal in `.ts`) reaches this via `visit_statement`
+    /// and begins its own fresh prefix from its own name.
     fn visit_ts_module_declaration(
         &mut self,
         ns: &oxc::ast::ast::TSModuleDeclaration<'_>,
+        out: &mut Contributors,
+        nesting: Option<u32>,
+    ) {
+        self.visit_ts_module_declaration_prefixed(ns, None, out, nesting);
+    }
+
+    /// Walk a `TSModuleDeclaration`, qualifying every function/class it
+    /// *directly* declares with a dotted namespace prefix so a function
+    /// in `namespace Foo` is recorded as `Foo.bar`, mirroring how a
+    /// class method is recorded `C.m`. `parent_prefix` is the dotted
+    /// path accumulated from any enclosing namespace (`Some("A")` while
+    /// walking `B`'s block inside `namespace A { namespace B { … } }`).
+    ///
+    /// `body` is `Option` — declaration-only forms (`declare namespace
+    /// Foo;`, ambient module headers like `declare module "x";`) carry
+    /// `None` and are a clean no-op. The body is one of two
+    /// `TSModuleDeclarationBody` variants:
+    ///
+    /// - `TSModuleBlock` — the executable `{ … }` block. Its statements
+    ///   go through [`Self::visit_namespace_statement`], which qualifies
+    ///   direct function/class declarations with the accumulated prefix
+    ///   and delegates everything else (decision points, IIFEs) to the
+    ///   ordinary `visit_statement`.
+    /// - `TSModuleDeclaration` — a dotted continuation (`namespace A.B`
+    ///   parses as `A` whose body is the nested declaration `B`).
+    ///   Recurse with the prefix extended by this segment so the
+    ///   eventual block sees the full `A.B` path.
+    ///
+    /// Qualification is **shallow**, exactly like class methods: only
+    /// the namespace's direct members are prefixed. A function nested
+    /// inside a namespace function keeps its bare local name (just as
+    /// `function inner` inside `class C { m() { … } }` is `inner`, not
+    /// `C.inner`).
+    ///
+    /// `nesting`/`out` are threaded straight through: at module scope
+    /// `nesting` is `None` so top-level decision points in the block are
+    /// not charged to any (non-existent) parent; a namespace nested in a
+    /// function body charges its decision points to that function,
+    /// matching the rest of the walker.
+    fn visit_ts_module_declaration_prefixed(
+        &mut self,
+        ns: &oxc::ast::ast::TSModuleDeclaration<'_>,
+        parent_prefix: Option<&str>,
         out: &mut Contributors,
         nesting: Option<u32>,
     ) {
@@ -1219,15 +1244,127 @@ impl<'src> FunctionFinder<'src> {
         let Some(body) = &ns.body else {
             return;
         };
+        let prefix: Option<String> = match module_declaration_name(&ns.id) {
+            Some(seg) => Some(match parent_prefix {
+                Some(p) => format!("{p}.{seg}"),
+                None => seg,
+            }),
+            // A string-literal module name with no usable segment keeps
+            // the inherited prefix unchanged (extreme edge — `module
+            // "x" { … }` augmentation; `module_declaration_name` already
+            // returns the literal value for the common case).
+            None => parent_prefix.map(str::to_string),
+        };
         match body {
             TSModuleDeclarationBody::TSModuleBlock(block) => {
                 for stmt in &block.body {
-                    self.visit_statement(stmt, out, nesting);
+                    self.visit_namespace_statement(stmt, prefix.as_deref(), out, nesting);
                 }
             }
             TSModuleDeclarationBody::TSModuleDeclaration(inner) => {
-                self.visit_ts_module_declaration(inner, out, nesting);
+                self.visit_ts_module_declaration_prefixed(
+                    inner,
+                    prefix.as_deref(),
+                    out,
+                    nesting,
+                );
             }
+        }
+    }
+
+    /// Dispatch one statement of a namespace block. Function / class /
+    /// arrow-or-function-expression variable declarations are recorded
+    /// with the `prefix`-qualified name; a nested `namespace` recurses
+    /// with the prefix extended; every other statement (decision
+    /// points, expression statements, IIFEs, …) is delegated unchanged
+    /// to [`Self::visit_statement`] so its behaviour — including charging
+    /// decision points to `out` — is identical to a non-namespace body.
+    fn visit_namespace_statement(
+        &mut self,
+        stmt: &Statement<'_>,
+        prefix: Option<&str>,
+        out: &mut Contributors,
+        nesting: Option<u32>,
+    ) {
+        let qualify = |name: &str| match prefix {
+            Some(p) => format!("{p}.{name}"),
+            None => name.to_string(),
+        };
+        match stmt {
+            Statement::FunctionDeclaration(func) => {
+                let local = func.id.as_ref().map(|id| id.name.as_str());
+                self.record_function(func, local.map(&qualify));
+            }
+            Statement::ClassDeclaration(class) => {
+                let local = class
+                    .id
+                    .as_ref()
+                    .map(|bi| bi.name.as_str())
+                    // Anonymous class in a namespace composes the
+                    // existing sentinel: `A.<anonymous class>.m`.
+                    .unwrap_or("<anonymous class>");
+                self.visit_class_body(class, &qualify(local));
+            }
+            Statement::VariableDeclaration(vd) => {
+                for declarator in &vd.declarations {
+                    let Some(init) = &declarator.init else {
+                        continue;
+                    };
+                    let name = binding_name(&declarator.id).map(|n| qualify(&n));
+                    self.record_initializer(init, name);
+                }
+            }
+            Statement::ExportNamedDeclaration(decl) => {
+                // `export function bar()` / `export class C` inside a
+                // namespace — unwrap to the inner declaration and apply
+                // the same qualification the bare forms get.
+                if let Some(inner) = &decl.declaration {
+                    self.visit_namespace_declaration(inner, prefix);
+                }
+            }
+            Statement::ExportDefaultDeclaration(decl) => {
+                self.visit_export_default(decl);
+            }
+            Statement::TSModuleDeclaration(inner) => {
+                self.visit_ts_module_declaration_prefixed(inner, prefix, out, nesting);
+            }
+            other => self.visit_statement(other, out, nesting),
+        }
+    }
+
+    /// Qualify a `Declaration` reached through a namespace's
+    /// `export …` statement, mirroring [`Self::visit_namespace_statement`]'s
+    /// function/class/variable arms.
+    fn visit_namespace_declaration(&mut self, decl: &Declaration<'_>, prefix: Option<&str>) {
+        let qualify = |name: &str| match prefix {
+            Some(p) => format!("{p}.{name}"),
+            None => name.to_string(),
+        };
+        match decl {
+            Declaration::FunctionDeclaration(func) => {
+                let local = func.id.as_ref().map(|id| id.name.as_str());
+                self.record_function(func, local.map(&qualify));
+            }
+            Declaration::ClassDeclaration(class) => {
+                let local = class
+                    .id
+                    .as_ref()
+                    .map(|bi| bi.name.as_str())
+                    .unwrap_or("<anonymous class>");
+                self.visit_class_body(class, &qualify(local));
+            }
+            Declaration::VariableDeclaration(vd) => {
+                for declarator in &vd.declarations {
+                    let Some(init) = &declarator.init else {
+                        continue;
+                    };
+                    let name = binding_name(&declarator.id).map(|n| qualify(&n));
+                    self.record_initializer(init, name);
+                }
+            }
+            // TS type / interface / enum declarations have no
+            // executable bodies (same as `visit_top_level_declaration`).
+            _ => {}
         }
     }
 }
@@ -1310,6 +1447,23 @@ fn binding_name(pattern: &BindingPattern<'_>) -> Option<String> {
     match pattern {
         BindingPattern::BindingIdentifier(bi) => Some(bi.name.as_str().to_string()),
         _ => None,
+    }
+}
+
+/// The name segment of a `namespace Foo` / `module "x"` declaration,
+/// used to build the dotted qualifier for functions discovered inside
+/// it. `namespace Foo` and `module Foo` yield `Foo`; the
+/// module-augmentation form `module "foo"` yields the literal value
+/// `foo` verbatim (so `module "foo" { function f }` qualifies as
+/// `foo.f`). Both `oxc` variants always carry a name, so this never
+/// returns `None` today — the `Option` is kept so callers degrade
+/// gracefully (keep the inherited prefix) if a future nameless form
+/// appears.
+fn module_declaration_name(id: &oxc::ast::ast::TSModuleDeclarationName<'_>) -> Option<String> {
+    use oxc::ast::ast::TSModuleDeclarationName as N;
+    match id {
+        N::Identifier(bi) => Some(bi.name.as_str().to_string()),
+        N::StringLiteral(lit) => Some(lit.value.as_str().to_string()),
     }
 }
 

--- a/crates/crap4ts/src/adapters/walker/mod.rs
+++ b/crates/crap4ts/src/adapters/walker/mod.rs
@@ -1301,12 +1301,25 @@ impl<'src> FunctionFinder<'src> {
                 self.visit_class_body(class, &qualify(local));
             }
             Statement::VariableDeclaration(vd) => {
+                // Mirror `visit_variable_declaration_in_body`: route
+                // function-valued initializers to their recorders with
+                // the qualified name, and thread `out`/`nesting` for
+                // every other initializer so a namespace nested in a
+                // function body charges its initializer decision points
+                // to that function (the contract this module documents).
                 for declarator in &vd.declarations {
+                    let name = binding_name(&declarator.id).map(|n| qualify(&n));
                     let Some(init) = &declarator.init else {
                         continue;
                     };
-                    let name = binding_name(&declarator.id).map(|n| qualify(&n));
-                    self.record_initializer(init, name);
+                    match init {
+                        Expression::ArrowFunctionExpression(arrow) => {
+                            self.record_arrow(arrow, name)
+                        }
+                        Expression::FunctionExpression(func) => self.record_function(func, name),
+                        Expression::ClassExpression(class) => self.visit_class(class, name),
+                        other => self.visit_expression(other, out, nesting),
+                    }
                 }
             }
             Statement::ExportNamedDeclaration(decl) => {
@@ -1314,11 +1327,31 @@ impl<'src> FunctionFinder<'src> {
                 // namespace — unwrap to the inner declaration and apply
                 // the same qualification the bare forms get.
                 if let Some(inner) = &decl.declaration {
-                    self.visit_namespace_declaration(inner, prefix);
+                    self.visit_namespace_declaration(inner, prefix, out, nesting);
                 }
             }
             Statement::ExportDefaultDeclaration(decl) => {
-                self.visit_export_default(decl);
+                // `export default function f` / `export default class C`
+                // inside a namespace must carry the prefix like every
+                // other namespace member; a default-exported *expression*
+                // has no declaration name to qualify, so it keeps the
+                // ordinary expression handling.
+                use oxc::ast::ast::ExportDefaultDeclarationKind as K;
+                match &decl.declaration {
+                    K::FunctionDeclaration(func) => {
+                        let local = func.id.as_ref().map(|id| id.name.as_str());
+                        self.record_function(func, local.map(&qualify));
+                    }
+                    K::ClassDeclaration(class) => {
+                        let local = class
+                            .id
+                            .as_ref()
+                            .map(|bi| bi.name.as_str())
+                            .unwrap_or("<anonymous class>");
+                        self.visit_class_body(class, &qualify(local));
+                    }
+                    _ => self.visit_export_default(decl),
+                }
             }
             Statement::TSModuleDeclaration(inner) => {
                 self.visit_ts_module_declaration_prefixed(inner, prefix, out, nesting);
@@ -1329,8 +1362,17 @@ impl<'src> FunctionFinder<'src> {
 
     /// Qualify a `Declaration` reached through a namespace's
     /// `export …` statement, mirroring [`Self::visit_namespace_statement`]'s
-    /// function/class/variable arms.
-    fn visit_namespace_declaration(&mut self, decl: &Declaration<'_>, prefix: Option<&str>) {
+    /// function/class/variable arms. `out`/`nesting` are threaded so the
+    /// variable-declaration arm stays byte-for-byte symmetric with the
+    /// bare-statement path (a namespace nested in a function body charges
+    /// `export const` initializer decision points to that function).
+    fn visit_namespace_declaration(
+        &mut self,
+        decl: &Declaration<'_>,
+        prefix: Option<&str>,
+        out: &mut Contributors,
+        nesting: Option<u32>,
+    ) {
         let qualify = |name: &str| match prefix {
             Some(p) => format!("{p}.{name}"),
             None => name.to_string(),
@@ -1350,11 +1392,18 @@ impl<'src> FunctionFinder<'src> {
             }
             Declaration::VariableDeclaration(vd) => {
                 for declarator in &vd.declarations {
+                    let name = binding_name(&declarator.id).map(|n| qualify(&n));
                     let Some(init) = &declarator.init else {
                         continue;
                     };
-                    let name = binding_name(&declarator.id).map(|n| qualify(&n));
-                    self.record_initializer(init, name);
+                    match init {
+                        Expression::ArrowFunctionExpression(arrow) => {
+                            self.record_arrow(arrow, name)
+                        }
+                        Expression::FunctionExpression(func) => self.record_function(func, name),
+                        Expression::ClassExpression(class) => self.visit_class(class, name),
+                        other => self.visit_expression(other, out, nesting),
+                    }
                 }
             }
             // TS type / interface / enum declarations have no

--- a/crates/crap4ts/tests/fixtures/ts-fixtures/array-literal-nested-fn.ts
+++ b/crates/crap4ts/tests/fixtures/ts-fixtures/array-literal-nested-fn.ts
@@ -1,0 +1,15 @@
+// `discovered` is reachable ONLY through an array-literal element: the
+// initializer is an ArrayExpression whose sole element wraps the
+// function. The walker's `Expression::ArrayExpression` arm forwards to
+// `visit_array_elements`, which maps each element through
+// `array_element_as_expression` before recursing. Deleting that arm,
+// stubbing `visit_array_elements` to a no-op, or making
+// `array_element_as_expression` return `None` each drop the function
+// to the no-op fallthrough so it is never found. One fixture pins all
+// three sites deterministically regardless of proptest generation.
+const probe = [function discovered(n: number): number {
+  if (n > 0) {
+    return n;
+  }
+  return 0;
+}];

--- a/crates/crap4ts/tests/fixtures/ts-fixtures/namespace-class.ts
+++ b/crates/crap4ts/tests/fixtures/ts-fixtures/namespace-class.ts
@@ -1,0 +1,16 @@
+// Class declared inside a namespace. The class methods must carry the
+// namespace prefix in front of the class qualifier: `Svc.Repo.find`,
+// not `Repo.find`. A namespace-level function alongside it qualifies as
+// `Svc.helper`.
+namespace Svc {
+  export function helper(): void {}
+
+  export class Repo {
+    find(id: number): number {
+      if (id > 0) {
+        return id;
+      }
+      return 0;
+    }
+  }
+}

--- a/crates/crap4ts/tests/fixtures/ts-fixtures/namespace-const-fn.ts
+++ b/crates/crap4ts/tests/fixtures/ts-fixtures/namespace-const-fn.ts
@@ -1,0 +1,20 @@
+// Function-valued `const` bindings inside a namespace. The bare form
+// (`const bare = …`) is reached through the direct namespace-statement
+// path; the exported form (`export const exported = …`) is reached
+// through the namespace `export` declaration path. Both must be
+// discovered with the namespace prefix: `Calc.bare`, `Calc.exported`.
+namespace Calc {
+  const bare = (n: number): number => {
+    if (n > 0) {
+      return n;
+    }
+    return 0;
+  };
+
+  export const exported = function (n: number): number {
+    if (n < 0) {
+      return -n;
+    }
+    return n;
+  };
+}

--- a/crates/crap4ts/tests/fixtures/ts-fixtures/namespace-dotted.ts
+++ b/crates/crap4ts/tests/fixtures/ts-fixtures/namespace-dotted.ts
@@ -1,0 +1,12 @@
+// Dotted-namespace continuation: `namespace A.B` parses as `A` whose
+// module body is the nested declaration `B`. `f` must qualify with the
+// full dotted path `A.B.f`, and its `if` must charge `A.B.f` (not
+// module scope, not a partial `B.f`).
+namespace A.B {
+  export function f(n: number): number {
+    if (n > 0) {
+      return n;
+    }
+    return 0;
+  }
+}

--- a/crates/crap4ts/tests/fixtures/ts-fixtures/namespace-export-default.ts
+++ b/crates/crap4ts/tests/fixtures/ts-fixtures/namespace-export-default.ts
@@ -1,0 +1,25 @@
+// A default-exported declaration inside a namespace must carry the
+// namespace prefix like every other member — `Api.handler` /
+// `Svc.Repo.find`, not the bare `handler` / `Repo.find`. Before the
+// fix this arm routed through the unqualified top-level
+// export-default path. Function and class defaults live in separate
+// namespaces because a namespace may have only one `export default`.
+namespace Api {
+  export default function handler(n: number): number {
+    if (n > 0) {
+      return n;
+    }
+    return 0;
+  }
+}
+
+namespace Svc {
+  export default class Repo {
+    find(id: number): number {
+      if (id > 0) {
+        return id;
+      }
+      return -1;
+    }
+  }
+}

--- a/crates/crap4ts/tests/fixtures/ts-fixtures/namespace-export-default.ts
+++ b/crates/crap4ts/tests/fixtures/ts-fixtures/namespace-export-default.ts
@@ -1,9 +1,17 @@
-// A default-exported declaration inside a namespace must carry the
-// namespace prefix like every other member — `Api.handler` /
-// `Svc.Repo.find`, not the bare `handler` / `Repo.find`. Before the
-// fix this arm routed through the unqualified top-level
-// export-default path. Function and class defaults live in separate
-// namespaces because a namespace may have only one `export default`.
+// INTENTIONALLY MALFORMED TypeScript. `export default` inside a
+// `namespace` is a type error (TS1063 "An export assignment cannot be
+// used in a namespace"), and two `export default`s in one file is
+// independently invalid. `tsc`/Biome reject this; oxc — a lenient
+// parser — still emits two `ExportDefaultDeclaration` AST nodes for it.
+// crap4ts is a complexity analyzer, not a type checker: it analyzes
+// whatever oxc emits, and real codebases contain type errors. This
+// fixture pins crap4ts's behavior on that lenient-parse AST: a
+// default-exported declaration reached through the namespace path must
+// still carry the namespace prefix (`Api.handler` / `Svc.Repo.find`),
+// not fall through to the bare top-level export-default path
+// (`handler` / `Repo.find`). It is split across two namespaces only so
+// the two distinct arms (function default, class default) are both
+// exercised in one file.
 namespace Api {
   export default function handler(n: number): number {
     if (n > 0) {

--- a/crates/crap4ts/tests/fixtures/ts-fixtures/namespace-nested.ts
+++ b/crates/crap4ts/tests/fixtures/ts-fixtures/namespace-nested.ts
@@ -1,0 +1,21 @@
+// Block-nested namespaces: `namespace A { namespace B { … } }`. The
+// inner `namespace B` is a statement inside A's block (a different
+// recursion path than the dotted-continuation form), yet the qualified
+// name must be the same `A.B.g`. A function declared directly in the
+// outer block stays `A.outer`. Shallow qualification: `inner` nested
+// inside `g` keeps its bare name (mirrors a function nested in a class
+// method).
+namespace A {
+  export function outer(): void {}
+
+  namespace B {
+    export function g(n: number): number {
+      if (n > 0) {
+        function inner(): void {}
+        inner();
+        return n;
+      }
+      return 0;
+    }
+  }
+}

--- a/crates/crap4ts/tests/fixtures/ts-fixtures/unary-operand-nested-fn.ts
+++ b/crates/crap4ts/tests/fixtures/ts-fixtures/unary-operand-nested-fn.ts
@@ -1,0 +1,13 @@
+// `discovered` is reachable ONLY through the `typeof` operand: the
+// initializer is a UnaryExpression whose argument wraps the function.
+// The walker's `Expression::UnaryExpression` arm recurses into that
+// argument; deleting it drops the unary node to the no-op `_ => {}`
+// fallthrough and the nested function is never found. This fixture
+// pins that arm deterministically so a single targeted test kills the
+// mutant regardless of proptest generation.
+const probe = typeof (function discovered(n: number): number {
+  if (n > 0) {
+    return n;
+  }
+  return 0;
+});

--- a/crates/crap4ts/tests/walker_proptest.rs
+++ b/crates/crap4ts/tests/walker_proptest.rs
@@ -91,6 +91,30 @@ enum Stmt {
     /// the enclosing function (invariant 4 — isolation); the nested
     /// function is its own complexity site.
     NestedFn(Box<Body>),
+    /// A `class _CN { _mN() { <inner> } }` declared **inside a function
+    /// body** (reached via `visit_statement`'s `Statement::Class
+    /// Declaration` arm, not the top-level path). The method
+    /// `_CN._mN` is its own complexity site holding `<inner>`; the
+    /// class adds ZERO decision points to the enclosing function (same
+    /// isolation as `NestedFn`). One discovered function site (the
+    /// method) plus whatever `<inner>` introduces.
+    ClassDecl(Box<Body>),
+    /// A labeled block `_lblN: { <inner> }`. The label is transparent:
+    /// `<inner>`'s decision points charge the *enclosing* function at
+    /// the *same* nesting depth (a labeled block, like a bare block,
+    /// does not bump nesting), and any nested function in `<inner>` is
+    /// its own site. Exercises `visit_statement`'s `LabeledStatement`
+    /// arm (`visit_statement(&l.body, …)`).
+    Labeled(Box<Body>),
+    /// `throw (() => { <inner> })();`. The IIFE arrow is a SEPARATE
+    /// complexity site holding `<inner>` (so `<inner>`'s decision points
+    /// charge the arrow, not the enclosing function — charges ZERO,
+    /// same isolation as `NestedFn`). Exercises `visit_statement`'s
+    /// `ThrowStatement` arm (`visit_expression(&th.argument, …)`).
+    /// Statements generated after a `throw` are unreachable but still
+    /// parse and are still walked — the oracle sums all statements, so
+    /// it stays consistent with the walker regardless of reachability.
+    Throw(Box<Body>),
     /// An IIFE arrow `(() => { <inner> })()` embedded inside a chosen
     /// expression context (`await`, array element, template-literal
     /// substitution, sequence, unary, `as`/`satisfies`/`!`,
@@ -177,8 +201,18 @@ impl Stmt {
             // `ExprWrap`'s decision points live inside its IIFE arrow
             // (a separate site), so it charges ZERO to the enclosing
             // function — same isolation as `NestedFn`.
-            Stmt::Noop | Stmt::NestedFn(_) | Stmt::ExprWrap(..) => 0,
-            Stmt::TryFinally(b) => b.increments(),
+            // `ClassDecl`'s decision points live in its method body (a
+            // separate site); `Throw`'s live in its IIFE arrow (a
+            // separate site) — both charge ZERO to the enclosing
+            // function, same isolation as `NestedFn`.
+            Stmt::Noop
+            | Stmt::NestedFn(_)
+            | Stmt::ExprWrap(..)
+            | Stmt::ClassDecl(_)
+            | Stmt::Throw(_) => 0,
+            // `Labeled` is transparent — its body charges the enclosing
+            // function exactly as if the label weren't there.
+            Stmt::TryFinally(b) | Stmt::Labeled(b) => b.increments(),
             // One decision point + whatever the inner body charges.
             Stmt::If(b)
             | Stmt::For(b)
@@ -286,6 +320,23 @@ impl Stmt {
                 b.emit(out, ctr, indent + 1);
                 out.push_str(&format!("{pad}}}\n"));
             }
+            Stmt::ClassDecl(b) => {
+                out.push_str(&format!("{pad}class _C{id} {{\n"));
+                out.push_str(&format!("{pad}  _m{id}(): void {{\n"));
+                b.emit(out, ctr, indent + 2);
+                out.push_str(&format!("{pad}  }}\n"));
+                out.push_str(&format!("{pad}}}\n"));
+            }
+            Stmt::Labeled(b) => {
+                out.push_str(&format!("{pad}_lbl{id}: {{\n"));
+                b.emit(out, ctr, indent + 1);
+                out.push_str(&format!("{pad}}}\n"));
+            }
+            Stmt::Throw(b) => {
+                out.push_str(&format!("{pad}throw (() => {{\n"));
+                b.emit(out, ctr, indent + 1);
+                out.push_str(&format!("{pad}}})();\n"));
+            }
             Stmt::ExprWrap(kind, b) => {
                 // Two nested function sites:
                 //   outer async IIFE  — makes `await` always legal
@@ -329,8 +380,15 @@ impl Stmt {
             | Stmt::DoWhile(b)
             | Stmt::Switch(b)
             | Stmt::TryCatch(b)
-            | Stmt::TryFinally(b) => b.nested_fn_count(),
+            | Stmt::TryFinally(b)
+            // `Labeled` is transparent: it introduces no site of its
+            // own; only its body's nested functions count.
+            | Stmt::Labeled(b) => b.nested_fn_count(),
             Stmt::NestedFn(b) => 1 + b.nested_fn_count(),
+            // `ClassDecl` introduces ONE site (the method `_C._m`);
+            // `Throw` introduces ONE site (the thrown IIFE arrow). Each
+            // body may itself introduce more.
+            Stmt::ClassDecl(b) | Stmt::Throw(b) => 1 + b.nested_fn_count(),
             // The wrapper introduces TWO IIFE sites (outer async +
             // inner); the inner's body may itself introduce more.
             Stmt::ExprWrap(_, b) => 2 + b.nested_fn_count(),
@@ -368,7 +426,15 @@ impl Stmt {
             // `ExprWrap`'s decision points live in its separate IIFE
             // arrow, so it contributes NOTHING to the enclosing
             // function's nesting multiset (same as `NestedFn`).
-            Stmt::Noop | Stmt::NestedFn(_) | Stmt::ExprWrap(..) => {}
+            // `ClassDecl`/`Throw` decision points live in their
+            // separate site (method body / thrown IIFE arrow), so they
+            // contribute NOTHING to the enclosing function's nesting
+            // multiset (same as `NestedFn`/`ExprWrap`).
+            Stmt::Noop
+            | Stmt::NestedFn(_)
+            | Stmt::ExprWrap(..)
+            | Stmt::ClassDecl(_)
+            | Stmt::Throw(_) => {}
             Stmt::If(b)
             | Stmt::For(b)
             | Stmt::ForIn(b)
@@ -384,8 +450,11 @@ impl Stmt {
                 // try-block body is NOT depth-bumped by visit_try.
                 b.collect_nestings(depth, out);
             }
-            Stmt::TryFinally(b) => {
-                // No contributor; body recurses at same depth.
+            // No contributor; body recurses at the SAME depth.
+            // `TryFinally`: `visit_try` does not bump the try-block.
+            // `Labeled`: a labeled block, like a bare block, does not
+            // bump nesting (the label is transparent).
+            Stmt::TryFinally(b) | Stmt::Labeled(b) => {
                 b.collect_nestings(depth, out);
             }
             Stmt::LogicalAnd
@@ -481,6 +550,9 @@ fn stmt_strategy() -> impl Strategy<Value = Stmt> {
             body.clone().prop_map(|b| Stmt::TryCatch(Box::new(b))),
             body.clone().prop_map(|b| Stmt::TryFinally(Box::new(b))),
             body.clone().prop_map(|b| Stmt::NestedFn(Box::new(b))),
+            body.clone().prop_map(|b| Stmt::ClassDecl(Box::new(b))),
+            body.clone().prop_map(|b| Stmt::Labeled(Box::new(b))),
+            body.clone().prop_map(|b| Stmt::Throw(Box::new(b))),
             (wrapkind_strategy(), body).prop_map(|(k, b)| Stmt::ExprWrap(k, Box::new(b))),
         ]
     })
@@ -515,6 +587,12 @@ enum Container {
     /// `function top() { return <div>{c && <span/>}</div>; <body> }`
     /// in a `.tsx` file — JSX-conditional decision point.
     JsxConditional,
+    /// `export default (function top() { <body> })();` at module scope
+    /// — exercises the `visit_export_default` expression-flavoured arm
+    /// (the default export is a call whose callee is the named function
+    /// expression `top` holding the body). Forced to a `.ts` extension
+    /// so the module-only `export default` always parses.
+    ExportDefaultExpr,
 }
 
 fn container_strategy() -> impl Strategy<Value = Container> {
@@ -527,6 +605,7 @@ fn container_strategy() -> impl Strategy<Value = Container> {
         Just(Container::Namespace),
         Just(Container::ComputedObjectKey),
         Just(Container::JsxConditional),
+        Just(Container::ExportDefaultExpr),
     ]
 }
 
@@ -578,6 +657,11 @@ impl Program {
             // JSX-conditional container; everything else honours the
             // generated extension.
             Container::JsxConditional => "tsx",
+            // `export default` is module-only — `.cjs` rejects it.
+            // Pin `.ts` (always a module SourceType in oxc) so the
+            // construct always parses and reliably exercises
+            // `visit_export_default`.
+            Container::ExportDefaultExpr => "ts",
             _ => self.ext,
         };
         format!("prop{}.{ext}", if self.unicode { "_uni" } else { "" })
@@ -649,6 +733,19 @@ impl Program {
                 self.body.emit(&mut out, &mut ctr, 1);
                 out.push_str("  return <div>{(_cond as any) && <span />}</div>;\n");
                 out.push_str("}\n");
+            }
+            Container::ExportDefaultExpr => {
+                // The default export is a CALL whose callee is the
+                // named function expression `top` holding the body —
+                // routed through `visit_export_default`'s
+                // expression-flavoured arm
+                // (`export_default_as_expression` → `visit_expression`).
+                // Deleting `visit_export_default` (or its expression
+                // arm) drops `top` from the discovered set, which the
+                // independent-oracle / isolation invariants catch.
+                out.push_str("export default (function top(): void {\n");
+                self.body.emit(&mut out, &mut ctr, 1);
+                out.push_str("})();\n");
             }
         }
         out
@@ -751,9 +848,14 @@ proptest! {
         // depends on the container shape.
         let holder_name: &str = match prog.container {
             Container::FunctionDecl
-            | Container::Namespace
-            | Container::JsxConditional => "top",
+            | Container::JsxConditional
+            // `export default (function top() {…})()` — the body holder
+            // is the named function expression `top`.
+            | Container::ExportDefaultExpr => "top",
             Container::ArrowConst => "top",
+            // `namespace N { export function top }` qualifies the body
+            // holder as `N.top` (mirrors class `C.m`).
+            Container::Namespace => "N.top",
             Container::ClassMethod
             | Container::ClassComputedKey => "C.m",
             Container::StaticBlock => "C.<static-init>",
@@ -812,8 +914,10 @@ proptest! {
 
         let holder_name: &str = match prog.container {
             Container::FunctionDecl
-            | Container::Namespace
-            | Container::ArrowConst => "top",
+            | Container::ArrowConst
+            | Container::ExportDefaultExpr => "top",
+            // `namespace N { export function top }` → `N.top`.
+            Container::Namespace => "N.top",
             Container::ClassMethod | Container::ClassComputedKey => "C.m",
             Container::StaticBlock => "C.<static-init>",
             Container::ComputedObjectKey | Container::JsxConditional => unreachable!(),

--- a/crates/crap4ts/tests/walker_smoke.rs
+++ b/crates/crap4ts/tests/walker_smoke.rs
@@ -56,6 +56,11 @@ const STATIC_BLOCK_TS: &str = include_str!("fixtures/ts-fixtures/static-block.ts
 // #200 + #205: walker traversal coverage-gap fixtures.
 const COMPUTED_OBJECT_KEY_TS: &str = include_str!("fixtures/ts-fixtures/computed-object-key.ts");
 const NAMESPACE_TS: &str = include_str!("fixtures/ts-fixtures/namespace.ts");
+const NAMESPACE_DOTTED_TS: &str = include_str!("fixtures/ts-fixtures/namespace-dotted.ts");
+const NAMESPACE_NESTED_TS: &str = include_str!("fixtures/ts-fixtures/namespace-nested.ts");
+const NAMESPACE_CLASS_TS: &str = include_str!("fixtures/ts-fixtures/namespace-class.ts");
+const NAMESPACE_CONST_FN_TS: &str =
+    include_str!("fixtures/ts-fixtures/namespace-const-fn.ts");
 const ASSIGNMENT_COMPUTED_LHS_TS: &str =
     include_str!("fixtures/ts-fixtures/assignment-computed-lhs.ts");
 const UPDATE_COMPUTED_OPERAND_TS: &str =
@@ -680,33 +685,121 @@ fn computed_object_key_decision_point_charges_enclosing_function() {
 
 #[test]
 fn namespace_nested_function_is_discovered_as_separate_site() {
-    // #200 item 2: `namespace Foo { export function bar() { if … } }`
-    // — `bar` is its own FunctionComplexity; its `if` charges `bar`,
-    // not module scope. The trailing declaration-only
-    // `declare module "side-effect-only";` (body: None) must be a
-    // clean no-op (no panic, no extra function).
+    // `namespace Foo { export function bar() { if … } }` — `bar` is
+    // its own FunctionComplexity, recorded namespace-qualified as
+    // `Foo.bar` (mirroring class methods, which qualify as `C.m`). Its
+    // `if` charges `Foo.bar`, not module scope. The trailing
+    // declaration-only `declare module "side-effect-only";` (body:
+    // None) must be a clean no-op (no panic, no extra function).
     let fns = extract(NAMESPACE_TS, "namespace.ts");
     let names: Vec<_> = fns
         .iter()
         .map(|f| f.identity.qualified_name.clone())
         .collect();
-    // The walker records the BARE local name `bar` here, not a
-    // namespace-qualified `Foo.bar` (contrast class methods, which
-    // qualify as `C.m`). #200 item 2's AC only requires `bar` be
-    // discovered as a separate FunctionComplexity, which it is.
-    // Namespace-qualified naming is a tracked enhancement:
-    // tracked: crap-rs#221 — namespace-qualified function names
     assert_eq!(
         fns.len(),
         1,
-        "expected exactly one function (local name `bar`); got names: {names:?}"
+        "expected exactly one function (`Foo.bar`); got names: {names:?}"
     );
-    let bar = find_fn(&fns, "bar");
+    let bar = find_fn(&fns, "Foo.bar");
     assert_eq!(bar.complexity, 2, "bar's `if` adds one decision point");
     assert_eq!(bar.contributors.len(), 1);
     assert_eq!(bar.contributors[0].kind, ContributorKind::IfBranch);
     // The `if` is on line 6 of the fixture (1-based).
     assert_eq!(bar.contributors[0].line, 6);
+}
+
+#[test]
+fn namespace_dotted_continuation_qualifies_with_full_path() {
+    // `namespace A.B { export function f }` parses as `A` whose module
+    // body is the nested declaration `B`. The qualified name carries
+    // the full dotted path `A.B.f` — not module scope, not a partial
+    // `B.f` — and the `if` charges `A.B.f`.
+    let fns = extract(NAMESPACE_DOTTED_TS, "namespace-dotted.ts");
+    assert_eq!(fns.len(), 1, "expected exactly one function (`A.B.f`)");
+    let f = find_fn(&fns, "A.B.f");
+    assert_eq!(f.complexity, 2, "f's `if` adds one decision point");
+    assert_eq!(f.contributors.len(), 1);
+    assert_eq!(f.contributors[0].kind, ContributorKind::IfBranch);
+}
+
+#[test]
+fn namespace_block_nested_qualifies_same_as_dotted_and_is_shallow() {
+    // `namespace A { function outer; namespace B { function g } }` —
+    // the block-nested path yields the same `A.B.g` as the dotted
+    // form, and `outer` declared in the outer block is `A.outer`.
+    // Qualification is SHALLOW: `inner`, nested inside `g`, keeps its
+    // bare name (mirrors a function nested inside a class method).
+    let fns = extract(NAMESPACE_NESTED_TS, "namespace-nested.ts");
+    let names: Vec<_> = fns
+        .iter()
+        .map(|f| f.identity.qualified_name.clone())
+        .collect();
+    assert_eq!(
+        fns.len(),
+        3,
+        "expected A.outer, A.B.g, inner; got: {names:?}"
+    );
+    find_fn(&fns, "A.outer");
+    let g = find_fn(&fns, "A.B.g");
+    assert_eq!(g.complexity, 2, "g's `if` adds one; `inner` does not bleed");
+    let inner = find_fn(&fns, "inner");
+    assert_eq!(
+        inner.complexity, 1,
+        "shallow qualification: nested `inner` stays bare and isolated"
+    );
+}
+
+#[test]
+fn namespace_class_methods_carry_namespace_then_class_prefix() {
+    // A class inside a namespace qualifies methods with both prefixes:
+    // `Svc.Repo.find`, not `Repo.find`. A namespace-level function
+    // alongside it is `Svc.helper`.
+    let fns = extract(NAMESPACE_CLASS_TS, "namespace-class.ts");
+    let names: Vec<_> = fns
+        .iter()
+        .map(|f| f.identity.qualified_name.clone())
+        .collect();
+    assert_eq!(
+        fns.len(),
+        2,
+        "expected Svc.helper + Svc.Repo.find; got: {names:?}"
+    );
+    find_fn(&fns, "Svc.helper");
+    let find = find_fn(&fns, "Svc.Repo.find");
+    assert_eq!(
+        find.complexity, 2,
+        "find's `if` adds one decision point"
+    );
+    assert_eq!(find.contributors[0].kind, ContributorKind::IfBranch);
+}
+
+#[test]
+fn namespace_function_valued_const_bindings_carry_namespace_prefix() {
+    // Function-valued `const`s in a namespace are discovered with the
+    // namespace prefix regardless of whether they reach the walker
+    // through the bare statement path (`const bare = …`) or the
+    // `export` declaration path (`export const exported = …`):
+    // `Calc.bare` and `Calc.exported`, each CC 2 from its own `if`.
+    let fns = extract(NAMESPACE_CONST_FN_TS, "namespace-const-fn.ts");
+    let names: Vec<_> = fns
+        .iter()
+        .map(|f| f.identity.qualified_name.clone())
+        .collect();
+    assert_eq!(
+        fns.len(),
+        2,
+        "expected Calc.bare + Calc.exported; got: {names:?}"
+    );
+    let bare = find_fn(&fns, "Calc.bare");
+    assert_eq!(bare.complexity, 2, "bare's `if` adds one decision point");
+    assert_eq!(bare.contributors[0].kind, ContributorKind::IfBranch);
+    let exported = find_fn(&fns, "Calc.exported");
+    assert_eq!(
+        exported.complexity, 2,
+        "exported's `if` adds one decision point"
+    );
+    assert_eq!(exported.contributors[0].kind, ContributorKind::IfBranch);
 }
 
 #[test]

--- a/crates/crap4ts/tests/walker_smoke.rs
+++ b/crates/crap4ts/tests/walker_smoke.rs
@@ -59,8 +59,7 @@ const NAMESPACE_TS: &str = include_str!("fixtures/ts-fixtures/namespace.ts");
 const NAMESPACE_DOTTED_TS: &str = include_str!("fixtures/ts-fixtures/namespace-dotted.ts");
 const NAMESPACE_NESTED_TS: &str = include_str!("fixtures/ts-fixtures/namespace-nested.ts");
 const NAMESPACE_CLASS_TS: &str = include_str!("fixtures/ts-fixtures/namespace-class.ts");
-const NAMESPACE_CONST_FN_TS: &str =
-    include_str!("fixtures/ts-fixtures/namespace-const-fn.ts");
+const NAMESPACE_CONST_FN_TS: &str = include_str!("fixtures/ts-fixtures/namespace-const-fn.ts");
 const ASSIGNMENT_COMPUTED_LHS_TS: &str =
     include_str!("fixtures/ts-fixtures/assignment-computed-lhs.ts");
 const UPDATE_COMPUTED_OPERAND_TS: &str =
@@ -767,10 +766,7 @@ fn namespace_class_methods_carry_namespace_then_class_prefix() {
     );
     find_fn(&fns, "Svc.helper");
     let find = find_fn(&fns, "Svc.Repo.find");
-    assert_eq!(
-        find.complexity, 2,
-        "find's `if` adds one decision point"
-    );
+    assert_eq!(find.complexity, 2, "find's `if` adds one decision point");
     assert_eq!(find.contributors[0].kind, ContributorKind::IfBranch);
 }
 

--- a/crates/crap4ts/tests/walker_smoke.rs
+++ b/crates/crap4ts/tests/walker_smoke.rs
@@ -60,6 +60,12 @@ const NAMESPACE_DOTTED_TS: &str = include_str!("fixtures/ts-fixtures/namespace-d
 const NAMESPACE_NESTED_TS: &str = include_str!("fixtures/ts-fixtures/namespace-nested.ts");
 const NAMESPACE_CLASS_TS: &str = include_str!("fixtures/ts-fixtures/namespace-class.ts");
 const NAMESPACE_CONST_FN_TS: &str = include_str!("fixtures/ts-fixtures/namespace-const-fn.ts");
+const NAMESPACE_EXPORT_DEFAULT_TS: &str =
+    include_str!("fixtures/ts-fixtures/namespace-export-default.ts");
+const UNARY_OPERAND_NESTED_FN_TS: &str =
+    include_str!("fixtures/ts-fixtures/unary-operand-nested-fn.ts");
+const ARRAY_LITERAL_NESTED_FN_TS: &str =
+    include_str!("fixtures/ts-fixtures/array-literal-nested-fn.ts");
 const ASSIGNMENT_COMPUTED_LHS_TS: &str =
     include_str!("fixtures/ts-fixtures/assignment-computed-lhs.ts");
 const UPDATE_COMPUTED_OPERAND_TS: &str =
@@ -796,6 +802,81 @@ fn namespace_function_valued_const_bindings_carry_namespace_prefix() {
         "exported's `if` adds one decision point"
     );
     assert_eq!(exported.contributors[0].kind, ContributorKind::IfBranch);
+}
+
+#[test]
+fn namespace_export_default_declaration_carries_namespace_prefix() {
+    // `export default function` AND `export default class` inside a
+    // namespace are qualified like every other member — `Api.handler`
+    // / `Svc.Repo.find`, not the bare `handler` / `Repo.find`. The
+    // class case also pins the `K::ClassDeclaration` arm: without it
+    // the declaration falls back to the unqualified top-level
+    // export-default path and the prefix is lost.
+    let fns = extract(NAMESPACE_EXPORT_DEFAULT_TS, "namespace-export-default.ts");
+    let names: Vec<_> = fns
+        .iter()
+        .map(|f| f.identity.qualified_name.clone())
+        .collect();
+    assert_eq!(
+        fns.len(),
+        2,
+        "expected Api.handler + Svc.Repo.find; got: {names:?}"
+    );
+    let handler = find_fn(&fns, "Api.handler");
+    assert_eq!(
+        handler.complexity, 2,
+        "handler's `if` adds one decision point"
+    );
+    assert_eq!(handler.contributors[0].kind, ContributorKind::IfBranch);
+    let find = find_fn(&fns, "Svc.Repo.find");
+    assert_eq!(find.complexity, 2, "find's `if` adds one decision point");
+    assert_eq!(find.contributors[0].kind, ContributorKind::IfBranch);
+}
+
+#[test]
+fn unary_expression_argument_is_recursed_for_nested_function_discovery() {
+    // `const probe = typeof (function discovered(){ if … })` — the
+    // function is reachable only through the UnaryExpression operand.
+    // With the walker's `Expression::UnaryExpression` arm it is
+    // discovered (CC 2 from its `if`); deleting that arm drops the
+    // unary node to the no-op fallthrough and `discovered` vanishes.
+    // Pins that arm so the mutant stays caught deterministically.
+    let fns = extract(UNARY_OPERAND_NESTED_FN_TS, "unary-operand-nested-fn.ts");
+    let names: Vec<_> = fns
+        .iter()
+        .map(|f| f.identity.qualified_name.clone())
+        .collect();
+    assert_eq!(fns.len(), 1, "expected `discovered`; got: {names:?}");
+    let discovered = find_fn(&fns, "discovered");
+    assert_eq!(
+        discovered.complexity, 2,
+        "discovered's `if` adds one decision point"
+    );
+    assert_eq!(discovered.contributors[0].kind, ContributorKind::IfBranch);
+}
+
+#[test]
+fn array_literal_element_is_recursed_for_nested_function_discovery() {
+    // `const probe = [function discovered(){ if … }]` — the function is
+    // reachable only through an ArrayExpression element. The walker's
+    // `Expression::ArrayExpression` arm forwards to `visit_array_elements`,
+    // which yields each element via `array_element_as_expression`.
+    // Deleting the arm, stubbing the helper to `()`, or returning `None`
+    // from `array_element_as_expression` all drop `discovered` to the
+    // no-op fallthrough. Pins all three sites deterministically so the
+    // mutants stay caught regardless of proptest generation.
+    let fns = extract(ARRAY_LITERAL_NESTED_FN_TS, "array-literal-nested-fn.ts");
+    let names: Vec<_> = fns
+        .iter()
+        .map(|f| f.identity.qualified_name.clone())
+        .collect();
+    assert_eq!(fns.len(), 1, "expected `discovered`; got: {names:?}");
+    let discovered = find_fn(&fns, "discovered");
+    assert_eq!(
+        discovered.complexity, 2,
+        "discovered's `if` adds one decision point"
+    );
+    assert_eq!(discovered.contributors[0].kind, ContributorKind::IfBranch);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

One bundled PR completing the crap4ts walker's behavioural net and reviving its mutation gate.

- **#219 — walker proptest grammar completion.** The `walker_proptest.rs` generator gains the residual constructs (`Stmt::ClassDecl` / `Stmt::Labeled` / `Stmt::Throw`, `Container::ExportDefaultExpr`) with the oracle updated (`increments` / `emit` / `nested_fn_count` / `expected_nestings`). The proptest net now kills the four long-standing walker mutants, so their `exclude_re` block in `.cargo/mutants.toml` is removed.
- **#221 — namespace-qualified function naming.** Functions declared inside a TS `namespace` are reported as `Foo.bar` / `A.B.f` (dotted **and** block-nested) / `Svc.Repo.find` (class method in a namespace), mirroring class-method `C.m` qualification. Shallow: only direct members carry the prefix; nested functions stay bare.
- **#224 — revive the dead per-merge walker mutants gate.** The gate had been silently dead (exit 4, zero mutants) for several merges; it now runs.

`Closes #219`
`Closes #221`

**#224 is intentionally NOT closed by this PR** — see "#224: gate revived, not closed" below.

## Namespace qualified-name scheme (#221)

| Source shape | Reported name |
|---|---|
| `namespace Foo { function bar() {} }` | `Foo.bar` |
| `namespace A.B { function f() {} }` (dotted) | `A.B.f` |
| `namespace A { namespace B { function g(){} } }` (block-nested) | `A.B.g` |
| function nested *inside* a namespaced function | bare (`inner`, not `A.inner`) — shallow |
| `namespace Svc { class Repo { find(){} } }` | `Svc.Repo.find` |
| anonymous class in a namespace | `A.<anonymous class>.m` (sentinel composes) |

`visit_class` was split into entry + `visit_class_body`; new `visit_ts_module_declaration` → `visit_ts_module_declaration_prefixed` / `visit_namespace_statement` / `visit_namespace_declaration` / `module_declaration_name`. Four fixtures + five smoke tests + the proptest `Container::Namespace` oracle (`N.top`) cover dotted / nested / class-in-namespace / function-valued-`const` (both bare and `export const`) paths.

## Mutants lifted (#219)

The four exclusions removed from `.cargo/mutants.toml`, all now **CAUGHT** by the extended proptest net (verified in the FINAL pre-exclude run):

| Mutant | Status after #219 |
|---|---|
| `visit_export_default` replacement | CAUGHT |
| `delete match arm Statement::ClassDeclaration(class)` (@458) | CAUGHT (no longer spurious-TIMEOUT — `minimum_test_timeout = 90`) |
| `LabeledStatement` arm | CAUGHT |
| `ThrowStatement` (nested-fn) arm | CAUGHT |

`minimum_test_timeout = 90` is added (self-contained WHY comment) because the ClassDeclaration mutant is reliably caught ~35 s solo but spuriously TIMED OUT under the 23 s auto-floor during a `-j 4` shrink pass.

## Dead-arm deletion — plan deviation (surfaced, not absorbed)

#221's namespace routing made the `Statement::ExportNamedDeclaration(decl)` arm in `visit_statement` unreachable: namespace-block exports now route through `visit_namespace_statement`, and top-level exports were already served by `visit_top_level_statement`'s own arm. Verified against `origin/main`: that arm existed pre-change and specifically served namespace-block exports — its death is a **consequence of #221's new routing**, not pre-existing cleanup. The arm is deleted; the walker mutant count dropping 173→172 in the pre-exclude run confirms the removal.

## #224: gate revived, NOT closed (option-B decision)

**Root cause.** A scoped `cargo mutants --package crap4ts` cannot build the `crap4rs` bin. `crates/crap4ts/tests/metric_unsupported_smoke.rs::crap4rs_no_flag_default_cognitive_still_works` shells out via `assert_cmd ... cargo_bin("crap4rs")`; `CARGO_BIN_EXE_crap4rs` is unset → it panics in the **unmutated baseline** → cargo-mutants exits 4 (zero mutants tested) before any mutant runs. The gate had been dead at f3ad303 / 2fdbc48 / 3b03c88. (The other three tests in that file exec `crap4ts`, which *is* built under `--package crap4ts`, so only this one fn is skipped.)

**Mechanism fix.** A third `--skip crap4rs_no_flag_default_cognitive_still_works` in `additional_cargo_test_args` (self-contained WHY comment). The unmutated baseline now passes; the gate runs.

**Why #224 stays open.** Reviving the gate surfaced **21 pre-existing surviving mutants** in walker code this PR never touched. Evidence they are not regressions:

- `origin/main` (3b03c88) targeted baseline: **21 missed, 14 caught, 1 unviable** — the identical pre-existing set.
- This branch, pre-exclude FINAL run: `172 mutants: 21 missed, 141 caught, 10 unviable` — same 21 (visit_if / visit_for_init / visit_chain_element / visit_expression untested arms / byte_to_line_col / property_key_name / for_init_as_expression). Net PR regressions = **0**.

Left un-excluded the revived gate would be permanently RED on every merge, masking any genuinely new walker regression. So an `exclude_re` block pins exactly those 21 (each `line:col`-anchored so a future edit fail-opens the mutant back into visibility), `tracked: crap-rs#224`. Closing them with real killing tests is the remaining accountable work of **#224, which therefore stays open**.

Population bridge: `172` base on the pre-exclude FINAL run → `−21` line-anchored excludes → `+2` viable arms exposed by the bot-fix's line shifts → `−1` (the ImportExpression arm added to `exclude_re` after its sibling array-path arms were pinned deterministically) = **152** on the authoritative run below.

**Green-main proof (authoritative final run, post bot-fix + determinism pins):** `152 mutants tested in 9m: 142 caught, 10 unviable` — **0 missed, exit 0**. The revived gate is green-and-meaningful: it still catches any genuinely new walker survivor while the standing pre-existing gaps stay accountable to #224.

## Bot review & determinism hardening (c9a0117)

Gemini (medium) and CodeRabbit (minor) each flagged a real defect in the #221 namespace code — load-bearing review since this PR modifies a mandatory gate. Both fixed in `c9a0117`:

- **Gemini:** the namespace `VariableDeclaration` arm walked initializers into a throwaway sink, discarding their decision points and violating the module's own thread-`out`/`nesting` contract. `visit_namespace_statement` and `visit_namespace_declaration` now inline-match the initializer exactly like `visit_variable_declaration_in_body`; `visit_namespace_declaration` gained `out`/`nesting` parameters to keep both paths symmetric.
- **CodeRabbit:** a namespace `export default function`/`class` bypassed the prefix (`handler` instead of `Api.handler`). The `ExportDefaultDeclaration` arm now qualifies both, pinned by a new `namespace-export-default.ts` fixture + smoke assertion. The previously-surviving `K::ClassDeclaration` mutant on that arm is now caught by the `Svc.Repo.find` assertion.

**Proptest-flaky arms — not regressions.** Several walker match arms are killed *only* by the randomized `walker_proptest.rs` suite, so whether a given mutant is CAUGHT or MISSED depends on that run's proptest seed — flaky across mutation passes, **not** a coverage regression introduced by #219's grammar work (a single short single-mutant run on `origin/main` is one seed, not proof of deterministic detection). Four such arms were pinned/parked deterministically:

- `Expression::UnaryExpression` operand recursion (`typeof (fn)`) → fixture `unary-operand-nested-fn.ts` + test.
- `Expression::ArrayExpression` / `visit_array_elements` / `array_element_as_expression` — one shared path → one fixture `array-literal-nested-fn.ts` + test kills all three deterministically.
- `Expression::ImportExpression` recursion — the one remaining flaky arm with no 5-minute-trivial deterministic fixture (a nested function reachable through an `import()` argument is contrived). Parked in `exclude_re` under its **own sub-comment** distinguishing it (proptest-dependent, deterministic pin owed) from the 21 hard line-anchored gaps, `tracked: crap-rs#224`.

These pins follow the established walker coverage-gap smoke-pin pattern (the #199/#200/#205 precedent) — deterministic fixtures rather than re-widening the proptest grammar (which would churn the mutant set).

## Wire-snapshot canary

**No drift — both wire snapshots byte-identical.** #219 is test-only. No fixture in the wire-snapshot corpus (`simple` / `arrow` / `Button` / `map` / `mixed`) uses a `namespace`, so #221's qualification machinery is not exercised by the envelope corpus. lefthook pre-push (`cargo insta test --check`) passed.

## Labels

`type:feature` · `type:bug` · `priority:soon`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Functions and classes declared inside TypeScript namespaces are now reported with qualified names (e.g., `Foo.bar`, `A.B.f`) instead of bare local names. This improves clarity in JSON envelope output and table/markdown reporter displays for namespaced code.

* **Tests**
  * Added comprehensive test coverage for namespace qualification across various namespace patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/breezy-bays-labs/crap-rs/pull/225?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
