### PR TITLE
feat(crap-rs): #191 — self-check thrice gate + crap4ts cucumber harness + Background block cleanup

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -82,30 +82,57 @@ copy_target = true
 # mutants above this floor.
 minimum_test_timeout = 90
 
-# Pre-existing walker mutation gaps — surfaced when the per-merge
-# `crap4ts walker` mutants gate was revived.
+# Walker mutation gaps — long-latent, surfaced when the per-merge
+# `crap4ts walker` mutants gate was revived; partially re-anchored
+# when W3.3 refactored walker/mod.rs.
 #
-# This gate had been silently dead for several merges: a scoped
+# The gate had been silently dead for several merges: a scoped
 # `cargo mutants --package crap4ts` cannot build the `crap4rs` bin,
 # so an adapter-bin-shelling test panicked in the UNMUTATED baseline
 # and cargo-mutants aborted before testing a single mutant (exit 4,
 # zero mutants). The `--skip crap4rs_no_flag_default_cognitive_still_works`
-# entry in `additional_cargo_test_args` above fixes that abort, so
-# the gate now actually runs.
+# entry in `additional_cargo_test_args` above fixes that abort. W3.3
+# then introduced the first cucumber `harness = false` binaries into
+# the `crap4ts` crate; their strict clap CLI rejected the `--skip`
+# libtest args this config injects into every package test binary —
+# re-triggering the same UNMUTATED-baseline abort (the crap-rs#224
+# gate-zeroing class). That is fixed at the harness, not here, via
+# `with_default_cli()` in `cyclomatic_walker_cucumber.rs` /
+# `metric_unsupported_cucumber.rs` (which skip argv parsing). So the
+# gate genuinely runs again.
 #
-# Reviving it exposed 21 long-latent surviving mutants in walker code
-# that the change reviving the gate never touched — verified against
-# the origin/main baseline, where the identical 21 survive too, so
-# they are not a regression. Left un-excluded, the revived gate would
-# be permanently RED on every merge to main, which would in turn mask
-# any genuinely NEW walker regression behind the standing noise.
+# W3.3 also decomposed `IstanbulCoverage::build_parse_output` and
+# `FunctionFinder::visit_namespace_statement` to clear the new
+# crap4ts-self-CRAP CI leg (CRAP <= 15). The `qualify` free fn added
+# in the helper section shifts everything from `byte_to_line_col`
+# onward by +8 lines; the namespace-helper extraction is also below
+# the walker decision-point functions. So the `visit_if` /
+# `visit_for_init` / `visit_expression` / `visit_chain_element`
+# regions are UNSHIFTED (those anchors are preserved verbatim from
+# the revived-gate block); only the `byte_to_line_col` /
+# `property_key_name` / `for_init_as_expression` anchors moved +8 and
+# are re-anchored below. The revived-gate block was 21 hard gaps + 1
+# proptest-flaky `ImportExpression`; this block is 22 hard (+ the
+# long-standing `888:13 TSNonNullExpression` omission, see below) + 2
+# proptest-flaky (+ `884:13 TSSatisfiesExpression`, see below) = 24.
+# The earlier "refactor killed it down to 10" reading was a
+# stale-anchor artifact (run-1's old anchors still matched the
+# unshifted regions and kept suppressing them, so only the +8-shifted
+# gaps surfaced); the set did not shrink.
 #
-# So: exclude these 21 hard line-anchored gaps (plus one further
-# proptest-flaky arm parked separately in its own sub-block below — see
-# the paragraph preceding `exclude_re`) to keep the revived gate
-# green-and-meaningful (it can still catch NEW survivors). Closing
-# them — adding real mutation-killing coverage for these functions —
-# is the remaining acceptance work of the issue that revived the gate.
+# Two entries are NEW to this block, both in `visit_expression` and
+# both pre-existing since #182 (b77be7e, the original minimal
+# walker) — long-standing omissions from the revived-gate block, not
+# regressions and not #219 additions:
+#   * `888:13 TSNonNullExpression` — a HARD gap (MISSED in every
+#     verification pass); included with the other hard arms.
+#   * `884:13 TSSatisfiesExpression` — a SECOND proptest-flaky arm
+#     (CAUGHT under two seeds, MISSED under a third), same class as
+#     `880:13 ImportExpression`; grouped with it in the seed-flaky
+#     sub-block. The per-merge CI gate runs `--in-place` single-worker
+#     with a per-run proptest seed, so an un-excluded flaky arm makes
+#     the gate intermittently RED — both flaky arms must be pinned.
+# Closing either is crap-rs#224 work like every other entry.
 #
 # Each pattern is anchored on the exact `mod.rs:LINE:COL:` of one
 # known-surviving mutant so it pins precisely that mutant and nothing
@@ -115,32 +142,18 @@ minimum_test_timeout = 90
 # visibility, which is the behaviour #224 wants (it forces re-triage
 # rather than silently masking).
 #
-# One further entry sits in a SEPARATE category: the
-# `Expression::ImportExpression` arm is killed on origin/main only by
-# the randomized `walker_proptest.rs` suite, so whether it is CAUGHT or
-# MISSED depends on the proptest seed of a given run — flaky across
-# mutants passes rather than a hard untested gap. Its sibling array-path
-# arms (ArrayExpression / visit_array_elements / array_element_as_expression)
-# were pinned deterministically in this PR with a single
-# `array-literal-nested-fn.ts` fixture; an equivalent deterministic pin
-# for the dynamic-`import()` recursion path is owed but is not 5-minute
-# trivial (reaching a nested function through an `import()` argument is
-# contrived), so it is parked here under the same #224 ownership rather
-# than blocking this PR. It is grouped below its own sub-comment so the
-# distinction (proptest-dependent, deterministic pin owed) is not lost.
-#
 # tracked: crap-rs#224 — delete each line below as the matching
 # function gains a mutation-killing test; the issue stays open until
 # all entries are killed and this block is empty.
 exclude_re = [
-    # FunctionFinder::visit_if
+    # FunctionFinder::visit_if (unshifted)
     "mod\\.rs:682:17: delete match arm Statement::IfStatement\\(_\\) in",
     "mod\\.rs:683:71: replace \\+ with \\* in",
-    # FunctionFinder::visit_for_init
+    # FunctionFinder::visit_for_init (unshifted)
     "mod\\.rs:719:9: replace FunctionFinder<'src>::visit_for_init with \\(\\)",
-    # FunctionFinder::visit_chain_element
+    # FunctionFinder::visit_chain_element (unshifted)
     "mod\\.rs:1050:9: replace FunctionFinder<'src>::visit_chain_element with \\(\\)",
-    # FunctionFinder::visit_expression — untested match arms
+    # FunctionFinder::visit_expression — untested match arms (unshifted)
     "mod\\.rs:773:13: delete match arm Expression::ClassExpression\\(class\\) in",
     "mod\\.rs:787:13: delete match arm Expression::JSXFragment\\(frag\\) in",
     "mod\\.rs:834:21: delete match arm AT::PrivateFieldExpression\\(m\\) in",
@@ -149,18 +162,28 @@ exclude_re = [
     "mod\\.rs:887:13: delete match arm Expression::TSTypeAssertion\\(ts\\) in",
     "mod\\.rs:891:13: delete match arm Expression::TSInstantiationExpression\\(ts\\) in",
     "mod\\.rs:905:13: delete match arm Expression::PrivateFieldExpression\\(m\\) in",
-    # byte_to_line_col — arithmetic / comparison operators
-    "mod\\.rs:1478:27: replace == with != in",
-    "mod\\.rs:1479:20: replace \\+ with - in",
-    "mod\\.rs:1479:20: replace \\+ with \\* in",
-    "mod\\.rs:1481:25: replace - with \\+ in",
-    "mod\\.rs:1481:46: replace \\+ with \\* in",
-    # property_key_name — match arms
-    "mod\\.rs:1520:9: delete match arm PropertyKey::PrivateIdentifier\\(id\\) in",
-    "mod\\.rs:1521:9: delete match arm PropertyKey::StringLiteral\\(s\\) in",
-    "mod\\.rs:1522:9: delete match arm PropertyKey::NumericLiteral\\(n\\) in",
-    # for_init_as_expression
-    "mod\\.rs:1559:5: replace for_init_as_expression -> Option<&'b Expression<'b>> with None",
-    # proptest-dependent kill, deterministic pin owed (see paragraph above)
+    # FunctionFinder::visit_expression — long-standing omission, new to
+    # this block (arm exists since #182; seed luck masked it before).
+    "mod\\.rs:888:13: delete match arm Expression::TSNonNullExpression\\(ts\\) in",
+    # byte_to_line_col — arithmetic / comparison operators (+8 shift)
+    "mod\\.rs:1486:27: replace == with != in",
+    "mod\\.rs:1487:20: replace \\+ with - in",
+    "mod\\.rs:1487:20: replace \\+ with \\* in",
+    "mod\\.rs:1489:25: replace - with \\+ in",
+    "mod\\.rs:1489:46: replace \\+ with \\* in",
+    # property_key_name — match arms (+8 shift)
+    "mod\\.rs:1528:9: delete match arm PropertyKey::PrivateIdentifier\\(id\\) in",
+    "mod\\.rs:1529:9: delete match arm PropertyKey::StringLiteral\\(s\\) in",
+    "mod\\.rs:1530:9: delete match arm PropertyKey::NumericLiteral\\(n\\) in",
+    # for_init_as_expression (+8 shift)
+    "mod\\.rs:1567:5: replace for_init_as_expression -> Option<&'b Expression<'b>> with None",
+    # visit_expression — proptest-dependent kills (seed-flaky across
+    # mutants passes: each is CAUGHT under some walker_proptest.rs
+    # seeds, MISSED under others — observed flipping across three
+    # verification passes). Deterministic pins owed; parked under the
+    # same #224 ownership. Both unshifted (lines 880/884 in pre- and
+    # post-refactor trees). Pinned so the per-merge CI gate
+    # (`--in-place`, per-run seed) is not intermittently RED.
     "mod\\.rs:880:13: delete match arm Expression::ImportExpression\\(ie\\) in",
+    "mod\\.rs:884:13: delete match arm Expression::TSSatisfiesExpression\\(ts\\) in",
 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,8 @@ jobs:
     name: Self-referential CRAP check
     runs-on: ubuntu-latest
     needs: [coverage, clippy, test]
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,15 @@ jobs:
         run: ./target/release/crap4rs --coverage lcov.info --src crates/crap-core/src --strict --color always
       - name: Self-CRAP — crap4rs
         run: ./target/release/crap4rs --coverage lcov.info --src crates/crap4rs/src --strict --color always
+      # crap4ts/src is Rust — analyzed by the crap4rs binary, NOT crap4ts
+      # (which needs Istanbul JSON; there is no TS in crates/crap4ts/src).
+      # --strict (same as the two legs above) lowers the CRAP-score gate
+      # to 15 — i.e. every function must score CRAP <= 15. This is the
+      # CRAP-score cutoff, orthogonal to the cognitive-complexity metric
+      # default. Reuses the single ./target/release/crap4rs built once
+      # above (rust-cache warm) — no per-leg recompile.
+      - name: Self-CRAP — crap4ts (Rust source)
+        run: ./target/release/crap4rs --coverage lcov.info --src crates/crap4ts/src --strict --color always
 
   self-crap-view:
     name: domain/view.rs per-function CC <= 15

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,6 +413,7 @@ version = "2.0.0-alpha.1"
 dependencies = [
  "assert_cmd",
  "crap-core",
+ "cucumber",
  "napi",
  "napi-build",
  "napi-derive",
@@ -421,6 +422,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/crap4ts/Cargo.toml
+++ b/crates/crap4ts/Cargo.toml
@@ -80,5 +80,28 @@ assert_cmd = { workspace = true }
 # Regression files in `proptest-regressions/` are committed to git.
 proptest = { workspace = true }
 
+# W3.3 (crap-rs#191): cucumber-rs harnesses execute the crap4ts Gherkin
+# specs as integration tests. `libtest` feature emits libtest-compatible
+# JSON so nextest's `--list` probe degrades gracefully; the harnesses
+# are still excluded from nextest via `.config/nextest.toml`'s
+# `binary(/.*_cucumber$/)` filter and run under `cargo test --test`.
+# The feature is crate-local (not lifted to workspace scope) — only
+# crap4rs and crap4ts run cucumber harnesses.
+cucumber = { workspace = true, features = ["libtest"] }
+tokio = { workspace = true }
+
 [build-dependencies]
 napi-build = { workspace = true }
+
+# ── Cucumber-rs test targets (crap-rs#191) ──
+# `harness = false` is mandatory for cucumber-rs (it prints its own
+# output instead of going through libtest). Names MUST end in
+# `_cucumber` so `.config/nextest.toml` excludes them from nextest
+# probing — the suffix is load-bearing, not cosmetic.
+[[test]]
+name = "cyclomatic_walker_cucumber"
+harness = false
+
+[[test]]
+name = "metric_unsupported_cucumber"
+harness = false

--- a/crates/crap4ts/src/adapters/coverage/mod.rs
+++ b/crates/crap4ts/src/adapters/coverage/mod.rs
@@ -340,16 +340,7 @@ impl IstanbulCoverage {
         for (_key, entry) in raw {
             // ── Path normalization ──────────────────────────────────
             let Some(normalized) = self.normalize_path(&entry.path) else {
-                diagnostics.push(IstanbulParseDiagnostic {
-                    file_path: entry.path.clone(),
-                    kind: IstanbulDiagnosticKind::PathUnresolved,
-                    message: format!(
-                        "path '{}' does not resolve to a discovered source file under {}",
-                        entry.path,
-                        self.effective_src.display()
-                    ),
-                    line: None,
-                });
+                diagnostics.push(self.path_unresolved_diagnostic(&entry.path));
                 continue;
             };
 
@@ -357,85 +348,13 @@ impl IstanbulCoverage {
             // or `statementMap` populated but `s` empty. Both cases
             // indicate a partial / corrupt emitter record; emit and
             // skip per breadboard W-3.
-            if entry.s.is_empty() != entry.statement_map.is_empty() {
-                let (present, missing) = if entry.s.is_empty() {
-                    ("statementMap", "s")
-                } else {
-                    ("s", "statementMap")
-                };
-                diagnostics.push(IstanbulParseDiagnostic {
-                    file_path: entry.path.clone(),
-                    kind: IstanbulDiagnosticKind::MissingField,
-                    message: format!(
-                        "entry for '{}' has `{}` records but `{}` is empty; one half of the statement-coverage pair is missing",
-                        entry.path, present, missing
-                    ),
-                    line: None,
-                });
+            if let Some(diag) = Self::missing_field_diagnostic(&entry) {
+                diagnostics.push(diag);
                 continue;
             }
 
-            // ── Line coverage (W1.1) ────────────────────────────────
-            // Build per-line records by joining `s` (counts) to
-            // `statementMap` (line spans). Statements whose IDs do not
-            // appear in `statementMap` are skipped; statements that
-            // span multiple lines emit one `LineCoverage` per line in
-            // the span keyed by `start.line` (Istanbul records hits at
-            // the start-of-statement granularity, per its emitter).
-            let mut lines: Vec<LineCoverage> = Vec::with_capacity(entry.s.len());
-            for (stmt_id, hits) in &entry.s {
-                if let Some(loc) = entry.statement_map.get(stmt_id) {
-                    lines.push(LineCoverage {
-                        line: loc.start.line as usize,
-                        hits: *hits,
-                    });
-                }
-            }
-            // Sort by line for deterministic downstream consumption
-            // (mirrors LCOV parser ordering).
-            lines.sort_by_key(|lc| lc.line);
-
-            // ── Branch coverage (W2.3) ──────────────────────────────
-            // For each branchId in `b`, look up its `branchMap` entry.
-            // Missing branchMap entries emit `BranchMismatch` and
-            // skip THAT branch only (rest of the file still parses).
-            // Per the consumer contract at
-            // `crap-core::domain::matching::compute_branch_coverage`,
-            // each `BranchCoverage` row represents ONE branch arm —
-            // total = N records, covered = records with taken > 0.
-            // So we fan one Istanbul branchId with K arms into K
-            // separate `BranchCoverage` rows at the branching site's
-            // line, each carrying that arm's `taken` count. (Summing
-            // arm hits into a single record would collapse partial
-            // coverage into 100% — see PR body's plan-of-record
-            // deviation note for the worked example.)
-            let mut branches: Vec<BranchCoverage> = Vec::new();
-            for (branch_id, arms) in &entry.b {
-                let Some(loc) = entry.branch_map.get(branch_id) else {
-                    diagnostics.push(IstanbulParseDiagnostic {
-                        file_path: entry.path.clone(),
-                        kind: IstanbulDiagnosticKind::BranchMismatch,
-                        message: format!(
-                            "branch coverage record for branchId `{branch_id}` references no entry in branchMap. This is likely a bug in your coverage tool — report at the coverage tool's issue tracker."
-                        ),
-                        line: None,
-                    });
-                    continue;
-                };
-                // Prefer the emitter-set `line` when present (some
-                // emitters set it to the branching keyword's line
-                // independent of `loc`); fall back to
-                // `loc.start.line`.
-                let line = loc.line.unwrap_or(loc.loc.start.line) as usize;
-                for hits in arms {
-                    branches.push(BranchCoverage {
-                        line,
-                        taken: Some(*hits),
-                    });
-                }
-            }
-            // Deterministic ordering for downstream consumers.
-            branches.sort_by_key(|b| b.line);
+            let lines = Self::line_coverage_for(&entry);
+            let branches = Self::branch_coverage_for(&entry, &mut diagnostics);
 
             let key = normalized.to_string_lossy().into_owned();
             coverage.insert(key.clone(), lines);
@@ -456,6 +375,109 @@ impl IstanbulCoverage {
             branches,
             diagnostics,
         }
+    }
+
+    /// `PathUnresolved` diagnostic for an entry whose `path` does not
+    /// resolve to a discovered source file under `effective_src`.
+    fn path_unresolved_diagnostic(&self, path: &str) -> IstanbulParseDiagnostic {
+        IstanbulParseDiagnostic {
+            file_path: path.to_string(),
+            kind: IstanbulDiagnosticKind::PathUnresolved,
+            message: format!(
+                "path '{}' does not resolve to a discovered source file under {}",
+                path,
+                self.effective_src.display()
+            ),
+            line: None,
+        }
+    }
+
+    /// `MissingField` diagnostic when exactly one half of the
+    /// statement-coverage pair (`s` / `statementMap`) is empty — a
+    /// partial / corrupt emitter record. `None` when both are present
+    /// or both are absent (a legitimately empty entry).
+    fn missing_field_diagnostic(entry: &IstanbulCoverageFile) -> Option<IstanbulParseDiagnostic> {
+        if entry.s.is_empty() == entry.statement_map.is_empty() {
+            return None;
+        }
+        let (present, missing) = if entry.s.is_empty() {
+            ("statementMap", "s")
+        } else {
+            ("s", "statementMap")
+        };
+        Some(IstanbulParseDiagnostic {
+            file_path: entry.path.clone(),
+            kind: IstanbulDiagnosticKind::MissingField,
+            message: format!(
+                "entry for '{}' has `{}` records but `{}` is empty; one half of the statement-coverage pair is missing",
+                entry.path, present, missing
+            ),
+            line: None,
+        })
+    }
+
+    /// Per-line coverage records (W1.1) for one entry: join `s`
+    /// (counts) to `statementMap` (line spans). Statements whose IDs do
+    /// not appear in `statementMap` are skipped; hits are keyed at the
+    /// start-of-statement line (Istanbul's emitter granularity). Sorted
+    /// by line for deterministic downstream consumption (mirrors the
+    /// LCOV parser's ordering).
+    fn line_coverage_for(entry: &IstanbulCoverageFile) -> Vec<LineCoverage> {
+        let mut lines: Vec<LineCoverage> = Vec::with_capacity(entry.s.len());
+        for (stmt_id, hits) in &entry.s {
+            if let Some(loc) = entry.statement_map.get(stmt_id) {
+                lines.push(LineCoverage {
+                    line: loc.start.line as usize,
+                    hits: *hits,
+                });
+            }
+        }
+        lines.sort_by_key(|lc| lc.line);
+        lines
+    }
+
+    /// Per-branch coverage records (W2.3) for one entry. Each branchId
+    /// in `b` is looked up in `branchMap`; a missing entry emits
+    /// `BranchMismatch` into `diagnostics` and skips THAT branch only
+    /// (the rest of the file still parses). Per the consumer contract
+    /// at `crap-core::domain::matching::compute_branch_coverage`, each
+    /// `BranchCoverage` row represents ONE branch arm — total = N
+    /// records, covered = records with taken > 0. So one Istanbul
+    /// branchId with K arms fans into K separate rows at the branching
+    /// site's line, each carrying that arm's `taken` count. (Summing
+    /// arm hits into a single record would collapse partial coverage
+    /// into 100% — see PR body's plan-of-record deviation note.)
+    /// Sorted by line for deterministic downstream consumers.
+    fn branch_coverage_for(
+        entry: &IstanbulCoverageFile,
+        diagnostics: &mut Vec<IstanbulParseDiagnostic>,
+    ) -> Vec<BranchCoverage> {
+        let mut branches: Vec<BranchCoverage> = Vec::new();
+        for (branch_id, arms) in &entry.b {
+            let Some(loc) = entry.branch_map.get(branch_id) else {
+                diagnostics.push(IstanbulParseDiagnostic {
+                    file_path: entry.path.clone(),
+                    kind: IstanbulDiagnosticKind::BranchMismatch,
+                    message: format!(
+                        "branch coverage record for branchId `{branch_id}` references no entry in branchMap. This is likely a bug in your coverage tool — report at the coverage tool's issue tracker."
+                    ),
+                    line: None,
+                });
+                continue;
+            };
+            // Prefer the emitter-set `line` when present (some emitters
+            // set it to the branching keyword's line independent of
+            // `loc`); fall back to `loc.start.line`.
+            let line = loc.line.unwrap_or(loc.loc.start.line) as usize;
+            for hits in arms {
+                branches.push(BranchCoverage {
+                    line,
+                    taken: Some(*hits),
+                });
+            }
+        }
+        branches.sort_by_key(|b| b.line);
+        branches
     }
 
     /// Try the one-level unwrap arm: `{"<single-key>": <flat-map>}`.

--- a/crates/crap4ts/src/adapters/walker/mod.rs
+++ b/crates/crap4ts/src/adapters/walker/mod.rs
@@ -1281,14 +1281,10 @@ impl<'src> FunctionFinder<'src> {
         out: &mut Contributors,
         nesting: Option<u32>,
     ) {
-        let qualify = |name: &str| match prefix {
-            Some(p) => format!("{p}.{name}"),
-            None => name.to_string(),
-        };
         match stmt {
             Statement::FunctionDeclaration(func) => {
                 let local = func.id.as_ref().map(|id| id.name.as_str());
-                self.record_function(func, local.map(&qualify));
+                self.record_function(func, local.map(|n| qualify(prefix, n)));
             }
             Statement::ClassDeclaration(class) => {
                 let local = class
@@ -1298,29 +1294,10 @@ impl<'src> FunctionFinder<'src> {
                     // Anonymous class in a namespace composes the
                     // existing sentinel: `A.<anonymous class>.m`.
                     .unwrap_or("<anonymous class>");
-                self.visit_class_body(class, &qualify(local));
+                self.visit_class_body(class, &qualify(prefix, local));
             }
             Statement::VariableDeclaration(vd) => {
-                // Mirror `visit_variable_declaration_in_body`: route
-                // function-valued initializers to their recorders with
-                // the qualified name, and thread `out`/`nesting` for
-                // every other initializer so a namespace nested in a
-                // function body charges its initializer decision points
-                // to that function (the contract this module documents).
-                for declarator in &vd.declarations {
-                    let name = binding_name(&declarator.id).map(|n| qualify(&n));
-                    let Some(init) = &declarator.init else {
-                        continue;
-                    };
-                    match init {
-                        Expression::ArrowFunctionExpression(arrow) => {
-                            self.record_arrow(arrow, name)
-                        }
-                        Expression::FunctionExpression(func) => self.record_function(func, name),
-                        Expression::ClassExpression(class) => self.visit_class(class, name),
-                        other => self.visit_expression(other, out, nesting),
-                    }
-                }
+                self.visit_namespace_var_decl(vd, prefix, out, nesting)
             }
             Statement::ExportNamedDeclaration(decl) => {
                 // `export function bar()` / `export class C` inside a
@@ -1331,32 +1308,70 @@ impl<'src> FunctionFinder<'src> {
                 }
             }
             Statement::ExportDefaultDeclaration(decl) => {
-                // `export default function f` / `export default class C`
-                // inside a namespace must carry the prefix like every
-                // other namespace member; a default-exported *expression*
-                // has no declaration name to qualify, so it keeps the
-                // ordinary expression handling.
-                use oxc::ast::ast::ExportDefaultDeclarationKind as K;
-                match &decl.declaration {
-                    K::FunctionDeclaration(func) => {
-                        let local = func.id.as_ref().map(|id| id.name.as_str());
-                        self.record_function(func, local.map(&qualify));
-                    }
-                    K::ClassDeclaration(class) => {
-                        let local = class
-                            .id
-                            .as_ref()
-                            .map(|bi| bi.name.as_str())
-                            .unwrap_or("<anonymous class>");
-                        self.visit_class_body(class, &qualify(local));
-                    }
-                    _ => self.visit_export_default(decl),
-                }
+                self.visit_namespace_export_default(decl, prefix)
             }
             Statement::TSModuleDeclaration(inner) => {
                 self.visit_ts_module_declaration_prefixed(inner, prefix, out, nesting);
             }
             other => self.visit_statement(other, out, nesting),
+        }
+    }
+
+    /// Shared namespace-member `VariableDeclaration` handling for both
+    /// [`Self::visit_namespace_statement`] (bare statement) and
+    /// [`Self::visit_namespace_declaration`] (reached through `export
+    /// …`). Mirrors `visit_variable_declaration_in_body`: route
+    /// function-valued initializers to their recorders with the
+    /// `prefix`-qualified name, and thread `out`/`nesting` for every
+    /// other initializer so a namespace nested in a function body
+    /// charges its initializer decision points to that function (the
+    /// contract this module documents).
+    fn visit_namespace_var_decl(
+        &mut self,
+        vd: &oxc::ast::ast::VariableDeclaration<'_>,
+        prefix: Option<&str>,
+        out: &mut Contributors,
+        nesting: Option<u32>,
+    ) {
+        for declarator in &vd.declarations {
+            let name = binding_name(&declarator.id).map(|n| qualify(prefix, &n));
+            let Some(init) = &declarator.init else {
+                continue;
+            };
+            match init {
+                Expression::ArrowFunctionExpression(arrow) => self.record_arrow(arrow, name),
+                Expression::FunctionExpression(func) => self.record_function(func, name),
+                Expression::ClassExpression(class) => self.visit_class(class, name),
+                other => self.visit_expression(other, out, nesting),
+            }
+        }
+    }
+
+    /// Shared namespace-member `export default …` handling. `export
+    /// default function f` / `export default class C` inside a
+    /// namespace must carry the prefix like every other namespace
+    /// member; a default-exported *expression* has no declaration name
+    /// to qualify, so it keeps the ordinary expression handling.
+    fn visit_namespace_export_default(
+        &mut self,
+        decl: &oxc::ast::ast::ExportDefaultDeclaration<'_>,
+        prefix: Option<&str>,
+    ) {
+        use oxc::ast::ast::ExportDefaultDeclarationKind as K;
+        match &decl.declaration {
+            K::FunctionDeclaration(func) => {
+                let local = func.id.as_ref().map(|id| id.name.as_str());
+                self.record_function(func, local.map(|n| qualify(prefix, n)));
+            }
+            K::ClassDeclaration(class) => {
+                let local = class
+                    .id
+                    .as_ref()
+                    .map(|bi| bi.name.as_str())
+                    .unwrap_or("<anonymous class>");
+                self.visit_class_body(class, &qualify(prefix, local));
+            }
+            _ => self.visit_export_default(decl),
         }
     }
 
@@ -1373,14 +1388,10 @@ impl<'src> FunctionFinder<'src> {
         out: &mut Contributors,
         nesting: Option<u32>,
     ) {
-        let qualify = |name: &str| match prefix {
-            Some(p) => format!("{p}.{name}"),
-            None => name.to_string(),
-        };
         match decl {
             Declaration::FunctionDeclaration(func) => {
                 let local = func.id.as_ref().map(|id| id.name.as_str());
-                self.record_function(func, local.map(&qualify));
+                self.record_function(func, local.map(|n| qualify(prefix, n)));
             }
             Declaration::ClassDeclaration(class) => {
                 let local = class
@@ -1388,23 +1399,10 @@ impl<'src> FunctionFinder<'src> {
                     .as_ref()
                     .map(|bi| bi.name.as_str())
                     .unwrap_or("<anonymous class>");
-                self.visit_class_body(class, &qualify(local));
+                self.visit_class_body(class, &qualify(prefix, local));
             }
             Declaration::VariableDeclaration(vd) => {
-                for declarator in &vd.declarations {
-                    let name = binding_name(&declarator.id).map(|n| qualify(&n));
-                    let Some(init) = &declarator.init else {
-                        continue;
-                    };
-                    match init {
-                        Expression::ArrowFunctionExpression(arrow) => {
-                            self.record_arrow(arrow, name)
-                        }
-                        Expression::FunctionExpression(func) => self.record_function(func, name),
-                        Expression::ClassExpression(class) => self.visit_class(class, name),
-                        other => self.visit_expression(other, out, nesting),
-                    }
-                }
+                self.visit_namespace_var_decl(vd, prefix, out, nesting)
             }
             // TS type / interface / enum declarations have no
             // executable bodies (same as `visit_top_level_declaration`).
@@ -1433,6 +1431,16 @@ impl Contributors {
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────────
+
+/// Compose a namespace-qualified member name: `prefix.name` when a
+/// prefix is in scope, else the bare `name`. Replaces the per-call
+/// `qualify` closure so the namespace dispatch helpers can share it.
+fn qualify(prefix: Option<&str>, name: &str) -> String {
+    match prefix {
+        Some(p) => format!("{p}.{name}"),
+        None => name.to_string(),
+    }
+}
 
 fn contributor(
     kind: ContributorKind,

--- a/crates/crap4ts/tests/cyclomatic_walker_cucumber.rs
+++ b/crates/crap4ts/tests/cyclomatic_walker_cucumber.rs
@@ -1,0 +1,353 @@
+//! Cucumber-rs runner for `tests/features/cyclomatic_walker.feature`.
+//!
+//! Wires the cyclomatic-walker BDD contract directly against
+//! `OxcWalker` (the same library entry point `walker_smoke.rs` unit
+//! tests), not the binary. The walker is pure (source in →
+//! `Vec<FunctionComplexity>` out), so the spec is executable without a
+//! coverage file or a tempdir: the feature's
+//! `crap4ts --coverage cov.json --src .` line is the *spec's* narration
+//! of "analyze this source"; the executable form is a direct
+//! `extract(...)` call. This keeps the BDD layer inside the public
+//! adapter contract and lets the spec stop drifting from the walker.
+//!
+//! The risk-classification scenario carries no source — it asserts the
+//! metric-invariant CRAP formula, so it routes through
+//! `crap_core::domain::crap::compute_crap` instead of the walker.
+//!
+//! Scenario-outline constructs (`if (cond) { … }`, `a ?? fallback`, …)
+//! are synthesized into minimal valid TS that yields exactly the one
+//! decision point under test — the canned bodies mirror the shapes
+//! `walker_smoke.rs` fixtures already pin, so the two layers agree.
+//!
+//! Named `*_cucumber` (suffix, not the `cucumber_*` prefix the plan
+//! prose used) because `.config/nextest.toml` excludes
+//! `binary(/.*_cucumber$/)` — the suffix is the load-bearing convention
+//! shared with crap4rs's `json_reporter_cucumber`.
+
+use crap_core::domain::crap::compute_crap;
+use crap_core::domain::types::{ComplexityMetric, CrapScore, FunctionComplexity, RiskLevel};
+use crap_core::ports::ComplexityPort;
+use crap4ts::adapters::walker::OxcWalker;
+use cucumber::{World, gherkin::Step, given, then, when, writer};
+
+/// State threaded through one scenario. Either `source` (→ run the
+/// walker) or `synth` (→ run the CRAP formula) is populated by a Given;
+/// the When materializes `fns` or `crap`.
+#[derive(Debug, Default, World)]
+struct WalkerWorld {
+    source: Option<String>,
+    is_jsx: bool,
+    fns: Vec<FunctionComplexity>,
+    synth: Option<(u32, f64)>,
+    crap: Option<CrapScore>,
+}
+
+impl WalkerWorld {
+    /// The single discovered function. Outline + JSX + compound
+    /// scenarios each define exactly one top-level function, so the
+    /// "the function's …" steps resolve unambiguously.
+    fn only_fn(&self) -> &FunctionComplexity {
+        assert_eq!(
+            self.fns.len(),
+            1,
+            "expected exactly one function in the source; got {:?}",
+            self.fns
+                .iter()
+                .map(|f| &f.identity.qualified_name)
+                .collect::<Vec<_>>()
+        );
+        &self.fns[0]
+    }
+
+    fn find_fn(&self, name: &str) -> &FunctionComplexity {
+        self.fns
+            .iter()
+            .find(|f| f.identity.qualified_name == name)
+            .unwrap_or_else(|| {
+                panic!(
+                    "function `{name}` not discovered; got {:?}",
+                    self.fns
+                        .iter()
+                        .map(|f| &f.identity.qualified_name)
+                        .collect::<Vec<_>>()
+                )
+            })
+    }
+
+    fn count_kind(f: &FunctionComplexity, kind: &str) -> usize {
+        f.contributors
+            .iter()
+            .filter(|c| c.kind.as_wire_str() == kind)
+            .count()
+    }
+}
+
+/// Strip backticks + collapse whitespace so the outline's
+/// `` `if (cond) { … }` `` cell (which the step wraps in another pair
+/// of backticks) normalizes to a stable match key.
+fn normalize_construct(raw: &str) -> String {
+    raw.replace('`', "")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Map an outline construct to minimal valid TS containing exactly the
+/// one decision point under test. Bodies are deliberately tiny (no
+/// stray branches) and reference undeclared helpers — oxc parses without
+/// type-checking, and the walker only counts decision points. The
+/// shapes mirror `walker_smoke.rs` fixtures so both layers agree on the
+/// count.
+fn synth_source(construct: &str) -> &'static str {
+    match normalize_construct(construct).as_str() {
+        "if (cond) { … }" => {
+            "function f(cond: boolean): number { if (cond) { return 1; } return 0; }"
+        }
+        "for (let i = 0; i < n; i++) { … }" => {
+            "function f(n: number): void { for (let i = 0; i < n; i++) { void i; } }"
+        }
+        "for (const x of xs) { … }" => {
+            "function f(xs: number[]): void { for (const x of xs) { void x; } }"
+        }
+        "for (const k in obj) { … }" => {
+            "function f(obj: Record<string, number>): void { for (const k in obj) { void k; } }"
+        }
+        "while (cond) { … }" => {
+            "function f(cond: boolean): void { while (cond) { cond = step(); } }"
+        }
+        "do { … } while (cond)" => {
+            "function f(cond: boolean): void { do { cond = step(); } while (cond); }"
+        }
+        // One `case`, plus a `default:` that is NOT a decision point —
+        // matches `walker_smoke.rs::switch_case_contributes_one_case_branch`.
+        "switch (x) { case 1: … }" => {
+            "function f(x: number): string { switch (x) { case 1: return \"one\"; default: return \"other\"; } }"
+        }
+        "a && b" => "function f(a: any, b: any): any { return a && b; }",
+        "a || b" => "function f(a: any, b: any): any { return a || b; }",
+        "cond ? a : b" => "function f(cond: boolean, a: any, b: any): any { return cond ? a : b; }",
+        "obj?.field" => "function f(obj: any): any { return obj?.field; }",
+        "obj?.method()" => "function f(obj: any): any { return obj?.method(); }",
+        "a ?? fallback" => "function f(a: any, fallback: any): any { return a ?? fallback; }",
+        "try { … } catch (e) { … }" => {
+            "function f(): void { try { risky(); } catch (e) { handle(e); } }"
+        }
+        other => panic!("no synthesized source for construct {other:?}"),
+    }
+}
+
+// ── Given ────────────────────────────────────────────────────────────
+
+/// cucumber-rs prefixes a docstring with a leading `\n` (the newline
+/// after the opening `"""`). Strip exactly one so line 1 of the spec's
+/// code block is line 1 to the walker — otherwise every reported
+/// contributor line is off by one versus the feature author's intent
+/// (e.g. the `if-branch at line 2` assertion).
+fn docstring_source(step: &Step) -> String {
+    let raw = step.docstring().expect("scenario docstring");
+    raw.strip_prefix('\n').unwrap_or(raw).to_string()
+}
+
+#[given("a TypeScript source file containing:")]
+fn given_ts_source(world: &mut WalkerWorld, step: &Step) {
+    world.source = Some(docstring_source(step));
+    world.is_jsx = false;
+}
+
+#[given("a TypeScript JSX source file containing:")]
+fn given_tsx_source(world: &mut WalkerWorld, step: &Step) {
+    world.source = Some(docstring_source(step));
+    world.is_jsx = true;
+}
+
+#[given(regex = r"^a TypeScript source file containing the construct (.+)$")]
+fn given_construct(world: &mut WalkerWorld, construct: String) {
+    world.source = Some(synth_source(&construct).to_string());
+    world.is_jsx = false;
+}
+
+#[given(regex = r"^a TypeScript function with cyclomatic complexity (\d+) and coverage (\d+)%$")]
+fn given_synthetic_function(world: &mut WalkerWorld, complexity: u32, coverage: f64) {
+    world.synth = Some((complexity, coverage));
+}
+
+// ── When ─────────────────────────────────────────────────────────────
+
+#[when(regex = r"^the operator runs `crap4ts .*`$")]
+fn when_analyzed(world: &mut WalkerWorld) {
+    if let Some((complexity, coverage)) = world.synth {
+        world.crap =
+            Some(compute_crap(complexity, coverage).expect("compute_crap on valid inputs"));
+        return;
+    }
+    let source = world.source.as_ref().expect("source set by a Given step");
+    let file = if world.is_jsx {
+        "snippet.tsx"
+    } else {
+        "snippet.ts"
+    };
+    world.fns = OxcWalker::new()
+        .extract(source, file, ComplexityMetric::Cyclomatic)
+        .unwrap_or_else(|e| panic!("walker extract failed for {file}: {e}"));
+}
+
+// ── Then: per-named-function ─────────────────────────────────────────
+
+#[then(regex = r"^the report includes function `(\w+)` with cyclomatic complexity (\d+)$")]
+fn then_named_complexity(world: &mut WalkerWorld, name: String, expected: u32) {
+    let f = world.find_fn(&name);
+    assert_eq!(
+        f.complexity, expected,
+        "`{name}` cyclomatic complexity: expected {expected}, got {} (contributors: {:?})",
+        f.complexity, f.contributors
+    );
+    assert_eq!(f.metric, ComplexityMetric::Cyclomatic);
+}
+
+#[then(regex = r"^no contributors are emitted for `(\w+)`$")]
+fn then_no_contributors(world: &mut WalkerWorld, name: String) {
+    let f = world.find_fn(&name);
+    assert!(
+        f.contributors.is_empty(),
+        "expected no contributors for `{name}`, got {:?}",
+        f.contributors
+    );
+}
+
+#[then(regex = r"^the contributors include one `([a-z-]+)` at line (\d+)$")]
+fn then_one_kind_at_line(world: &mut WalkerWorld, kind: String, line: usize) {
+    let f = world.only_fn();
+    let matching: Vec<_> = f
+        .contributors
+        .iter()
+        .filter(|c| c.kind.as_wire_str() == kind)
+        .collect();
+    assert_eq!(
+        matching.len(),
+        1,
+        "expected exactly one `{kind}` contributor, got {:?}",
+        f.contributors
+    );
+    assert_eq!(
+        matching[0].line, line,
+        "`{kind}` should be at line {line}, got {}",
+        matching[0].line
+    );
+}
+
+#[then(regex = r"^`(\w+)`'s contributors include one `([a-z-]+)` entry$")]
+fn then_named_one_kind(world: &mut WalkerWorld, name: String, kind: String) {
+    let f = world.find_fn(&name);
+    assert_eq!(
+        WalkerWorld::count_kind(f, &kind),
+        1,
+        "`{name}` should have exactly one `{kind}` contributor, got {:?}",
+        f.contributors
+    );
+}
+
+// ── Then: single-function ────────────────────────────────────────────
+
+#[then(regex = r"^the function's cyclomatic complexity is `?(\d+)`?$")]
+fn then_single_complexity(world: &mut WalkerWorld, expected: u32) {
+    let f = world.only_fn();
+    assert_eq!(
+        f.complexity, expected,
+        "cyclomatic complexity: expected {expected}, got {} (contributors: {:?})",
+        f.complexity, f.contributors
+    );
+}
+
+#[then(regex = r"^the contributors include exactly (one|two|three) `([a-z-]+)` (?:entry|entries)$")]
+fn then_exact_count(world: &mut WalkerWorld, count_word: String, kind: String) {
+    let expected = match count_word.as_str() {
+        "one" => 1,
+        "two" => 2,
+        "three" => 3,
+        other => panic!("unhandled count word {other:?}"),
+    };
+    let f = world.only_fn();
+    assert_eq!(
+        WalkerWorld::count_kind(f, &kind),
+        expected,
+        "expected {expected} `{kind}` contributor(s), got {:?}",
+        f.contributors
+    );
+}
+
+#[then(regex = r"^the contributors list contains exactly one entry of kind `([a-z-]+)`$")]
+fn then_exactly_one_of_kind(world: &mut WalkerWorld, kind: String) {
+    let f = world.only_fn();
+    assert_eq!(
+        WalkerWorld::count_kind(f, &kind),
+        1,
+        "expected exactly one `{kind}` contributor, got {:?}",
+        f.contributors
+    );
+}
+
+#[then("the JSX conditional is counted via the existing `logical-operator` contributor")]
+fn then_jsx_via_logical(world: &mut WalkerWorld) {
+    let f = world.only_fn();
+    assert!(
+        WalkerWorld::count_kind(f, "logical-operator") >= 1,
+        "expected a logical-operator contributor for the JSX `&&`, got {:?}",
+        f.contributors
+    );
+}
+
+// ── Then: CRAP formula (metric-invariant risk) ───────────────────────
+
+#[then(regex = r"^the function's CRAP score is (\d+\.\d+)$")]
+fn then_crap_score(world: &mut WalkerWorld, expected: f64) {
+    let crap = world.crap.as_ref().expect("crap computed by the When step");
+    assert!(
+        (crap.value - expected).abs() < 1e-9,
+        "CRAP score: expected {expected}, got {}",
+        crap.value
+    );
+}
+
+#[then(regex = r"^the function's risk classification is `([a-z]+)`$")]
+fn then_risk(world: &mut WalkerWorld, expected: String) {
+    let crap = world.crap.as_ref().expect("crap computed by the When step");
+    let actual = match crap.risk_level {
+        RiskLevel::Low => "low",
+        RiskLevel::Acceptable => "acceptable",
+        RiskLevel::Moderate => "moderate",
+        RiskLevel::High => "high",
+    };
+    assert_eq!(actual, expected, "risk classification");
+}
+
+// ── Runner ───────────────────────────────────────────────────────────
+
+#[tokio::main]
+async fn main() {
+    // `@wired`-only filter per AGENTS.md rule 5: scenarios still
+    // `@unwired` (none in this file once W3.3 migrates them, but the
+    // filter is the durable contract) are skipped, not failed.
+    // `Libtest::or_basic()` emits libtest-JSON under nextest probing and
+    // the human writer under plain `cargo test`. `filter_run_and_exit`
+    // (not `run`) gives a non-zero exit on scenario failure.
+    //
+    // `with_default_cli()` skips argv parsing. `cargo mutants --package
+    // crap4ts` (the per-merge walker-mutants gate) runs `cargo test --
+    // --skip <name>` and those trailing libtest args reach EVERY crap4ts
+    // test binary. cucumber's strict clap CLI rejects `--skip`, which
+    // aborts the UNMUTATED baseline (`cargo test failed in an unmutated
+    // tree`) and zeroes the gate — the crap-rs#224 gate-zeroing class.
+    // A default `cli::Opts` makes the harness ignore those passthrough
+    // args entirely, keeping the gate live with zero mutants-config
+    // growth. (No libtest formatting args are lost: this binary is
+    // excluded from nextest probing by the `_cucumber$` filter and runs
+    // under plain `cargo test` everywhere else, where no libtest args
+    // are passed.)
+    WalkerWorld::cucumber()
+        .with_writer(writer::Libtest::or_basic())
+        .with_default_cli()
+        .filter_run_and_exit("tests/features/cyclomatic_walker.feature", |_, _, sc| {
+            sc.tags.iter().any(|t| t == "wired")
+        })
+        .await;
+}

--- a/crates/crap4ts/tests/features/arrow_function_coverage.feature
+++ b/crates/crap4ts/tests/features/arrow_function_coverage.feature
@@ -3,22 +3,9 @@ Feature: Arrow-function coverage accuracy
   I want crap4ts to count my arrow-function executions correctly
   So that my CRAP scores reflect what's actually exercised by my test suite
 
-  Background:
-    # Promoted from breadboard reflection note #5 to a W1.1 AC per CPO Concern 2.
-    # Istanbul records coverage in two parallel tables: `s` (statement counts +
-    # statementMap) and `f` (function counts + fnMap). Line-coverage-from-statements
-    # may undercount arrow-function invocations because the function-invocation
-    # site is in `f`/`fnMap`, not necessarily `s`/`statementMap`. Modern TS
-    # codebases are arrow-function-heavy (useCallback, hooks, Svelte stores).
-    # If this scenario fails on the W1.1 minimal parser, W2.3 grows to populate
-    # coverage from f/fnMap rather than just s/statementMap.
-    # CQO BDD audit: all 4 scenarios use concrete docstring fixtures + explicit
-    # expected percentages — assertions must distinguish 100% covered from 10%
-    # covered (the exact undercount failure mode this feature canary catches).
-
   @unwired
   Scenario: An invoked arrow function has matching coverage
-    # tracked: crap-rs#173 — W1.1 arrow-function fixture sanity; harness lands in W3.3
+    # tracked: crap-rs#229 — cucumber harness deferred from W3.3 #191 (pre-GA)
     Given a TypeScript source file `src/arrow.ts` containing:
       """
       export const square = (x: number) => x * x;
@@ -32,7 +19,7 @@ Feature: Arrow-function coverage accuracy
 
   @unwired
   Scenario: A useCallback-style arrow has matching coverage
-    # tracked: crap-rs#173 — W1.1 React-idiom arrow-heavy fixture; harness lands in W3.3
+    # tracked: crap-rs#229 — cucumber harness deferred from W3.3 #191 (pre-GA)
     Given a TypeScript source file `src/Button.tsx` containing:
       """
       import { useCallback } from 'react';
@@ -48,7 +35,7 @@ Feature: Arrow-function coverage accuracy
 
   @unwired
   Scenario: An array.map(arrow) covers the inner arrow
-    # tracked: crap-rs#173 — W1.1 functional-pattern arrow coverage; harness lands in W3.3
+    # tracked: crap-rs#229 — cucumber harness deferred from W3.3 #191 (pre-GA)
     Given a TypeScript source file `src/map.ts` containing:
       """
       export function increment(xs: number[]): number[] {
@@ -62,7 +49,7 @@ Feature: Arrow-function coverage accuracy
 
   @unwired
   Scenario: Mixed function-expression / arrow / declared-function bodies in one file
-    # tracked: crap-rs#173 — W1.1 mixed-syntax fixture sanity; harness lands in W3.3
+    # tracked: crap-rs#229 — cucumber harness deferred from W3.3 #191 (pre-GA)
     Given a TypeScript source file `src/mixed.ts` containing:
       """
       export function declared() { return 1; }

--- a/crates/crap4ts/tests/features/branch_coverage.feature
+++ b/crates/crap4ts/tests/features/branch_coverage.feature
@@ -3,16 +3,9 @@ Feature: Istanbul branch coverage flows through to the scorecard
   I want crap4ts to surface per-function branch coverage alongside line coverage
   So that I can identify functions whose branches are tested but whose statements are not (or vice versa)
 
-  Background:
-    # Per CAO advisory A-3, branch coverage uses the EXISTING
-    # ParseOutput.branches: Option<HashMap<String, Vec<BranchCoverage>>> slot
-    # already defined in crap-core::ports::ParseOutput. No new parallel seam.
-    # W2.3 lands this: extend IstanbulCoverage::parse to consume `b` records
-    # alongside `s` records.
-
   @unwired
   Scenario: A coverage-final.json with branch records populates ParseOutput.branches
-    # tracked: crap-rs#173 — W2.3 branch coverage extension; harness lands in W3.3
+    # tracked: crap-rs#229 — cucumber harness deferred from W3.3 #191 (pre-GA)
     Given an Istanbul `coverage-final.json` whose entries include `b` and `branchMap` records
     When the operator runs `crap4ts --coverage coverage-final.json --src src`
     Then the report includes a branch-coverage column for every covered function
@@ -21,7 +14,7 @@ Feature: Istanbul branch coverage flows through to the scorecard
 
   @unwired
   Scenario: A coverage-final.json with NO branch records leaves ParseOutput.branches as None
-    # tracked: crap-rs#173 — W2.3 default branches=None when adapter doesn't emit; harness lands in W3.3
+    # tracked: crap-rs#229 — cucumber harness deferred from W3.3 #191 (pre-GA)
     Given an Istanbul `coverage-final.json` whose entries have empty `b` and empty `branchMap`
     When the operator runs `crap4ts --coverage coverage-final.json --src src`
     Then the scorecard renders with no branch-coverage column
@@ -29,7 +22,7 @@ Feature: Istanbul branch coverage flows through to the scorecard
 
   @unwired
   Scenario: A function's branch coverage joins its line coverage in the report
-    # tracked: crap-rs#173 — W2.3 per-function branch coverage join; harness lands in W3.3
+    # tracked: crap-rs#229 — cucumber harness deferred from W3.3 #191 (pre-GA)
     Given a TypeScript function with cyclomatic complexity 3 (one if/else, one ternary)
     And a coverage-final.json showing 4 of 6 branches hit (66% branch coverage)
     And the same function shows 100% line coverage in the `s` record
@@ -40,7 +33,7 @@ Feature: Istanbul branch coverage flows through to the scorecard
 
   @unwired
   Scenario: A b record references a branchId not in branchMap emits BranchMismatch
-    # tracked: crap-rs#173 — W2.3 mismatch surfaces as diagnostic, not silent drop; harness lands in W3.3
+    # tracked: crap-rs#229 — cucumber harness deferred from W3.3 #191 (pre-GA)
     Given an Istanbul `coverage-final.json` whose `b` references branchId `42` and `branchMap` omits `42`
     When the operator runs `crap4ts --coverage coverage-final.json --src src`
     Then the parser emits an `IstanbulParseDiagnostic` with kind `branch-mismatch`

--- a/crates/crap4ts/tests/features/cyclomatic_walker.feature
+++ b/crates/crap4ts/tests/features/cyclomatic_walker.feature
@@ -3,15 +3,8 @@ Feature: Cyclomatic complexity for TypeScript via the oxc walker
   I want cyclomatic complexity scores that match my intuition about decision points
   So that I can identify functions that need refactoring or more tests
 
-  Background:
-    # Cyclomatic complexity counts decision points. Per ADR D5, crap4ts defaults
-    # to --metric cyclomatic with threshold 16. Per ADR D8, risk-cutoffs are
-    # metric-invariant (5/8/30). Decision points map to ContributorKind
-    # variants already in crap-core's domain (no new variants for TS).
-
-  @unwired
+  @wired
   Scenario: A function with no decision points scores complexity 1
-    # tracked: crap-rs#173 — W1.2 baseline; harness lands in W3.3
     Given a TypeScript source file containing:
       """
       export function greet(name: string): string {
@@ -22,9 +15,8 @@ Feature: Cyclomatic complexity for TypeScript via the oxc walker
     Then the report includes function `greet` with cyclomatic complexity 1
     And no contributors are emitted for `greet`
 
-  @unwired
+  @wired
   Scenario: An if/else branch increments complexity by 1
-    # tracked: crap-rs#173 — W1.2 IfBranch contributor; harness lands in W3.3
     Given a TypeScript source file containing:
       """
       export function classify(x: number): string {
@@ -36,9 +28,8 @@ Feature: Cyclomatic complexity for TypeScript via the oxc walker
     Then the report includes function `classify` with cyclomatic complexity 2
     And the contributors include one `if-branch` at line 2
 
-  @unwired
+  @wired
   Scenario Outline: Each universal decision-point construct contributes 1
-    # tracked: crap-rs#173 — W1.2 universal decision points; harness lands in W3.3
     Given a TypeScript source file containing the construct `<construct>`
     When the operator runs `crap4ts --coverage cov.json --src .`
     Then the function's cyclomatic complexity is `<base + 1>`
@@ -56,9 +47,8 @@ Feature: Cyclomatic complexity for TypeScript via the oxc walker
       | `a && b`                               | 2        | logical-operator |
       | `a \|\| b`                             | 2        | logical-operator |
 
-  @unwired
+  @wired
   Scenario Outline: TypeScript-specific decision points add to cyclomatic
-    # tracked: crap-rs#173 — W2.1 TS-specific decision points; harness lands in W3.3
     Given a TypeScript source file containing the construct `<construct>`
     When the operator runs `crap4ts --coverage cov.json --src .`
     Then the function's cyclomatic complexity is `<base + 1>`
@@ -72,9 +62,8 @@ Feature: Cyclomatic complexity for TypeScript via the oxc walker
       | `a ?? fallback`                        | 2        | logical-operator |
       | `try { … } catch (e) { … }`            | 2        | catch            |
 
-  @unwired
+  @wired
   Scenario: JSX conditional rendering decomposes through logical-operator
-    # tracked: crap-rs#173 — W2.1 JSX patterns reuse existing logical-operator variant
     Given a TypeScript JSX source file containing:
       """
       function Greeting({ visible, name }: { visible: boolean, name: string }) {
@@ -86,9 +75,8 @@ Feature: Cyclomatic complexity for TypeScript via the oxc walker
     And the JSX conditional is counted via the existing `logical-operator` contributor
     And the contributors list contains exactly one entry of kind `logical-operator`
 
-  @unwired
+  @wired
   Scenario: Nested functions are tracked as their own complexity sites
-    # tracked: crap-rs#173 — W1.2 function discovery semantics; harness lands in W3.3
     Given a TypeScript source file containing:
       """
       export function outer(xs: number[]) {
@@ -101,9 +89,8 @@ Feature: Cyclomatic complexity for TypeScript via the oxc walker
     And the report includes function `inner` with cyclomatic complexity 2
     And `inner`'s contributors include one `ternary` entry
 
-  @unwired
+  @wired
   Scenario: A chained ternary contributes one decision point per `?`
-    # tracked: crap-rs#173 — W2.1 chained-construct stacking grounds ADR (a); harness lands in W3.3
     Given a TypeScript source file containing:
       """
       export function classify(x: number): string {
@@ -114,9 +101,8 @@ Feature: Cyclomatic complexity for TypeScript via the oxc walker
     Then the report includes function `classify` with cyclomatic complexity 3
     And the contributors include exactly two `ternary` entries
 
-  @unwired
+  @wired
   Scenario: A chained logical-operator expression contributes one per operator
-    # tracked: crap-rs#173 — W2.1 chained-construct stacking grounds ADR (a); harness lands in W3.3
     Given a TypeScript source file containing:
       """
       export function allTruthy(a: any, b: any, c: any, d: any): boolean {
@@ -127,9 +113,8 @@ Feature: Cyclomatic complexity for TypeScript via the oxc walker
     Then the report includes function `allTruthy` with cyclomatic complexity 4
     And the contributors include exactly three `logical-operator` entries
 
-  @unwired
+  @wired
   Scenario: Nested if-statements contribute one per if-branch (no flattening)
-    # tracked: crap-rs#173 — W1.2 nested-if stacking grounds ADR (a); harness lands in W3.3
     Given a TypeScript source file containing:
       """
       export function deep(a: number, b: number): string {
@@ -143,9 +128,8 @@ Feature: Cyclomatic complexity for TypeScript via the oxc walker
     Then the report includes function `deep` with cyclomatic complexity 3
     And the contributors include exactly two `if-branch` entries
 
-  @unwired
+  @wired
   Scenario: Compound construct `if (a && b)` counts the `if` AND the `&&` (no skipping)
-    # tracked: crap-rs#173 — W1.2 compound-construct stacking; harness lands in W3.3
     # Per CQO BDD audit — outline tests isolation only; this scenario catches the
     # failure mode where the walker visits the `if` but skips into-`&&`-descent.
     Given a TypeScript source file containing:
@@ -160,9 +144,8 @@ Feature: Cyclomatic complexity for TypeScript via the oxc walker
     And the contributors include exactly one `if-branch` entry
     And the contributors include exactly one `logical-operator` entry
 
-  @unwired
+  @wired
   Scenario: Risk classification is metric-invariant per ADR D8
-    # tracked: crap-rs#173 — W1.2 risk bucket parity with crap4rs; harness lands in W3.3
     Given a TypeScript function with cyclomatic complexity 4 and coverage 50%
     When the operator runs `crap4ts --coverage cov.json --src .`
     Then the function's CRAP score is 6.0

--- a/crates/crap4ts/tests/features/file_extensions.feature
+++ b/crates/crap4ts/tests/features/file_extensions.feature
@@ -3,14 +3,9 @@ Feature: TypeScript file extension discovery and parsing
   I want crap4ts to discover and parse my .ts, .tsx, .jsx, .mjs, and .cjs files
   So that I don't have to pre-filter the file list or write a custom discovery script
 
-  Background:
-    # crap4ts's AdapterMeta.extensions = ["ts", "tsx", "js", "jsx", "mjs", "cjs"].
-    # The walker dispatches to oxc with the correct SourceType per extension
-    # (W2.2). All five extensions discover + parse without runtime panic.
-
   @unwired
   Scenario Outline: Files with supported extensions are discovered and parsed
-    # tracked: crap-rs#173 — W2.2 extension dispatch matrix; per CQO each row specifies dialect-appropriate content; harness lands in W3.3
+    # tracked: crap-rs#229 — cucumber harness deferred from W3.3 #191 (pre-GA)
     Given a source tree under `src/` containing a single file `example<extension>` with contents `<content>`
     And a valid Istanbul `coverage-final.json` covering that file
     When the operator runs `crap4ts --coverage coverage-final.json --src src`
@@ -28,7 +23,7 @@ Feature: TypeScript file extension discovery and parsing
 
   @unwired
   Scenario: A .d.ts file is skipped by default (declaration-only, no executable code)
-    # tracked: crap-rs#173 — W2.2 declaration-only exclusion; harness lands in W3.3
+    # tracked: crap-rs#229 — cucumber harness deferred from W3.3 #191 (pre-GA)
     Given a source tree under `src/` containing `types.d.ts` and `app.ts`
     And the operator's `crap4ts.toml` does NOT explicitly include `.d.ts`
     When the operator runs `crap4ts --coverage coverage-final.json --src src`
@@ -37,7 +32,7 @@ Feature: TypeScript file extension discovery and parsing
 
   @unwired
   Scenario: A .test.ts file is included unless excluded via crap4ts.toml
-    # tracked: crap-rs#173 — W2.2 test-file inclusion default; harness lands in W3.3
+    # tracked: crap-rs#229 — cucumber harness deferred from W3.3 #191 (pre-GA)
     Given a source tree under `src/` containing `app.ts` and `app.test.ts`
     And the operator's `crap4ts.toml` has no exclusion for `.test.ts`
     When the operator runs `crap4ts --coverage coverage-final.json --src src`
@@ -45,7 +40,7 @@ Feature: TypeScript file extension discovery and parsing
 
   @unwired
   Scenario: A .test.ts file is excluded when crap4ts.toml lists it in excludes
-    # tracked: crap-rs#173 — W2.2 explicit exclude works for test files; harness lands in W3.3
+    # tracked: crap-rs#229 — cucumber harness deferred from W3.3 #191 (pre-GA)
     Given a source tree under `src/` containing `app.ts` and `app.test.ts`
     And the operator's `crap4ts.toml` has `excludes = ["**/*.test.ts"]`
     When the operator runs `crap4ts --coverage coverage-final.json --src src`
@@ -54,7 +49,7 @@ Feature: TypeScript file extension discovery and parsing
 
   @unwired
   Scenario: An unrecognized extension is silently skipped
-    # tracked: crap-rs#173 — W2.2 unknown-extension behavior; harness lands in W3.3
+    # tracked: crap-rs#229 — cucumber harness deferred from W3.3 #191 (pre-GA)
     Given a source tree under `src/` containing `app.ts` and `notes.txt`
     When the operator runs `crap4ts --coverage coverage-final.json --src src`
     Then the report includes functions from `app.ts`
@@ -63,7 +58,7 @@ Feature: TypeScript file extension discovery and parsing
 
   @unwired
   Scenario: A parser failure on one file does not abort the run for others
-    # tracked: crap-rs#173 — W1.2 parse-failure pattern mirrors crap4rs syn walker; harness lands in W3.3
+    # tracked: crap-rs#229 — cucumber harness deferred from W3.3 #191 (pre-GA)
     # Note: verified via crap-core/src/core/mod.rs:286-310 — orchestrator catches per-file
     # ComplexityPort::extract errors and increments AnalysisDiagnostics.files_unparseable
     # before continuing. crap4ts inherits this behavior automatically.

--- a/crates/crap4ts/tests/features/istanbul_parser.feature
+++ b/crates/crap4ts/tests/features/istanbul_parser.feature
@@ -3,17 +3,9 @@ Feature: Istanbul JSON coverage parsing
   I want crap4ts to consume my coverage-final.json out of the box
   So that I don't have to translate or pre-process my coverage output
 
-  Background:
-    # Istanbul JSON is the schema emitted by jest, vitest, and nyc.
-    # Per Resolved Q10 (shaping), crap4ts@2.0.0 tolerates all three emitters;
-    # unknown emitters surface a ParseDiagnostic rather than aborting.
-    # The CoveragePort signature is `parse(&self, data: &str)` (slurp at
-    # orchestrator boundary, parse via serde_json::from_str). A separate
-    # `validate(&Path)` pre-flight checks structural sanity before parse.
-
   @unwired
   Scenario: A jest-emitted coverage-final.json parses cleanly
-    # tracked: crap-rs#173 — W1.1 jest fixture baseline; harness lands in W3.3
+    # tracked: crap-rs#229 — cucumber harness deferred from W3.3 #191 (pre-GA)
     Given a jest-emitted Istanbul `coverage-final.json` covering 3 source files
     And the report's source root resolves all 3 file paths to discovered sources
     When the operator runs `crap4ts --coverage coverage-final.json --src src`
@@ -22,7 +14,7 @@ Feature: Istanbul JSON coverage parsing
 
   @unwired
   Scenario: A vitest-emitted coverage-final.json parses with the same shape
-    # tracked: crap-rs#173 — W2.4 vitest variance fixture; harness lands in W3.3
+    # tracked: crap-rs#229 — cucumber harness deferred from W3.3 #191 (pre-GA)
     Given a vitest-emitted Istanbul `coverage-final.json` covering 3 source files
     When the operator runs `crap4ts --coverage coverage-final.json --src src`
     Then the report attributes line coverage to all 3 files
@@ -30,7 +22,7 @@ Feature: Istanbul JSON coverage parsing
 
   @unwired
   Scenario: An nyc-emitted coverage-final.json parses with the same shape
-    # tracked: crap-rs#173 — W2.4 nyc variance fixture; harness lands in W3.3
+    # tracked: crap-rs#229 — cucumber harness deferred from W3.3 #191 (pre-GA)
     Given an nyc-emitted Istanbul `coverage-final.json` covering 3 source files
     When the operator runs `crap4ts --coverage coverage-final.json --src src`
     Then the report attributes line coverage to all 3 files
@@ -38,7 +30,7 @@ Feature: Istanbul JSON coverage parsing
 
   @unwired
   Scenario: A coverage entry whose path cannot resolve to a source file emits PathUnresolved
-    # tracked: crap-rs#173 — W2.4 path-mismatch contract per CPO #3; harness lands in W3.3
+    # tracked: crap-rs#229 — cucumber harness deferred from W3.3 #191 (pre-GA)
     Given an Istanbul `coverage-final.json` with one entry pointing at `/private/build/transpiled/foo.js`
     And no source file resolves to that path under `--src src`
     When the operator runs `crap4ts --coverage coverage-final.json --src src`
@@ -49,7 +41,7 @@ Feature: Istanbul JSON coverage parsing
 
   @unwired
   Scenario: A JSON file that is not Istanbul-shaped emits SchemaUnrecognized
-    # tracked: crap-rs#173 — W2.4 schema-unrecognized contract per CPO sharpening; harness lands in W3.3
+    # tracked: crap-rs#229 — cucumber harness deferred from W3.3 #191 (pre-GA)
     Given a `coverage.json` whose top-level shape is `{ "foo": "bar" }` (not Istanbul)
     When the operator runs `crap4ts --coverage coverage.json --src src`
     Then `crap4ts` exits with a non-zero status
@@ -59,7 +51,7 @@ Feature: Istanbul JSON coverage parsing
 
   @unwired
   Scenario: A branch-record references an unknown branchId — emits BranchMismatch
-    # tracked: crap-rs#173 — W2.3 + W2.4 branch coverage mismatch UX; harness lands in W3.3
+    # tracked: crap-rs#229 — cucumber harness deferred from W3.3 #191 (pre-GA)
     Given a `coverage-final.json` whose `b` record references branchId `42`
     And `branchMap` contains no entry for branchId `42`
     When the operator runs `crap4ts --coverage coverage-final.json --src src`
@@ -69,7 +61,7 @@ Feature: Istanbul JSON coverage parsing
 
   @unwired
   Scenario: validate() pre-flight catches an empty coverage file before parse
-    # tracked: crap-rs#173 — W1.1 validate() impl per port trait docstring; harness lands in W3.3
+    # tracked: crap-rs#229 — cucumber harness deferred from W3.3 #191 (pre-GA)
     Given a `coverage-final.json` that decodes as Istanbul JSON but every entry's `statementMap` is empty
     When the operator runs `crap4ts --coverage coverage-final.json --src src`
     Then `crap4ts` exits with a non-zero status before reaching the parse pass
@@ -78,7 +70,7 @@ Feature: Istanbul JSON coverage parsing
 
   @unwired
   Scenario: A coverage entry with extra unknown fields is ignored permissively
-    # tracked: crap-rs#173 — W1.1 unknown-field tolerance for jest/vitest/nyc metadata; harness lands in W3.3
+    # tracked: crap-rs#229 — cucumber harness deferred from W3.3 #191 (pre-GA)
     Given a jest-emitted `coverage-final.json` with `hash` and `contentHash` fields
     And no other deviation from the expected schema
     When the operator runs `crap4ts --coverage coverage-final.json --src src`
@@ -87,7 +79,7 @@ Feature: Istanbul JSON coverage parsing
 
   @unwired
   Scenario: Relative paths in the coverage report are resolved against --src
-    # tracked: crap-rs#173 — W2.4 relative-path normalization; harness lands in W3.3
+    # tracked: crap-rs#229 — cucumber harness deferred from W3.3 #191 (pre-GA)
     Given an Istanbul `coverage-final.json` whose entries use relative paths like `src/foo.ts`
     And the operator invokes `crap4ts --coverage coverage-final.json --src /home/me/project/src`
     When the parser normalizes the entry paths

--- a/crates/crap4ts/tests/features/metric_unsupported.feature
+++ b/crates/crap4ts/tests/features/metric_unsupported.feature
@@ -3,18 +3,8 @@ Feature: --metric cognitive returns a helpful error in crap4ts@2.0.0
   I want a clear, actionable error message
   So that I know to switch to `--metric cyclomatic` (the default) without re-reading the manual
 
-  Background:
-    # crap4ts@2.0.0 ships --metric cyclomatic only. Cognitive complexity for
-    # TS is deferred to a follow-up issue (per shaping resolved Q2). When a
-    # user requests cognitive, the walker returns a metric-named CrapError
-    # variant (MetricNotSupported per CAO blocking finding), and the binary's
-    # error path renders adapter-specific phrasing from AdapterMeta.
-    # The user message uses Display format (not Debug) and gives direct
-    # guidance, not "run --help" indirection (per CPO sharpening).
-
-  @unwired
+  @wired
   Scenario: --metric cognitive on crap4ts exits non-zero with direct guidance
-    # tracked: crap-rs#173 — W2.5 metric-not-supported error UX; harness lands in W3.3
     Given a TypeScript source tree under `src/`
     And a valid Istanbul `coverage-final.json`
     When the operator runs `crap4ts --coverage coverage-final.json --src src --metric cognitive`
@@ -24,9 +14,8 @@ Feature: --metric cognitive returns a helpful error in crap4ts@2.0.0
       crap4ts: complexity metric `cognitive` is not yet supported. Use `--metric cyclomatic` (the default for crap4ts) or track support at https://github.com/breezy-bays-labs/crap-rs.
       """
 
-  @unwired
+  @wired
   Scenario: --metric cyclomatic on crap4ts is the default and works
-    # tracked: crap-rs#173 — W2.5 default-metric happy path; harness lands in W3.3
     Given a TypeScript source tree under `src/`
     And a valid Istanbul `coverage-final.json`
     When the operator runs `crap4ts --coverage coverage-final.json --src src --metric cyclomatic`
@@ -35,23 +24,24 @@ Feature: --metric cognitive returns a helpful error in crap4ts@2.0.0
 
   @unwired
   Scenario: crap4rs's --metric cognitive default continues to work (sanity)
-    # tracked: crap-rs#173 — W2.5 cross-adapter check: only crap4ts is affected; harness lands in W3.3
+    # tracked: crap-rs#229 — this crap4rs-shelling scenario stays deferred: a crap4ts cucumber
+    # harness shelling the crap4rs bin re-triggers the crap-rs#224 mutants-baseline class
+    # (CARGO_BIN_EXE_crap4rs unset under `cargo mutants --package crap4ts`). Contract stays
+    # pinned by the mutants-skipped metric_unsupported_smoke.rs::crap4rs_no_flag_default_cognitive_still_works.
     Given a Rust source tree under `src/`
     And a valid LCOV `lcov.info`
     When the operator runs `crap4rs --coverage lcov.info --src src --metric cognitive`
     Then `crap4rs` produces a complete CRAP scorecard
     And no MetricNotSupported error is emitted
 
-  @unwired
+  @wired
   Scenario: The MetricNotSupported error uses metric Display format, not Debug
-    # tracked: crap-rs#173 — W2.5 message rendering; harness lands in W3.3
     When the binary renders the MetricNotSupported error for metric `Cognitive`
     Then the rendered metric name in the user message is `cognitive` (lowercase, matching CLI input)
     And the rendered metric name is NOT `Cognitive` (PascalCase, Debug format)
 
-  @unwired
+  @wired
   Scenario: --metric an-unknown-value exits with clap's standard error (not MetricNotSupported)
-    # tracked: crap-rs#173 — W2.5 invalid-metric is distinct from unsupported-metric; harness lands in W3.3
     When the operator runs `crap4ts --coverage cov.json --src src --metric halstead`
     Then `crap4ts` exits with status 2
     And the error originates from clap's argument validation, NOT from MetricNotSupported

--- a/crates/crap4ts/tests/features/parity_with_v1.feature
+++ b/crates/crap4ts/tests/features/parity_with_v1.feature
@@ -3,20 +3,9 @@ Feature: crap4ts@2 parity with crap4ts@1.x reference outputs
   I want CRAP scores that diverge only by documented, intentional reasons
   So that score regressions in CI surface real issues, not adapter swaps
 
-  Background:
-    # crap4ts@1.x source (~/Github/crap4ts/) is the primary TS test corpus
-    # AND the cross-validation oracle. W3.1 snapshots the v1.x source as
-    # `crates/crap4ts/tests/fixtures/crap4ts-v1/` and captures v1.x's own
-    # CRAP outputs as `crap4ts-v1-reference.json` via one-shot `pnpm run crap`.
-    # W3.2 cross-validates new crap4ts against the captured reference.
-    #
-    # Per CPO sharpening, the parity harness reports per-function CONTRIBUTOR
-    # BREAKDOWNS in its diff output, not just per-function score diffs —
-    # so divergence triage is one line, not manual grep + read per disagreement.
-
   @unwired
   Scenario: crap4ts@2 cyclomatic scores match crap4ts@1.x within tolerance
-    # tracked: crap-rs#173 — W3.2 score parity harness; harness lands in W3.3
+    # tracked: crap-rs#229 — cucumber harness deferred from W3.3 #191 (pre-GA)
     Given the snapshotted crap4ts@1.x source corpus at `tests/fixtures/crap4ts-v1/`
     And the captured v1.x reference outputs at `tests/fixtures/crap4ts-v1-reference.json`
     When the parity harness runs `crap4ts --src tests/fixtures/crap4ts-v1/src --coverage <v1-coverage>` and compares
@@ -26,7 +15,7 @@ Feature: crap4ts@2 parity with crap4ts@1.x reference outputs
 
   @unwired
   Scenario: Divergence output shows per-function contributor breakdown, not just score diff
-    # tracked: crap-rs#173 — W3.2 diff is actionable (CPO sharpening); harness lands in W3.3
+    # tracked: crap-rs#229 — cucumber harness deferred from W3.3 #191 (pre-GA)
     Given a function whose v1.x reference has cyclomatic 4 (contributors: 2× if-branch, 1× ternary)
     And whose v2 output has cyclomatic 3 (contributors: 2× if-branch only — ternary missed)
     When the parity harness reports the divergence
@@ -37,7 +26,7 @@ Feature: crap4ts@2 parity with crap4ts@1.x reference outputs
 
   @unwired
   Scenario: Risk classification labels match across versions (D8 invariance check)
-    # tracked: crap-rs#173 — W3.2 D8 risk-cutoffs metric-invariant cross-version check; harness lands in W3.3
+    # tracked: crap-rs#229 — cucumber harness deferred from W3.3 #191 (pre-GA)
     Given the v1.x corpus + reference outputs
     When the parity harness compares risk labels function-by-function
     Then every function's risk classification matches v1.x to v2 exactly
@@ -45,7 +34,7 @@ Feature: crap4ts@2 parity with crap4ts@1.x reference outputs
 
   @unwired
   Scenario: Threshold-default difference is documented, not a parity failure
-    # tracked: crap-rs#173 — W3.2 threshold default 12→16 is intentional break, not a regression; harness lands in W3.3
+    # tracked: crap-rs#229 — cucumber harness deferred from W3.3 #191 (pre-GA)
     # Three documented compounding reasons (per MIGRATION.md): threshold 12→16
     # calibration, Rust-derived calibration awaiting TS validation, possible
     # arrow-function undercount. The parity harness must distinguish these
@@ -58,7 +47,7 @@ Feature: crap4ts@2 parity with crap4ts@1.x reference outputs
 
   @unwired
   Scenario: A discovered score divergence triggers a tracked follow-up
-    # tracked: crap-rs#173 — W3.2 divergence response policy; harness lands in W3.3
+    # tracked: crap-rs#229 — cucumber harness deferred from W3.3 #191 (pre-GA)
     Given the parity harness has identified a function with score divergence > ε
     When the divergence is NOT explained by threshold-default-change or arrow-function-undercount
     Then the harness output recommends filing a follow-up issue under epic #173

--- a/crates/crap4ts/tests/metric_unsupported_cucumber.rs
+++ b/crates/crap4ts/tests/metric_unsupported_cucumber.rs
@@ -1,0 +1,247 @@
+//! Cucumber-rs runner for `tests/features/metric_unsupported.feature`.
+//!
+//! Wires the user-facing `--metric` error UX by shelling the `crap4ts`
+//! binary (`assert_cmd::cargo_bin`) — these scenarios are about exit
+//! codes and exact stderr strings, so the binary IS the unit under
+//! test (mirrors `metric_unsupported_smoke.rs`).
+//!
+//! Scenario 3 ("crap4rs's --metric cognitive default continues to
+//! work") is deliberately left `@unwired`: a crap4ts cucumber harness
+//! shelling the **crap4rs** binary re-triggers the crap-rs#224
+//! mutants-baseline bug class — `CARGO_BIN_EXE_crap4rs` is unset under
+//! `cargo mutants --package crap4ts`, so the unmutated baseline would
+//! panic and zero the per-merge walker-mutants gate. That cross-adapter
+//! contract stays pinned by the already-mutants-skipped
+//! `metric_unsupported_smoke.rs::crap4rs_no_flag_default_cognitive_still_works`.
+//! Wiring the remaining feature is tracked at crap-rs#229 (pre-GA).
+//!
+//! Named `*_cucumber` (suffix) so `.config/nextest.toml`'s
+//! `binary(/.*_cucumber$/)` filter excludes it from nextest probing —
+//! same convention as crap4rs's `json_reporter_cucumber`.
+
+use std::path::PathBuf;
+use std::process::Output;
+
+use assert_cmd::Command;
+use cucumber::{World, gherkin::Step, given, then, when, writer};
+use tempfile::TempDir;
+
+const FIXTURE_TEMPLATE: &str = include_str!("fixtures/istanbul-jest/coverage-final.json");
+
+/// Build a canonicalized tempdir with the W1.1 jest fixture TS files
+/// and a `coverage-final.json` whose `{SRC_ROOT}` is substituted with
+/// the canonical path (macOS routes `/tmp` → `/private/tmp`;
+/// forward-slash normalize so the JSON parses on any platform).
+/// Mirrors `metric_unsupported_smoke.rs::build_jest_fixture` — copy-3
+/// of the per-file tempdir helper is still under the threshold where a
+/// shared `crap4ts-fixtures` support crate would pay off.
+fn build_jest_fixture() -> (TempDir, PathBuf) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let canonical = std::fs::canonicalize(tmp.path()).expect("canonicalize tempdir");
+
+    for (name, content) in [
+        ("simple.ts", include_str!("fixtures/ts-fixtures/simple.ts")),
+        ("arrow.ts", include_str!("fixtures/ts-fixtures/arrow.ts")),
+        (
+            "Button.tsx",
+            include_str!("fixtures/ts-fixtures/Button.tsx"),
+        ),
+        ("map.ts", include_str!("fixtures/ts-fixtures/map.ts")),
+        ("mixed.ts", include_str!("fixtures/ts-fixtures/mixed.ts")),
+    ] {
+        std::fs::write(canonical.join(name), content).expect("write fixture");
+    }
+
+    let payload = FIXTURE_TEMPLATE.replace(
+        "{SRC_ROOT}",
+        &canonical.to_string_lossy().replace('\\', "/"),
+    );
+    std::fs::write(canonical.join("coverage-final.json"), payload)
+        .expect("write coverage-final.json");
+
+    (tmp, canonical)
+}
+
+/// State for one scenario. The fixture guard is held so the tempdir
+/// survives until the scenario ends; `output` is the captured `crap4ts`
+/// process result the Then steps assert against.
+#[derive(Debug, Default, World)]
+struct MetricWorld {
+    fixture: Option<(TempDir, PathBuf)>,
+    output: Option<Output>,
+}
+
+impl MetricWorld {
+    fn ensure_fixture(&mut self) -> PathBuf {
+        if self.fixture.is_none() {
+            self.fixture = Some(build_jest_fixture());
+        }
+        self.fixture.as_ref().unwrap().1.clone()
+    }
+
+    /// Run `crap4ts` against the jest fixture with the given metric.
+    /// `--no-fail` so threshold violations in the fixture don't mask
+    /// the exit-code contract under test.
+    fn run_crap4ts(&mut self, metric: &str) {
+        let root = self.ensure_fixture();
+        let coverage = root.join("coverage-final.json");
+        let out = Command::cargo_bin("crap4ts")
+            .expect("crap4ts binary discoverable in workspace")
+            .arg("--coverage")
+            .arg(&coverage)
+            .arg("--src")
+            .arg(&root)
+            .args(["--metric", metric, "--no-fail"])
+            .output()
+            .expect("crap4ts executes");
+        self.output = Some(out);
+    }
+
+    fn out(&self) -> &Output {
+        self.output
+            .as_ref()
+            .expect("a When step must run crap4ts first")
+    }
+
+    fn stderr(&self) -> String {
+        String::from_utf8_lossy(&self.out().stderr).into_owned()
+    }
+}
+
+// ── Given ────────────────────────────────────────────────────────────
+
+#[given("a TypeScript source tree under `src/`")]
+fn given_ts_tree(world: &mut MetricWorld) {
+    world.ensure_fixture();
+}
+
+#[given("a valid Istanbul `coverage-final.json`")]
+fn given_istanbul_coverage(world: &mut MetricWorld) {
+    let root = world.ensure_fixture();
+    assert!(
+        root.join("coverage-final.json").is_file(),
+        "fixture coverage-final.json should exist"
+    );
+}
+
+// ── When ─────────────────────────────────────────────────────────────
+
+#[when(regex = r"^the operator runs `crap4ts .*--metric (\w+)`$")]
+fn when_run_with_metric(world: &mut MetricWorld, metric: String) {
+    world.run_crap4ts(&metric);
+}
+
+#[when("the binary renders the MetricNotSupported error for metric `Cognitive`")]
+fn when_render_metric_not_supported(world: &mut MetricWorld) {
+    world.run_crap4ts("cognitive");
+}
+
+// ── Then ─────────────────────────────────────────────────────────────
+
+#[then(regex = r"^`crap4ts` exits with status (\d+)$")]
+fn then_exit_status(world: &mut MetricWorld, code: i32) {
+    assert_eq!(
+        world.out().status.code(),
+        Some(code),
+        "expected exit {code}; stderr=\n{}",
+        world.stderr()
+    );
+}
+
+#[then("the user-facing error reads exactly:")]
+fn then_error_reads_exactly(world: &mut MetricWorld, step: &Step) {
+    let expected = step.docstring().expect("expected-error docstring").trim();
+    let stderr = world.stderr();
+    assert!(
+        stderr.contains(expected),
+        "stderr missing exact MetricNotSupported message.\nExpected to contain:\n{expected}\nActual stderr:\n{stderr}"
+    );
+}
+
+#[then("`crap4ts` produces a complete CRAP scorecard")]
+fn then_complete_scorecard(world: &mut MetricWorld) {
+    let out = world.out();
+    assert!(
+        out.status.success(),
+        "expected success exit; stderr=\n{}",
+        world.stderr()
+    );
+    assert!(
+        !out.stdout.is_empty(),
+        "expected a scorecard on stdout, got empty output"
+    );
+}
+
+#[then("no MetricNotSupported error is emitted")]
+fn then_no_metric_not_supported(world: &mut MetricWorld) {
+    let stderr = world.stderr();
+    assert!(
+        !stderr.contains("is not yet supported"),
+        "unexpected MetricNotSupported signal in stderr:\n{stderr}"
+    );
+}
+
+#[then(
+    "the rendered metric name in the user message is `cognitive` (lowercase, matching CLI input)"
+)]
+fn then_display_lowercase(world: &mut MetricWorld) {
+    let stderr = world.stderr();
+    assert!(
+        stderr.contains("`cognitive`"),
+        "expected Display-format lowercase `cognitive` in the message; stderr=\n{stderr}"
+    );
+}
+
+#[then("the rendered metric name is NOT `Cognitive` (PascalCase, Debug format)")]
+fn then_not_debug_pascalcase(world: &mut MetricWorld) {
+    let stderr = world.stderr();
+    assert!(
+        !stderr.contains("`Cognitive`"),
+        "message leaked Debug-format PascalCase `Cognitive`; stderr=\n{stderr}"
+    );
+}
+
+#[then("the error originates from clap's argument validation, NOT from MetricNotSupported")]
+fn then_clap_not_metric_not_supported(world: &mut MetricWorld) {
+    let stderr = world.stderr();
+    assert!(
+        !stderr.contains("is not yet supported"),
+        "expected a clap validation error, but got the MetricNotSupported message:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("invalid value") || stderr.contains("possible values"),
+        "expected clap's invalid-value phrasing; stderr=\n{stderr}"
+    );
+}
+
+#[then("the error names the valid `--metric` values")]
+fn then_names_valid_metrics(world: &mut MetricWorld) {
+    let stderr = world.stderr();
+    assert!(
+        stderr.contains("cyclomatic") && stderr.contains("cognitive"),
+        "clap error should list the valid --metric values (cyclomatic, cognitive); stderr=\n{stderr}"
+    );
+}
+
+// ── Runner ───────────────────────────────────────────────────────────
+
+#[tokio::main]
+async fn main() {
+    // `@wired`-only filter (AGENTS.md rule 5). Scenario 3 (crap4rs
+    // sanity) stays `@unwired` — see the module doc for the crap-rs#224
+    // rationale — so this filter skips it rather than the harness
+    // shelling crap4rs.
+    //
+    // `with_default_cli()` skips argv parsing so the `--skip <name>`
+    // libtest args `cargo mutants --package crap4ts` injects into every
+    // crap4ts test binary do not abort cucumber's strict clap CLI (the
+    // crap-rs#224 gate-zeroing class — see the matching note in
+    // `cyclomatic_walker_cucumber.rs`).
+    MetricWorld::cucumber()
+        .with_writer(writer::Libtest::or_basic())
+        .with_default_cli()
+        .filter_run_and_exit("tests/features/metric_unsupported.feature", |_, _, sc| {
+            sc.tags.iter().any(|t| t == "wired")
+        })
+        .await;
+}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -86,7 +86,7 @@ pre-push:
       # cucumber-rs harness=false targets bypass libtest's
       # `--list --format terse` probing, so nextest excludes them
       # via `.config/nextest.toml` and they run via `cargo test`.
-      run: cargo test --test json_reporter_cucumber
+      run: cargo test --test json_reporter_cucumber --test metric_unsupported_cucumber --test cyclomatic_walker_cucumber
       timeout: 180s
     docs:
       env:


### PR DESCRIPTION
## Summary

W3.3 of the crap4ts TypeScript-adapter pipeline. Three planned deliverables plus one user-approved plan deviation:

1. **Self-check thrice gate** — `.github/workflows/ci.yml` gains a 3rd `self-check` leg: `crap4rs` analyzes `crates/crap4ts/src` (Rust source — crap4ts/src has no TS) under `--strict`, reusing the single warm `./target/release/crap4rs` (no per-leg recompile).
2. **crap4ts cucumber harnesses** — `cyclomatic_walker_cucumber.rs` (11 scenarios, 23 with outlines) + `metric_unsupported_cucumber.rs` (scenarios 1/2/4/5) wired as `harness = false` `[[test]]` binaries; `lefthook.yml` `cucumber:` pre-push extended to run them.
3. **Background-block cleanup** — all 7 prose-only `Background:` blocks deleted from `crates/crap4ts/tests/features/*.feature` (verified pure prose). Scenario tags migrated `@unwired`→`@wired` where a harness/smoke counterpart exists (15 `@wired`, 29 `@unwired`); remaining `@unwired` re-pointed `# tracked: crap-rs#229` (new sub-issue, blocked-by #191, closes pre-GA). `metric_unsupported.feature` scenario 3 stays `@unwired` (shells crap4rs — #224 boundary).

### Plan deviation (surfaced, user-resolved)

The new 3rd leg failed: `IstanbulCoverage::build_parse_output` (CC 27 / CRAP 27.00) and `FunctionFinder::visit_namespace_statement` (CC 17 / CRAP 25.53) exceeded the `--strict` CRAP-15 gate. Issue #191 Discovery forbids loosening the threshold. Surfaced via the plan-deviation protocol; **the user chose to refactor inside W3.3** (vs. a prerequisite PR off main). `crap4rs/src` and `crap-core/src` both pass cleanly under 15 (worst 11.0 / 13.0), confirming the gate is well-calibrated and crap4ts/src was the genuine outlier.

- `build_parse_output` → 4 extracted helpers (`path_unresolved_diagnostic`, `missing_field_diagnostic`, `line_coverage_for`, `branch_coverage_for`): **CC 10 / CRAP 10.00**.
- `visit_namespace_statement` → shared `visit_namespace_var_decl` + `visit_namespace_export_default` + free `qualify()` (also dedupes the sibling `visit_namespace_declaration`'s closures): **CC 4 / CRAP 4.71**.
- 3rd leg now **PASSES** (worst CRAP 10.5, 0 above 15). Behaviour byte-identical: 1078 workspace tests + both wire snapshots green; istanbul smoke + `parity_v1` unchanged.

### Cascading scope from the in-PR refactor (flagged for reviewers)

- **Fresh crap-rs#224-class gate-zeroing bug fixed.** W3.3 added the first cucumber `harness = false` binaries to the `crap4ts` crate. `.cargo/mutants.toml`'s injected `-- --skip <name>` reaches every crap4ts test binary; cucumber's strict clap CLI rejects `--skip`, aborting the unmutated baseline of the per-merge `--package crap4ts` walker-mutants gate (#209) → zero mutants. Fixed at the harness via `.with_default_cli()` (cucumber 0.22.1 — skips argv parsing), documented inline in both harness mains.
- **`.cargo/mutants.toml` partially re-anchored (no set change).** The `qualify` free fn shifts `byte_to_line_col`/`property_key_name`/`for_init_as_expression` anchors +8; `visit_if`/`visit_for_init`/`visit_expression`/`visit_chain_element` are unshifted (edits sit below them). The standing surviving set did **not shrink** — an initial "shrank to 10" reading was a stale-anchor artifact (unshifted old anchors kept suppressing 12 gaps; only the +8-shifted ones surfaced), caught and corrected before merge by unioning complementary-mask mutants passes. Revived-gate block was 21 hard + 1 proptest-flaky; corrected block is **22 hard + 2 proptest-flaky = 24**: 12 unshifted anchors verbatim, 9 +8-shifted re-anchored, plus two long-standing `visit_expression` omissions (both since #182 `b77be7e`, masked by seed luck — not regressions): `888:13 TSNonNullExpression` (hard) and `884:13 TSSatisfiesExpression` (second proptest-flaky, joins `880:13 ImportExpression` in the seed-flaky sub-block — pinned because the per-merge gate runs `--in-place` per-run-seed and flaky arms would otherwise flake it RED). crap-rs#224 ownership + restoration condition unchanged; `exclude_re` re-anchored, never loosened.
- **CI comment corrected.** The 3rd-leg comment wrongly said "cognitive 25 applies uniformly"; `--strict` lowers the **CRAP-score** cutoff to 15 (orthogonal to the cognitive-complexity metric default). Comment now accurate.

## Verification

- `cargo nextest run --workspace --all-targets` — 1078 pass (incl. `walker_proptest`, both new cucumber harnesses, wire snapshots byte-identical)
- `cargo +1.93 check --workspace --all-targets`, `cargo clippy --workspace --all-targets -- -D warnings`, `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps`, `cargo deny check`, `cargo fmt --check` — all clean
- 3rd self-check leg: `./target/release/crap4rs --coverage lcov.info --src crates/crap4ts/src --strict` → 91 functions, 0 above 15, worst 10.5, **PASS**
- `cargo mutants -j 4 --package crap4ts --file crates/crap4ts/src/adapters/walker/mod.rs --no-shuffle` — clean baseline, 0 missed with re-anchored `exclude_re` (CI-parity for the #209 per-merge gate)
- Wire-snapshot canary: **no drift** — both `wire_envelope_crap4rs` / `wire_envelope_crap4ts` byte-identical (refactors are behaviour-preserving; error/diagnostic paths don't touch the envelope)

## Context

- Epic: #173
- Closes #191
- Follow-up filed: #229 (remaining cucumber feature wiring — 5 features + 1 cross-adapter scenario; blocked-by #191; closes pre-GA)
- crap-rs#224 (per-merge walker-mutants gate) ownership + restoration condition unchanged; `exclude_re` re-anchored, not loosened

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added cucumber integration tests for cyclomatic complexity analysis and metric validation scenarios
  * Updated feature specifications with refined test coverage for coverage parsing, file extension handling, and parity validation
  * Enhanced pre-push verification to run additional test targets

* **Chores**
  * Updated CI workflow to include additional CRAP coverage verification
  * Refined mutation testing configuration with extended exclusion patterns

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/breezy-bays-labs/crap-rs/pull/230?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->