### PR TITLE
test(crap4ts): #190 — parity cross-validation harness (per-function contributor breakdown, threshold-default-change distinction)

### DIFF
--- a/crates/crap4ts/tests/parity_helpers/mod.rs
+++ b/crates/crap4ts/tests/parity_helpers/mod.rs
@@ -1,0 +1,525 @@
+//! Pure-Rust parse + diff for the crap4ts@1.x parity oracle (W3.2 #190).
+//!
+//! No node/pnpm. Consumes the committed `crap4ts-v1-reference.json`
+//! (captured once during W3.1) and a live crap4ts@2 `--format json`
+//! envelope, matches per function, and classifies every divergence.
+//!
+//! ## The oracle carries no contributor breakdown
+//!
+//! crap4ts@1.x's JSON emits a per-function cyclomatic *number* but no
+//! per-contributor list. So the harness cannot diff a v1 contributor
+//! list against v2's — there is none. Instead, divergence reports
+//! surface v2's contributor breakdown (kind × count) so triaging a
+//! score disagreement is one line, not a manual AST read (the CPO
+//! sharpening). The README/plan "±1 line contributor drift" tolerance
+//! presupposes oracle contributor data the v1.x format does not carry;
+//! that is a documented surviving limitation, not a harness gap.
+//!
+//! ## Three-way classification (per the W3.1 fixture README)
+//!
+//! Every matched function falls into exactly one bucket:
+//!
+//! - **Match** — within tolerance, same risk class. Pass.
+//! - **ThresholdDefaultChange** — score unchanged, only the pass/fail
+//!   gate flips because the oracle used per-glob defaults (8/12) and
+//!   crap4ts@2 uses 16. Pass (an intentional calibration break, not a
+//!   regression).
+//! - **Crap37Improvement** — v1.x reported 0% coverage where v2 reports
+//!   real coverage on the same complexity. This is the crap4ts#37 v1.x
+//!   span-overlap-ratio matcher bug; v2's strict line-range containment
+//!   is structurally immune. Pass, logged as an improvement. A risk
+//!   class that moves *because of* this also passes.
+//! - **ScoreRegression** — anything else: complexity differs, coverage
+//!   differs without being a #37 improvement, or |Δcrap| > 0.5 with no
+//!   benign explanation. Fail.
+
+use std::collections::BTreeMap;
+
+use serde::Deserialize;
+
+/// `|Δcrap|` within this absolute band counts as "score unchanged"
+/// (per the W3.1 README tolerance table).
+pub const CRAP_EPS: f64 = 0.5;
+
+/// Coverage delta within this band counts as "coverage unchanged". The
+/// oracle rounds coverage to 2 decimals; crap4ts@2 emits full `f64`,
+/// so an exact-equal test would spuriously fail on rounding alone.
+pub const COV_EPS: f64 = 0.1;
+
+/// Minimum fraction of matched functions that must exact-match
+/// cyclomatic complexity (W3.1 README: "≥ 95%").
+pub const MIN_EXACT_CC_RATE: f64 = 0.95;
+
+// ── Oracle (crap4ts@1.x reference JSON) ──────────────────────────────
+
+#[derive(Debug, Deserialize)]
+struct OracleRoot {
+    functions: Vec<OracleEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OracleEntry {
+    scored: OracleScored,
+    // The oracle's per-function threshold is deliberately not read:
+    // threshold-default-change is detected from the `exceeds` gate
+    // verdict each side computed against its own threshold, not from
+    // comparing raw threshold numbers. serde ignores the unread field.
+    exceeds: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct OracleScored {
+    identity: OracleIdentity,
+    #[serde(rename = "cyclomaticComplexity")]
+    cyclomatic_complexity: u32,
+    #[serde(rename = "coveragePercent")]
+    coverage_percent: f64,
+    crap: OracleCrap,
+}
+
+#[derive(Debug, Deserialize)]
+struct OracleIdentity {
+    #[serde(rename = "filePath")]
+    file_path: String,
+    #[serde(rename = "qualifiedName")]
+    qualified_name: String,
+    span: OracleSpan,
+}
+
+#[derive(Debug, Deserialize)]
+struct OracleSpan {
+    #[serde(rename = "startLine")]
+    start_line: i64,
+}
+
+#[derive(Debug, Deserialize)]
+struct OracleCrap {
+    value: f64,
+    #[serde(rename = "riskLevel")]
+    risk_level: String,
+}
+
+// ── crap4ts@2 (`--format json` envelope) ─────────────────────────────
+
+#[derive(Debug, Deserialize)]
+struct V2Root {
+    result: V2Result,
+}
+
+#[derive(Debug, Deserialize)]
+struct V2Result {
+    functions: Vec<V2Entry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct V2Entry {
+    scored: V2Scored,
+    // crap4ts@2's per-function threshold is likewise unread — same
+    // rationale as `OracleEntry`: the `exceeds` verdict is the signal.
+    exceeds: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct V2Scored {
+    identity: V2Identity,
+    complexity: u32,
+    coverage_percent: f64,
+    crap: V2Crap,
+    #[serde(default)]
+    contributors: Vec<V2Contributor>,
+}
+
+#[derive(Debug, Deserialize)]
+struct V2Identity {
+    file_path: String,
+    qualified_name: String,
+    span: V2Span,
+}
+
+#[derive(Debug, Deserialize)]
+struct V2Span {
+    start_line: i64,
+}
+
+#[derive(Debug, Deserialize)]
+struct V2Crap {
+    value: f64,
+    risk_level: String,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+struct V2Contributor {
+    kind: String,
+}
+
+// ── Normalized records ───────────────────────────────────────────────
+
+/// A function as seen by either side, normalized for cross-version
+/// matching. `file` is forward-slash, `src/`-prefix-stripped.
+#[derive(Debug, Clone)]
+pub struct FnRecord {
+    pub file: String,
+    pub name: String,
+    pub start_line: i64,
+    pub cc: u32,
+    pub coverage: f64,
+    pub crap: f64,
+    pub risk: String,
+    /// Did this side's threshold gate mark the function as exceeding?
+    pub exceeds: bool,
+    /// v2 only — empty for the oracle (v1.x emits no contributor list).
+    pub contributors: Vec<String>,
+}
+
+/// Strip a single leading `src/` so oracle paths
+/// (`src/adapters/x.ts`) align with crap4ts@2 `--src`-relative paths
+/// (`adapters/x.ts`). Forward slashes only — both sides normalize.
+fn norm_path(p: &str) -> String {
+    p.strip_prefix("src/").unwrap_or(p).to_string()
+}
+
+/// Parse the committed oracle JSON. Panics with context on malformed
+/// input — the oracle is a committed fixture, so a parse failure is a
+/// fixture defect, not a runtime condition to recover from.
+pub fn parse_oracle(json: &str) -> Vec<FnRecord> {
+    let root: OracleRoot =
+        serde_json::from_str(json).expect("crap4ts-v1-reference.json is valid oracle JSON");
+    root.functions
+        .into_iter()
+        .map(|e| FnRecord {
+            file: norm_path(&e.scored.identity.file_path),
+            name: e.scored.identity.qualified_name,
+            start_line: e.scored.identity.span.start_line,
+            cc: e.scored.cyclomatic_complexity,
+            coverage: e.scored.coverage_percent,
+            crap: e.scored.crap.value,
+            risk: e.scored.crap.risk_level,
+            exceeds: e.exceeds,
+            contributors: Vec::new(),
+        })
+        .collect()
+}
+
+/// Parse a crap4ts@2 `--format json` envelope (`.result.functions`).
+pub fn parse_v2(json: &str) -> Vec<FnRecord> {
+    let root: V2Root =
+        serde_json::from_str(json).expect("crap4ts --format json emits a valid envelope");
+    root.result
+        .functions
+        .into_iter()
+        .map(|e| FnRecord {
+            file: norm_path(&e.scored.identity.file_path),
+            name: e.scored.identity.qualified_name,
+            start_line: e.scored.identity.span.start_line,
+            cc: e.scored.complexity,
+            coverage: e.scored.coverage_percent,
+            crap: e.scored.crap.value,
+            risk: e.scored.crap.risk_level,
+            exceeds: e.exceeds,
+            contributors: e.scored.contributors.into_iter().map(|c| c.kind).collect(),
+        })
+        .collect()
+}
+
+// ── Classification ───────────────────────────────────────────────────
+
+/// Which bucket a matched (oracle, v2) pair falls into.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Class {
+    /// Within tolerance, same risk class.
+    Match,
+    /// Score unchanged; only the pass/fail gate flips (oracle 8/12 vs
+    /// crap4ts@2 16). Intentional calibration break — passes.
+    ThresholdDefaultChange,
+    /// v1.x reported 0% coverage on a function v2 covers (crap4ts#37
+    /// v1.x matcher bug). Passes, logged as an improvement.
+    Crap37Improvement,
+    /// A genuine adapter divergence. Fails the parity gate.
+    ScoreRegression,
+}
+
+impl Class {
+    /// Does this classification pass the parity gate?
+    pub fn is_pass(self) -> bool {
+        !matches!(self, Class::ScoreRegression)
+    }
+}
+
+/// One classified divergence, carrying both sides for the report.
+#[derive(Debug, Clone)]
+pub struct Divergence {
+    pub file: String,
+    pub name: String,
+    pub class: Class,
+    pub v1_cc: u32,
+    pub v2_cc: u32,
+    pub v1_cov: f64,
+    pub v2_cov: f64,
+    pub v1_crap: f64,
+    pub v2_crap: f64,
+    pub v1_risk: String,
+    pub v2_risk: String,
+    /// v2's contributor breakdown (`2× if-branch + 1× ternary`) — the
+    /// actionable triage line. Empty when v2 reported none.
+    pub v2_contributors: String,
+}
+
+/// Render `["if-branch","if-branch","ternary"]` as
+/// `2× if-branch + 1× ternary` (kinds in first-seen order).
+fn summarize_contributors(kinds: &[String]) -> String {
+    if kinds.is_empty() {
+        return "(none)".to_string();
+    }
+    let mut order: Vec<String> = Vec::new();
+    let mut counts: BTreeMap<String, usize> = BTreeMap::new();
+    for k in kinds {
+        if !counts.contains_key(k) {
+            order.push(k.clone());
+        }
+        *counts.entry(k.clone()).or_insert(0) += 1;
+    }
+    order
+        .iter()
+        .map(|k| format!("{}× {}", counts[k], k))
+        .collect::<Vec<_>>()
+        .join(" + ")
+}
+
+fn classify(v1: &FnRecord, v2: &FnRecord) -> Class {
+    let same_cc = v1.cc == v2.cc;
+    let cov_unchanged = (v1.coverage - v2.coverage).abs() <= COV_EPS;
+    let crap_unchanged = (v1.crap - v2.crap).abs() <= CRAP_EPS;
+
+    // crap4ts#37: v1.x's 80%-overlap matcher reported literal 0%
+    // coverage where real test data existed; v2's line-range
+    // containment recovers it. Same complexity + v1 0% + v2 > 0%.
+    if same_cc && v1.coverage == 0.0 && v2.coverage > 0.0 {
+        return Class::Crap37Improvement;
+    }
+
+    if same_cc && cov_unchanged && crap_unchanged {
+        // Score is unchanged. If the gate verdict nonetheless flipped
+        // while the risk class held, that is purely the threshold
+        // default moving (oracle 8/12 → crap4ts@2 16), not a score
+        // drift. The `v1.risk == v2.risk` guard is load-bearing: the
+        // |Δcrap| ≤ 0.5 band can straddle a risk cutoff, so a
+        // same-score gate-flip that ALSO shifts risk class is a real
+        // divergence and must fall through to ScoreRegression rather
+        // than be absorbed here (README "risk hard-match" intent).
+        if v1.exceeds != v2.exceeds && v1.risk == v2.risk {
+            return Class::ThresholdDefaultChange;
+        }
+        // Score and risk both stable → clean parity. (A risk move with
+        // an otherwise-unchanged score is itself a divergence — fall
+        // through to ScoreRegression below.)
+        if v1.risk == v2.risk {
+            return Class::Match;
+        }
+    }
+
+    Class::ScoreRegression
+}
+
+// ── Report ───────────────────────────────────────────────────────────
+
+/// The full parity outcome. `gate_passes()` is the single source of
+/// truth for the test assertion; `render()` is the human-facing diff.
+#[derive(Debug)]
+pub struct ParityReport {
+    pub matched: usize,
+    pub exact_cc: usize,
+    /// Oracle functions with no crap4ts@2 match — a discovery failure
+    /// (crap4ts@2 must discover a superset of the oracle).
+    pub v1_only: Vec<String>,
+    /// crap4ts@2 functions absent from the oracle. Informational:
+    /// v2's walker is more thorough; a superset is expected, not a
+    /// regression.
+    pub v2_only_count: usize,
+    pub divergences: Vec<Divergence>,
+}
+
+impl ParityReport {
+    pub fn exact_cc_rate(&self) -> f64 {
+        if self.matched == 0 {
+            return 0.0;
+        }
+        self.exact_cc as f64 / self.matched as f64
+    }
+
+    /// Divergences that fail the gate (genuine regressions only).
+    pub fn regressions(&self) -> Vec<&Divergence> {
+        self.divergences
+            .iter()
+            .filter(|d| !d.class.is_pass())
+            .collect()
+    }
+
+    fn count(&self, c: Class) -> usize {
+        self.divergences.iter().filter(|d| d.class == c).count()
+    }
+
+    /// The hierarchical tolerance gate (W3.1 README + CQO ADVISORY-4):
+    /// every oracle function discovered, ≥95% exact CC, zero genuine
+    /// score-regressions. Risk hard-match is enforced *through* the
+    /// classifier — a risk move explained by an improvement or a
+    /// threshold change is not a regression; only an unexplained one
+    /// classifies as `ScoreRegression`.
+    pub fn gate_passes(&self) -> bool {
+        self.v1_only.is_empty()
+            && self.exact_cc_rate() >= MIN_EXACT_CC_RATE
+            && self.regressions().is_empty()
+    }
+
+    /// Structured, copy-pasteable diff. Lists every non-`Match`
+    /// divergence with both sides + v2's contributor breakdown, then a
+    /// follow-up recommendation for any genuine regression (feature
+    /// scenario 5: a divergence not explained by a benign bucket
+    /// recommends a tracked follow-up under epic #173).
+    pub fn render(&self) -> String {
+        let mut s = String::new();
+        s.push_str(&format!(
+            "parity: {} oracle functions, {} matched ({} exact CC = {:.1}%), \
+             {} v1-only, {} v2-only\n",
+            self.matched + self.v1_only.len(),
+            self.matched,
+            self.exact_cc,
+            self.exact_cc_rate() * 100.0,
+            self.v1_only.len(),
+            self.v2_only_count,
+        ));
+        s.push_str(&format!(
+            "  buckets: {} match · {} threshold-default-change · \
+             {} crap4ts#37-improvement · {} score-regression\n",
+            self.count(Class::Match),
+            self.count(Class::ThresholdDefaultChange),
+            self.count(Class::Crap37Improvement),
+            self.count(Class::ScoreRegression),
+        ));
+
+        if !self.v1_only.is_empty() {
+            s.push_str("\n  DISCOVERY FAILURE — oracle functions crap4ts@2 did not find:\n");
+            for k in &self.v1_only {
+                s.push_str(&format!("    - {k}\n"));
+            }
+        }
+
+        let interesting: Vec<&Divergence> = self
+            .divergences
+            .iter()
+            .filter(|d| d.class != Class::Match)
+            .collect();
+        if !interesting.is_empty() {
+            s.push_str("\n  per-function divergences:\n");
+            for d in interesting {
+                let tag = match d.class {
+                    Class::Match => "match",
+                    Class::ThresholdDefaultChange => "threshold-default-change",
+                    Class::Crap37Improvement => "crap4ts#37-improvement",
+                    Class::ScoreRegression => "SCORE-REGRESSION",
+                };
+                s.push_str(&format!(
+                    "    [{tag}] {}::{}\n      v1: cc={} cov={:.2}% crap={:.2} risk={}\n      \
+                     v2: cc={} cov={:.2}% crap={:.2} risk={}  contributors: {}\n",
+                    d.file,
+                    d.name,
+                    d.v1_cc,
+                    d.v1_cov,
+                    d.v1_crap,
+                    d.v1_risk,
+                    d.v2_cc,
+                    d.v2_cov,
+                    d.v2_crap,
+                    d.v2_risk,
+                    d.v2_contributors,
+                ));
+            }
+        }
+
+        let regs = self.regressions();
+        if !regs.is_empty() {
+            s.push_str(
+                "\n  ACTION: the following are unexplained regressions — file a \
+                 follow-up under epic #173 with the function name + v2 \
+                 contributor breakdown:\n",
+            );
+            for d in regs {
+                s.push_str(&format!(
+                    "    - {}::{} (v1 crap {:.2} → v2 {:.2}; v2 contributors: {})\n",
+                    d.file, d.name, d.v1_crap, d.v2_crap, d.v2_contributors,
+                ));
+            }
+        }
+        s
+    }
+}
+
+/// Match oracle → v2 by `(file, qualified_name)`, choosing the nearest
+/// v2 candidate by start line and requiring ≤ 1 line drift (half-open
+/// span boundary tolerance). Classify every matched pair; collect
+/// unmatched oracle functions as discovery failures.
+pub fn diff(oracle: &[FnRecord], v2: &[FnRecord]) -> ParityReport {
+    // (file, name) → candidates, so duplicate anonymous functions in
+    // one file (`<arrow>` ×N) are disambiguated by start line.
+    let mut v2_index: BTreeMap<(&str, &str), Vec<&FnRecord>> = BTreeMap::new();
+    for f in v2 {
+        v2_index
+            .entry((f.file.as_str(), f.name.as_str()))
+            .or_default()
+            .push(f);
+    }
+
+    let oracle_keys: std::collections::HashSet<(&str, &str)> = oracle
+        .iter()
+        .map(|f| (f.file.as_str(), f.name.as_str()))
+        .collect();
+
+    let mut report = ParityReport {
+        matched: 0,
+        exact_cc: 0,
+        v1_only: Vec::new(),
+        v2_only_count: 0,
+        divergences: Vec::new(),
+    };
+
+    for o in oracle {
+        let key = (o.file.as_str(), o.name.as_str());
+        let cand = v2_index.get(&key).and_then(|cands| {
+            cands
+                .iter()
+                .copied()
+                .filter(|c| (c.start_line - o.start_line).abs() <= 1)
+                .min_by_key(|c| (c.start_line - o.start_line).abs())
+        });
+        match cand {
+            None => report.v1_only.push(format!("{}::{}", o.file, o.name)),
+            Some(m) => {
+                report.matched += 1;
+                if o.cc == m.cc {
+                    report.exact_cc += 1;
+                }
+                let class = classify(o, m);
+                report.divergences.push(Divergence {
+                    file: o.file.clone(),
+                    name: o.name.clone(),
+                    class,
+                    v1_cc: o.cc,
+                    v2_cc: m.cc,
+                    v1_cov: o.coverage,
+                    v2_cov: m.coverage,
+                    v1_crap: o.crap,
+                    v2_crap: m.crap,
+                    v1_risk: o.risk.clone(),
+                    v2_risk: m.risk.clone(),
+                    v2_contributors: summarize_contributors(&m.contributors),
+                });
+            }
+        }
+    }
+
+    report.v2_only_count = v2
+        .iter()
+        .filter(|f| !oracle_keys.contains(&(f.file.as_str(), f.name.as_str())))
+        .count();
+
+    report
+}

--- a/crates/crap4ts/tests/parity_helpers/mod.rs
+++ b/crates/crap4ts/tests/parity_helpers/mod.rs
@@ -173,9 +173,12 @@ pub struct FnRecord {
 
 /// Strip a single leading `src/` so oracle paths
 /// (`src/adapters/x.ts`) align with crap4ts@2 `--src`-relative paths
-/// (`adapters/x.ts`). Forward slashes only — both sides normalize.
+/// (`adapters/x.ts`). Backslashes are folded to `/` first so a
+/// Windows-emitted path matches the forward-slash oracle regardless of
+/// the platform the matrix runs on.
 fn norm_path(p: &str) -> String {
-    p.strip_prefix("src/").unwrap_or(p).to_string()
+    let p = p.replace('\\', "/");
+    p.strip_prefix("src/").unwrap_or(&p).to_string()
 }
 
 /// Parse the committed oracle JSON. Panics with context on malformed
@@ -458,20 +461,16 @@ impl ParityReport {
 /// span boundary tolerance). Classify every matched pair; collect
 /// unmatched oracle functions as discovery failures.
 pub fn diff(oracle: &[FnRecord], v2: &[FnRecord]) -> ParityReport {
-    // (file, name) → candidates, so duplicate anonymous functions in
-    // one file (`<arrow>` ×N) are disambiguated by start line.
-    let mut v2_index: BTreeMap<(&str, &str), Vec<&FnRecord>> = BTreeMap::new();
-    for f in v2 {
+    // (file, name) → candidate indices into `v2`, so duplicate
+    // anonymous functions in one file (`<arrow>` ×N) are disambiguated
+    // by start line.
+    let mut v2_index: BTreeMap<(&str, &str), Vec<usize>> = BTreeMap::new();
+    for (i, f) in v2.iter().enumerate() {
         v2_index
             .entry((f.file.as_str(), f.name.as_str()))
             .or_default()
-            .push(f);
+            .push(i);
     }
-
-    let oracle_keys: std::collections::HashSet<(&str, &str)> = oracle
-        .iter()
-        .map(|f| (f.file.as_str(), f.name.as_str()))
-        .collect();
 
     let mut report = ParityReport {
         matched: 0,
@@ -481,18 +480,27 @@ pub fn diff(oracle: &[FnRecord], v2: &[FnRecord]) -> ParityReport {
         divergences: Vec::new(),
     };
 
+    // Each v2 record is consumed by at most one oracle entry. Without
+    // this, a future regression where v2 drops a function but a sibling
+    // (same file+name, start line within ±1) absorbs two oracle entries
+    // would be silently masked — both oracle entries "match" the same
+    // surviving v2 record and the dropped one never surfaces as v1_only.
+    let mut consumed: std::collections::HashSet<usize> = std::collections::HashSet::new();
+
     for o in oracle {
         let key = (o.file.as_str(), o.name.as_str());
-        let cand = v2_index.get(&key).and_then(|cands| {
-            cands
-                .iter()
+        let cand = v2_index.get(&key).and_then(|idxs| {
+            idxs.iter()
                 .copied()
-                .filter(|c| (c.start_line - o.start_line).abs() <= 1)
-                .min_by_key(|c| (c.start_line - o.start_line).abs())
+                .filter(|&i| !consumed.contains(&i))
+                .filter(|&i| (v2[i].start_line - o.start_line).abs() <= 1)
+                .min_by_key(|&i| (v2[i].start_line - o.start_line).abs())
         });
         match cand {
             None => report.v1_only.push(format!("{}::{}", o.file, o.name)),
-            Some(m) => {
+            Some(mi) => {
+                consumed.insert(mi);
+                let m = &v2[mi];
                 report.matched += 1;
                 if o.cc == m.cc {
                     report.exact_cc += 1;
@@ -516,10 +524,12 @@ pub fn diff(oracle: &[FnRecord], v2: &[FnRecord]) -> ParityReport {
         }
     }
 
-    report.v2_only_count = v2
-        .iter()
-        .filter(|f| !oracle_keys.contains(&(f.file.as_str(), f.name.as_str())))
-        .count();
+    // v2 records never consumed by a 1-to-1 oracle match. crap4ts@2's
+    // walker is a deliberate superset of v1.x, so this is the genuine
+    // extra-discovery delta — not a `(file, name)`-existence heuristic,
+    // which undercounts whenever v2 adds a function sharing a name with
+    // an oracle entry (common for anonymous `<arrow>` / nested fns).
+    report.v2_only_count = v2.len() - report.matched;
 
     report
 }

--- a/crates/crap4ts/tests/parity_v1.rs
+++ b/crates/crap4ts/tests/parity_v1.rs
@@ -1,0 +1,347 @@
+//! W3.2 #190 — parity cross-validation harness.
+//!
+//! Shells the `crap4ts` Rust binary (NOT pnpm/node) against the
+//! committed W3.1 crap4ts@1.x corpus, parses its `--format json`
+//! envelope, and diffs every function against the committed oracle
+//! `crap4ts-v1-reference.json`. The reference was captured **once**
+//! during W3.1 and is consumed here byte-for-byte — this harness never
+//! regenerates a baseline; pure Rust, no node toolchain in CI.
+//!
+//! See `parity_helpers` for the three-way classification (Match /
+//! ThresholdDefaultChange / Crap37Improvement / ScoreRegression), the
+//! hierarchical tolerance gate, and why the oracle carries no
+//! contributor breakdown.
+//!
+//! The pure-`diff()` scenario tests below pin the
+//! `parity_with_v1.feature` contract directly (the 5 scenarios stay
+//! `@unwired` with their `# tracked:` comment until W3.3 wires the
+//! cucumber harness; these tests assert the same acceptance now).
+
+mod parity_helpers;
+
+use parity_helpers::{Class, FnRecord, ParityReport, diff, parse_oracle, parse_v2};
+
+const ORACLE_JSON: &str = include_str!("fixtures/crap4ts-v1-reference.json");
+
+/// Run `crap4ts --format json` against the committed v1.x corpus and
+/// return a classified parity report.
+fn run_parity() -> ParityReport {
+    let manifest = env!("CARGO_MANIFEST_DIR");
+    let src = format!("{manifest}/tests/fixtures/crap4ts-v1/src");
+    let coverage = format!("{manifest}/tests/fixtures/crap4ts-v1/coverage-final.json");
+
+    let out = assert_cmd::Command::cargo_bin("crap4ts")
+        .expect("crap4ts binary discoverable")
+        .arg("--src")
+        .arg(&src)
+        .arg("--coverage")
+        .arg(&coverage)
+        .arg("--format")
+        .arg("json")
+        .arg("--no-fail")
+        .output()
+        .expect("crap4ts executes");
+
+    assert!(
+        out.status.success(),
+        "crap4ts exited non-zero under --no-fail: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let oracle = parse_oracle(ORACLE_JSON);
+    let v2 = parse_v2(std::str::from_utf8(&out.stdout).expect("stdout is utf8"));
+    diff(&oracle, &v2)
+}
+
+/// THE GATE. crap4ts@2 reproduces the v1.x oracle within the
+/// hierarchical tolerance band: every oracle function discovered
+/// (crap4ts@2 ⊇ v1.x), ≥ 95% exact cyclomatic complexity, zero
+/// genuine score-regressions. Risk hard-match is enforced through the
+/// classifier — a risk move explained by a crap4ts#37 improvement or a
+/// threshold-default change is not a regression.
+///
+/// On failure the full structured per-function diff is printed so a
+/// divergence is one read, not a manual re-run.
+#[test]
+fn crap4ts2_reproduces_v1_oracle_within_tolerance() {
+    let report = run_parity();
+    assert!(
+        report.gate_passes(),
+        "crap4ts@2 diverged from the v1.x oracle beyond tolerance:\n{}",
+        report.render()
+    );
+
+    // Discovery contract: crap4ts@2 must find a superset of every
+    // oracle function. Pin to the committed oracle's own size (not a
+    // capture-variable corpus count) so this fails loudly if the
+    // oracle is ever silently shrunk.
+    assert!(
+        report.v1_only.is_empty(),
+        "crap4ts@2 failed to discover {} oracle function(s):\n{}",
+        report.v1_only.len(),
+        report.render()
+    );
+    assert_eq!(
+        report.matched,
+        parse_oracle(ORACLE_JSON).len(),
+        "every oracle function must match exactly one crap4ts@2 function"
+    );
+
+    // Documented surviving state (see PR body): on the W3.1 corpus the
+    // matched set is 100% exact-CC with zero genuine regressions; all
+    // score/risk movement is the crap4ts#37 coverage-matcher
+    // improvement. This is asserted as a band, not a brittle pin —
+    // exact-CC rate must clear 95% and regressions must stay zero.
+    assert!(
+        report.exact_cc_rate() >= 0.95,
+        "exact-CC rate {:.3} fell below 0.95:\n{}",
+        report.exact_cc_rate(),
+        report.render()
+    );
+    assert!(
+        report.regressions().is_empty(),
+        "{} unexplained score-regression(s):\n{}",
+        report.regressions().len(),
+        report.render()
+    );
+}
+
+// ── parity_with_v1.feature scenario contracts (pure, deterministic) ──
+//
+// These exercise the classifier through the public `diff()` entry with
+// synthetic records, pinning each BDD scenario's acceptance without the
+// binary. W3.3 wires the cucumber step defs; the contract is verified
+// here now.
+
+// A flat positional builder keeps each scenario's expected record on
+// one readable line; a struct literal per call would triple the line
+// count of every scenario for no clarity gain in test-only code.
+#[allow(clippy::too_many_arguments)]
+fn rec(
+    name: &str,
+    sl: i64,
+    cc: u32,
+    cov: f64,
+    crap: f64,
+    risk: &str,
+    exceeds: bool,
+    contribs: &[&str],
+) -> FnRecord {
+    FnRecord {
+        file: "src/x.ts".to_string(),
+        name: name.to_string(),
+        start_line: sl,
+        cc,
+        coverage: cov,
+        crap,
+        risk: risk.to_string(),
+        exceeds,
+        contributors: contribs.iter().map(|s| s.to_string()).collect(),
+    }
+}
+
+/// Scenario: scores match within tolerance — exact CC + same risk
+/// class classifies as `Match` and the gate passes.
+#[test]
+fn scenario_scores_match_within_tolerance() {
+    let oracle = vec![rec("f", 10, 3, 100.0, 3.0, "low", false, &[])];
+    let v2 = vec![rec("f", 10, 3, 100.0, 3.0, "low", false, &[])];
+    let r = diff(&oracle, &v2);
+    assert!(r.gate_passes());
+    assert_eq!(r.divergences[0].class, Class::Match);
+    assert!(r.v1_only.is_empty());
+    assert_eq!(r.exact_cc_rate(), 1.0);
+}
+
+/// Scenario: divergence output shows per-function contributor
+/// breakdown, not just a score diff. v1.x has CC 4; v2 has CC 3 with
+/// `2× if-branch` — the report names the function, shows v2's
+/// contributor breakdown, and the missing kind is inferable from it.
+#[test]
+fn scenario_divergence_shows_contributor_breakdown() {
+    let oracle = vec![rec("dropTernary", 5, 4, 100.0, 4.0, "low", false, &[])];
+    let v2 = vec![rec(
+        "dropTernary",
+        5,
+        3,
+        100.0,
+        3.0,
+        "low",
+        false,
+        &["if-branch", "if-branch"],
+    )];
+    let r = diff(&oracle, &v2);
+    // CC differs with no benign explanation → regression, gate fails.
+    assert_eq!(r.divergences[0].class, Class::ScoreRegression);
+    assert!(!r.gate_passes());
+    let out = r.render();
+    assert!(out.contains("dropTernary"), "report names the function");
+    assert!(
+        out.contains("2× if-branch"),
+        "report shows v2 contributor breakdown; got:\n{out}"
+    );
+    assert!(
+        out.contains("file a follow-up under epic #173"),
+        "report recommends a tracked follow-up; got:\n{out}"
+    );
+}
+
+/// Scenario: risk classification labels match across versions (D8
+/// invariance) — when nothing diverges, every risk label matches and
+/// no risk-class divergence is emitted.
+#[test]
+fn scenario_risk_labels_match_when_no_divergence() {
+    let oracle = vec![
+        rec("a", 1, 2, 100.0, 2.0, "low", false, &[]),
+        rec("b", 9, 9, 90.0, 9.01, "moderate", true, &[]),
+    ];
+    let v2 = vec![
+        rec("a", 1, 2, 100.0, 2.0, "low", false, &[]),
+        rec("b", 9, 9, 90.0, 9.01, "moderate", true, &[]),
+    ];
+    let r = diff(&oracle, &v2);
+    assert!(r.gate_passes());
+    assert!(r.divergences.iter().all(|d| d.class == Class::Match));
+}
+
+/// Scenario: threshold-default difference is documented, not a parity
+/// failure. Same score; oracle gate says exceeding (threshold 12), v2
+/// says passing (threshold 16) → `ThresholdDefaultChange`, gate passes.
+#[test]
+fn scenario_threshold_default_change_is_not_a_regression() {
+    let oracle = vec![rec(
+        "borderline",
+        20,
+        13,
+        100.0,
+        13.0,
+        "moderate",
+        true,
+        &[],
+    )];
+    let v2 = vec![rec(
+        "borderline",
+        20,
+        13,
+        100.0,
+        13.0,
+        "moderate",
+        false,
+        &[],
+    )];
+    let r = diff(&oracle, &v2);
+    assert_eq!(
+        r.divergences[0].class,
+        Class::ThresholdDefaultChange,
+        "same score, only the gate verdict flipped → threshold-default-change"
+    );
+    assert!(
+        r.gate_passes(),
+        "threshold-default-change must NOT fail the gate"
+    );
+    assert!(r.render().contains("threshold-default-change"));
+}
+
+/// Scenario: a discovered score divergence triggers a tracked
+/// follow-up. An unexplained crap jump (same CC + coverage, |Δcrap| >
+/// 0.5) classifies as `ScoreRegression` and the report recommends a
+/// follow-up under epic #173 with the function + v2 contributors.
+#[test]
+fn scenario_unexplained_divergence_recommends_followup() {
+    let oracle = vec![rec("regressed", 30, 5, 80.0, 6.0, "acceptable", false, &[])];
+    let v2 = vec![rec(
+        "regressed",
+        30,
+        5,
+        80.0,
+        9.0,
+        "moderate",
+        false,
+        &["if-branch", "ternary", "ternary"],
+    )];
+    let r = diff(&oracle, &v2);
+    assert_eq!(r.divergences[0].class, Class::ScoreRegression);
+    assert!(!r.gate_passes());
+    let out = r.render();
+    assert!(out.contains("epic #173"));
+    assert!(out.contains("regressed"));
+    assert!(
+        out.contains("1× if-branch + 2× ternary"),
+        "follow-up includes v2 contributor breakdown; got:\n{out}"
+    );
+}
+
+/// crap4ts#37 improvement: v1.x reported 0% coverage (its
+/// span-overlap-matcher bug); v2 reports real coverage on the same
+/// complexity. Classifies as an improvement and PASSES — the risk
+/// class moving because of it is not a regression (this is how the
+/// README's "risk hard-match" and "improvement passes" rules
+/// reconcile).
+#[test]
+fn crap37_improvement_passes_and_absorbs_risk_shift() {
+    let oracle = vec![rec("buggyV1", 40, 3, 0.0, 12.0, "moderate", true, &[])];
+    let v2 = vec![rec(
+        "buggyV1",
+        40,
+        3,
+        100.0,
+        3.0,
+        "low",
+        false,
+        &["if-branch", "if-branch"],
+    )];
+    let r = diff(&oracle, &v2);
+    assert_eq!(r.divergences[0].class, Class::Crap37Improvement);
+    assert!(
+        r.gate_passes(),
+        "a crap4ts#37 improvement (incl. its risk-class move) must pass"
+    );
+}
+
+/// Discovery contract: an oracle function crap4ts@2 fails to discover
+/// is a hard gate failure (crap4ts@2 must be a superset of v1.x).
+#[test]
+fn missing_discovery_is_a_hard_gate_failure() {
+    let oracle = vec![
+        rec("found", 1, 1, 100.0, 1.0, "low", false, &[]),
+        rec("vanished", 50, 2, 100.0, 2.0, "low", false, &[]),
+    ];
+    let v2 = vec![rec("found", 1, 1, 100.0, 1.0, "low", false, &[])];
+    let r = diff(&oracle, &v2);
+    assert!(!r.gate_passes());
+    assert_eq!(r.v1_only.len(), 1);
+    assert!(r.render().contains("vanished"));
+    assert!(r.render().contains("DISCOVERY FAILURE"));
+}
+
+/// crap4ts@2 discovering functions the oracle lacks (its walker is
+/// more thorough) is informational, never a regression.
+#[test]
+fn v2_only_functions_are_informational_not_a_failure() {
+    let oracle = vec![rec("shared", 1, 1, 100.0, 1.0, "low", false, &[])];
+    let v2 = vec![
+        rec("shared", 1, 1, 100.0, 1.0, "low", false, &[]),
+        rec("<arrow>", 7, 1, 100.0, 1.0, "low", false, &[]),
+        rec("extraNested", 9, 2, 100.0, 2.0, "low", false, &[]),
+    ];
+    let r = diff(&oracle, &v2);
+    assert!(r.gate_passes());
+    assert_eq!(r.v2_only_count, 2);
+}
+
+/// Line-drift tolerance: a ±1 start-line shift (half-open span
+/// boundary) still matches; a larger shift does not.
+#[test]
+fn start_line_drift_within_one_still_matches() {
+    let oracle = vec![rec("shifted", 100, 2, 100.0, 2.0, "low", false, &[])];
+    let within = vec![rec("shifted", 101, 2, 100.0, 2.0, "low", false, &[])];
+    let beyond = vec![rec("shifted", 103, 2, 100.0, 2.0, "low", false, &[])];
+    assert_eq!(diff(&oracle, &within).matched, 1);
+    assert!(diff(&oracle, &within).gate_passes());
+    assert_eq!(
+        diff(&oracle, &beyond).matched,
+        0,
+        ">1 line drift is not a match"
+    );
+    assert!(!diff(&oracle, &beyond).gate_passes());
+}


### PR DESCRIPTION
## Summary

W3.2 of the crap4ts TypeScript-adapter pipeline. A pure-Rust parity
harness that proves crap4ts@2 reproduces the crap4ts@1.x CRAP scorecard
on the v1.x corpus, within a documented tolerance band, while
distinguishing legitimate improvements from genuine regressions.

- `crates/crap4ts/tests/parity_helpers/mod.rs` — parse/diff core:
  oracle + envelope serde models, path normalization, the four-way
  classifier, and a structured `ParityReport` with a v2 contributor
  breakdown for actionable triage.
- `crates/crap4ts/tests/parity_v1.rs` — the e2e gate (shells
  `crap4ts` via `assert_cmd::cargo_bin`, **not** node/pnpm) plus 9
  pure scenario-contract tests pinning the 5 `parity_with_v1.feature`
  scenarios.

The committed `crap4ts-v1-reference.json` oracle is **consumed
byte-untouched** — no baseline regeneration.

## Authoritative corpus result

Run against the complete repaired fixture (post #227):

| Metric | Value |
|---|---|
| crap4ts@2 functions discovered | 191 |
| Oracle functions | 137 |
| Matched | 137 / 137 |
| Cyclomatic exact-match | 137 / 137 (100%) |
| crap4ts#37 coverage-matcher improvements | 24 (absorb all 18 risk shifts, all improvement-direction) |
| crap4ts@2-only (superset) | 54 (`v2.len() − matched`) |
| Genuine score regressions | **0** |

The gate passes: crap4ts@2 discovers a superset of every oracle
function, exact CC ≥ 95%, zero unexplained divergences.

## Classification model

Four-way per-function, per the W3.1 README three-way contract +
clean `Match`:

1. **Match** — within tolerance, risk class held → pass.
2. **ThresholdDefaultChange** — score unchanged, gate verdict flipped
   purely from the threshold default moving (oracle 8/12 → crap4ts@2
   16). Guarded by `v1.risk == v2.risk`: the `|Δcrap| ≤ 0.5` band can
   straddle a D8 risk cutoff, so a same-score gate-flip that *also*
   shifts risk class falls through to `ScoreRegression` (README "risk
   hard-match" intent). Empirically zero such cases in this corpus.
3. **Crap37Improvement** — same CC, v1 reported 0% coverage from its
   80%-overlap span matcher (crap4ts#37); v2's line-range containment
   is structurally immune → pass, logged as improvement.
4. **ScoreRegression** — anything else → hard fail.

## Tolerance band

Per the W3.1 fixture README "Tolerance band" table and the impl-plan
W3.2 hierarchical spec: risk-class mismatch = hard fail (zero
tolerance); ≥95% CC exact-match; `|Δcrap| ≤ 0.5` acceptable only if
complexity **and** coverage both unchanged; contributor line drift
±1; missing/extra match = hard discovery failure.

## Surviving limitation (deliberate scope decision)

The crap4ts@1.x oracle records only the cyclomatic **number** — it has
no per-contributor list. The ±1 contributor-line-drift tolerance
therefore cannot be enforced *against the oracle*. The harness instead
renders crap4ts@2's contributor breakdown in the divergence report so
any future regression is triagable at a glance. This is a property of
the oracle's schema, not a harness gap; called out rather than buried.

## Plan deviation acknowledged

W3.2 pre-flight surfaced that the W3.1 fixture was missing
`src/adapters/coverage/` (an unanchored `rsync --exclude='coverage/'`
over-match). Repaired via prerequisite PR #227 (merged) before this
harness landed; this branch is rebased on the repaired `main`. The
oracle JSON was untouched by #227 — corpus repair, not baseline
regeneration.

## Bot review resolution

Gemini + CodeRabbit (CHILL) reviewed; all findings addressed in
`fe07728`:

- **Cross-platform path norm** — `norm_path` now folds `\` → `/`
  before the `src/` strip so a Windows-emitted binary path matches the
  forward-slash oracle on any matrix leg.
- **1-to-1 oracle↔v2 matching** — `diff()` consumes each v2 record at
  most once. Previously two oracle entries sharing `(file, name)`
  within ±1 line could both bind the same surviving v2 record, masking
  a future regression where v2 drops one (the dropped one never
  surfaced as `v1_only`). This strengthens the regression-locking gate.
- **`v2_only_count` accuracy** — now `v2.len() − matched` (54, the
  true extra-discovery delta) instead of the `(file, name)`-existence
  heuristic, which undercounted (21) whenever v2 adds a function
  sharing a name with an oracle entry. Both bots flagged this; the
  fix falls out of the 1-to-1 tracking.

Gate behaviour is unchanged on the live corpus (137/137 matched, 100%
exact CC, 0 regressions); the changes harden the harness against
*future* corpora, which is its purpose.

## Gate battery

`cargo nextest run --workspace --all-targets` (1078 passed, wire
snapshots byte-identical), `cargo fmt --check`, `cargo clippy
--workspace --all-targets -- -D warnings`, `cargo +1.93 check
--workspace --all-targets`, `RUSTDOCFLAGS=-D warnings cargo doc
--workspace --no-deps`, `cargo deny check` — all green. The harness
shells the in-package `crap4ts` bin from `crap4ts` tests, so the
cargo-mutants #224 bug class does not apply (no `.cargo/mutants.toml`
skip token needed).

## Context

- Epic: #173 · Blocked-by: #189 (W3.1, merged) · Prerequisite: #227
  (merged)
- Pipeline: crap-rs/20260513-typescript-adapter (build phase,
  mid-pipeline; W3.3 #191 + W4 GA remain)

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive parity validation suite to ensure consistency of code quality metrics across versions and prevent regressions between releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/breezy-bays-labs/crap-rs/pull/228?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
