### PR TITLE
fix(crap-core): #239 — derive the --metric help default from AdapterMeta

### DIFF
--- a/crates/crap-core/src/cli/mod.rs
+++ b/crates/crap-core/src/cli/mod.rs
@@ -37,7 +37,7 @@ mod view_args;
 /// Complexity metric for CRAP score computation.
 #[derive(Debug, Clone, Copy, ValueEnum)]
 pub enum MetricArg {
-    /// Nesting depth + structural complexity (default for Rust)
+    /// Nesting depth + structural complexity
     Cognitive,
     /// Decision-point count, classic CRAP metric
     Cyclomatic,
@@ -290,7 +290,7 @@ pub struct InputArgs {
     #[arg(long, value_name = "DIR", value_hint = ValueHint::DirPath)]
     pub src: Option<PathBuf>,
 
-    /// Complexity metric to use [default: cognitive]
+    /// Complexity metric to use
     #[arg(long, value_enum)]
     pub metric: Option<MetricArg>,
 
@@ -828,6 +828,18 @@ fn build_command(meta: &AdapterMeta) -> clap::Command {
     if !meta.after_help.is_empty() {
         cmd = cmd.after_help(meta.after_help);
     }
+    // The `--metric` help advertises the adapter's default metric. The
+    // doc-comment-derived help is static and shared between adapters,
+    // but the effective default differs per adapter (crap4rs resolves
+    // to cognitive, crap4ts to cyclomatic), so the displayed default is
+    // injected at runtime from `AdapterMeta::default_metric` rather
+    // than hardcoded in the comment.
+    cmd = cmd.mut_arg("metric", |arg| {
+        arg.help(format!(
+            "Complexity metric to use [default: {}]",
+            meta.default_metric
+        ))
+    });
     cmd
 }
 


### PR DESCRIPTION
## Summary

`crap4ts --help` displayed `--metric … [default: cognitive]`, but crap4ts's effective default metric is **cyclomatic** — resolved per-adapter from `AdapterMeta::default_metric` (#188, W2.5). The default was hardcoded as literal text in the shared `--metric` doc comment, so both adapters showed `cognitive`. The binary always resolved the metric correctly; only the help text misreported.

## Fix

- Removed the hardcoded `[default: cognitive]` from the `--metric` doc comment and the `(default for Rust)` parenthetical from the `MetricArg::Cognitive` variant doc — both are shared between adapters and cannot carry a per-adapter default.
- `build_command` now injects the `--metric` help at runtime via `mut_arg`, formatting the displayed default from `meta.default_metric`.

Result:

```
crap4ts --help  →  --metric … Complexity metric to use [default: cyclomatic]
crap4rs --help  →  --metric … Complexity metric to use [default: cognitive]
```

## Testing

- `cargo fmt --check`, `cargo clippy -p crap-core --all-targets -- -D warnings` — clean.
- `cargo nextest run -p crap-core` — 651 passed.
- Built both binaries; verified `crap4ts --help` shows `cyclomatic` and `crap4rs --help` shows `cognitive`.

Closes #239
