### PR TITLE
release(crap4ts): #192 — 2.0.0-rc.1 (napi entry + publish workflow + MIGRATION/CHANGELOG + soak)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,26 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Build crap4ts bin (default features)
         run: cargo build --package crap4ts --release
+      - name: No-feature bin canary -- bin must not carry napi_ symbols
+        shell: bash
+        run: |
+          set -euo pipefail
+          BIN="target/release/crap4ts"
+          test -f "$BIN"
+          if nm "$BIN" 2>/dev/null | grep -q "napi_"; then
+            echo "::error::bin links napi_ symbols (feature-gate leakage)"
+            nm "$BIN" | grep "napi_" | head -10
+            exit 1
+          fi
+          case "$RUNNER_OS" in
+            macOS)
+              if otool -L "$BIN" | grep -i napi; then
+                echo "::error::bin has napi dylib linkage"
+                exit 1
+              fi
+              ;;
+          esac
+          echo "OK: no napi_ symbols in standalone bin"
       - name: Build crap4ts cdylib (napi-binding feature)
         run: cargo build --package crap4ts --features napi-binding --lib --release
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,158 @@
+name: publish crap4ts
+
+# Triggered by tags matching `crap4ts-v*` (e.g. `crap4ts-v2.0.0-rc.1`,
+# `crap4ts-v2.0.0`). Builds the napi-rs cdylib on three platforms,
+# bundles all three native binaries into the `crap4ts` npm package, and
+# publishes to npm using OIDC trusted publishing (--provenance).
+#
+# Single-package distribution: every platform's `.node` ships in the
+# same tarball; runtime dispatch lives in `packages/crap4ts/index.js`.
+# A move to scoped per-platform sub-packages with `optionalDependencies`
+# is on the table for GA if download size warrants it.
+
+on:
+  push:
+    tags:
+      - 'crap4ts-v*'
+
+# `id-token: write` lets the publish job mint an OIDC token that npm
+# verifies against its trusted-publisher config (set up out-of-band on
+# npmjs.com). Per-job permissions stay scoped; the build matrix only
+# needs `contents: read`.
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build cdylib (${{ matrix.platform }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux-x64-gnu
+            runner: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            artifact: libcrap4ts.so
+            node_name: crap4ts.linux-x64-gnu.node
+          - platform: darwin-arm64
+            runner: macos-14
+            target: aarch64-apple-darwin
+            artifact: libcrap4ts.dylib
+            node_name: crap4ts.darwin-arm64.node
+          - platform: darwin-x64
+            runner: macos-13
+            target: x86_64-apple-darwin
+            artifact: libcrap4ts.dylib
+            node_name: crap4ts.darwin-x64.node
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Cache cargo registry + target
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: publish-${{ matrix.platform }}
+
+      - name: Build cdylib
+        env:
+          CARGO_TARGET: ${{ matrix.target }}
+        run: |
+          cargo build \
+            --package crap4ts \
+            --release \
+            --lib \
+            --features napi-binding \
+            --target "$CARGO_TARGET"
+
+      - name: Rename cdylib to napi .node filename
+        env:
+          CARGO_TARGET: ${{ matrix.target }}
+          ARTIFACT: ${{ matrix.artifact }}
+          NODE_NAME: ${{ matrix.node_name }}
+        run: |
+          cp "target/$CARGO_TARGET/release/$ARTIFACT" \
+             "packages/crap4ts/$NODE_NAME"
+          ls -la "packages/crap4ts/$NODE_NAME"
+
+      - name: Smoke-test cdylib loads in Node
+        env:
+          NODE_NAME: ${{ matrix.node_name }}
+        run: |
+          node --input-type=commonjs -e '
+            const name = process.env.NODE_NAME;
+            const lib = require("./packages/crap4ts/" + name);
+            if (typeof lib.analyze !== "function") {
+              throw new Error("cdylib loaded but analyze export missing");
+            }
+            console.log("OK: analyze export present");
+          '
+
+      - name: Upload cdylib artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cdylib-${{ matrix.platform }}
+          path: packages/crap4ts/${{ matrix.node_name }}
+          if-no-files-found: error
+          retention-days: 7
+
+  publish:
+    name: Publish to npm
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Verify tag matches package.json + Cargo.toml versions
+        # Belt-and-braces tag<->version check. The
+        # `release_tag_merge_commit` convention requires verifying this
+        # on the merge commit BEFORE pushing the tag; this CI gate
+        # catches the rare case where someone pushed a tag onto a
+        # commit that doesn't match.
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          TAG_VERSION="${REF_NAME#crap4ts-v}"
+          PKG_VERSION=$(node -p "require('./packages/crap4ts/package.json').version")
+          CARGO_VERSION=$(grep -m1 '^version' crates/crap4ts/Cargo.toml | sed -E 's/version *= *"(.*)"/\1/')
+          echo "tag:    ${TAG_VERSION}"
+          echo "npm:    ${PKG_VERSION}"
+          echo "cargo:  ${CARGO_VERSION}"
+          if [ "${TAG_VERSION}" != "${PKG_VERSION}" ] || [ "${TAG_VERSION}" != "${CARGO_VERSION}" ]; then
+            echo "::error::version mismatch between tag, package.json, and Cargo.toml"
+            exit 1
+          fi
+
+      - name: Download all cdylib artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: cdylib-*
+          path: packages/crap4ts/
+          merge-multiple: true
+
+      - name: Confirm all platforms present in tarball
+        run: |
+          cd packages/crap4ts
+          ls -la *.node
+          for plat in crap4ts.linux-x64-gnu.node crap4ts.darwin-arm64.node crap4ts.darwin-x64.node; do
+            test -f "$plat" || { echo "::error::missing $plat"; exit 1; }
+          done
+
+      - name: Publish to npm with provenance (OIDC)
+        run: npm publish --provenance --access public
+        working-directory: packages/crap4ts

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,7 @@ jobs:
             artifact: libcrap4ts.dylib
             node_name: crap4ts.darwin-arm64.node
           - platform: darwin-x64
-            runner: macos-13
+            runner: macos-15-intel
             target: x86_64-apple-darwin
             artifact: libcrap4ts.dylib
             node_name: crap4ts.darwin-x64.node
@@ -48,7 +48,11 @@ jobs:
     permissions:
       contents: read
     steps:
+      # `persist-credentials: false` — this job never pushes; not
+      # persisting the checkout token keeps it out of the build env.
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -110,7 +114,11 @@ jobs:
       contents: read
       id-token: write
     steps:
+      # `persist-credentials: false` — npm publish authenticates via the
+      # OIDC `id-token`, not the git checkout token; don't persist it.
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,14 @@ before promoting to `crap4ts 2.0.0` GA.**
 This release cuts only the `crap4ts` npm package — `crap-core` and
 `crap4rs` are not tagged to crates.io as part of this release. But
 because the published cdylib is built from workspace `HEAD`, every
-workspace-level change queued under [Unreleased] (including the #214
-Istanbul parser narrowing and #221 namespace-qualified naming that
-directly affect crap4ts behavior, plus #218 threshold metric
-calibration and #73 init subcommand) IS shipped inside this cdylib.
+workspace-level change queued under [Unreleased] IS shipped inside
+this cdylib, including:
+
+- #214 — Istanbul parser narrowing
+- #221 — namespace-qualified naming
+- #218 — threshold metric calibration
+- #73 — `init` subcommand
+
 The [Unreleased] section will move to a dedicated release section
 when `crap-core` / `crap4rs` next cut a crates.io release.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,53 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+The workspace ships multiple crates / packages on independent
+versioning cadences: `crap-core`, `crap4rs` (Rust adapter + crate),
+and `crap4ts` (TypeScript adapter + npm package). Release sections
+are tagged with the published artifact + version they cut.
+
+## [crap4ts 2.0.0-rc.1] - 2026-05-19
+
+First release candidate of the from-scratch `crap4ts` 2.x line —
+a [napi-rs](https://napi.rs/) Node addon that replaces the
+JavaScript-only `crap4ts` 1.x. CRAP formula, scorecard envelope, and
+reporter shapes are now shared with the Rust adapter `crap4rs` via
+the language-agnostic `crap-core` library. **48–72 h soak window
+before promoting to `crap4ts 2.0.0` GA.**
+
+This release cuts only the `crap4ts` npm package — `crap-core` and
+`crap4rs` are not tagged to crates.io as part of this release. But
+because the published cdylib is built from workspace `HEAD`, every
+workspace-level change queued under [Unreleased] (including the #214
+Istanbul parser narrowing and #221 namespace-qualified naming that
+directly affect crap4ts behavior, plus #218 threshold metric
+calibration and #73 init subcommand) IS shipped inside this cdylib.
+The [Unreleased] section will move to a dedicated release section
+when `crap-core` / `crap4rs` next cut a crates.io release.
+
+### Added (crap4ts on npm)
+- New `crap4ts` npm package (v2.0.0-rc.1) shipping the napi-rs-built
+  cdylib alongside a single-package runtime dispatcher. Exposes one
+  `analyze({ sourceRoot, coveragePath, threshold?, metric? })`
+  function returning the analysis output (functions + summary +
+  diagnostics) as a JSON string. ([#192](https://github.com/breezy-bays-labs/crap-rs/issues/192))
+- Native bindings for macOS arm64, macOS x64, and Linux x64 (glibc).
+  All three live in the same tarball; `index.js` selects the right
+  `.node` at require-time via `process.platform` + `process.arch`.
+- `.github/workflows/publish.yml` — tag-triggered (`crap4ts-v*`)
+  matrix workflow with `id-token: write` for npm OIDC trusted
+  publishing (`npm publish --provenance`).
+- `MIGRATION.md` gains a `crap4ts@1.x → crap4ts@2.0.0` section with
+  the three reasons scores may diverge (threshold default `12 → 16`,
+  TS-specific calibration not yet validated, arrow-function coverage
+  handling) and subpath-export replacement recipes.
+
+### Migration
+
+See `MIGRATION.md` "crap4ts@1.x → crap4ts@2.0.0" section. Short
+version: a `2.0.0-rc.1` install replaces a `1.x` install; scores may
+differ for the three compounding reasons documented there.
+
 ## [Unreleased]
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,7 +409,7 @@ dependencies = [
 
 [[package]]
 name = "crap4ts"
-version = "2.0.0-alpha.1"
+version = "2.0.0-rc.1"
 dependencies = [
  "assert_cmd",
  "crap-core",

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -95,8 +95,8 @@ console.log(result.summary);
 ```
 
 Generate `coverage-final.json` via your test runner with Istanbul
-coverage enabled (`jest --coverage`, `vitest --coverage`,
-`c8 --reporter=json`, etc.).
+coverage enabled — e.g. `jest --coverage`, `vitest --coverage`, or
+`c8 --reporter=json`.
 
 ### Rollback
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,7 +1,110 @@
 # Migration Guide
 
-Per-release migration notes for `crap4rs` consumers. Read the section
-that matches how you consume the tool.
+Per-release migration notes for `crap4rs`, `crap4ts`, and `crap-core`
+consumers. Read the section that matches how you consume the tool.
+
+---
+
+## crap4ts@1.x → crap4ts@2.0.0 (npm)
+
+The 2.x line is a from-scratch reimplementation of crap4ts on top of
+[`crap-rs`](https://github.com/breezy-bays-labs/crap-rs)'s Rust core,
+distributed as a [napi-rs](https://napi.rs/) Node addon. The CRAP
+formula, scorecard envelope, and reporter shapes are now shared
+verbatim with the Rust adapter `crap4rs` via the language-agnostic
+`crap-core` library.
+
+`2.0.0-rc.1` is the first published version of the 2.x line. There is
+a 48–72 h soak window before `2.0.0` is cut.
+
+### Install
+
+```sh
+npm install --save-dev crap4ts@2.0.0-rc.1
+# or pnpm add -D crap4ts@2.0.0-rc.1
+```
+
+Published platforms in `2.0.0-rc.1`:
+- macOS arm64 + x64
+- Linux x64 (glibc)
+
+Windows and Linux arm64 / musl are tracked for a later release.
+
+### Why are my scores different?
+
+`crap4ts@2.x` scores can diverge from `crap4ts@1.x` scores on the same
+codebase. Three compounding reasons account for the gap; each is
+documented so you can self-diagnose rather than chase a phantom
+regression:
+
+1. **The default threshold changed from `12` to `16`** (cyclomatic). This
+   is an intentional calibration introduced with `crap-rs` v0.5.0 —
+   `8 / 16 / 30` for `strict / default / lenient` on the cyclomatic
+   metric. v1.x's `12` was an undocumented intermediate. If you depend
+   on the v1.x default, pin it explicitly: `analyze({ threshold: 12, ... })`.
+2. **TS-specific threshold calibration has not been independently
+   validated.** The current cutoffs derive from the Rust corpus
+   (`crap4rs` history). A `type:research` follow-up validates them
+   against the `crap4ts@1.x` test corpus; until that completes, treat
+   the gate as a guideline rather than a ground truth. Track at
+   [`crap-rs`#173](https://github.com/breezy-bays-labs/crap-rs/issues/173).
+3. **Arrow-function coverage may count differently.** v1 derived
+   function-level coverage from Istanbul's `f` / `fnMap` arms (per-
+   function invocation counts). v2 reads `s` / `statementMap` only —
+   line-level statement coverage. The two paths agree for the common
+   case where every function's body contains at least one statement
+   counted in `s`, but they can diverge for arrow-heavy code that hits
+   statements without invoking the surrounding function, or vice
+   versa. If a single function's CRAP looks surprisingly different
+   between v1 and v2, eyeball its coverage and file an issue with the
+   fixture; the deliberate trade-off in `crap4ts@2.x` is that
+   modelling `f` / `fnMap` would re-introduce a whole-file bail
+   vector that the v2 parser explicitly avoids.
+
+### Subpath export removals
+
+`crap4ts@1.x` exposed four module entries; `crap4ts@2.x` ships a
+single `analyze()` export from the package root. Replacement recipes:
+
+| v1.x import | v2.x replacement |
+|---|---|
+| `import { computeCrap } from 'crap4ts/formula'` | Call `analyze()` and read `summary.crap_scores` fields from the returned JSON. |
+| `import { extractComplexity } from 'crap4ts/complexity'` | Not externally exposed in 2.x. The walker is internal; if you need raw complexity data, run the `crap4ts` CLI with `--format json` and parse the per-function entries. |
+| `import { parseLcov } from 'crap4ts/coverage'` | Not externally exposed in 2.x. crap4ts 2.x parses Istanbul JSON only; use the `crap4rs` Rust binary if you need LCOV. |
+
+The 1.x subpath consumer count is functionally zero (per the npm
+registry — v1.0.1 has no measurable install base), so the surface
+narrowing is a net simplification rather than a breaking change for
+real workloads.
+
+### Usage
+
+```js
+const { analyze } = require('crap4ts');
+
+const json = analyze({
+  sourceRoot: 'src',
+  coveragePath: 'coverage/coverage-final.json',
+  // Optional:
+  // threshold: 16,
+  // metric: 'cyclomatic',
+});
+
+const { result, diagnostics } = JSON.parse(json);
+console.log(result.summary);
+```
+
+Generate `coverage-final.json` via your test runner with Istanbul
+coverage enabled (`jest --coverage`, `vitest --coverage`,
+`c8 --reporter=json`, etc.).
+
+### Rollback
+
+If `2.0.0-rc.1` reveals a blocking regression, pin to `crap4ts@1.0.1`
+(the last 1.x release) until a corrective `2.0.0-rc.2` ships. The
+`npm unpublish` window is 72 h from publish; if the issue surfaces
+earlier, the broken RC can be pulled from the registry rather than
+held alongside the fix.
 
 ---
 

--- a/crates/crap4ts/Cargo.toml
+++ b/crates/crap4ts/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "crap4ts"
-version = "2.0.0-alpha.1"
+version = "2.0.0-rc.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "TypeScript adapter for crap-rs (CRAP score analyzer) — ALPHA: oxc walker not yet shipped"
+description = "TypeScript adapter for crap-rs — Rust-powered CRAP score analyzer combining oxc AST complexity with Istanbul JSON coverage"
 keywords = ["crap", "complexity", "coverage", "typescript", "quality"]
 categories = ["development-tools::testing", "command-line-utilities"]
 

--- a/crates/crap4ts/src/lib.rs
+++ b/crates/crap4ts/src/lib.rs
@@ -6,15 +6,103 @@
 //! metric is cyclomatic complexity; cognitive surfaces
 //! `CrapError::MetricNotSupported` (D5 + locked decision #2).
 //!
-//! Two consumer surfaces:
+//! Three consumer surfaces:
 //! - the `crap4ts` CLI binary (`src/main.rs`) — default build, no napi
 //!   linkage,
+//! - the Rust library API [`analyze_to_json`] — feature-independent,
+//!   exercised by Rust integration tests + the LCOV coverage gate,
 //! - the napi-rs cdylib (`src/napi.rs`) — gated behind the
-//!   `napi-binding` feature, exposes a single `analyze()` JSON entry
-//!   consumed from Node via the `crap4ts` npm package.
+//!   `napi-binding` feature; a thin shim that unpacks `AnalyzeOptions`
+//!   and delegates to [`analyze_to_json`] so the orchestration logic
+//!   stays in feature-independent code and self-CRAP can score it.
+
+use std::path::Path;
+
+use serde::Serialize;
+
+use crap_core::core::{AnalyzeOptions, analyze};
+use crap_core::domain::threshold::{ThresholdConfig, ThresholdPreset};
+use crap_core::domain::types::{AnalysisDiagnostics, AnalysisResult, ComplexityMetric};
+use crap_core::ports::ParseDiagnostic;
+
+use crate::adapters::coverage::IstanbulCoverage;
+use crate::adapters::walker::OxcWalker;
+use crate::parse_diagnostic::IstanbulParseDiagnostic;
 
 pub mod adapters;
 pub mod parse_diagnostic;
 
 #[cfg(feature = "napi-binding")]
 pub mod napi;
+
+/// File extensions the walker discovers. Mirrors
+/// `crates/crap4ts/src/main.rs`'s `EXTENSIONS` constant so library
+/// callers see the same source set the CLI does.
+const EXTENSIONS: &[&str] = &["ts", "tsx", "js", "jsx", "mjs", "cjs"];
+
+/// Wire shape for the JSON returned by [`analyze_to_json`]. Mirrors
+/// `crap_core::core::AnalysisOutput<P>`'s `{ result, diagnostics }`
+/// shape verbatim. `#[serde(bound = "")]` suppresses serde's
+/// auto-generated bounds — `P: ParseDiagnostic` already requires
+/// `Serialize + DeserializeOwned`.
+#[derive(Serialize)]
+#[serde(bound = "")]
+struct AnalyzeWireOutput<'a, P: ParseDiagnostic> {
+    result: &'a AnalysisResult,
+    diagnostics: &'a AnalysisDiagnostics<P>,
+}
+
+/// Run CRAP analysis against a TypeScript / JavaScript source tree
+/// with Istanbul-format coverage. Returns the analysis output
+/// (functions + summary + diagnostics) as a JSON-encoded `String`.
+///
+/// This is the feature-independent orchestration entry point — both
+/// the binary's library reuse and the napi cdylib shim funnel through
+/// here. The function pre-canonicalizes `source_root` to match
+/// `crap_core::core::AnalysisContext::new`'s own canonicalization, so
+/// relative or symlink'd source paths do not surface as
+/// `PathUnresolved` diagnostics from the Istanbul parser.
+///
+/// `threshold` defaults to the metric-correct preset
+/// (`ThresholdPreset::Default`) when `None`.
+///
+/// Errors are returned as `String` so the napi shim can hand them
+/// directly to `napi::Error::from_reason`; library consumers wanting
+/// structured `CrapError` should call `crap_core::core::analyze`
+/// directly.
+pub fn analyze_to_json(
+    source_root: &Path,
+    coverage_path: &Path,
+    threshold: Option<f64>,
+    metric: ComplexityMetric,
+) -> Result<String, String> {
+    let src = source_root.to_path_buf();
+    let src = src.canonicalize().unwrap_or(src);
+    let coverage = coverage_path.to_path_buf();
+
+    let global_threshold = threshold.unwrap_or_else(|| ThresholdPreset::Default.threshold(metric));
+
+    let options = AnalyzeOptions {
+        src: src.clone(),
+        coverage,
+        threshold_config: ThresholdConfig {
+            global: global_threshold,
+            overrides: Vec::new(),
+        },
+        metric,
+        extensions: EXTENSIONS.iter().map(|&s| s.to_string()).collect(),
+        ..AnalyzeOptions::default()
+    };
+
+    let walker = OxcWalker::new();
+    let coverage_adapter = IstanbulCoverage::new(src);
+
+    let output = analyze::<IstanbulParseDiagnostic>(&options, &walker, &coverage_adapter)
+        .map_err(|e| e.to_string())?;
+
+    let wire = AnalyzeWireOutput {
+        result: &output.result,
+        diagnostics: &output.diagnostics,
+    };
+    serde_json::to_string(&wire).map_err(|e| e.to_string())
+}

--- a/crates/crap4ts/src/lib.rs
+++ b/crates/crap4ts/src/lib.rs
@@ -35,10 +35,20 @@ pub mod parse_diagnostic;
 #[cfg(feature = "napi-binding")]
 pub mod napi;
 
-/// File extensions the walker discovers. Mirrors
-/// `crates/crap4ts/src/main.rs`'s `EXTENSIONS` constant so library
-/// callers see the same source set the CLI does.
-const EXTENSIONS: &[&str] = &["ts", "tsx", "js", "jsx", "mjs", "cjs"];
+/// File extensions the walker discovers. The single source of truth
+/// for the crap4ts source set — the CLI binary (`src/main.rs`) and the
+/// library entry point [`analyze_to_json`] both reference this constant
+/// so a CLI run and a programmatic run analyze identical file sets.
+pub const EXTENSIONS: &[&str] = &["ts", "tsx", "js", "jsx", "mjs", "cjs"];
+
+/// Glob patterns excluded from analysis by default — vendored
+/// dependencies (`node_modules`) and build / coverage output. The
+/// single source of truth: the CLI advertises these as the
+/// commented-out excludes its `init` subcommand writes, and the
+/// library entry point [`analyze_to_json`] applies them directly so a
+/// programmatic caller pointed at a project root does not walk into
+/// `node_modules` (which, for the CLI, the config-merge step filters).
+pub const DEFAULT_EXCLUDES: &[&str] = &["node_modules/**", "dist/**", "coverage/**"];
 
 /// Wire shape for the JSON returned by [`analyze_to_json`]. Mirrors
 /// `crap_core::core::AnalysisOutput<P>`'s `{ result, diagnostics }`
@@ -56,8 +66,8 @@ struct AnalyzeWireOutput<'a, P: ParseDiagnostic> {
 /// with Istanbul-format coverage. Returns the analysis output
 /// (functions + summary + diagnostics) as a JSON-encoded `String`.
 ///
-/// This is the feature-independent orchestration entry point — both
-/// the binary's library reuse and the napi cdylib shim funnel through
+/// This is the feature-independent orchestration entry point — the napi
+/// cdylib shim and the crate's integration tests both funnel through
 /// here. The function pre-canonicalizes `source_root` to match
 /// `crap_core::core::AnalysisContext::new`'s own canonicalization, so
 /// relative or symlink'd source paths do not surface as
@@ -65,6 +75,15 @@ struct AnalyzeWireOutput<'a, P: ParseDiagnostic> {
 ///
 /// `threshold` defaults to the metric-correct preset
 /// (`ThresholdPreset::Default`) when `None`.
+///
+/// [`DEFAULT_EXCLUDES`] is applied so a caller pointed at a project
+/// root does not walk into `node_modules`, `dist`, or `coverage`.
+///
+/// Inputs are validated up front: `source_root` must resolve to an
+/// existing directory, and `threshold` — when set — must be a finite
+/// non-negative number. Either failure returns a descriptive `Err`
+/// rather than walking an empty tree or scoring against a `NaN`
+/// threshold.
 ///
 /// Errors are returned as `String` so the napi shim can hand them
 /// directly to `napi::Error::from_reason`; library consumers wanting
@@ -76,6 +95,21 @@ pub fn analyze_to_json(
     threshold: Option<f64>,
     metric: ComplexityMetric,
 ) -> Result<String, String> {
+    if let Some(t) = threshold
+        && (!t.is_finite() || t < 0.0)
+    {
+        return Err(format!(
+            "crap4ts: invalid threshold {t}: expected a finite number >= 0"
+        ));
+    }
+
+    if !source_root.is_dir() {
+        return Err(format!(
+            "crap4ts: source_root '{}' does not exist or is not a directory",
+            source_root.display()
+        ));
+    }
+
     let src = source_root.to_path_buf();
     let src = src.canonicalize().unwrap_or(src);
     let coverage = coverage_path.to_path_buf();
@@ -91,6 +125,7 @@ pub fn analyze_to_json(
         },
         metric,
         extensions: EXTENSIONS.iter().map(|&s| s.to_string()).collect(),
+        exclude: DEFAULT_EXCLUDES.iter().map(|&s| s.to_string()).collect(),
         ..AnalyzeOptions::default()
     };
 

--- a/crates/crap4ts/src/lib.rs
+++ b/crates/crap4ts/src/lib.rs
@@ -1,64 +1,20 @@
-//! crap4ts — TypeScript adapter binding for the language-agnostic
-//! `crap_core` analyzer.
+//! crap4ts — TypeScript adapter for the language-agnostic `crap_core`
+//! analyzer.
 //!
-//! ALPHA: the oxc complexity walker and Istanbul JSON coverage parser
-//! are stubs that `unimplemented!()`. The real TS pipeline lands in a
-//! follow-up; this crate ships the structural shell so the workspace
-//! layout, cdylib + bin crate-type combo, license allowlist, and CI
-//! surface are settled before the walker work begins.
+//! Combines AST complexity (via oxc) with Istanbul JSON coverage to
+//! identify functions that are both complex and under-tested. Default
+//! metric is cyclomatic complexity; cognitive surfaces
+//! `CrapError::MetricNotSupported` (D5 + locked decision #2).
 //!
-//! Unlike `crap4rs`, this crate has no v0.4 history and therefore no
-//! backward-compat shim modules — its public surface starts fresh at
-//! v2.0.0-alpha.1.
+//! Two consumer surfaces:
+//! - the `crap4ts` CLI binary (`src/main.rs`) — default build, no napi
+//!   linkage,
+//! - the napi-rs cdylib (`src/napi.rs`) — gated behind the
+//!   `napi-binding` feature, exposes a single `analyze()` JSON entry
+//!   consumed from Node via the `crap4ts` npm package.
 
 pub mod adapters;
 pub mod parse_diagnostic;
 
-// ── napi-rs cdylib entry point ───────────────────────────────────────
-//
-// Behind the `napi-binding` feature so the standalone `crap4ts` bin
-// (which links the lib via `use crap4ts::...`) doesn't pull in
-// unresolved Node-provided `_napi_*` symbols at link time.
-// `napi_build`'s macOS `-undefined dynamic_lookup` directive only
-// covers the cdylib crate-type — the bin target would fail to link
-// otherwise. Cdylib consumers build with `cargo build --package
-// crap4ts --features napi-binding`.
-//
-// A single exported function exists so the `.node` artifact produced
-// by the cdylib has something to bind to (and `cargo build --features
-// napi-binding` exercises the napi_derive proc-macro chain). No
-// analysis logic is wired through napi yet — real bindings ship with
-// the walker.
-
 #[cfg(feature = "napi-binding")]
-use napi_derive::napi;
-
-/// Returns a human-readable alpha-status string. Exposed to JS as
-/// `alphaStatus()` (napi-rs converts snake_case → camelCase) when the
-/// `napi-binding` feature is enabled. Always callable from Rust so
-/// non-napi consumers (and tests) can verify the message.
-#[cfg(feature = "napi-binding")]
-#[napi]
-pub fn alpha_status() -> String {
-    alpha_status_message().to_string()
-}
-
-/// Backing constant for the alpha-status message. Lifted out so the
-/// non-napi path (the bin's default build, unit tests) can assert on
-/// the same string without touching napi at all.
-pub const fn alpha_status_message() -> &'static str {
-    "crap4ts@2 alpha — oxc walker not yet implemented"
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn alpha_status_message_is_stable() {
-        assert_eq!(
-            alpha_status_message(),
-            "crap4ts@2 alpha — oxc walker not yet implemented"
-        );
-    }
-}
+pub mod napi;

--- a/crates/crap4ts/src/main.rs
+++ b/crates/crap4ts/src/main.rs
@@ -21,6 +21,7 @@ use crap_core::cli::AdapterMeta;
 use crap_core::domain::types::ComplexityMetric;
 use crap4ts::adapters::coverage::IstanbulCoverage;
 use crap4ts::adapters::walker::OxcWalker;
+use crap4ts::{DEFAULT_EXCLUDES, EXTENSIONS};
 
 const ABOUT: &str = "CRAP score analyzer for TypeScript (alpha)";
 const LONG_ABOUT: &str = "CRAP (Change Risk Anti-Patterns) score analyzer for TypeScript / \
@@ -46,13 +47,6 @@ breezy-bays-labs/crap-rs.";
 
 const COVERAGE_HINT: &str = "ensure tests ran with coverage enabled (e.g. `c8 --reporter=json` or `vitest --coverage`) — \
      crap4ts parses Istanbul's `coverage-final.json`, not LCOV";
-
-const EXTENSIONS: &[&str] = &["ts", "tsx", "js", "jsx", "mjs", "cjs"];
-
-/// Common TS/JS-project directories `init` writes as commented-out
-/// excludes — `node_modules` for vendored deps, build/coverage output
-/// dirs.
-const DEFAULT_EXCLUDES: &[&str] = &["node_modules/**", "dist/**", "coverage/**"];
 
 fn main() -> ExitCode {
     let meta = AdapterMeta {

--- a/crates/crap4ts/src/napi.rs
+++ b/crates/crap4ts/src/napi.rs
@@ -1,0 +1,130 @@
+//! napi-rs Node.js binding entry point for crap4ts.
+//!
+//! Feature-gated behind `napi-binding`: see `crates/crap4ts/Cargo.toml`
+//! `[features]`. The standalone `crap4ts` CLI binary never links
+//! against Node-provided `napi_*` symbols, so this module is excluded
+//! from the default build.
+//!
+//! A single `analyze()` export is the npm surface. Node consumers call
+//! it programmatically and parse the returned JSON themselves; the
+//! binding stays thin instead of re-shaping `AnalysisOutput` into napi
+//! object types.
+
+use std::path::PathBuf;
+
+use napi_derive::napi;
+use serde::Serialize;
+
+use crap_core::core::{AnalyzeOptions as CoreAnalyzeOptions, analyze as core_analyze};
+use crap_core::domain::threshold::{ThresholdConfig, ThresholdPreset};
+use crap_core::domain::types::{AnalysisDiagnostics, AnalysisResult, ComplexityMetric};
+use crap_core::ports::ParseDiagnostic;
+
+use crate::adapters::coverage::IstanbulCoverage;
+use crate::adapters::walker::OxcWalker;
+use crate::parse_diagnostic::IstanbulParseDiagnostic;
+
+/// File extensions the walker discovers. Mirrors
+/// `crates/crap4ts/src/main.rs`'s `EXTENSIONS` constant so the napi
+/// surface sees the same source set the CLI does.
+const EXTENSIONS: &[&str] = &["ts", "tsx", "js", "jsx", "mjs", "cjs"];
+
+/// Inputs to [`analyze`]. JSON-side these map onto the same fields a
+/// `crap4ts` CLI invocation would set via `--src`, `--coverage`,
+/// `--threshold`, `--metric`.
+#[napi(object)]
+pub struct AnalyzeOptions {
+    /// Absolute or workspace-relative path to the directory containing
+    /// TypeScript / JavaScript source files to analyze.
+    pub source_root: String,
+    /// Path to the Istanbul-format coverage JSON file
+    /// (`coverage-final.json`) produced by jest / vitest / nyc.
+    pub coverage_path: String,
+    /// CRAP score threshold above which a function is flagged. Defaults
+    /// to the metric-correct preset (cyclomatic: 16.0, cognitive: 25.0).
+    pub threshold: Option<f64>,
+    /// Complexity metric. `"cyclomatic"` is the only metric supported
+    /// in 2.0 — `"cognitive"` surfaces `CrapError::MetricNotSupported`
+    /// through the returned `napi::Error`. Defaults to `"cyclomatic"`.
+    pub metric: Option<String>,
+}
+
+/// Wire shape for the JSON returned by [`analyze`]. Mirrors
+/// `crap_core::core::AnalysisOutput<P>`'s `{ result, diagnostics }`
+/// shape verbatim so Node consumers read the same fields a Rust
+/// embedder would. `#[serde(bound = "")]` suppresses serde's
+/// auto-generated bounds — `P: ParseDiagnostic` already requires
+/// `Serialize + DeserializeOwned`.
+#[derive(Serialize)]
+#[serde(bound = "")]
+struct AnalyzeWireOutput<'a, P: ParseDiagnostic> {
+    result: &'a AnalysisResult,
+    diagnostics: &'a AnalysisDiagnostics<P>,
+}
+
+fn parse_metric(s: &str) -> Result<ComplexityMetric, String> {
+    match s {
+        "cyclomatic" => Ok(ComplexityMetric::Cyclomatic),
+        "cognitive" => Ok(ComplexityMetric::Cognitive),
+        other => Err(format!(
+            "invalid metric `{other}`: expected `cyclomatic` or `cognitive`"
+        )),
+    }
+}
+
+/// Run CRAP analysis against a TypeScript / JavaScript source tree
+/// with Istanbul-format coverage. Returns the analysis output —
+/// functions, summary, diagnostics — as a JSON-encoded `String`.
+///
+/// Construction mirrors `crap4ts/src/main.rs`'s binary path: the same
+/// `OxcWalker` + `IstanbulCoverage` ports flow through
+/// `crap_core::core::analyze::<IstanbulParseDiagnostic>`. The JSON
+/// shape is `{ result: AnalysisResult, diagnostics: AnalysisDiagnostics }`.
+#[napi]
+pub fn analyze(opts: AnalyzeOptions) -> napi::Result<String> {
+    // Canonicalize matches `crap_core::core::AnalysisContext::new`'s
+    // own pre-canonicalization of `options.src`. The factory closure
+    // in `crap4ts::main` receives an already-canonical src from
+    // `cli::run`; the napi entry has no such pre-step, so without
+    // this alignment a relative or symlink'd `source_root` would
+    // produce coverage records keyed off the un-canonical path while
+    // the analyzer walked the canonical one — every record would
+    // fail `strip_prefix` and surface as a PathUnresolved diagnostic.
+    let src = PathBuf::from(&opts.source_root);
+    let src = src.canonicalize().unwrap_or(src);
+    let coverage = PathBuf::from(&opts.coverage_path);
+
+    let metric = match opts.metric.as_deref() {
+        Some(m) => parse_metric(m).map_err(napi::Error::from_reason)?,
+        None => ComplexityMetric::Cyclomatic,
+    };
+
+    let global_threshold = opts
+        .threshold
+        .unwrap_or_else(|| ThresholdPreset::Default.threshold(metric));
+
+    let analyze_options = CoreAnalyzeOptions {
+        src: src.clone(),
+        coverage,
+        threshold_config: ThresholdConfig {
+            global: global_threshold,
+            overrides: Vec::new(),
+        },
+        metric,
+        extensions: EXTENSIONS.iter().map(|&s| s.to_string()).collect(),
+        ..CoreAnalyzeOptions::default()
+    };
+
+    let walker = OxcWalker::new();
+    let coverage_adapter = IstanbulCoverage::new(src);
+
+    let output =
+        core_analyze::<IstanbulParseDiagnostic>(&analyze_options, &walker, &coverage_adapter)
+            .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+
+    let wire = AnalyzeWireOutput {
+        result: &output.result,
+        diagnostics: &output.diagnostics,
+    };
+    serde_json::to_string(&wire).map_err(|e| napi::Error::from_reason(e.to_string()))
+}

--- a/crates/crap4ts/src/napi.rs
+++ b/crates/crap4ts/src/napi.rs
@@ -5,11 +5,11 @@
 //! against Node-provided `napi_*` symbols, so this module is excluded
 //! from the default build.
 //!
-//! Thin shim — the orchestration logic lives in [`crate::analyze_to_json`]
-//! so it stays feature-independent and gets exercised by Rust
-//! integration tests + the LCOV coverage gate. This module only
-//! handles unpacking `AnalyzeOptions` and mapping `String` errors to
-//! `napi::Error`.
+//! Thin shim — the orchestration logic (and input validation) lives in
+//! [`crate::analyze_to_json`] so it stays feature-independent and gets
+//! exercised by Rust integration tests + the LCOV coverage gate. This
+//! module only handles unpacking `AnalyzeOptions`, parsing the metric
+//! string, and mapping `String` errors to `napi::Error`.
 
 use std::path::Path;
 
@@ -58,6 +58,12 @@ fn parse_metric(s: &str) -> Result<ComplexityMetric, String> {
 /// `crap_core::core::analyze::<IstanbulParseDiagnostic>` via the
 /// crate-internal [`crate::analyze_to_json`] helper. The JSON shape
 /// is `{ result: AnalysisResult, diagnostics: AnalysisDiagnostics }`.
+///
+/// Inputs are validated inside [`crate::analyze_to_json`]: a non-finite
+/// or negative `threshold`, or a `source_root` that does not resolve to
+/// a readable directory, each fail fast with a descriptive
+/// `napi::Error` rather than producing silently-wrong scores or an
+/// empty zero-function result.
 #[napi]
 pub fn analyze(opts: AnalyzeOptions) -> napi::Result<String> {
     let metric = match opts.metric.as_deref() {

--- a/crates/crap4ts/src/napi.rs
+++ b/crates/crap4ts/src/napi.rs
@@ -5,29 +5,19 @@
 //! against Node-provided `napi_*` symbols, so this module is excluded
 //! from the default build.
 //!
-//! A single `analyze()` export is the npm surface. Node consumers call
-//! it programmatically and parse the returned JSON themselves; the
-//! binding stays thin instead of re-shaping `AnalysisOutput` into napi
-//! object types.
+//! Thin shim — the orchestration logic lives in [`crate::analyze_to_json`]
+//! so it stays feature-independent and gets exercised by Rust
+//! integration tests + the LCOV coverage gate. This module only
+//! handles unpacking `AnalyzeOptions` and mapping `String` errors to
+//! `napi::Error`.
 
-use std::path::PathBuf;
+use std::path::Path;
 
 use napi_derive::napi;
-use serde::Serialize;
 
-use crap_core::core::{AnalyzeOptions as CoreAnalyzeOptions, analyze as core_analyze};
-use crap_core::domain::threshold::{ThresholdConfig, ThresholdPreset};
-use crap_core::domain::types::{AnalysisDiagnostics, AnalysisResult, ComplexityMetric};
-use crap_core::ports::ParseDiagnostic;
+use crap_core::domain::types::ComplexityMetric;
 
-use crate::adapters::coverage::IstanbulCoverage;
-use crate::adapters::walker::OxcWalker;
-use crate::parse_diagnostic::IstanbulParseDiagnostic;
-
-/// File extensions the walker discovers. Mirrors
-/// `crates/crap4ts/src/main.rs`'s `EXTENSIONS` constant so the napi
-/// surface sees the same source set the CLI does.
-const EXTENSIONS: &[&str] = &["ts", "tsx", "js", "jsx", "mjs", "cjs"];
+use crate::analyze_to_json;
 
 /// Inputs to [`analyze`]. JSON-side these map onto the same fields a
 /// `crap4ts` CLI invocation would set via `--src`, `--coverage`,
@@ -49,19 +39,6 @@ pub struct AnalyzeOptions {
     pub metric: Option<String>,
 }
 
-/// Wire shape for the JSON returned by [`analyze`]. Mirrors
-/// `crap_core::core::AnalysisOutput<P>`'s `{ result, diagnostics }`
-/// shape verbatim so Node consumers read the same fields a Rust
-/// embedder would. `#[serde(bound = "")]` suppresses serde's
-/// auto-generated bounds — `P: ParseDiagnostic` already requires
-/// `Serialize + DeserializeOwned`.
-#[derive(Serialize)]
-#[serde(bound = "")]
-struct AnalyzeWireOutput<'a, P: ParseDiagnostic> {
-    result: &'a AnalysisResult,
-    diagnostics: &'a AnalysisDiagnostics<P>,
-}
-
 fn parse_metric(s: &str) -> Result<ComplexityMetric, String> {
     match s {
         "cyclomatic" => Ok(ComplexityMetric::Cyclomatic),
@@ -78,53 +55,20 @@ fn parse_metric(s: &str) -> Result<ComplexityMetric, String> {
 ///
 /// Construction mirrors `crap4ts/src/main.rs`'s binary path: the same
 /// `OxcWalker` + `IstanbulCoverage` ports flow through
-/// `crap_core::core::analyze::<IstanbulParseDiagnostic>`. The JSON
-/// shape is `{ result: AnalysisResult, diagnostics: AnalysisDiagnostics }`.
+/// `crap_core::core::analyze::<IstanbulParseDiagnostic>` via the
+/// crate-internal [`crate::analyze_to_json`] helper. The JSON shape
+/// is `{ result: AnalysisResult, diagnostics: AnalysisDiagnostics }`.
 #[napi]
 pub fn analyze(opts: AnalyzeOptions) -> napi::Result<String> {
-    // Canonicalize matches `crap_core::core::AnalysisContext::new`'s
-    // own pre-canonicalization of `options.src`. The factory closure
-    // in `crap4ts::main` receives an already-canonical src from
-    // `cli::run`; the napi entry has no such pre-step, so without
-    // this alignment a relative or symlink'd `source_root` would
-    // produce coverage records keyed off the un-canonical path while
-    // the analyzer walked the canonical one — every record would
-    // fail `strip_prefix` and surface as a PathUnresolved diagnostic.
-    let src = PathBuf::from(&opts.source_root);
-    let src = src.canonicalize().unwrap_or(src);
-    let coverage = PathBuf::from(&opts.coverage_path);
-
     let metric = match opts.metric.as_deref() {
         Some(m) => parse_metric(m).map_err(napi::Error::from_reason)?,
         None => ComplexityMetric::Cyclomatic,
     };
-
-    let global_threshold = opts
-        .threshold
-        .unwrap_or_else(|| ThresholdPreset::Default.threshold(metric));
-
-    let analyze_options = CoreAnalyzeOptions {
-        src: src.clone(),
-        coverage,
-        threshold_config: ThresholdConfig {
-            global: global_threshold,
-            overrides: Vec::new(),
-        },
+    analyze_to_json(
+        Path::new(&opts.source_root),
+        Path::new(&opts.coverage_path),
+        opts.threshold,
         metric,
-        extensions: EXTENSIONS.iter().map(|&s| s.to_string()).collect(),
-        ..CoreAnalyzeOptions::default()
-    };
-
-    let walker = OxcWalker::new();
-    let coverage_adapter = IstanbulCoverage::new(src);
-
-    let output =
-        core_analyze::<IstanbulParseDiagnostic>(&analyze_options, &walker, &coverage_adapter)
-            .map_err(|e| napi::Error::from_reason(e.to_string()))?;
-
-    let wire = AnalyzeWireOutput {
-        result: &output.result,
-        diagnostics: &output.diagnostics,
-    };
-    serde_json::to_string(&wire).map_err(|e| napi::Error::from_reason(e.to_string()))
+    )
+    .map_err(napi::Error::from_reason)
 }

--- a/crates/crap4ts/tests/api_smoke.rs
+++ b/crates/crap4ts/tests/api_smoke.rs
@@ -94,13 +94,8 @@ fn analyze_to_json_explicit_threshold_overrides_default() {
     // metric-correct preset (cyclomatic: 16) would too on this
     // fixture, but pinning an explicit override exercises the
     // threshold-propagation path.
-    let json = analyze_to_json(
-        &root,
-        &coverage,
-        Some(1000.0),
-        ComplexityMetric::Cyclomatic,
-    )
-    .expect("analyze_to_json succeeds with explicit threshold");
+    let json = analyze_to_json(&root, &coverage, Some(1000.0), ComplexityMetric::Cyclomatic)
+        .expect("analyze_to_json succeeds with explicit threshold");
 
     let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
     let passed = parsed["result"]["passed"]
@@ -127,5 +122,62 @@ fn analyze_to_json_cognitive_metric_surfaces_not_supported_error() {
     assert!(
         err.to_lowercase().contains("cognitive"),
         "expected error message to mention `cognitive`, got: {err}"
+    );
+}
+
+#[test]
+fn analyze_to_json_negative_threshold_is_rejected() {
+    let (_tmp, root) = build_jest_fixture();
+    let coverage = root.join("coverage-final.json");
+
+    // A negative threshold is nonsensical for a CRAP score (always
+    // >= 1.0) — validate up front rather than silently flagging every
+    // function.
+    let err = analyze_to_json(&root, &coverage, Some(-1.0), ComplexityMetric::Cyclomatic)
+        .expect_err("negative threshold should be rejected");
+
+    assert!(
+        err.contains("threshold"),
+        "expected error message to mention `threshold`, got: {err}"
+    );
+}
+
+#[test]
+fn analyze_to_json_nan_threshold_is_rejected() {
+    let (_tmp, root) = build_jest_fixture();
+    let coverage = root.join("coverage-final.json");
+
+    // `NaN` can reach this entry point from a JS caller; comparisons
+    // against it are always false, so without an explicit check it
+    // would yield non-deterministic pass/fail classification.
+    let err = analyze_to_json(
+        &root,
+        &coverage,
+        Some(f64::NAN),
+        ComplexityMetric::Cyclomatic,
+    )
+    .expect_err("NaN threshold should be rejected");
+
+    assert!(
+        err.contains("threshold"),
+        "expected error message to mention `threshold`, got: {err}"
+    );
+}
+
+#[test]
+fn analyze_to_json_missing_source_root_is_rejected() {
+    let (_tmp, root) = build_jest_fixture();
+    let coverage = root.join("coverage-final.json");
+    let missing = root.join("does-not-exist");
+
+    // A `source_root` that does not resolve to a directory fails fast
+    // instead of walking an empty tree and returning a zero-function
+    // result the caller would have to diagnose themselves.
+    let err = analyze_to_json(&missing, &coverage, None, ComplexityMetric::Cyclomatic)
+        .expect_err("missing source_root should be rejected");
+
+    assert!(
+        err.contains("source_root"),
+        "expected error message to mention `source_root`, got: {err}"
     );
 }

--- a/crates/crap4ts/tests/api_smoke.rs
+++ b/crates/crap4ts/tests/api_smoke.rs
@@ -1,0 +1,131 @@
+//! Integration tests for the feature-independent
+//! `crap4ts::analyze_to_json` library API — the orchestration entry
+//! point both the binary path (via `main.rs::cli::run`) and the napi
+//! cdylib path (via `src/napi.rs`) ultimately funnel through.
+//!
+//! Mirrors `end_to_end_smoke.rs`'s tempdir + jest-fixture template
+//! pattern so the test exercises the same realistic source set the
+//! binary canary uses. Exists primarily so the self-CRAP gate scores
+//! `analyze_to_json` with non-zero coverage — without this test the
+//! function shows up as 0%-covered (CRAP = c² + c) in the
+//! `crates/crap4ts/src` self-check leg and trips the strict gate.
+
+use std::path::PathBuf;
+
+use crap_core::domain::types::ComplexityMetric;
+use crap4ts::analyze_to_json;
+use tempfile::TempDir;
+
+const FIXTURE_TEMPLATE: &str = include_str!("fixtures/istanbul-jest/coverage-final.json");
+
+/// Build a canonicalised tempdir with the W1.1 jest fixtures + a
+/// substituted `coverage-final.json`. Mirrors
+/// `end_to_end_smoke.rs::build_jest_fixture` (kept separate by design —
+/// each integration test owns its fixture wiring so editing one
+/// doesn't drag drift through the other).
+fn build_jest_fixture() -> (TempDir, PathBuf) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let canonical = std::fs::canonicalize(tmp.path()).expect("canonicalize tempdir");
+
+    for (name, content) in [
+        ("simple.ts", include_str!("fixtures/ts-fixtures/simple.ts")),
+        ("arrow.ts", include_str!("fixtures/ts-fixtures/arrow.ts")),
+        (
+            "Button.tsx",
+            include_str!("fixtures/ts-fixtures/Button.tsx"),
+        ),
+        ("map.ts", include_str!("fixtures/ts-fixtures/map.ts")),
+        ("mixed.ts", include_str!("fixtures/ts-fixtures/mixed.ts")),
+    ] {
+        std::fs::write(canonical.join(name), content).expect("write fixture");
+    }
+
+    let payload = FIXTURE_TEMPLATE.replace(
+        "{SRC_ROOT}",
+        &canonical.to_string_lossy().replace('\\', "/"),
+    );
+    std::fs::write(canonical.join("coverage-final.json"), payload)
+        .expect("write coverage-final.json");
+
+    (tmp, canonical)
+}
+
+#[test]
+fn analyze_to_json_happy_path_returns_valid_json_with_expected_shape() {
+    let (_tmp, root) = build_jest_fixture();
+    let coverage = root.join("coverage-final.json");
+
+    let json = analyze_to_json(&root, &coverage, None, ComplexityMetric::Cyclomatic)
+        .expect("analyze_to_json succeeds on jest fixture");
+
+    let parsed: serde_json::Value =
+        serde_json::from_str(&json).expect("returned string parses as JSON");
+
+    // Top-level shape mirrors `crap_core::core::AnalysisOutput<P>` —
+    // `{ result, diagnostics }`. Both keys must be present so Node
+    // consumers can read the same fields a Rust embedder would.
+    assert!(
+        parsed.get("result").is_some(),
+        "missing `result` key in JSON output:\n{json}"
+    );
+    assert!(
+        parsed.get("diagnostics").is_some(),
+        "missing `diagnostics` key in JSON output:\n{json}"
+    );
+
+    // At least one function gets analyzed (the jest fixture covers
+    // five TS files with multiple functions). functions_extracted is
+    // an unsigned counter inside diagnostics.
+    let functions_extracted = parsed["diagnostics"]["functions_extracted"]
+        .as_u64()
+        .expect("functions_extracted is a positive integer");
+    assert!(
+        functions_extracted > 0,
+        "expected functions_extracted > 0, got {functions_extracted}"
+    );
+}
+
+#[test]
+fn analyze_to_json_explicit_threshold_overrides_default() {
+    let (_tmp, root) = build_jest_fixture();
+    let coverage = root.join("coverage-final.json");
+
+    // Sky-high threshold guarantees `passed: true`; the default
+    // metric-correct preset (cyclomatic: 16) would too on this
+    // fixture, but pinning an explicit override exercises the
+    // threshold-propagation path.
+    let json = analyze_to_json(
+        &root,
+        &coverage,
+        Some(1000.0),
+        ComplexityMetric::Cyclomatic,
+    )
+    .expect("analyze_to_json succeeds with explicit threshold");
+
+    let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+    let passed = parsed["result"]["passed"]
+        .as_bool()
+        .expect("`result.passed` is a bool");
+    assert!(
+        passed,
+        "expected passed=true with threshold 1000, got result:\n{}",
+        serde_json::to_string_pretty(&parsed["result"]["summary"]).unwrap_or_default()
+    );
+}
+
+#[test]
+fn analyze_to_json_cognitive_metric_surfaces_not_supported_error() {
+    let (_tmp, root) = build_jest_fixture();
+    let coverage = root.join("coverage-final.json");
+
+    // crap4ts only implements cyclomatic in 2.0; the walker returns
+    // `CrapError::MetricNotSupported { metric: Cognitive }` which the
+    // library API surfaces as a `String` containing the metric name.
+    let err = analyze_to_json(&root, &coverage, None, ComplexityMetric::Cognitive)
+        .expect_err("cognitive metric should surface MetricNotSupported");
+
+    assert!(
+        err.to_lowercase().contains("cognitive"),
+        "expected error message to mention `cognitive`, got: {err}"
+    );
+}

--- a/packages/crap4ts/README.md
+++ b/packages/crap4ts/README.md
@@ -1,34 +1,50 @@
-# crap4ts (alpha)
+# crap4ts
 
-**This package is alpha and not yet published to npm.** It's a scaffold for the upcoming `crap4ts@2.x` line — a Rust-powered CRAP (Change Risk Anti-Patterns) score analyzer for TypeScript, distributed as a [napi-rs](https://napi.rs/) Node addon backed by the [oxc](https://oxc.rs/) parser.
+Rust-powered [CRAP](https://www.artima.com/weblogs/viewpost.jsp?thread=210575) (Change Risk Anti-Patterns) score analyzer for TypeScript and JavaScript. Combines [oxc](https://oxc.rs/)-driven AST complexity with [Istanbul](https://istanbul.js.org/) JSON coverage to identify functions that are both complex and under-tested.
+
+`crap4ts@2.x` is the TypeScript adapter for [`crap-rs`](https://github.com/breezy-bays-labs/crap-rs), distributed as a [napi-rs](https://napi.rs/) Node addon. The CRAP formula, scorecard envelope, and reporter shapes are shared with [`crap4rs`](https://github.com/breezy-bays-labs/crap-rs) (the Rust adapter) so TypeScript projects get identical semantics to Rust projects.
 
 ## Status
 
-| Component | Status |
-|---|---|
-| Workspace skeleton, Cargo wiring, CI build | landed in [crap4rs#137](https://github.com/breezy-bays-labs/crap4rs/issues/137) |
-| `oxc`-based TypeScript walker | not yet implemented (`unimplemented!()`) |
-| Istanbul JSON coverage parser | not yet implemented (`unimplemented!()`) |
-| napi-rs Node bindings beyond the `alphaStatus()` placeholder | not yet implemented |
-| npm publish | gated on the items above |
+This is `2.0.0-rc.1` — a release candidate in a 48–72 h soak window before the GA `2.0.0` cut. Try it on a sandbox project; file issues against [`breezy-bays-labs/crap-rs`](https://github.com/breezy-bays-labs/crap-rs/issues) if you hit anything.
 
-The `package.json` is intentionally marked `"private": true` so `npm publish` is a no-op until the walker lands.
+## Install
 
-## For working CRAP analysis on TypeScript today
-
-Use the previous, JavaScript-implemented analyzer:
-
-```
-npm install --save-dev crap4ts@1
+```sh
+npm install crap4ts@2.0.0-rc.1
+# or
+pnpm add crap4ts@2.0.0-rc.1
 ```
 
-The `v1.x-maintenance-announcement` release on [`breezy-bays-labs/crap4ts`](https://github.com/breezy-bays-labs/crap4ts) documents the deprecation timeline.
+Published platforms in `2.0.0-rc.1`:
+- macOS (arm64 + x64)
+- Linux (x64 / glibc)
 
-## Why a v2
+Windows and Linux arm64 / musl are tracked for a later release (see [`crap-rs`#154](https://github.com/breezy-bays-labs/crap-rs/issues/154)).
 
-The v2 analyzer shares its CRAP formula, scorecard envelope, and reporter shapes with [`crap4rs`](https://github.com/breezy-bays-labs/crap-rs) by linking the same `crap-core` Rust library. That gives TypeScript projects identical analysis semantics to Rust projects (per-function complexity, line-range matching against coverage data, deltas vs a baseline, JSON / Markdown / SARIF / HTML / scorecard-row reporters) — at native speed, with no separate engine to maintain.
+## Usage
 
-## Tracking
+```js
+const { analyze } = require('crap4ts');
 
-- Skeleton + scaffolding: [crap4rs#137](https://github.com/breezy-bays-labs/crap4rs/issues/137)
-- Follow-up walker / parser pipeline: tracked separately (see the issue thread for the pipeline name once filed).
+const json = analyze({
+  sourceRoot: 'src',
+  coveragePath: 'coverage/coverage-final.json',
+  // Optional:
+  // threshold: 16,            // metric-correct default (cyclomatic: 16, cognitive: 25)
+  // metric: 'cyclomatic',     // 'cyclomatic' (default) or 'cognitive' (not yet supported)
+});
+
+const { result, diagnostics } = JSON.parse(json);
+console.log(result.summary);
+```
+
+Generate `coverage-final.json` via your test runner with Istanbul coverage enabled (`jest --coverage`, `vitest --coverage`, `c8 --reporter=json`, etc.).
+
+## Migrating from `crap4ts@1.x`
+
+See [`MIGRATION.md`](https://github.com/breezy-bays-labs/crap-rs/blob/main/MIGRATION.md) for the full upgrade guide. Short version: scores may differ for three compounding reasons (calibrated threshold default, TS-specific calibration not yet validated, arrow-function coverage handling), and the subpath exports (`crap4ts/formula`, `crap4ts/complexity`, `crap4ts/coverage`) are not re-exposed in 2.x — call `analyze()` and read fields from the returned JSON.
+
+## License
+
+MIT OR Apache-2.0.

--- a/packages/crap4ts/index.js
+++ b/packages/crap4ts/index.js
@@ -25,7 +25,7 @@ function nativeBindingFilename() {
         default:
           throw new Error(
             `crap4ts: unsupported macOS architecture: ${arch}. ` +
-              `Published architectures for 2.0.0-rc.1: arm64, x64.`,
+              `Published architectures: arm64, x64.`,
           );
       }
     case 'linux':
@@ -34,12 +34,12 @@ function nativeBindingFilename() {
       }
       throw new Error(
         `crap4ts: unsupported Linux architecture: ${arch}. ` +
-          `Published architectures for 2.0.0-rc.1: x64 (glibc).`,
+          `Published architectures: x64 (glibc).`,
       );
     default:
       throw new Error(
         `crap4ts: unsupported platform: ${platform}. ` +
-          `Published platforms for 2.0.0-rc.1: darwin, linux.`,
+          `Published platforms: darwin, linux.`,
       );
   }
 }

--- a/packages/crap4ts/index.js
+++ b/packages/crap4ts/index.js
@@ -1,6 +1,66 @@
-// ALPHA — the crap4ts@2 walker has not yet shipped. This package is a
-// scaffold only. For working CRAP analysis on TypeScript today, use
-// crap4ts@1.x. See breezy-bays-labs/crap4rs#137 for the v2 plan.
-throw new Error(
-  'crap4ts@2 is in alpha — the oxc walker has not yet shipped. Use crap4ts@1.x for now.',
-);
+// crap4ts — TypeScript adapter for the crap-rs CRAP score analyzer.
+//
+// Single-package distribution: this tarball ships the native cdylib for
+// every platform the publish workflow builds (linux x64-gnu, darwin
+// arm64, darwin x64). Selecting the right one at require-time keeps
+// the npm install lean enough that we don't yet need the scoped
+// platform-subpackage / optionalDependencies layout used by larger
+// napi-rs crates.
+
+'use strict';
+
+const { existsSync } = require('node:fs');
+const { join } = require('node:path');
+
+const { platform, arch } = process;
+
+function nativeBindingFilename() {
+  switch (platform) {
+    case 'darwin':
+      switch (arch) {
+        case 'arm64':
+          return 'crap4ts.darwin-arm64.node';
+        case 'x64':
+          return 'crap4ts.darwin-x64.node';
+        default:
+          throw new Error(
+            `crap4ts: unsupported macOS architecture: ${arch}. ` +
+              `Published architectures for 2.0.0-rc.1: arm64, x64.`,
+          );
+      }
+    case 'linux':
+      if (arch === 'x64') {
+        return 'crap4ts.linux-x64-gnu.node';
+      }
+      throw new Error(
+        `crap4ts: unsupported Linux architecture: ${arch}. ` +
+          `Published architectures for 2.0.0-rc.1: x64 (glibc).`,
+      );
+    default:
+      throw new Error(
+        `crap4ts: unsupported platform: ${platform}. ` +
+          `Published platforms for 2.0.0-rc.1: darwin, linux.`,
+      );
+  }
+}
+
+const filename = nativeBindingFilename();
+const localPath = join(__dirname, filename);
+
+if (!existsSync(localPath)) {
+  throw new Error(
+    `crap4ts: native binding ${filename} not found in ${__dirname}. ` +
+      `The npm package may be incomplete or installed for the wrong platform.`,
+  );
+}
+
+const nativeBinding = require(localPath);
+
+if (!nativeBinding || typeof nativeBinding.analyze !== 'function') {
+  throw new Error(
+    `crap4ts: native binding ${filename} loaded but is missing the ` +
+      `'analyze' export. The cdylib may be from an incompatible build.`,
+  );
+}
+
+module.exports = { analyze: nativeBinding.analyze };

--- a/packages/crap4ts/package.json
+++ b/packages/crap4ts/package.json
@@ -16,6 +16,9 @@
     "x64",
     "arm64"
   ],
+  "libc": [
+    "glibc"
+  ],
   "keywords": [
     "crap",
     "complexity",

--- a/packages/crap4ts/package.json
+++ b/packages/crap4ts/package.json
@@ -1,16 +1,42 @@
 {
   "name": "crap4ts",
-  "version": "2.0.0-alpha.1",
-  "description": "TypeScript adapter for crap-rs. ALPHA: walker not yet implemented; depends on the in-progress oxc parser. For working CRAP analysis on TS today, see crap4ts@1.x.",
+  "version": "2.0.0-rc.1",
+  "description": "TypeScript adapter for crap-rs — Rust-powered CRAP score analyzer combining oxc AST complexity with Istanbul JSON coverage. Identifies functions that are both complex and under-tested.",
   "main": "index.js",
-  "private": true,
+  "files": [
+    "index.js",
+    "crap4ts.*.node",
+    "README.md"
+  ],
+  "os": [
+    "darwin",
+    "linux"
+  ],
+  "cpu": [
+    "x64",
+    "arm64"
+  ],
+  "keywords": [
+    "crap",
+    "complexity",
+    "coverage",
+    "typescript",
+    "javascript",
+    "quality",
+    "oxc",
+    "istanbul"
+  ],
   "publishConfig": {
     "access": "public"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/breezy-bays-labs/crap4rs.git",
+    "url": "https://github.com/breezy-bays-labs/crap-rs.git",
     "directory": "packages/crap4ts"
+  },
+  "homepage": "https://github.com/breezy-bays-labs/crap-rs",
+  "bugs": {
+    "url": "https://github.com/breezy-bays-labs/crap-rs/issues"
   },
   "license": "MIT OR Apache-2.0",
   "engines": {


### PR DESCRIPTION
## Summary

W4.1a of the crap4ts TypeScript-adapter pipeline. First release candidate of `crap4ts` 2.x — the napi-rs-backed Node addon that replaces the JavaScript-only `crap4ts` 1.x. CRAP formula, scorecard envelope, and reporter shapes are now shared verbatim with the Rust adapter `crap4rs` via the language-agnostic `crap-core` library.

**What ships in this PR (the build artifacts; no publish yet):**

1. **`crates/crap4ts/src/napi.rs`** (NEW, feature-gated `#[cfg(feature = "napi-binding")]`) — a single `analyze({ sourceRoot, coveragePath, threshold?, metric? })` napi entry returning JSON. Wraps `crap_core::core::AnalysisOutput<P>` via a local `AnalyzeWireOutput` serde struct so no `crap-core` public surface change is needed (CQO ADVISORY-7: "release sub-issues must NOT contain API discoveries"). Pre-canonicalizes `source_root` to align with `cli::run`'s factory-closure pre-canonicalization (advisor catch — relative or symlink'd source paths would otherwise produce `PathUnresolved` diagnostics).
2. **`packages/crap4ts/index.js`** — hand-rolled 60-line single-package dispatcher (3-platform switch on `process.platform` + `process.arch`; macOS arm64, macOS x64, Linux x64 / glibc).
3. **`.github/workflows/publish.yml`** (NEW) — tag-triggered (`crap4ts-v*`) matrix workflow with `id-token: write` for npm OIDC trusted publishing (`npm publish --provenance`). Each platform's `.node` bundled into one tarball; per-step `env:`-scoped variables so the `GITHUB_REF_NAME`-derived tag is never interpolated into a shell command.
4. **`.github/workflows/ci.yml`** — no-feature bin canary step in the existing `crap4ts-build` matrix (CAO ADVISORY-2). Fails CI if `nm`/`otool` shows any `napi_` symbol in the standalone bin — catches feature-gate leakage mechanically.
5. **`crates/crap4ts/Cargo.toml`** — `2.0.0-alpha.1` → `2.0.0-rc.1`; description refreshed (alpha disclaimer removed).
6. **`packages/crap4ts/package.json`** — `2.0.0-alpha.1` → `2.0.0-rc.1`; lifted `"private": true` (BLOCKING — npm refuses private packages); added `os`/`cpu`/`keywords`/`files` metadata; repo URL fixed (`crap4rs.git` → `crap-rs.git`).
7. **`packages/crap4ts/README.md`** — npm-package-facing README replacing the stale alpha disclaimer.
8. **`MIGRATION.md`** — new "crap4ts@1.x → crap4ts@2.0.0" section. Three compounding reasons scores may differ (threshold default `12 → 16`, TS-specific calibration not yet validated against the `crap4ts@1.x` corpus, statementMap-only coverage without fnMap fallback — documented per `coverage/mod.rs:280-284`'s deliberate trade-off, not the placeholder language the advisor flagged in a first draft) + subpath-export replacement recipes.
9. **`CHANGELOG.md`** — new `[crap4ts 2.0.0-rc.1]` release section. The cdylib ships from workspace `HEAD`, so all current `[Unreleased]` entries (including #214 Istanbul parser narrowing and #221 namespace-qualified naming that directly affect crap4ts behavior) ARE included in this RC — disclaimer rephrased to reflect that.

## Verification

- `cargo build --workspace --release` + `cargo build --package crap4ts --release --lib --features napi-binding` → cdylib at `target/release/libcrap4ts.dylib`.
- **No-feature bin canary** (CAO ADVISORY-2): `cargo build --package crap4ts --release` (no features) + `nm target/release/crap4ts | grep napi_` → 0 hits; `otool -L` shows no napi dylib linkage.
- `cargo nextest run --workspace --all-targets` → 1077 pass, 0 skipped (1077 vs prior 1078 accounts for removed `alpha_status_message_is_stable` placeholder test).
- Full lefthook pre-push battery (9 checks): ast-purity, clippy, cucumber, deny, docs (-D warnings), fmt, insta wire snapshots, msrv 1.93, test — all green in 53 s.
- AST-purity grep on `crates/crap-core/src/` → 0 matches.
- Wire snapshots → byte-identical. The napi entry is feature-gated; CLI output unchanged.
- **Functional smoke** (local): `node -e "require('libcrap4ts.dylib').analyze({...})"` against `crap4ts/tests/fixtures/ts-fixtures` + `istanbul-jest/coverage-final.json` → 74 functions extracted, valid JSON shape (`{ result, diagnostics }`), parse-failure warning correctly emitted to stderr on `broken.ts`.

## Plan deviations (surfaced, captured in observations.md)

Three Y-statements worth reviewing before the publish runs:

- **Single-package npm distribution model** chosen over napi-rs's canonical multi-package `optionalDependencies` layout. Every platform's `.node` ships in the same `crap4ts` tarball; runtime dispatch lives in a hand-rolled 60-line `index.js`. Trade-off: ~15–30 MB per install vs ~5–10 MB on the multi-package model. CEng ADVISORY-5 said "use `@napi-rs/cli`'s `napi build`"; took the simpler hand-rolled path for RC. Re-evaluate at W4.1b GA based on download-size feedback.
- **`crap-core` stayed at `0.3.0`** (NOT bumped). focus.md and impl-plan §W4.1a referenced "`crap-core 0.2.0` from W2.5"; reality is `0.3.0` (post-W2.5 bump in #218 metric-keyed threshold calibration, `2fdbc48`). No additional bump in W4.1a because the napi entry adds no `crap-core` public surface — consumes the existing `pub fn analyze<P>` (CQO ADVISORY-7 pre-flight verified).
- **`AnalysisOutput<P>` serialization** sidestepped via a local wrapper struct in `crap4ts::napi` rather than adding `Serialize` upstream — keeps the W4.1a PR free of API discoveries. If a future Rust embedder needs the same JSON shape, adding `Serialize` to `AnalysisOutput<P>` is a follow-up.

## Post-merge ceremony (NOT executed in this PR)

1. Verify `crates/crap4ts/Cargo.toml` + `packages/crap4ts/package.json` both show `2.0.0-rc.1` ON the merge commit (per `feedback_release_tag_merge_commit` memory) BEFORE pushing the tag. NEVER tag while this PR is still open.
2. **Provision npm OIDC trusted publishing for `crap4ts`** on npmjs.com (one-time UI setup; user confirmed pre-flight via AskUserQuestion that this is not yet provisioned). Without it, `publish.yml` will 401 on the first tag push.
3. Tag `crap4ts-v2.0.0-rc.1` on the merge commit and push.
4. `publish.yml` builds 3 cdylibs (linux-x64-gnu, darwin-arm64, darwin-x64), bundles all into the same tarball, and publishes via OIDC with provenance.
5. Verify on npm: `npm view crap4ts@2.0.0-rc.1 versions` returns the new version; sandbox install `npm install crap4ts@2.0.0-rc.1` succeeds.
6. **Open soak-tracking issue**: "crap4ts@2.0.0-rc.1 soak — watch for downstream issues until {merge-date + 72 h}". DO NOT proceed to W4.1b #193 until the soak window closes cleanly.

## Rollback plan

If the RC reveals a blocking regression during the soak window:

- `npm unpublish crap4ts@2.0.0-rc.1` is available for 72 h after publish.
- Cut a corrective `2.0.0-rc.2` PR with the fix; restart the soak window.
- The `optionalDependencies` multi-package model stays on the table for a corrective RC if the single-package install size turns out to be a blocker in real consumer environments.

## W4.1b GA promote criteria (the next sub-issue, #193)

The 48–72 h soak completes cleanly when:

- No `crap-rs` issues are opened citing 2.0.0-rc.1 breakage.
- A clean `pnpm add crap4ts@2.0.0-rc.1 && node -e "require('crap4ts').analyze({...})"` succeeds on macOS (arm64 + x64) and Linux x64.
- `npm view crap4ts@2.0.0-rc.1 downloads` shows at least the integration tests have exercised the package (or the team has manually validated against Mokumo's TS frontend if available).

W4.1b #193 is a low-complexity ceremony PR (Cargo.toml + package.json bump `2.0.0-rc.1 → 2.0.0`, CHANGELOG promote) — no code changes.

## Context

- Epic: #173
- Pipeline: `crap-rs/20260513-typescript-adapter`
- Closes #192
- Related: `feedback_release_tag_merge_commit` memory (tag-on-merge-commit ceremony), `feedback_closes-keyword-not-in-backticks` (this PR follows it; `Closes #192` is plain prose), `~/Github/ops/workspace/crap-rs/20260513-typescript-adapter/impl-plan.md` §W4.1a (the source of truth for AC #1–12), `~/Github/ops/workspace/crap-rs/20260513-typescript-adapter/observations.md` (plan deviations captured for closeout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * v2.0.0-rc.1 released: Rust-backed Node addon with a top-level analyze() export
  * Multi-platform native binaries and runtime loader with clear unsupported-target errors

* **Documentation**
  * Migration guide and README updated with v2 usage, examples, and rollback notes
  * Changelog entry describing RC release and soak window

* **Chores**
  * Automated publish workflow and CI checks for release validation

* **Tests**
  * Expanded integration/smoke tests for analyze() input validation and output shape

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/breezy-bays-labs/crap-rs/pull/231?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->