### PR TITLE
fix(crap4ts): #226 — restore crap4ts-v1 fixture src/adapters/coverage subtree

### DIFF
--- a/crates/crap4ts/tests/fixtures/crap4ts-v1/README.md
+++ b/crates/crap4ts/tests/fixtures/crap4ts-v1/README.md
@@ -73,7 +73,7 @@ maintenance mode pending the v2.x cutover, see crap4ts#38).**
 
    ```bash
    rsync -av --exclude='__tests__/' --exclude='*.test.ts' --exclude='dist/' \
-         --exclude='coverage/' --exclude='node_modules/' --exclude='.DS_Store' \
+         --exclude='node_modules/' --exclude='.DS_Store' \
          ~/Github/crap4ts/src/ \
          crates/crap4ts/tests/fixtures/crap4ts-v1/src/
    cp ~/Github/crap4ts/coverage/coverage-final.json \
@@ -81,6 +81,19 @@ maintenance mode pending the v2.x cutover, see crap4ts#38).**
    cp crap4ts-v1-reference.json \
       crates/crap4ts/tests/fixtures/
    ```
+
+   **Do NOT add `--exclude='coverage/'` back.** The build-artifact
+   `coverage/` directory lives at the repo *root*
+   (`~/Github/crap4ts/coverage/`), which is outside this rsync's
+   `~/Github/crap4ts/src/` source root — it is never in the transfer set,
+   so excluding it is unnecessary. Worse, rsync's `coverage/` pattern is
+   unanchored: it matches a directory named `coverage` at *any* depth, so
+   it silently drops the `src/adapters/coverage/` *source* subtree (5 files,
+   26 scored functions in the oracle). That defect shipped in the first
+   capture and was caught during W3.2 #190 pre-flight. The remaining
+   directory excludes (`__tests__/`) are intentionally unanchored —
+   co-located test directories at any depth should be dropped. `dist/`
+   and `node_modules/` do not occur under `src/`; they are belt-and-braces.
 
 6. Revert v1.x's local-only modifications:
 

--- a/crates/crap4ts/tests/fixtures/crap4ts-v1/src/adapters/coverage/detect.ts
+++ b/crates/crap4ts/tests/fixtures/crap4ts-v1/src/adapters/coverage/detect.ts
@@ -1,0 +1,34 @@
+export type CoverageFormat = "istanbul" | "v8" | "unknown";
+
+export function detectCoverageFormat(data: unknown): CoverageFormat {
+  // V8: top-level array of script entries
+  if (Array.isArray(data)) {
+    return "v8";
+  }
+
+  if (typeof data !== "object" || data === null) {
+    return "unknown";
+  }
+
+  const obj = data as Record<string, unknown>;
+
+  // V8: object with `result` array
+  if ("result" in obj && Array.isArray(obj.result)) {
+    return "v8";
+  }
+
+  // Istanbul: object keyed by file paths, each value has fnMap/statementMap/branchMap
+  const keys = Object.keys(obj);
+  if (keys.length > 0) {
+    const firstValue = obj[keys[0]!];
+    if (
+      typeof firstValue === "object" &&
+      firstValue !== null &&
+      "fnMap" in firstValue
+    ) {
+      return "istanbul";
+    }
+  }
+
+  return "unknown";
+}

--- a/crates/crap4ts/tests/fixtures/crap4ts-v1/src/adapters/coverage/facade.ts
+++ b/crates/crap4ts/tests/fixtures/crap4ts-v1/src/adapters/coverage/facade.ts
@@ -1,0 +1,153 @@
+import { readFile } from "node:fs/promises";
+import { IstanbulCoverageAdapter } from "./istanbul.js";
+import { V8CoverageAdapter } from "./v8.js";
+import { detectCoverageFormat } from "./detect.js";
+import type { CoverageFormat } from "./detect.js";
+import type { CoveragePort, CoverageParseResult } from "../../ports/coverage-port.js";
+
+// ── API Boundary Errors ───────────────────────────────────────────
+
+export class CoverageParseError extends Error {
+  readonly filePath?: string;
+  constructor(message: string, filePath?: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "CoverageParseError";
+    this.filePath = filePath;
+  }
+}
+
+export class UnsupportedFormatError extends Error {
+  constructor(detail?: string) {
+    const base =
+      "Unknown coverage format. Expected Istanbul JSON (object with fnMap) or V8 format (array or object with result array).";
+    super(detail ? `${base} Got: ${detail}` : base);
+    this.name = "UnsupportedFormatError";
+  }
+}
+
+// ── Types ─────────────────────────────────────────────────────────
+
+type UserFormat = Exclude<CoverageFormat, "unknown">;
+
+export interface ParseCoverageOptions {
+  readonly format?: UserFormat;
+  readonly sources?: ReadonlyMap<string, string>;
+  readonly cwd?: string;
+}
+
+export type ParseCoverageResult = CoverageParseResult;
+
+// ── Factory ──────────────────────────────────────────────────────
+
+export function createAutoDetectCoveragePort(
+  cwd?: string,
+): CoveragePort {
+  const istanbul = new IstanbulCoverageAdapter(cwd);
+  const v8 = new V8CoverageAdapter(cwd);
+  return {
+    parse(
+      data: unknown,
+      sources?: ReadonlyMap<string, string>,
+    ): CoverageParseResult {
+      const format = detectCoverageFormat(data);
+      if (format === "unknown") {
+        throw new UnsupportedFormatError();
+      }
+      const adapter = format === "istanbul" ? istanbul : v8;
+      try {
+        return adapter.parse(data, sources);
+      } catch (error) {
+        if (error instanceof CoverageParseError) throw error;
+        throw new CoverageParseError("Failed to parse coverage data", undefined, {
+          cause: error,
+        });
+      }
+    },
+  };
+}
+
+// ── Sync: parseCoverage(data, options?) ──────────────────────────
+
+export function parseCoverage(
+  data: object,
+  options?: ParseCoverageOptions,
+): ParseCoverageResult {
+  const cwd = options?.cwd;
+  const istanbul = new IstanbulCoverageAdapter(cwd);
+  const v8 = new V8CoverageAdapter(cwd);
+
+  let format: UserFormat;
+  try {
+    format = options?.format ?? detectAndValidateFormat(data);
+  } catch (error) {
+    if (error instanceof UnsupportedFormatError) throw error;
+    throw new CoverageParseError("Failed to detect coverage format", undefined, {
+      cause: error,
+    });
+  }
+
+  const adapter = format === "istanbul" ? istanbul : v8;
+
+  try {
+    return adapter.parse(data, options?.sources);
+  } catch (error) {
+    if (error instanceof CoverageParseError) throw error;
+    throw new CoverageParseError("Failed to parse coverage data", undefined, {
+      cause: error,
+    });
+  }
+}
+
+// ── Async: parseCoverageFile(path, options?) ─────────────────────
+
+export async function parseCoverageFile(
+  filePath: string,
+  options?: ParseCoverageOptions,
+): Promise<ParseCoverageResult> {
+  let content: string;
+  try {
+    content = await readFile(filePath, "utf-8");
+  } catch (error) {
+    throw new CoverageParseError(
+      `Failed to read coverage file: ${filePath}`,
+      filePath,
+      { cause: error },
+    );
+  }
+
+  let data: unknown;
+  try {
+    data = JSON.parse(content);
+  } catch (error) {
+    throw new CoverageParseError(
+      `Coverage file contains invalid JSON: ${filePath}`,
+      filePath,
+      { cause: error },
+    );
+  }
+
+  if (data === null || typeof data !== "object") {
+    throw new CoverageParseError(
+      `Coverage file does not contain a JSON object: ${filePath}`,
+      filePath,
+    );
+  }
+
+  return parseCoverage(data, options);
+}
+
+// ── Internal Helpers ──────────────────────────────────────────────
+
+function detectAndValidateFormat(data: unknown): UserFormat {
+  const format = detectCoverageFormat(data);
+  if (format === "unknown") {
+    throw new UnsupportedFormatError();
+  }
+  return format;
+}
+
+// Re-export adapters for advanced usage
+export { IstanbulCoverageAdapter } from "./istanbul.js";
+export { V8CoverageAdapter } from "./v8.js";
+export { detectCoverageFormat } from "./detect.js";
+export type { CoverageFormat } from "./detect.js";

--- a/crates/crap4ts/tests/fixtures/crap4ts-v1/src/adapters/coverage/index.ts
+++ b/crates/crap4ts/tests/fixtures/crap4ts-v1/src/adapters/coverage/index.ts
@@ -1,0 +1,5 @@
+export { IstanbulCoverageAdapter } from "./istanbul.js";
+export { V8CoverageAdapter } from "./v8.js";
+export { detectCoverageFormat } from "./detect.js";
+export { createAutoDetectCoveragePort } from "./facade.js";
+export type { CoverageFormat } from "./detect.js";

--- a/crates/crap4ts/tests/fixtures/crap4ts-v1/src/adapters/coverage/istanbul.ts
+++ b/crates/crap4ts/tests/fixtures/crap4ts-v1/src/adapters/coverage/istanbul.ts
@@ -1,0 +1,224 @@
+import type { CoveragePort, CoverageParseResult } from "../../ports/coverage-port.js";
+import type {
+  FunctionCoverage,
+  CoverageRatio,
+  SourceSpan,
+} from "../../domain/types.js";
+
+// ── Istanbul JSON types ────────────────────────────────────────────
+
+interface IstanbulPosition {
+  readonly line: number;
+  readonly column: number;
+}
+
+interface IstanbulRange {
+  readonly start: IstanbulPosition;
+  readonly end: IstanbulPosition;
+}
+
+interface IstanbulFnEntry {
+  readonly name: string;
+  readonly decl: IstanbulRange;
+  readonly loc: IstanbulRange;
+}
+
+interface IstanbulBranchEntry {
+  readonly type: string;
+  readonly loc: IstanbulRange;
+  readonly locations: readonly IstanbulRange[];
+}
+
+interface IstanbulFileCoverage {
+  readonly path: string;
+  readonly fnMap: Record<string, IstanbulFnEntry>;
+  readonly f: Record<string, number>;
+  readonly statementMap: Record<string, IstanbulRange>;
+  readonly s: Record<string, number>;
+  readonly branchMap: Record<string, IstanbulBranchEntry>;
+  readonly b: Record<string, readonly number[]>;
+}
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+function isWithinSpan(range: IstanbulRange, fnLoc: IstanbulRange): boolean {
+  // A statement/branch is within the function if its start line is >= the
+  // function start line and its end line is <= the function end line.
+  // For same-line boundaries, also check column positions.
+  if (range.start.line < fnLoc.start.line) return false;
+  if (range.end.line > fnLoc.end.line) return false;
+  if (
+    range.start.line === fnLoc.start.line &&
+    range.start.column < fnLoc.start.column
+  )
+    return false;
+  if (
+    range.end.line === fnLoc.end.line &&
+    range.end.column > fnLoc.end.column
+  )
+    return false;
+  return true;
+}
+
+function computeLineCoverage(
+  statementMap: Record<string, IstanbulRange>,
+  s: Record<string, number>,
+  fnLoc: IstanbulRange,
+): CoverageRatio {
+  let total = 0;
+  let covered = 0;
+  for (const key of Object.keys(statementMap)) {
+    const stmt = statementMap[key];
+    if (stmt && isWithinSpan(stmt, fnLoc)) {
+      total++;
+      if ((s[key] ?? 0) > 0) {
+        covered++;
+      }
+    }
+  }
+  return {
+    covered,
+    total,
+    percent: total === 0 ? 100 : Math.round((covered / total) * 10000) / 100,
+  };
+}
+
+function computeBranchCoverage(
+  branchMap: Record<string, IstanbulBranchEntry>,
+  b: Record<string, readonly number[]>,
+  fnLoc: IstanbulRange,
+): CoverageRatio | null {
+  let total = 0;
+  let covered = 0;
+  for (const key of Object.keys(branchMap)) {
+    const branch = branchMap[key];
+    if (branch && isWithinSpan(branch.loc, fnLoc)) {
+      const counts = b[key];
+      if (counts) {
+        for (const count of counts) {
+          total++;
+          if (count > 0) {
+            covered++;
+          }
+        }
+      }
+    }
+  }
+  if (total === 0) return null;
+  return {
+    covered,
+    total,
+    percent: Math.round((covered / total) * 10000) / 100,
+  };
+}
+
+function findLongestCommonPrefix(paths: readonly string[]): string {
+  if (paths.length === 0) return "";
+  if (paths.length === 1) {
+    // Use the directory portion of the single path
+    const lastSlash = paths[0]!.lastIndexOf("/");
+    return lastSlash >= 0 ? paths[0]!.slice(0, lastSlash + 1) : "";
+  }
+
+  const sorted = [...paths].sort();
+  const first = sorted[0]!;
+  const last = sorted[sorted.length - 1]!;
+
+  let i = 0;
+  while (i < first.length && i < last.length && first[i] === last[i]) {
+    i++;
+  }
+
+  // Trim back to last directory separator
+  const prefix = first.slice(0, i);
+  const lastSlash = prefix.lastIndexOf("/");
+  return lastSlash >= 0 ? prefix.slice(0, lastSlash + 1) : "";
+}
+
+function normalizePath(absolutePath: string, prefix: string): string {
+  let relative = absolutePath;
+  if (prefix && absolutePath.startsWith(prefix)) {
+    relative = absolutePath.slice(prefix.length);
+  }
+  // Ensure forward slashes and strip leading slash
+  return relative.replace(/\\/g, "/").replace(/^\/+/, "");
+}
+
+// ── Adapter ────────────────────────────────────────────────────────
+
+export class IstanbulCoverageAdapter implements CoveragePort {
+  private readonly cwd: string | undefined;
+
+  constructor(cwd?: string) {
+    this.cwd = cwd;
+  }
+
+  parse(data: unknown, _sources?: ReadonlyMap<string, string>): CoverageParseResult {
+    if (data === null || typeof data !== "object" || Array.isArray(data)) {
+      throw new Error(
+        "Invalid Istanbul coverage data: expected an object keyed by file paths",
+      );
+    }
+
+    const record = data as Record<string, unknown>;
+    const entries = Object.entries(record).filter(
+      ([, v]) => v !== null && typeof v === "object" && !Array.isArray(v),
+    ) as [string, IstanbulFileCoverage][];
+
+    // Determine prefix to strip
+    const prefix = this.cwd
+      ? this.cwd.replace(/\\/g, "/").replace(/\/?$/, "/")
+      : findLongestCommonPrefix(entries.map(([key]) => key));
+
+    const result = new Map<string, FunctionCoverage[]>();
+
+    for (const [, fileCov] of entries) {
+      const relativePath = normalizePath(fileCov.path, prefix);
+      const functions: FunctionCoverage[] = [];
+
+      // Process fnMap entries in key order (numeric)
+      const fnKeys = Object.keys(fileCov.fnMap).sort(
+        (a, b) => Number(a) - Number(b),
+      );
+
+      for (const fnKey of fnKeys) {
+        const fnEntry = fileCov.fnMap[fnKey];
+        if (!fnEntry?.loc?.start || !fnEntry.loc.end) continue;
+
+        const fnLoc = fnEntry.loc;
+
+        // Convert inclusive endLine to exclusive (domain convention)
+        const span: SourceSpan = {
+          startLine: fnLoc.start.line,
+          startColumn: fnLoc.start.column,
+          endLine: fnLoc.end.line + 1,
+          endColumn: fnLoc.end.column,
+        };
+
+        const lineCoverage = computeLineCoverage(
+          fileCov.statementMap,
+          fileCov.s,
+          fnLoc,
+        );
+
+        const branchCoverage = computeBranchCoverage(
+          fileCov.branchMap,
+          fileCov.b,
+          fnLoc,
+        );
+
+        functions.push({
+          filePath: relativePath,
+          name: fnEntry.name,
+          span,
+          lineCoverage,
+          branchCoverage,
+        });
+      }
+
+      result.set(relativePath, functions);
+    }
+
+    return { coverage: result, warnings: [] };
+  }
+}

--- a/crates/crap4ts/tests/fixtures/crap4ts-v1/src/adapters/coverage/v8.ts
+++ b/crates/crap4ts/tests/fixtures/crap4ts-v1/src/adapters/coverage/v8.ts
@@ -1,0 +1,267 @@
+import type { CoveragePort, CoverageParseResult } from "../../ports/coverage-port.js";
+import type {
+  FunctionCoverage,
+  CoverageRatio,
+  SourceSpan,
+  Warning,
+} from "../../domain/types.js";
+
+// ── V8 Coverage JSON types ────────────────────────────────────────
+
+interface V8Range {
+  readonly startOffset: number;
+  readonly endOffset: number;
+  readonly count: number;
+}
+
+interface V8FunctionCoverage {
+  readonly functionName: string;
+  readonly ranges: readonly V8Range[];
+  readonly isBlockCoverage: boolean;
+}
+
+interface V8ScriptCoverage {
+  readonly scriptId: string;
+  readonly url: string;
+  readonly functions: readonly V8FunctionCoverage[];
+}
+
+// ── Constants ─────────────────────────────────────────────────────
+
+/** Approximate characters per line for Tier 3 fallback. */
+const APPROX_CHARS_PER_LINE = 40;
+
+// ── Line Offset Table (Tier 2) ───────────────────────────────────
+
+/**
+ * Build a table of cumulative byte offsets for each line boundary.
+ * table[i] = byte offset of the start of line (i+1).
+ * table[0] = 0 (line 1 starts at byte 0).
+ */
+export function buildLineOffsetTable(source: string): number[] {
+  const table: number[] = [0];
+  for (let i = 0; i < source.length; i++) {
+    if (source[i] === "\n") {
+      table.push(i + 1);
+    }
+  }
+  return table;
+}
+
+/**
+ * Convert a byte offset to a 1-based line number using binary search
+ * on a line offset table.
+ */
+export function byteOffsetToLineFromTable(
+  offset: number,
+  table: readonly number[],
+): number {
+  let lo = 0;
+  let hi = table.length - 1;
+  while (lo < hi) {
+    const mid = (lo + hi + 1) >>> 1;
+    if (table[mid]! <= offset) {
+      lo = mid;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  return lo + 1; // 1-based
+}
+
+// ── Tier 3 Fallback ──────────────────────────────────────────────
+
+function byteOffsetToLineApprox(offset: number): number {
+  return Math.max(1, Math.ceil(offset / APPROX_CHARS_PER_LINE));
+}
+
+// ── Helpers ───────────────────────────────────────────────────────
+
+function stripFileProtocol(url: string): string {
+  if (url.startsWith("file:///")) {
+    const stripped = url.slice("file:///".length);
+    // On Unix, paths start with / (e.g. file:///home/...) → restore leading /
+    // On Windows, paths start with drive letter (e.g. file:///C:/...) → no leading /
+    if (/^[a-zA-Z]:/.test(stripped)) {
+      return stripped;
+    }
+    return "/" + stripped;
+  }
+  return url;
+}
+
+function findLongestCommonPrefix(paths: readonly string[]): string {
+  if (paths.length === 0) return "";
+  if (paths.length === 1) {
+    const lastSlash = paths[0]!.lastIndexOf("/");
+    return lastSlash >= 0 ? paths[0]!.slice(0, lastSlash + 1) : "";
+  }
+
+  const sorted = [...paths].sort();
+  const first = sorted[0]!;
+  const last = sorted[sorted.length - 1]!;
+
+  let i = 0;
+  while (i < first.length && i < last.length && first[i] === last[i]) {
+    i++;
+  }
+
+  const prefix = first.slice(0, i);
+  const lastSlash = prefix.lastIndexOf("/");
+  return lastSlash >= 0 ? prefix.slice(0, lastSlash + 1) : "";
+}
+
+function normalizePath(absolutePath: string, prefix: string): string {
+  let relative = absolutePath;
+  if (prefix && absolutePath.startsWith(prefix)) {
+    relative = absolutePath.slice(prefix.length);
+  }
+  return relative.replace(/\\/g, "/").replace(/^\/+/, "");
+}
+
+function computeByteCoverage(ranges: readonly V8Range[]): CoverageRatio {
+  const outer = ranges[0]!;
+  const totalBytes = outer.endOffset - outer.startOffset;
+
+  if (totalBytes === 0) {
+    return { covered: 0, total: 0, percent: 100 };
+  }
+
+  // Sum bytes from ranges with count === 0
+  let uncoveredBytes = 0;
+  for (const range of ranges) {
+    if (range.count === 0) {
+      uncoveredBytes += range.endOffset - range.startOffset;
+    }
+  }
+
+  const coveredBytes = totalBytes - uncoveredBytes;
+  const percent =
+    Math.round((coveredBytes / totalBytes) * 10000) / 100;
+
+  return { covered: coveredBytes, total: totalBytes, percent };
+}
+
+function computeSpan(
+  outerRange: V8Range,
+  table: readonly number[] | null,
+): SourceSpan {
+  if (table) {
+    const startLine = byteOffsetToLineFromTable(outerRange.startOffset, table);
+    const endLine = Math.max(
+      startLine + 1,
+      byteOffsetToLineFromTable(outerRange.endOffset, table) + 1,
+    );
+    return { startLine, startColumn: 0, endLine, endColumn: 0 };
+  }
+
+  // Tier 3: approximation
+  const startLine = byteOffsetToLineApprox(outerRange.startOffset);
+  const endLine = Math.max(
+    startLine + 1,
+    Math.ceil(outerRange.endOffset / APPROX_CHARS_PER_LINE) + 1,
+  );
+  return { startLine, startColumn: 0, endLine, endColumn: 0 };
+}
+
+// ── Adapter ───────────────────────────────────────────────────────
+
+export class V8CoverageAdapter implements CoveragePort {
+  private readonly cwd: string | undefined;
+
+  constructor(cwd?: string) {
+    this.cwd = cwd;
+  }
+
+  parse(
+    data: unknown,
+    sources?: ReadonlyMap<string, string>,
+  ): CoverageParseResult {
+    const scripts = this.validateAndExtractScripts(data);
+
+    // Resolve absolute paths from URLs
+    const absolutePaths = scripts.map((s) => stripFileProtocol(s.url));
+
+    // Determine prefix to strip
+    const prefix = this.cwd
+      ? this.cwd.replace(/\\/g, "/").replace(/\/?$/, "/")
+      : findLongestCommonPrefix(absolutePaths);
+
+    const result = new Map<string, FunctionCoverage[]>();
+    const warnings: Warning[] = [];
+    const warnedFiles = new Set<string>();
+
+    for (let i = 0; i < scripts.length; i++) {
+      const script = scripts[i]!;
+      const relativePath = normalizePath(absolutePaths[i]!, prefix);
+      const { functions, warning } = this.processScript(script, relativePath, sources, warnedFiles);
+      result.set(relativePath, functions);
+      if (warning) warnings.push(warning);
+    }
+
+    return { coverage: result, warnings };
+  }
+
+  private validateAndExtractScripts(data: unknown): V8ScriptCoverage[] {
+    if (data === null || typeof data !== "object" || Array.isArray(data)) {
+      throw new Error(
+        "Invalid V8 coverage data: expected an object with a 'result' array",
+      );
+    }
+
+    const v8Data = data as Record<string, unknown>;
+
+    if (!Array.isArray(v8Data.result)) {
+      throw new Error(
+        "Invalid V8 coverage data: expected an object with a 'result' array",
+      );
+    }
+
+    return (v8Data.result as V8ScriptCoverage[]).filter(
+      (s) => s && typeof s === "object" && typeof s.url === "string" && Array.isArray(s.functions),
+    );
+  }
+
+  private processScript(
+    script: V8ScriptCoverage,
+    relativePath: string,
+    sources: ReadonlyMap<string, string> | undefined,
+    warnedFiles: Set<string>,
+  ): { functions: FunctionCoverage[]; warning: Warning | null } {
+    const sourceContent = sources?.get(relativePath) ?? null;
+    const lineTable = sourceContent
+      ? buildLineOffsetTable(sourceContent)
+      : null;
+
+    const needsApproximationWarning =
+      !lineTable &&
+      !warnedFiles.has(relativePath) &&
+      script.functions.some((fn) => fn.functionName && fn.ranges.length > 0);
+
+    let warning: Warning | null = null;
+    if (needsApproximationWarning) {
+      warning = {
+        code: "approximate-span",
+        message: `Source content unavailable for "${relativePath}" — using approximate byte-to-line conversion`,
+        file: relativePath,
+      };
+      warnedFiles.add(relativePath);
+    }
+
+    const functions: FunctionCoverage[] = [];
+    for (const fn of script.functions) {
+      if (!fn.functionName || fn.ranges.length === 0) continue;
+
+      const outerRange = fn.ranges[0]!;
+      functions.push({
+        filePath: relativePath,
+        name: fn.functionName,
+        span: computeSpan(outerRange, lineTable),
+        lineCoverage: computeByteCoverage(fn.ranges),
+        branchCoverage: null,
+      });
+    }
+
+    return { functions, warning };
+  }
+}

--- a/crates/crap4ts/tests/istanbul_smoke.rs
+++ b/crates/crap4ts/tests/istanbul_smoke.rs
@@ -949,13 +949,21 @@ fn fix215_ambiguous_suffix_longest_wins_deterministically() {
 /// pipeline (`crap4ts` binary) against the captured crap4ts@1.x
 /// fixture whose `coverage-final.json` carries machine-absolute paths
 /// (`/Users/cmbays/github/crap4ts/src/...`) that share no prefix with
-/// the fixture's local `--src`. Before this fix every one of the 158
-/// discovered functions reported 0% coverage. Asserts a FLOOR of
-/// ≥ 100/158 functions with non-zero coverage — exact classification
-/// is W3.2/#190's domain; a precise pin would be brittle now. This is
-/// the GATE: if it can't reach the floor, the fix is incomplete.
+/// the fixture's local `--src`. Without the suffix-fallback fix every
+/// discovered function reports 0% coverage; with it, the large
+/// majority resolve. This is the GATE: if it can't reach the floor,
+/// the fix is incomplete — re-diagnose, do not loosen the floor.
+///
+/// The denominator is asserted as a lower bound, not an exact pin: the
+/// oracle (`crap4ts-v1-reference.json`) scores 137 functions and
+/// crap4ts@2 discovers a superset, so a complete corpus yields ≥ 137.
+/// An exact pin here previously rotted — a capture defect that dropped
+/// the `src/adapters/coverage/` subtree silently shrank the count, and
+/// the stale `== 158` assertion masked it instead of failing loudly.
+/// The floor is a fraction of whatever the corpus discovers, so it
+/// stays meaningful across legitimate corpus growth.
 #[test]
-fn fix215_v1_corpus_e2e_floor_at_least_100_of_158_functions_have_coverage() {
+fn fix215_v1_corpus_e2e_floor_majority_functions_have_nonzero_coverage() {
     let manifest = env!("CARGO_MANIFEST_DIR");
     let src = format!("{manifest}/tests/fixtures/crap4ts-v1/src");
     let coverage = format!("{manifest}/tests/fixtures/crap4ts-v1/coverage-final.json");
@@ -994,16 +1002,22 @@ fn fix215_v1_corpus_e2e_floor_at_least_100_of_158_functions_have_coverage() {
         })
         .count();
 
-    assert_eq!(
-        total, 158,
-        "walker discovers 158 functions in the v1.x corpus (NOT a regression target — \
-         pins the denominator so the floor stays meaningful)"
-    );
     assert!(
-        nonzero >= 100,
-        "FLOOR: expected >= 100/158 functions with non-zero coverage after the \
-         suffix-fallback fix; got {nonzero}/{total}. If this fails the fix is \
-         incomplete — re-diagnose, do not loosen the floor."
+        total >= 137,
+        "corpus discovered {total} functions but the v1.x oracle scores 137 \
+         and crap4ts@2 discovers a superset — a count below 137 means the \
+         source corpus is incomplete (e.g. an over-broad rsync exclude \
+         dropping a subtree), not a coverage-resolution problem"
+    );
+    // ≥ 60% mirrors the original ≈63% intent (≥100/158) but as a
+    // fraction of the live corpus so it never rots on corpus changes.
+    let floor = total * 60 / 100;
+    assert!(
+        nonzero >= floor,
+        "FLOOR: expected >= {floor}/{total} (60%) functions with non-zero \
+         coverage after the suffix-fallback fix; got {nonzero}/{total}. If \
+         this fails the fix is incomplete — re-diagnose, do not loosen the \
+         floor."
     );
 }
 


### PR DESCRIPTION
## Summary

Prerequisite repair blocking W3.2 #190. The W3.1 parity-oracle fixture was
missing its entire `src/adapters/coverage/` source subtree — 26 of the 137
oracle functions had no corresponding source in the committed corpus.

- **Root cause:** the W3.1 capture procedure used `rsync --exclude='coverage/'`
  to drop the top-level build-artifact `coverage/` directory. That directory
  lives at the repo *root* (`~/Github/crap4ts/coverage/`), **outside** the
  `~/Github/crap4ts/src/`-rooted rsync — so the exclude was unnecessary. Worse,
  rsync's unanchored `coverage/` pattern matches a directory named `coverage`
  at **any depth**, so it silently ate the `src/adapters/coverage/` *source*
  subtree.
- **Fix:** restore `detect/facade/index/istanbul/v8.ts` verbatim from upstream
  `breezy-bays-labs/crap4ts` @ `44eb2c2` (the README-pinned capture commit).
  The README capture procedure drops the `coverage/` exclude entirely, with a
  note explaining the over-match failure mode so it cannot recur.

This is **corpus repair, not baseline regeneration**: `crap4ts-v1-reference.json`
(the oracle) is left **byte-identical**. The incomplete source snapshot is made
to match what the oracle was *already* captured against.

## Verification

- All 5 restored files are byte-identical to upstream `44eb2c2` (`git show`
  per-file diff = empty).
- `git diff --cached` confirms the oracle JSON is **not** in the changeset.
- Post-repair: `crap4ts --src .../crap4ts-v1/src` discovers the
  `adapters/coverage/{detect,facade,istanbul,v8}.ts` functions; `index.ts` is
  a re-export barrel and correctly contributes 0 (it was part of v1.x's
  analysis input regardless, so it's included for corpus fidelity).
- The **v1-only function set drops 26 → 0** — crap4ts@2 now discovers a
  superset of every oracle function. Matched-function parity is otherwise
  clean (111/111 exact cyclomatic complexity, 0 genuine score-regressions,
  24 documented crap4ts#37 coverage-matcher improvements). #190's harness can
  now assert discovery parity against a complete corpus.

## Scope note (surfaced, not absorbed)

`istanbul_smoke::fix215_v1_corpus_e2e_*` (the #215 suffix-fallback regression
gate) hardcoded the pre-repair function count (`assert_eq!(total, 158)`).
Restoring the subtree raised it to 191. Re-pinning `158 → 191` would replant
the exact rot this PR exists to fix, so instead:

- the denominator is now a **lower bound** — `total >= 137` (the oracle's
  function count, which crap4ts@2 must superset; a count below it means an
  incomplete corpus, failing loudly instead of masking),
- the coverage floor is a **fraction of the live corpus** (≥ 60%, mirroring
  the original ≈63% `≥100/158` intent) so it never rots on legitimate corpus
  growth.

The test's gate semantics are preserved (without the #215 fix, ~0% of
functions resolve coverage; with it, 171/191 ≈ 89%). This is a one-test
robustness change beyond pure fixture data — called out explicitly rather
than buried.

## Gate battery

`cargo nextest run --workspace --all-targets` (1068 passed, wire snapshots
byte-identical), `cargo fmt --check`, `cargo clippy --workspace --all-targets
-- -D warnings`, `cargo +1.93 check --workspace --all-targets`, `cargo doc
--workspace --no-deps`, `cargo deny check` — all green.

## Context

- Epic: #173 · Introduced by: PR #213 (W3.1, #189) · Blocks: #190 (W3.2)
- Pipeline: crap-rs/20260513-typescript-adapter (build phase, mid-pipeline)

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)