### PR TITLE
docs(crap-rs): #238 — de-alpha crap4ts CLI + reframe root README for the monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,21 @@
-# crap4rs
+# crap-rs
 
 [![CI](https://github.com/breezy-bays-labs/crap-rs/actions/workflows/ci.yml/badge.svg)](https://github.com/breezy-bays-labs/crap-rs/actions/workflows/ci.yml)
 [![crates.io](https://img.shields.io/crates/v/crap4rs.svg)](https://crates.io/crates/crap4rs)
+[![npm](https://img.shields.io/npm/v/crap4ts.svg)](https://www.npmjs.com/package/crap4ts)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](#license)
 
-CRAP (Change Risk Anti-Patterns) score analyzer for Rust codebases. Finds complex, under-tested functions.
+**CRAP (Change Risk Anti-Patterns) score analysis with a shared Rust core and language-specific adapters.** A CRAP score fuses a function's complexity with its test coverage into a single number — high complexity plus low coverage means high risk when the code changes.
+
+This workspace ships two analyzers over one shared core:
+
+| Crate / package | Analyzes | Coverage format | Published to |
+|-----------------|----------|-----------------|--------------|
+| **`crap4rs`** | Rust | LCOV | [crates.io](https://crates.io/crates/crap4rs) |
+| **`crap4ts`** | TypeScript / JavaScript | Istanbul JSON | [npm](https://www.npmjs.com/package/crap4ts) — see its [package README](packages/crap4ts/README.md) |
+| **`crap-core`** | _shared library_ | — | internal: CRAP formula, thresholds, reporters, analysis types |
+
+Both adapters link the same `crap-core`, so Rust and TypeScript projects get identical CRAP semantics — the same formula, envelope, and reporters.
 
 ## What is CRAP?
 
@@ -28,6 +39,10 @@ Every score lands in one of four risk levels. The classification is intrinsic to
 | > 30 | High |
 
 The build gate is a separate axis — see [Threshold (the gate)](#threshold-the-gate) below.
+
+## crap4rs — the Rust analyzer
+
+Everything from here down documents the `crap4rs` Rust CLI. For TypeScript / JavaScript projects, see the [crap4ts package README](packages/crap4ts/README.md).
 
 ## Usage
 
@@ -74,7 +89,7 @@ A function with CRAP `7` is `Acceptable` and never trips any preset. A function 
 
 Risk classification feeds SARIF severity (`high → error`, `moderate → warning`, `acceptable/low → note`); threshold feeds the exit code. Scorecard-row status (`Red`/`Yellow`/`Green`) — see [docs/scorecard-row-contract.md](docs/scorecard-row-contract.md) — is minted from the threshold gate, not from risk classification.
 
-These thresholds do not match `crap4ts` exactly. The long-term goal is shared CRAP math and shared analysis concepts via `crap-core`, with language-specific adapters and threshold policy above that core.
+`crap4rs` and `crap4ts` share the CRAP formula and analysis concepts through `crap-core`, but threshold policy is language-specific — the two analyzers deliberately do not use identical thresholds.
 
 ### Why cognitive by default?
 
@@ -405,45 +420,21 @@ cargo build --release
 
 - [cargo-llvm-cov](https://github.com/taiki-e/cargo-llvm-cov) for generating LCOV coverage data
 
-## Architecture
+## Workspace layout
 
-Hexagonal (ports & adapters) design for future extraction into a polyglot `crap-core` library:
+crap-rs is a Cargo workspace built on a hexagonal (ports & adapters) core:
 
-```
-domain/    Pure logic: CRAP formula, thresholds, types
-ports/     Trait definitions (ComplexityPort, CoveragePort)
-adapters/  syn walker, LCOV parser, reporters
-core/      Wires adapters through ports
-cli/       clap argument parsing
-```
+| Crate | Role |
+|-------|------|
+| `crap-core` | Language-agnostic core — the CRAP formula, threshold model, result types, reporters, and analysis orchestration (`domain/` → `ports/` → `core/`). |
+| `crap4rs` | Rust adapter — `syn`-based complexity walker, LCOV coverage parser, and the Rust CLI. |
+| `crap4ts` | TypeScript adapter — `oxc`-based complexity walker, Istanbul JSON coverage parser, published to npm as a napi-rs addon. |
 
-## Extraction roadmap
-
-This repo is the Rust implementation today, but the longer-term direction is a shared multi-language CRAP toolchain:
-
-- `crap-core` — shared CRAP math, thresholds model, result types, and language-agnostic analysis interfaces
-- `crap4rs` — Rust-specific complexity and coverage adapters plus Rust-facing CLI/package surfaces
-- `crap4ts` — TypeScript-specific complexity and coverage adapters plus npm-facing package surfaces
-
-That split means:
-
-- shared analysis concepts should converge in `crap-core`
-- language parsers, coverage formats, and default threshold policy remain language-specific
-- matching `crap4rs` and `crap4ts` behavior does not require identical thresholds
-
-The current directory layout already reflects that extraction boundary:
-
-- `domain/`, `ports/`, and `core/` are the future `crap-core` seam
-- `adapters/` is the Rust-specific layer
-- `cli/` is the Rust delivery surface that may later become part of a unified monorepo layout
+Each adapter supplies its own `ComplexityPort` and `CoveragePort` implementations; `crap-core` never imports a language toolchain. An `ast-purity` CI gate enforces this — it bans `syn`, `oxc`, and coverage-format types from `crap-core/src/`. The CRAP math is shared; threshold policy stays language-specific, so `crap4rs` and `crap4ts` need not use identical thresholds.
 
 ## Self-check
 
-The self-referential CI check runs at `--strict` (15) against `src`, excluding `cli/**`.
-
-## Related
-
-- [crap4ts](https://github.com/breezy-bays-labs/crap4ts) — CRAP analyzer for TypeScript
+crap-rs analyzes its own source as a CI gate — `crap4rs` runs at `--strict` against each workspace crate (`crap-core`, `crap4rs`, and `crap4ts`).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This workspace ships two analyzers over one shared core:
 | **`crap4ts`** | TypeScript / JavaScript | Istanbul JSON | [npm](https://www.npmjs.com/package/crap4ts) — see its [package README](packages/crap4ts/README.md) |
 | **`crap-core`** | _shared library_ | — | internal: CRAP formula, thresholds, reporters, analysis types |
 
-Both adapters link the same `crap-core`, so Rust and TypeScript projects get identical CRAP semantics — the same formula, envelope, and reporters.
+Both adapters link the same `crap-core`, so Rust and TypeScript / JavaScript projects get identical CRAP semantics — the same formula, envelope, and reporters.
 
 ## What is CRAP?
 
@@ -428,7 +428,7 @@ crap-rs is a Cargo workspace built on a hexagonal (ports & adapters) core:
 |-------|------|
 | `crap-core` | Language-agnostic core — the CRAP formula, threshold model, result types, reporters, and analysis orchestration (`domain/` → `ports/` → `core/`). |
 | `crap4rs` | Rust adapter — `syn`-based complexity walker, LCOV coverage parser, and the Rust CLI. |
-| `crap4ts` | TypeScript adapter — `oxc`-based complexity walker, Istanbul JSON coverage parser, published to npm as a napi-rs addon. |
+| `crap4ts` | TypeScript / JavaScript adapter — `oxc`-based complexity walker, Istanbul JSON coverage parser, published to npm as a napi-rs addon. |
 
 Each adapter supplies its own `ComplexityPort` and `CoveragePort` implementations; `crap-core` never imports a language toolchain. An `ast-purity` CI gate enforces this — it bans `syn`, `oxc`, and coverage-format types from `crap-core/src/`. The CRAP math is shared; threshold policy stays language-specific, so `crap4rs` and `crap4ts` need not use identical thresholds.
 

--- a/crates/crap4ts/src/adapters/mod.rs
+++ b/crates/crap4ts/src/adapters/mod.rs
@@ -1,13 +1,12 @@
 //! crap4ts adapters — TypeScript-specific bindings for the language-
 //! agnostic `crap_core` analyzer.
 //!
-//! Two stubs live here; both runtime-panic via `unimplemented!()` and
-//! will be filled in by the follow-up TypeScript-adapter pipeline:
+//! Two adapter modules live here:
 //!
-//! - **`walker`**: `oxc`-based AST walker that will extract per-function
-//!   cognitive / cyclomatic complexity from `.ts`/`.tsx` sources.
+//! - **`walker`**: `oxc`-based AST walker that extracts per-function
+//!   cyclomatic complexity from TypeScript and JavaScript sources.
 //! - **`coverage`**: Istanbul JSON coverage parser
-//!   (`coverage-final.json`) that will convert vitest / jest coverage
+//!   (`coverage-final.json`) that converts jest / vitest / nyc coverage
 //!   into `ParseOutput<IstanbulParseDiagnostic>`.
 //!
 //! Both modules are TypeScript / oxc-toolchain coupled and live in

--- a/crates/crap4ts/src/main.rs
+++ b/crates/crap4ts/src/main.rs
@@ -1,12 +1,9 @@
 //! Thin TypeScript adapter binary — wires `crap_core::cli::run<P>` with
-//! the oxc/Istanbul ports (currently stubs).
+//! the oxc walker and Istanbul coverage ports.
 //!
 //! Mirrors `crates/crap4rs/src/main.rs` exactly so future maintenance
-//! sees one shape. ALPHA: invoking the real analysis path runtime-
-//! panics inside the walker / coverage parser stubs. `--help` and
-//! `--version` work because clap dispatch lives in `crap_core::cli`
-//! and the `AdapterMeta` plumbing renders TS-flavored help text
-//! correctly even while the walker is unimplemented.
+//! sees one shape. clap dispatch lives in `crap_core::cli`; the
+//! `AdapterMeta` plumbing renders TS-flavored help text.
 //!
 //! The coverage adapter is supplied as a factory closure so
 //! `crap_core::cli::run` can construct the Istanbul parser *after*
@@ -23,27 +20,22 @@ use crap4ts::adapters::coverage::IstanbulCoverage;
 use crap4ts::adapters::walker::OxcWalker;
 use crap4ts::{DEFAULT_EXCLUDES, EXTENSIONS};
 
-const ABOUT: &str = "CRAP score analyzer for TypeScript (alpha)";
+const ABOUT: &str = "CRAP score analyzer for TypeScript";
 const LONG_ABOUT: &str = "CRAP (Change Risk Anti-Patterns) score analyzer for TypeScript / \
                          JavaScript codebases.\n\n\
-                         ALPHA: the oxc-based walker and Istanbul coverage parser are stubs — \
-                         invoking the analysis path will runtime-panic. `--help`, `--version`, \
-                         and `completions` work end-to-end so downstream packaging can be wired \
-                         up ahead of the parser ship in the next pipeline.\n\n\
-                         When the real adapters land, combines AST complexity (via oxc) with \
-                         Istanbul JSON coverage to identify functions that are both complex \
-                         and under-tested. Default metric is cyclomatic complexity; cognitive \
-                         is not yet supported on crap4ts.";
+                         Combines AST complexity (via oxc) with Istanbul JSON coverage to \
+                         identify functions that are both complex and under-tested. Default \
+                         metric is cyclomatic complexity; cognitive is not yet supported on \
+                         crap4ts.";
 
 const AFTER_HELP: &str = "\
-EXAMPLES (alpha — walker not yet implemented):
+EXAMPLES:
   crap4ts --coverage coverage/coverage-final.json
   crap4ts --coverage coverage/coverage-final.json --threshold 15 --metric cyclomatic
   crap4ts --coverage coverage/coverage-final.json --format sarif --no-fail > crap.sarif
 
-For working CRAP analysis on TypeScript codebases today, see crap4ts@1.x \
-on npm. crap4ts@2 (this binary) is in pre-release alpha tracking \
-breezy-bays-labs/crap-rs.";
+crap4ts is the TypeScript adapter for crap-rs: \
+https://github.com/breezy-bays-labs/crap-rs";
 
 const COVERAGE_HINT: &str = "ensure tests ran with coverage enabled (e.g. `c8 --reporter=json` or `vitest --coverage`) — \
      crap4ts parses Istanbul's `coverage-final.json`, not LCOV";

--- a/crates/crap4ts/src/main.rs
+++ b/crates/crap4ts/src/main.rs
@@ -20,7 +20,7 @@ use crap4ts::adapters::coverage::IstanbulCoverage;
 use crap4ts::adapters::walker::OxcWalker;
 use crap4ts::{DEFAULT_EXCLUDES, EXTENSIONS};
 
-const ABOUT: &str = "CRAP score analyzer for TypeScript";
+const ABOUT: &str = "CRAP score analyzer for TypeScript / JavaScript";
 const LONG_ABOUT: &str = "CRAP (Change Risk Anti-Patterns) score analyzer for TypeScript / \
                          JavaScript codebases.\n\n\
                          Combines AST complexity (via oxc) with Istanbul JSON coverage to \


### PR DESCRIPTION
## Summary

Two crap-rs documentation surfaces still carried pre-implementation "alpha" framing — the crap4ts walker and Istanbul parser have worked since W1/W2, and crap-rs is a working monorepo, not a future one.

**`crates/crap4ts/src/main.rs`** — the module doc and the `ABOUT` / `LONG_ABOUT` / `AFTER_HELP` constants said *"ALPHA … the oxc walker and Istanbul parser are stubs … invoking the analysis path will runtime-panic … for working analysis today, see crap4ts@1.x on npm."* `crap4ts --help` now describes a working analyzer. **`adapters/mod.rs`** module doc no longer calls the two adapter modules `unimplemented!()` stubs.

**`README.md`** reframed for the monorepo:
- retitled `crap4rs` → `crap-rs`, opens with an overview table of the three artifacts (`crap-core` + `crap4rs` + `crap4ts`) and an npm badge
- the stale "Architecture" / "Extraction roadmap" sections — which described the monorepo split as a *future* — rewritten present-tense as "Workspace layout"
- the "Related" link to the deprecated standalone `breezy-bays-labs/crap4ts` repo dropped
- a `## crap4rs — the Rust analyzer` heading added so the CLI reference content is clearly scoped

Reframe only — the crap4rs CLI reference content stays in place. Migrating it into an mdbook handbook is epic #236.

The crap4ts **npm package** README (`packages/crap4ts/README.md`) was already correct (#231) and is untouched here.

## Out of scope — tracked

`crap4ts --help` shows `--metric … [default: cognitive]`, but crap4ts's effective default is **cyclomatic** (the W2.5 `AdapterMeta::default_metric` mechanism — the binary behaves correctly; only the help text misreports). That is a pre-existing inaccuracy in shared `crap_core::cli` plumbing, unrelated to alpha framing — tracked as #239.

## Testing

- `cargo fmt --check`, `cargo clippy -p crap4ts --all-targets -- -D warnings` — clean.
- `cargo build -p crap4ts` + `crap4ts --help` — verified the de-alpha'd help text renders.
- No test asserts the `--help` / `ABOUT` text (grep-confirmed). README is markdown-only; no dangling internal anchors after the section rewrites (grep-confirmed).

Closes #238
