### PR TITLE
ci(crap4ts): #232 — bump publish.yml darwin-arm64 runner macos-14 → macos-15

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,7 @@ jobs:
             artifact: libcrap4ts.so
             node_name: crap4ts.linux-x64-gnu.node
           - platform: darwin-arm64
-            runner: macos-14
+            runner: macos-15
             target: aarch64-apple-darwin
             artifact: libcrap4ts.dylib
             node_name: crap4ts.darwin-arm64.node


### PR DESCRIPTION
## Summary

Bumps the `darwin-arm64` build runner in `publish.yml` from `macos-14` to `macos-15`. GitHub deprecates the `macos-14` runner image starting 2026-07-06; the GA publish should not ship on a runner with a known expiry. `darwin-x64` already uses `macos-15-intel`, so both macOS build legs now land on the macos-15 generation.

`macos-14` was kept deliberately during the RC PR (#231) to avoid scope creep, and tracked here instead.

## Testing

- `actionlint` reports no unknown-runner-label warnings for the change. (It surfaces one pre-existing `info`-level SC2035 on the untouched "Confirm all platforms present" step — unrelated to this PR, left as-is.)

Closes #232

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure for macOS platform support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/breezy-bays-labs/crap-rs/pull/246?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->