### PR TITLE
ci(crap4ts): #245 — npm install-gating check in publish.yml build matrix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,6 +60,15 @@ jobs:
           shared-key: publish-${{ matrix.platform }}
           targets: ${{ matrix.target }}
 
+      # Node 24 (npm 11.x) is pinned so the install-gating check below
+      # exercises an npm new enough to enforce the `libc` field, and so
+      # the path-require smoke test runs on a deterministic Node rather
+      # than whatever the runner image happens to ship.
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
       - name: Build cdylib
         env:
           CARGO_TARGET: ${{ matrix.target }}
@@ -93,6 +102,36 @@ jobs:
             }
             console.log("OK: analyze export present");
           '
+
+      # The smoke test above require()s the .node directly, which bypasses
+      # npm's os/cpu/libc install-gating — so a bad gating field is invisible
+      # to it. crap4ts 2.0.0-rc.1 shipped a stray `libc` entry that made
+      # `npm install` reject every macOS install with EBADPLATFORM; the
+      # path-require smoke test stayed green and the defect reached npm,
+      # caught only by a sandbox install during the soak. Packing the
+      # package and installing the tarball into a clean project reproduces
+      # that gating on this runner's native platform, pre-publish, so a
+      # packaging defect fails the workflow instead of reaching the registry.
+      - name: Verify npm packaging + install-gating
+        run: |
+          set -euo pipefail
+          work="$(mktemp -d)"
+          ( cd packages/crap4ts && npm pack --pack-destination "$work" )
+          tarball="$(ls "$work"/crap4ts-*.tgz)"
+          echo "packed: $(basename "$tarball")"
+          consumer="$work/consumer"
+          mkdir -p "$consumer"
+          cd "$consumer"
+          npm init -y >/dev/null
+          # `npm install` exits non-zero on EBADPLATFORM; the explicit
+          # node_modules check is a backstop so the failure stays loud even
+          # if a future npm softens platform mismatch to a warning.
+          npm install --no-audit --no-fund "$tarball"
+          if [ ! -d node_modules/crap4ts ]; then
+            echo "::error::npm did not install crap4ts — os/cpu/libc gating rejected this platform (see EBADPLATFORM above). Packaging defect."
+            exit 1
+          fi
+          node -e 'const m = require("crap4ts"); if (typeof m.analyze !== "function") { throw new Error("crap4ts installed from the packed tarball but the analyze export is missing"); } console.log("OK: npm install-gating passed and analyze export present");'
 
       - name: Upload cdylib artifact
         uses: actions/upload-artifact@v4
@@ -161,7 +200,7 @@ jobs:
       - name: Confirm all platforms present in tarball
         run: |
           cd packages/crap4ts
-          ls -la *.node
+          ls -la ./*.node
           for plat in crap4ts.linux-x64-gnu.node crap4ts.darwin-arm64.node crap4ts.darwin-x64.node; do
             test -f "$plat" || { echo "::error::missing $plat"; exit 1; }
           done


### PR DESCRIPTION
## Summary

`publish.yml`'s build jobs smoke-test each cdylib by `require()`-ing the `.node` file directly by path. That confirms the addon loads, but it bypasses npm's `os` / `cpu` / `libc` install-gating — so a `package.json` packaging defect that blocks `npm install` is invisible to CI.

The `crap4ts@2.0.0-rc.1` `libc` bug (#242) reached npm exactly this way: the path-require smoke test stayed green, and the defect was caught only by a sandbox install during the rc.1 soak — after publish, not before.

This adds a per-platform step to the `build` matrix that packs the package and installs the tarball into a clean project, exercising npm's real install-gating on each build runner's native platform.

## What changed

- **New `Verify npm packaging + install-gating` step** in the `build` job — runs `npm pack`, installs the resulting tarball into a fresh `mktemp` project, and `require()`s `crap4ts` through `index.js`. Runs on all three build runners (`linux-x64-gnu`, `darwin-arm64`, `darwin-x64`), so `os`/`cpu`/`libc` gating is checked on each native platform.
- **`actions/setup-node@v4` (Node 24)** added to the `build` job — pins an npm (11.x) new enough to enforce the `libc` field, and gives the existing path-require smoke test a deterministic Node instead of the runner image default.
- **Drive-by:** fixes a pre-existing actionlint `SC2035` finding in the same file (`ls *.node` → `ls ./*.node`) in the `publish` job, so actionlint is clean on `publish.yml`.

## Design note — pre-publish `npm pack`, not post-publish registry install

AC #1 reads literally as "install the just-published version from the npm registry." The issue's own Discovery section authorizes the alternative and says to decide during implementation — this PR takes the **`npm pack` pre-publish** path:

- A post-publish registry-install job catches a defect **after** it has shipped — the exact failure mode #242 demonstrated. The `npm pack` check runs **before** `npm publish`, so a packaging defect fails the workflow and the bad version never reaches the registry.
- It avoids the chicken-and-egg (version must exist to install it) and npm-propagation flakiness of a post-publish job.
- `npm install <tarball>` runs npm's identical `os`/`cpu`/`libc` `checkPlatform` codepath as a registry install — the gating is on `package.json` metadata, not on the resolver source.

The build-job path-require smoke test is **kept** for diagnostic layering: a path-require pass + npm-pack fail isolates the failure to packaging/gating rather than the cdylib itself.

## Validation (local, on macOS arm64)

- **Bug path** — re-added `"libc": ["glibc"]` to the real `packages/crap4ts/package.json` and ran the new step body: `npm install` fails with `EBADPLATFORM`, `npm` exits 1, step exits non-zero. Reverted.
- **Happy path** — built the release cdylib (`--features napi-binding`), ran the exact step body against the real package: `npm pack` → install → `require("crap4ts")` → `OK: npm install-gating passed and analyze export present`, exit 0.
- **Backstop** — the explicit `node_modules/crap4ts` presence check keeps the failure loud with an `::error::` annotation even if a future npm softens platform mismatch to a warning.
- `actionlint .github/workflows/publish.yml` — clean.

This is a CI-workflow-only change; the Rust gate battery is unaffected and runs on this PR's own CI.

## Acceptance criteria

- [x] Installs the package in a clean environment and `require()`s it — on macOS **and** Linux (all three build runners)
- [x] Fails the workflow if the install or load fails — packaging defects are loud at release time
- [x] Exercises the `os`/`cpu`/`libc` install-gating path the path-`require()` smoke test does not

Closes #245
