### PR TITLE
ci(crap4ts): #234 — make publish.yml OIDC-capable (Node 24 + version-derived dist-tag)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -120,18 +120,26 @@ jobs:
         with:
           persist-credentials: false
 
+      # Node 24 + npm >= 11.5.1 are the floor for npm OIDC trusted
+      # publishing (https://docs.npmjs.com/trusted-publishers). Node 20
+      # ships npm 10.x, which cannot mint the OIDC token and 401s.
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Upgrade npm to an OIDC-capable version
+        run: npm install -g npm@^11.5.1
 
       - name: Verify tag matches package.json + Cargo.toml versions
         # Belt-and-braces tag<->version check. The
         # `release_tag_merge_commit` convention requires verifying this
         # on the merge commit BEFORE pushing the tag; this CI gate
         # catches the rare case where someone pushed a tag onto a
-        # commit that doesn't match.
+        # commit that doesn't match. The verified version is exported so
+        # the publish step derives the dist-tag without re-parsing.
+        id: verify
         env:
           REF_NAME: ${{ github.ref_name }}
         run: |
@@ -145,6 +153,7 @@ jobs:
             echo "::error::version mismatch between tag, package.json, and Cargo.toml"
             exit 1
           fi
+          echo "version=${TAG_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Download all cdylib artifacts
         uses: actions/download-artifact@v4
@@ -161,6 +170,20 @@ jobs:
             test -f "$plat" || { echo "::error::missing $plat"; exit 1; }
           done
 
+      # Prereleases (version contains a hyphen, e.g. `2.0.0-rc.1`) publish
+      # under the `rc` dist-tag so `latest` keeps pointing at the current
+      # stable release during a soak; a plain `2.0.0` publishes to
+      # `latest`. Without an explicit `--tag`, npm sends every version —
+      # prereleases included — to `latest`.
       - name: Publish to npm with provenance (OIDC)
-        run: npm publish --provenance --access public
+        env:
+          VERSION: ${{ steps.verify.outputs.version }}
+        run: |
+          if [[ "$VERSION" == *-* ]]; then
+            NPM_TAG="rc"
+          else
+            NPM_TAG="latest"
+          fi
+          echo "publishing crap4ts@${VERSION} under dist-tag '${NPM_TAG}'"
+          npm publish --provenance --access public --tag "$NPM_TAG"
         working-directory: packages/crap4ts


### PR DESCRIPTION
## Summary

`publish.yml` as merged in #231 could not perform npm OIDC trusted publishing, and would have published prereleases to the `latest` dist-tag. Two `publish`-job fixes:

1. **Node 20 → 24 + npm >= 11.5.1.** npm OIDC trusted publishing requires npm >= 11.5.1 and Node >= 22.14.0 ([npm docs](https://docs.npmjs.com/trusted-publishers)). Node 20 ships npm 10.x, which cannot mint the OIDC token — `npm publish --provenance` falls back to a non-existent `NODE_AUTH_TOKEN` and 401s. The explicit `npm install -g npm@^11.5.1` step semantically pins the requirement so the diff documents *why*.
2. **Version-derived dist-tag.** `npm publish` ran with no `--tag`, so npm's default would send `2.0.0-rc.1` to `latest`. The publish step now derives the tag from the verified version: prerelease (`2.0.0-rc.1`) → `rc`, stable (`2.0.0`) → `latest`. The version is parsed once in the existing `verify` step and passed forward via a step output — no duplicate parsing.

## Why this matters now

Discovered during the W4.1a #192 post-merge ceremony (provisioning npm OIDC trusted publishing for `crap4ts`). Without this fix, pushing the `crap4ts-v2.0.0-rc.1` tag builds all three cdylibs and then fails the `npm publish` step. Neither CodeRabbit nor Gemini flagged it on #231.

## Post-tag verification recipe

After `crap4ts-v2.0.0-rc.1` is pushed and `publish.yml` completes:

```
npm view crap4ts@2.0.0-rc.1 version    # -> 2.0.0-rc.1
npm view crap4ts dist-tags             # -> { latest: '1.0.1', rc: '2.0.0-rc.1' }
```

`latest` must stay at `1.0.1` — that is the dist-tag fix working.

## Out of scope (tracked separately)

- `macos-14 → macos-15` darwin-arm64 runner bump — #232
- GitHub Actions SHA-pinning — #233
- `actionlint` reports one pre-existing `info`-level SC2035 (`ls -la *.node`) on the untouched "Confirm all platforms present" step — pre-dates this PR, left as-is to keep the change single-purpose.

## Testing

- `actionlint` clean on all changed lines (only the pre-existing SC2035 above).
- YAML parses; `publish` job step count 6 → 7 (the npm-upgrade step).
- `publish.yml` runs only on a `crap4ts-v*` tag push — it cannot execute on this PR; the post-tag recipe above is the live verification.

Closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated npm publishing workflow to Node.js 24 and npm v11.5.1 with OIDC support
  * Enhanced version distribution: prerelease versions now automatically published under `rc` dist-tag while stable releases use `latest`
  * Added npm provenance signing for improved package verification

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/breezy-bays-labs/crap-rs/pull/237?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->