### PR TITLE
fix(crap4ts): #242 — remove package.json libc field that blocked macOS install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ versioning cadences: `crap-core`, `crap4rs` (Rust adapter + crate),
 and `crap4ts` (TypeScript adapter + npm package). Release sections
 are tagged with the published artifact + version they cut.
 
+## [crap4ts 2.0.0-rc.2] - 2026-05-21
+
+Corrective re-release of the `crap4ts` 2.x release candidate.
+`2.0.0-rc.1` declared `"libc": ["glibc"]` in `package.json`; npm
+evaluates `libc` on every platform, so the field blocked installation
+on macOS (`EBADPLATFORM` — macOS has no glibc). `2.0.0-rc.1` is
+deprecated on npm; the 48–72 h soak window restarts on this release.
+
+### Fixed (crap4ts on npm)
+- Removed the `"libc"` constraint from the npm package so the
+  single-package multi-OS tarball installs on macOS as well as
+  Linux/glibc. ([#242](https://github.com/breezy-bays-labs/crap-rs/issues/242))
+
 ## [crap4ts 2.0.0-rc.1] - 2026-05-19
 
 First release candidate of the from-scratch `crap4ts` 2.x line —

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,7 +409,7 @@ dependencies = [
 
 [[package]]
 name = "crap4ts"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 dependencies = [
  "assert_cmd",
  "crap-core",

--- a/crates/crap4ts/Cargo.toml
+++ b/crates/crap4ts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crap4ts"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/packages/crap4ts/package.json
+++ b/packages/crap4ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crap4ts",
-  "version": "2.0.0-rc.1",
+  "version": "2.0.0-rc.2",
   "description": "TypeScript adapter for crap-rs — Rust-powered CRAP score analyzer combining oxc AST complexity with Istanbul JSON coverage. Identifies functions that are both complex and under-tested.",
   "main": "index.js",
   "files": [
@@ -15,9 +15,6 @@
   "cpu": [
     "x64",
     "arm64"
-  ],
-  "libc": [
-    "glibc"
   ],
   "keywords": [
     "crap",


### PR DESCRIPTION
## Summary

`crap4ts@2.0.0-rc.1` cannot be installed on macOS. `package.json` declared `"libc": ["glibc"]`, and npm evaluates the `libc` field on **every** platform, not just Linux. On macOS `libc` is `undefined`, so npm rejected the install with `EBADPLATFORM`:

```
npm error notsup  Valid libc:  glibc
npm error notsup  Actual libc: undefined
```

`crap4ts` is a **single-package multi-OS** distribution — one tarball bundles the darwin-arm64, darwin-x64, and linux-x64-gnu addons — so a flat global `libc` constraint cannot express "glibc on Linux, not-applicable on macOS." Removing the field lets npm gate on `os` + `cpu` only (darwin ✓, linux ✓).

## Changes

- Removed `"libc": ["glibc"]` from `packages/crap4ts/package.json`.
- Bumped `2.0.0-rc.1` → `2.0.0-rc.2` (`package.json` + `Cargo.toml` + `Cargo.lock`) — `2.0.0-rc.1` is immutable on npm; `2.0.0-rc.2` is the corrective release.
- `CHANGELOG.md` — rc.2 corrective-release section.

## Why CI missed it

`publish.yml`'s build jobs smoke-test each cdylib by `require()`-ing the `.node` file directly — that bypasses npm's `os`/`cpu`/`libc` install-gating. No job ran `npm install crap4ts` from the registry. The rc.1 soak's first sandbox install (macOS arm64) caught it.

## After merge

Tag `crap4ts-v2.0.0-rc.2` → `publish.yml` publishes under `--tag rc`. `2.0.0-rc.1` will be `npm deprecate`d with a pointer to rc.2. Verified post-publish with a macOS sandbox install.

Closes #242


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed EBADPLATFORM errors that prevented users from installing on macOS by removing restrictive platform constraints, enabling a single distribution package to work across macOS and Linux systems.

* **Chores**
  * Bumped crap4ts version to 2.0.0-rc.2 for this corrective release.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/breezy-bays-labs/crap-rs/pull/243?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->