### PR TITLE
feat(crap-core): #251 — surface per-function branch coverage (table column + JSON envelope)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,7 @@ jobs:
           --test istanbul_parser_cucumber
           --test arrow_function_coverage_cucumber
           --test file_extensions_cucumber
+          --test branch_coverage_cucumber
 
   crap4ts-build:
     # Per-platform build check for the new `crap4ts` shell crate (S5,

--- a/crates/crap-core/src/adapters/reporters/advice_summary.rs
+++ b/crates/crap-core/src/adapters/reporters/advice_summary.rs
@@ -112,6 +112,7 @@ mod tests {
                 complexity: 5,
                 complexity_metric: ComplexityMetric::Cognitive,
                 coverage_percent: 50.0,
+                branch_coverage_percent: None,
                 crap: CrapScore {
                     value: 12.34,
                     risk_level: RiskLevel::Moderate,

--- a/crates/crap-core/src/adapters/reporters/mod.rs
+++ b/crates/crap-core/src/adapters/reporters/mod.rs
@@ -165,6 +165,7 @@ pub(crate) mod test_fixtures {
                 complexity,
                 complexity_metric: crate::domain::types::ComplexityMetric::Cognitive,
                 coverage_percent: coverage_pct,
+                branch_coverage_percent: None,
                 crap: CrapScore {
                     value: crap_value,
                     risk_level: risk,

--- a/crates/crap-core/src/adapters/reporters/table.rs
+++ b/crates/crap-core/src/adapters/reporters/table.rs
@@ -90,25 +90,19 @@ pub fn format_table_with_explain(
 
     let shown: &[&crate::domain::types::FunctionVerdict] = &view.shown;
 
-    // Build table
-    let mut table = Table::new();
-    table.set_content_arrangement(ContentArrangement::Dynamic);
-    table.set_header(vec!["File", "Function", "CC", "Cov%", "CRAP", "Risk"]);
+    // Conditional `Branch%` column (crap-rs#251). The column appears
+    // when at least one row in the shaped view carries
+    // `branch_coverage_percent: Some(_)` — i.e. the coverage parser
+    // produced branch records that fell inside at least one function's
+    // span. When no row has it (LCOV runs, jest without branch
+    // instrumentation, or branches that all fell outside function
+    // spans), the column is omitted entirely so the default Rust /
+    // line-only scorecard stays byte-identical to its pre-#251 width.
+    let has_branch_coverage = shown
+        .iter()
+        .any(|v| v.scored.branch_coverage_percent.is_some());
 
-    for verdict in shown {
-        let s = &verdict.scored;
-        let cov_str = format!("{:.1}", s.coverage_percent);
-        let crap_str = format!("{:.2}", s.crap.value);
-
-        table.add_row(vec![
-            s.identity.file_path.clone(),
-            s.identity.qualified_name.clone(),
-            s.complexity.to_string(),
-            coverage_color(s.coverage_percent, &cov_str),
-            crap_color(verdict.exceeds, &crap_str),
-            risk_color(&s.crap.risk_level, &s.crap.risk_level.to_string()),
-        ]);
-    }
+    let table = build_function_table(shown, has_branch_coverage);
 
     output.push('\n');
 
@@ -144,6 +138,77 @@ while/for/loop bodies, let-else diverging branches, and closures.\n",
     }
 
     output
+}
+
+/// Build the per-function `comfy_table::Table` body. Header and row
+/// shape are parameterised by `has_branch_coverage` — when true the
+/// `Branch%` column is woven in between `Cov%` and `CRAP`; when false
+/// the table renders the pre-#251 line-only shape byte-identically.
+///
+/// Extracted from `format_table_with_explain` so that body stays
+/// focused on flow control (grouped-vs-default, breakdown subrows,
+/// summary block, delta block); CRAP fingerprint sits well below the
+/// strict-mode threshold this way (focus #251 cross-impact note).
+fn build_function_table(
+    shown: &[&crate::domain::types::FunctionVerdict],
+    has_branch_coverage: bool,
+) -> Table {
+    let mut table = Table::new();
+    table.set_content_arrangement(ContentArrangement::Dynamic);
+
+    let mut header: Vec<&str> = vec!["File", "Function", "CC", "Cov%"];
+    if has_branch_coverage {
+        header.push("Branch%");
+    }
+    header.extend(["CRAP", "Risk"]);
+    table.set_header(header);
+
+    for verdict in shown {
+        table.add_row(build_function_row(verdict, has_branch_coverage));
+    }
+    table
+}
+
+/// Render a single function verdict as the cell vector its row needs.
+/// Pushes the optional `Branch%` cell in the same conditional shape as
+/// the header — keeping the two in lockstep means a missing-column /
+/// shifted-row bug surface can't open up at the row builder alone.
+fn build_function_row(
+    verdict: &crate::domain::types::FunctionVerdict,
+    has_branch_coverage: bool,
+) -> Vec<String> {
+    let s = &verdict.scored;
+    let cov_str = format!("{:.1}", s.coverage_percent);
+    let crap_str = format!("{:.2}", s.crap.value);
+
+    let mut row: Vec<String> = vec![
+        s.identity.file_path.clone(),
+        s.identity.qualified_name.clone(),
+        s.complexity.to_string(),
+        coverage_color(s.coverage_percent, &cov_str),
+    ];
+    if has_branch_coverage {
+        row.push(format_branch_cell(s.branch_coverage_percent));
+    }
+    row.push(crap_color(verdict.exceeds, &crap_str));
+    row.push(risk_color(
+        &s.crap.risk_level,
+        &s.crap.risk_level.to_string(),
+    ));
+    row
+}
+
+/// Format the `Branch%` cell for one row. `Some(p)` ⇒ one-decimal
+/// percentage coloured by the same coverage-band gradient line
+/// coverage uses (a low branch number reads as red just as a low line
+/// number does). `None` ⇒ the `—` (em-dash) sentinel, deliberately
+/// distinct from `0.0` so absent data and zero-covered data don't
+/// alias visually. Mirrors the grouped table's `worst_fn` "—" fallback.
+fn format_branch_cell(branch_coverage_percent: Option<f64>) -> String {
+    match branch_coverage_percent {
+        Some(p) => coverage_color(p, &format!("{:.1}", p)),
+        None => "—".to_string(),
+    }
 }
 
 /// Append the delta block. Reads `view.full.summary` (the unshapeable
@@ -431,7 +496,7 @@ static COLOR_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 mod tests {
     use super::*;
     use crate::adapters::reporters::test_fixtures::*;
-    use crate::domain::types::{AnalysisResult, RiskLevel};
+    use crate::domain::types::{AnalysisResult, AnalysisSummary, RiskLevel};
 
     // ── Snapshot tests (color disabled) ────────────────────────────────
 
@@ -570,6 +635,140 @@ mod tests {
             TEST_TOOL_VERSION,
         );
         assert!(output.contains("85.0"));
+    }
+
+    // ── Branch% column (crap-rs#251) ──────────────────────────────────
+
+    /// The Rust / line-only path stays byte-identical: when no verdict
+    /// carries `branch_coverage_percent`, the `Branch%` column is
+    /// absent from the header entirely.
+    #[test]
+    fn branch_column_omitted_when_no_branch_data() {
+        let _guard = COLOR_LOCK.lock().unwrap();
+        colored::control::set_override(false);
+        let result = make_single_function_result(
+            "no_branches",
+            "src/lib.rs",
+            1,
+            100.0,
+            1.0,
+            RiskLevel::Low,
+            8.0,
+        );
+        let output = format_table(
+            &make_view_default(&result),
+            8.0,
+            false,
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
+        );
+        assert!(
+            !output.contains("Branch%"),
+            "expected no `Branch%` column when no verdict has branch data; got:\n{output}",
+        );
+    }
+
+    /// When at least one verdict has `branch_coverage_percent = Some(_)`
+    /// the `Branch%` column appears and renders the value to one
+    /// decimal — the same precision as the line `Cov%` column.
+    #[test]
+    fn branch_column_present_when_branch_data_some() {
+        let _guard = COLOR_LOCK.lock().unwrap();
+        colored::control::set_override(false);
+        let mut result = make_single_function_result(
+            "classify",
+            "src/lib.rs",
+            3,
+            100.0,
+            3.0,
+            RiskLevel::Low,
+            8.0,
+        );
+        // Mutate the single verdict to carry branch data — mirrors what
+        // a real branch-rich Istanbul fixture would produce after
+        // `score_and_summarize` lifts `cov.branch_coverage.percent`
+        // onto `ScoredFunction.branch_coverage_percent`.
+        result.functions[0].scored.branch_coverage_percent = Some(66.7);
+
+        let output = format_table(
+            &make_view_default(&result),
+            8.0,
+            false,
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
+        );
+        assert!(
+            output.contains("Branch%"),
+            "expected `Branch%` column when a verdict has branch data; got:\n{output}",
+        );
+        assert!(
+            output.contains("66.7"),
+            "expected branch percentage `66.7` in the row; got:\n{output}",
+        );
+    }
+
+    /// Mixed view (some functions have branch data, others don't): the
+    /// column appears once at the header, and rows without branch data
+    /// show the `—` sentinel — visibly distinct from a genuine `0.0`.
+    #[test]
+    fn branch_column_dash_for_rows_without_branch_data() {
+        let _guard = COLOR_LOCK.lock().unwrap();
+        colored::control::set_override(false);
+
+        // Two verdicts: one carries branch coverage, one doesn't.
+        let v_with = {
+            let mut v = make_verdict(
+                "with_branches",
+                "src/with.rs",
+                3,
+                100.0,
+                3.0,
+                RiskLevel::Low,
+                8.0,
+            );
+            v.scored.branch_coverage_percent = Some(100.0);
+            v
+        };
+        let v_without = make_verdict(
+            "without_branches",
+            "src/without.rs",
+            1,
+            100.0,
+            1.0,
+            RiskLevel::Low,
+            8.0,
+        );
+        let result = AnalysisResult {
+            functions: vec![v_with, v_without],
+            summary: AnalysisSummary {
+                total_functions: 2,
+                total_files: 2,
+                exceeding_threshold: 0,
+                average_crap: 2.0,
+                median_crap: 2.0,
+                ..Default::default()
+            },
+            passed: true,
+        };
+
+        let output = format_table(
+            &make_view_default(&result),
+            8.0,
+            false,
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
+        );
+        assert!(
+            output.contains("Branch%"),
+            "expected `Branch%` column when any verdict has branch data; got:\n{output}",
+        );
+        // The `—` (em-dash) sentinel marks rows with no branch data so
+        // they're visibly distinct from a genuine zero — see the row
+        // builder in `format_table_with_explain`.
+        assert!(
+            output.contains("—"),
+            "expected `—` sentinel in the branch column for the verdict without branch data; got:\n{output}",
+        );
     }
 
     #[test]
@@ -1505,6 +1704,11 @@ mod proptests {
                         complexity,
                         complexity_metric: crate::domain::types::ComplexityMetric::Cognitive,
                         coverage_percent: coverage,
+                        // The table-reporter proptest strategies focus
+                        // on the line-coverage rendering path; branch
+                        // coverage gets dedicated coverage in the
+                        // `branch_column_*` unit tests below.
+                        branch_coverage_percent: None,
                         crap: CrapScore {
                             value: crap_value,
                             risk_level: risk,

--- a/crates/crap-core/src/core/mod.rs
+++ b/crates/crap-core/src/core/mod.rs
@@ -568,6 +568,14 @@ fn score_and_summarize(
                 complexity: comp.complexity,
                 complexity_metric: comp.metric,
                 coverage_percent: cov.line_coverage.percent,
+                // Surface the branch coverage already computed by
+                // `domain::matching::compute_branch_coverage`. `None`
+                // when the parser produced no branches for this file
+                // (LCOV runs, jest without branch instrumentation) or
+                // when none of the file's branches fell inside this
+                // function's span — both cases are collapsed at the
+                // matcher.
+                branch_coverage_percent: cov.branch_coverage.as_ref().map(|bc| bc.percent),
                 crap,
                 contributors: comp.contributors.clone(),
             },

--- a/crates/crap-core/src/domain/delta.rs
+++ b/crates/crap-core/src/domain/delta.rs
@@ -591,6 +591,7 @@ mod tests {
                 complexity: 5,
                 complexity_metric: ComplexityMetric::Cognitive,
                 coverage_percent: 50.0,
+                branch_coverage_percent: None,
                 crap: CrapScore {
                     value: score,
                     risk_level: if score > 30.0 {

--- a/crates/crap-core/src/domain/diagnostic.rs
+++ b/crates/crap-core/src/domain/diagnostic.rs
@@ -794,6 +794,7 @@ mod tests {
                 complexity: contributors.iter().map(|c| c.increment).sum::<u32>().max(1),
                 complexity_metric: ComplexityMetric::Cognitive,
                 coverage_percent: 100.0,
+                branch_coverage_percent: None,
                 crap: CrapScore {
                     value: 50.0,
                     risk_level: RiskLevel::High,

--- a/crates/crap-core/src/domain/summary.rs
+++ b/crates/crap-core/src/domain/summary.rs
@@ -580,6 +580,7 @@ mod tests {
                 complexity: 1,
                 complexity_metric: ComplexityMetric::Cognitive,
                 coverage_percent: 100.0,
+                branch_coverage_percent: None,
                 crap: CrapScore {
                     value: crap_value,
                     risk_level,
@@ -750,6 +751,7 @@ mod file_summary_tests {
                 complexity: 1,
                 complexity_metric: ComplexityMetric::Cognitive,
                 coverage_percent: 100.0,
+                branch_coverage_percent: None,
                 crap: CrapScore {
                     value: crap_value,
                     risk_level,
@@ -930,6 +932,7 @@ mod file_summary_tests {
                 complexity: 1,
                 complexity_metric: ComplexityMetric::Cognitive,
                 coverage_percent: f64::NAN,
+                branch_coverage_percent: None,
                 crap: CrapScore {
                     value: 5.0,
                     risk_level: RiskLevel::Low,
@@ -1133,6 +1136,7 @@ mod crap_delta_tests {
                 complexity: 1,
                 complexity_metric: ComplexityMetric::Cognitive,
                 coverage_percent: 100.0,
+                branch_coverage_percent: None,
                 crap: CrapScore {
                     value: crap_value,
                     risk_level,

--- a/crates/crap-core/src/domain/types.rs
+++ b/crates/crap-core/src/domain/types.rs
@@ -353,6 +353,27 @@ pub struct ScoredFunction {
     pub complexity: u32,
     pub complexity_metric: ComplexityMetric,
     pub coverage_percent: f64,
+    /// Branch coverage percentage for this function, when branch data
+    /// is available. `None` when no branch records overlap the
+    /// function's span — either the parser produced no branches at all
+    /// (LCOV runs, jest without branch instrumentation), or the
+    /// function's span contained no usable branch arms (every
+    /// `BranchMismatch`-orphaned branchId fell out at parse time).
+    ///
+    /// Wire shape uses `#[serde(skip_serializing_if = "Option::is_none")]`
+    /// so envelopes for non-branch-aware runs stay byte-identical to
+    /// the pre-#251 shape — the field is absent when no signal exists.
+    /// Crosses to the JSON envelope automatically via serde; the table
+    /// reporter renders a conditional `Branch%` column when any
+    /// function in the shaped view has `Some`.
+    ///
+    /// Computed in `core::score_and_summarize` from
+    /// `FunctionCoverage::branch_coverage` (which itself is produced by
+    /// `domain::matching::compute_branch_coverage`); not gating —
+    /// `--threshold` continues to apply against line coverage only
+    /// (`coverage_percent`). Gating-on-branch would be a separate ADR.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub branch_coverage_percent: Option<f64>,
     pub crap: CrapScore,
     /// Individual constructs that contributed to the complexity score.
     /// Always present; empty when complexity == 1.

--- a/crates/crap-core/src/domain/view.rs
+++ b/crates/crap-core/src/domain/view.rs
@@ -609,6 +609,11 @@ mod tests {
                 complexity,
                 complexity_metric: ComplexityMetric::Cognitive,
                 coverage_percent: coverage,
+                // View-layer test fixtures don't exercise branch
+                // coverage today; branch_coverage_percent stays None so
+                // sort / filter / truncate invariants are isolated from
+                // the new field.
+                branch_coverage_percent: None,
                 crap: CrapScore {
                     value: crap_value,
                     risk_level,

--- a/crates/crap-core/src/test_strategies.rs
+++ b/crates/crap-core/src/test_strategies.rs
@@ -67,6 +67,11 @@ pub fn arb_verdict() -> impl Strategy<Value = FunctionVerdict> {
                     complexity,
                     complexity_metric: ComplexityMetric::Cognitive,
                     coverage_percent: coverage,
+                    // Branch coverage is independent of the line-coverage path
+                    // these proptest strategies exercise — leaving it `None`
+                    // keeps the verdict shape default for sort / filter / view
+                    // invariants without coupling the strategies to branch data.
+                    branch_coverage_percent: None,
                     crap: CrapScore {
                         value: crap_value,
                         risk_level: risk,
@@ -112,6 +117,9 @@ pub fn arb_verdict_with_nan_coverage() -> impl Strategy<Value = FunctionVerdict>
                         complexity,
                         complexity_metric: ComplexityMetric::Cognitive,
                         coverage_percent: coverage,
+                        // NaN-coverage strategy exercises line-coverage sort
+                        // paths only; branch coverage stays `None`.
+                        branch_coverage_percent: None,
                         crap: CrapScore {
                             value: crap_value,
                             risk_level: risk,

--- a/crates/crap-core/tests/snapshots/wire_envelope_crap4ts_branches__envelope.snap
+++ b/crates/crap-core/tests/snapshots/wire_envelope_crap4ts_branches__envelope.snap
@@ -1,0 +1,320 @@
+---
+source: crates/crap-core/tests/wire_envelope_crap4ts_branches.rs
+expression: pretty
+---
+{
+  "diff_ref": null,
+  "language": "rust",
+  "metric": "cyclomatic",
+  "result": {
+    "functions": [
+      {
+        "exceeds": false,
+        "scored": {
+          "branch_coverage_percent": 100.0,
+          "complexity": 2,
+          "complexity_metric": "cyclomatic",
+          "contributors": [
+            {
+              "column": 3,
+              "end_line": 15,
+              "increment": 1,
+              "kind": "if-branch",
+              "line": 11,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.0
+          },
+          "identity": {
+            "file_path": "branch-heavy.ts",
+            "qualified_name": "classify",
+            "span": {
+              "end_column": 1,
+              "end_line": 16,
+              "start_column": 8,
+              "start_line": 10
+            }
+          }
+        },
+        "threshold": 16.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "branch_coverage_percent": 100.0,
+          "complexity": 2,
+          "complexity_metric": "cyclomatic",
+          "contributors": [
+            {
+              "column": 10,
+              "end_line": 19,
+              "increment": 1,
+              "kind": "ternary",
+              "line": 19,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.0
+          },
+          "identity": {
+            "file_path": "branch-heavy.ts",
+            "qualified_name": "sign",
+            "span": {
+              "end_column": 1,
+              "end_line": 20,
+              "start_column": 8,
+              "start_line": 18
+            }
+          }
+        },
+        "threshold": 16.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "branch_coverage_percent": 100.0,
+          "complexity": 3,
+          "complexity_metric": "cyclomatic",
+          "contributors": [
+            {
+              "column": 5,
+              "end_line": 24,
+              "increment": 1,
+              "kind": "case-branch",
+              "line": 24,
+              "nesting_depth": 0
+            },
+            {
+              "column": 5,
+              "end_line": 25,
+              "increment": 1,
+              "kind": "case-branch",
+              "line": 25,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 3.0
+          },
+          "identity": {
+            "file_path": "branch-heavy.ts",
+            "qualified_name": "bucket",
+            "span": {
+              "end_column": 1,
+              "end_line": 28,
+              "start_column": 8,
+              "start_line": 22
+            }
+          }
+        },
+        "threshold": 16.0
+      }
+    ],
+    "passed": true,
+    "summary": {
+      "average_complexity": 2.3333333333333335,
+      "average_coverage": 100.0,
+      "average_crap": 2.3333333333333335,
+      "distribution": {
+        "acceptable": 0,
+        "high": 0,
+        "low": 3,
+        "moderate": 0
+      },
+      "exceeding_threshold": 0,
+      "max_complexity": 3,
+      "max_crap": {
+        "risk_level": "low",
+        "value": 3.0
+      },
+      "median_complexity": 2.0,
+      "median_coverage": 100.0,
+      "median_crap": 2.0,
+      "min_coverage": 100.0,
+      "total_files": 1,
+      "total_functions": 3,
+      "worst_function": {
+        "file_path": "branch-heavy.ts",
+        "qualified_name": "bucket",
+        "span": {
+          "end_column": 1,
+          "end_line": 28,
+          "start_column": 8,
+          "start_line": 22
+        }
+      }
+    }
+  },
+  "schema_version": 2,
+  "threshold": 16.0,
+  "timestamp": "[STRIPPED:timestamp]",
+  "tool_version": "[STRIPPED:tool_version]",
+  "view": {
+    "eligible_count": 3,
+    "grouped": null,
+    "shown": [
+      {
+        "exceeds": false,
+        "scored": {
+          "branch_coverage_percent": 100.0,
+          "complexity": 3,
+          "complexity_metric": "cyclomatic",
+          "contributors": [
+            {
+              "column": 5,
+              "end_line": 24,
+              "increment": 1,
+              "kind": "case-branch",
+              "line": 24,
+              "nesting_depth": 0
+            },
+            {
+              "column": 5,
+              "end_line": 25,
+              "increment": 1,
+              "kind": "case-branch",
+              "line": 25,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 3.0
+          },
+          "identity": {
+            "file_path": "branch-heavy.ts",
+            "qualified_name": "bucket",
+            "span": {
+              "end_column": 1,
+              "end_line": 28,
+              "start_column": 8,
+              "start_line": 22
+            }
+          }
+        },
+        "threshold": 16.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "branch_coverage_percent": 100.0,
+          "complexity": 2,
+          "complexity_metric": "cyclomatic",
+          "contributors": [
+            {
+              "column": 3,
+              "end_line": 15,
+              "increment": 1,
+              "kind": "if-branch",
+              "line": 11,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.0
+          },
+          "identity": {
+            "file_path": "branch-heavy.ts",
+            "qualified_name": "classify",
+            "span": {
+              "end_column": 1,
+              "end_line": 16,
+              "start_column": 8,
+              "start_line": 10
+            }
+          }
+        },
+        "threshold": 16.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "branch_coverage_percent": 100.0,
+          "complexity": 2,
+          "complexity_metric": "cyclomatic",
+          "contributors": [
+            {
+              "column": 10,
+              "end_line": 19,
+              "increment": 1,
+              "kind": "ternary",
+              "line": 19,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.0
+          },
+          "identity": {
+            "file_path": "branch-heavy.ts",
+            "qualified_name": "sign",
+            "span": {
+              "end_column": 1,
+              "end_line": 20,
+              "start_column": 8,
+              "start_line": 18
+            }
+          }
+        },
+        "threshold": 16.0
+      }
+    ],
+    "shown_summary": {
+      "average_complexity": 2.3333333333333335,
+      "average_coverage": 100.0,
+      "average_crap": 2.3333333333333335,
+      "distribution": {
+        "acceptable": 0,
+        "high": 0,
+        "low": 3,
+        "moderate": 0
+      },
+      "exceeding_threshold": 0,
+      "max_complexity": 3,
+      "max_crap": {
+        "risk_level": "low",
+        "value": 3.0
+      },
+      "median_complexity": 2.0,
+      "median_coverage": 100.0,
+      "median_crap": 2.0,
+      "min_coverage": 100.0,
+      "total_files": 1,
+      "total_functions": 3,
+      "worst_function": {
+        "file_path": "branch-heavy.ts",
+        "qualified_name": "bucket",
+        "span": {
+          "end_column": 1,
+          "end_line": 28,
+          "start_column": 8,
+          "start_line": 22
+        }
+      }
+    },
+    "spec": {
+      "filters": {
+        "coverage_range": null,
+        "only_failing": false
+      },
+      "group_by": null,
+      "limit": null,
+      "sort": "crap"
+    },
+    "truncated": false
+  }
+}

--- a/crates/crap-core/tests/wire_envelope_crap4ts_branches.rs
+++ b/crates/crap-core/tests/wire_envelope_crap4ts_branches.rs
@@ -1,0 +1,152 @@
+//! Wire-envelope shape lock for the **branch-coverage-populated**
+//! crap4ts `--format json` envelope (crap-rs#251).
+//!
+//! Sibling of `wire_envelope_crap4ts.rs`. Together they cover the two
+//! wire shapes the JSON envelope can produce:
+//!
+//! | Canary                          | Fixture                                          | Wire shape locked |
+//! |---------------------------------|--------------------------------------------------|-------------------|
+//! | `wire_envelope_crap4ts`         | `istanbul-jest/coverage-final.json` (empty `b`)  | `branch_coverage_percent` field ABSENT (skip_serializing_if(None)) |
+//! | `wire_envelope_crap4ts_branches`| `istanbul-jest/coverage-with-branches.json` (full `b` + `branchMap`) | `branch_coverage_percent` field PRESENT with `f64` value           |
+//!
+//! ## Why a second canary
+//!
+//! crap-rs#251 introduced `branch_coverage_percent: Option<f64>` on
+//! `ScoredFunction` with `#[serde(skip_serializing_if = "Option::is_none")]`.
+//! The default `wire_envelope_crap4ts` fixture has all-empty `branchMap`
+//! entries, so its envelope's per-function rows continue to omit the
+//! branch field — the canary stays byte-identical to its pre-#251 form,
+//! which is the right behavior for "no branch data in play."
+//!
+//! That leaves the branch-populated shape uncovered by the snapshot
+//! gate. This module fixes that asymmetry by exercising the same binary
+//! against the branch-rich fixture committed in W2.3 (#186) — locking
+//! the wire shape the JSON envelope produces when Istanbul branch
+//! records WERE parsed and joined per-function.
+//!
+//! ## Volatile fields stripped
+//!
+//! Identical to `wire_envelope_crap4ts.rs`: `tool_version`, `timestamp`,
+//! `baseline_tool_version`, `baseline_timestamp`. Per-tempdir paths
+//! collapsed to `[TEMPDIR]` via defense-in-depth scrub.
+//!
+//! To update after a deliberate envelope change:
+//!   `cargo insta review` → accept the new snapshot.
+
+use std::path::PathBuf;
+
+use assert_cmd::Command;
+use serde_json::Value;
+use tempfile::TempDir;
+
+const BRANCH_FIXTURE: &str =
+    include_str!("../../crap4ts/tests/fixtures/istanbul-jest/coverage-with-branches.json");
+
+/// Strip per-build / per-run fields so the snapshot only catches
+/// shape drift, not version/timestamp churn. Identical to the
+/// `wire_envelope_crap4ts.rs` strip.
+fn strip_volatile(value: &mut Value) {
+    match value {
+        Value::Object(map) => {
+            for key in [
+                "tool_version",
+                "timestamp",
+                "baseline_tool_version",
+                "baseline_timestamp",
+            ] {
+                if let Some(slot) = map.get_mut(key) {
+                    *slot = Value::String(format!("[STRIPPED:{key}]"));
+                }
+            }
+            for child in map.values_mut() {
+                strip_volatile(child);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                strip_volatile(item);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Build a canonicalized tempdir with the branch-heavy TS source and
+/// the matching Istanbul coverage JSON (with full `b` + `branchMap`
+/// records). The `{SRC_ROOT}` template is substituted with the
+/// canonical path, mirroring the same trick `wire_envelope_crap4ts.rs`
+/// uses for the empty-branches fixture.
+fn build_fixture() -> (TempDir, PathBuf) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    // Canonicalize: macOS's /tmp routes through /private/tmp; without
+    // canonicalization the parser sees a different prefix than the
+    // fixture path entries and the snapshot bakes absolute paths.
+    let canonical = std::fs::canonicalize(tmp.path()).expect("canonicalize tempdir");
+
+    std::fs::write(
+        canonical.join("branch-heavy.ts"),
+        include_str!("../../crap4ts/tests/fixtures/ts-fixtures/branch-heavy.ts"),
+    )
+    .expect("write branch-heavy.ts");
+
+    // Normalize path separators before string-substituting into the
+    // JSON template — same Windows-safety as `wire_envelope_crap4ts.rs`.
+    let payload = BRANCH_FIXTURE.replace(
+        "{SRC_ROOT}",
+        &canonical.to_string_lossy().replace('\\', "/"),
+    );
+    std::fs::write(canonical.join("coverage-with-branches.json"), payload)
+        .expect("write coverage-with-branches.json");
+
+    (tmp, canonical)
+}
+
+/// Defense-in-depth tempdir scrub — same as `wire_envelope_crap4ts.rs`.
+fn strip_tempdir_paths(value: &mut Value, tempdir: &str) {
+    match value {
+        Value::String(s) => *s = s.replace(tempdir, "[TEMPDIR]"),
+        Value::Object(map) => {
+            for v in map.values_mut() {
+                strip_tempdir_paths(v, tempdir);
+            }
+        }
+        Value::Array(items) => {
+            for v in items {
+                strip_tempdir_paths(v, tempdir);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[test]
+fn envelope() {
+    let (_tmp, root) = build_fixture();
+    let coverage = root.join("coverage-with-branches.json");
+    let tempdir_str = root.to_string_lossy().replace('\\', "/");
+
+    let output = Command::cargo_bin("crap4ts")
+        .expect("crap4ts binary discoverable in workspace")
+        .arg("--coverage")
+        .arg(&coverage)
+        .arg("--src")
+        .arg(&root)
+        .args(["--threshold", "16", "--format", "json", "--no-fail"])
+        .output()
+        .expect("crap4ts binary executes");
+
+    assert!(
+        output.status.success(),
+        "crap4ts exited non-zero: stdout={}\nstderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let mut envelope: Value =
+        serde_json::from_slice(&output.stdout).expect("crap4ts --format json emits valid JSON");
+    strip_volatile(&mut envelope);
+    strip_tempdir_paths(&mut envelope, &tempdir_str);
+
+    let pretty = serde_json::to_string_pretty(&envelope).expect("envelope re-serializes");
+    insta::assert_snapshot!("envelope", pretty);
+}

--- a/crates/crap4ts/Cargo.toml
+++ b/crates/crap4ts/Cargo.toml
@@ -121,3 +121,7 @@ harness = false
 [[test]]
 name = "file_extensions_cucumber"
 harness = false
+
+[[test]]
+name = "branch_coverage_cucumber"
+harness = false

--- a/crates/crap4ts/tests/branch_coverage_cucumber.rs
+++ b/crates/crap4ts/tests/branch_coverage_cucumber.rs
@@ -1,0 +1,539 @@
+//! Cucumber-rs runner for `tests/features/branch_coverage.feature`.
+//!
+//! The four scenarios under #251 split across two output surfaces:
+//!
+//! - **Table** — scenarios 1 and 2 assert the conditional `Branch%`
+//!   column rendered by `format_table_with_explain` (presence iff any
+//!   verdict carries `branch_coverage_percent`).
+//! - **JSON** — scenarios 2, 3, and 4 assert the per-function row
+//!   shape of the `--format json` envelope, including
+//!   `branch_coverage_percent` value, absence-vs-null semantics, and
+//!   the BranchMismatch diagnostic emitted alongside a still-scored
+//!   line-coverage row.
+//!
+//! Per-scenario the When-step shells the binary TWICE — once with
+//! `--format table` and once with `--format json --verbose` — and the
+//! Then-steps assert against the appropriate buffer. Both invocations
+//! use `--no-fail` so threshold gating never short-circuits the
+//! envelope.
+//!
+//! Named `*_cucumber` (suffix) so `.config/nextest.toml`'s
+//! `binary(/.*_cucumber$/)` filter excludes it from nextest probing.
+//! Pattern mirrors `arrow_function_coverage_cucumber.rs` /
+//! `file_extensions_cucumber.rs` (lib-call shape would lose the
+//! reporter half — table column rendering only exists end-to-end).
+
+use std::path::PathBuf;
+
+use cucumber::{World, given, then, when, writer};
+use serde::Deserialize;
+use serde_json::Value;
+use tempfile::TempDir;
+
+// ── Minimal envelope projection ──────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+struct Envelope {
+    result: EnvelopeResult,
+    #[serde(default)]
+    diagnostics: Option<Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct EnvelopeResult {
+    functions: Vec<EnvelopeFn>,
+}
+
+#[derive(Debug, Deserialize)]
+struct EnvelopeFn {
+    scored: EnvelopeScored,
+}
+
+#[derive(Debug, Deserialize)]
+struct EnvelopeScored {
+    identity: EnvelopeIdentity,
+    coverage_percent: f64,
+    /// Per #251: `Option<f64>` with `skip_serializing_if = is_none`.
+    /// Absent in the envelope ⇒ deserializes as `None` here.
+    #[serde(default)]
+    branch_coverage_percent: Option<f64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct EnvelopeIdentity {
+    file_path: String,
+    qualified_name: String,
+}
+
+// ── Fixture shapes ───────────────────────────────────────────────────
+
+/// Branch-rich fixture: the W2.3 committed
+/// `branch-heavy.ts` + `coverage-with-branches.json` pair (3 functions,
+/// every arm taken — 100% branch coverage across the board). Scenario
+/// 1 ("a branch-coverage column for every covered function").
+const BRANCH_HEAVY_TS: &str = include_str!("fixtures/ts-fixtures/branch-heavy.ts");
+const COVERAGE_WITH_BRANCHES: &str =
+    include_str!("fixtures/istanbul-jest/coverage-with-branches.json");
+
+/// Empty-branches fixture: scenario 2 ("renders with no branch-coverage
+/// column" + "envelope omits the `branches` field"). Uses the W1.1
+/// `simple.ts` source — single function, no decision points.
+const SIMPLE_TS: &str = include_str!("fixtures/ts-fixtures/simple.ts");
+
+/// Authored inline for scenario 3 — a function whose branch arms add
+/// up to 4 taken / 6 total so the rounded branch percentage is 66.7.
+/// CC=3 (one if/else + one ternary), 100% line coverage; the Istanbul
+/// `b`/`branchMap` declare 6 arms across two branchIds with `[1,1]`
+/// + `[1,0,1,0]` hit counts — 4 of 6 taken.
+///
+/// The "6 branches" wording in the feature file is narration over
+/// Istanbul arm counts (not the walker's CC primitive); the BDD
+/// assertion is on the rounded 66.7 value.
+const MIXED_TS: &str = "export function classify(n: number): string {\n  if (n > 0) {\n    return n === 0 ? \"zero\" : \"positive\";\n  } else {\n    return \"non-positive\";\n  }\n}\n";
+
+/// Coverage JSON template for scenario 3 — substituted with `{SRC_ROOT}`
+/// canonical path at fixture-build time. Two branchIds: an if (2 arms,
+/// both taken) at line 2 and a 4-arm switch-style branch at line 3
+/// (2 of 4 taken). Total: 4 of 6 arms taken → 66.7%. All five
+/// statements covered → 100% line coverage.
+const MIXED_COVERAGE_JSON: &str = r#"{
+  "{SRC_ROOT}/mixed.ts": {
+    "path": "{SRC_ROOT}/mixed.ts",
+    "statementMap": {
+      "0": { "start": { "line": 2, "column": 2 }, "end": { "line": 6, "column": 3 } },
+      "1": { "start": { "line": 3, "column": 4 }, "end": { "line": 3, "column": 50 } },
+      "2": { "start": { "line": 5, "column": 4 }, "end": { "line": 5, "column": 28 } }
+    },
+    "s": { "0": 5, "1": 3, "2": 2 },
+    "branchMap": {
+      "0": {
+        "loc": { "start": { "line": 2, "column": 2 }, "end": { "line": 6, "column": 3 } },
+        "type": "if",
+        "locations": [
+          { "start": { "line": 2, "column": 2 }, "end": { "line": 4, "column": 3 } },
+          { "start": { "line": 4, "column": 9 }, "end": { "line": 6, "column": 3 } }
+        ],
+        "line": 2
+      },
+      "1": {
+        "loc": { "start": { "line": 3, "column": 11 }, "end": { "line": 3, "column": 49 } },
+        "type": "switch",
+        "locations": [
+          { "start": { "line": 3, "column": 17 }, "end": { "line": 3, "column": 23 } },
+          { "start": { "line": 3, "column": 26 }, "end": { "line": 3, "column": 36 } },
+          { "start": { "line": 3, "column": 39 }, "end": { "line": 3, "column": 44 } },
+          { "start": { "line": 3, "column": 47 }, "end": { "line": 3, "column": 49 } }
+        ],
+        "line": 3
+      }
+    },
+    "b": {
+      "0": [1, 1],
+      "1": [1, 0, 1, 0]
+    },
+    "fnMap": {
+      "0": {
+        "name": "classify",
+        "decl": { "start": { "line": 1, "column": 16 }, "end": { "line": 1, "column": 24 } },
+        "loc": { "start": { "line": 1, "column": 41 }, "end": { "line": 7, "column": 1 } },
+        "line": 1
+      }
+    },
+    "f": { "0": 5 }
+  }
+}"#;
+
+/// Orphan-branch fixture (committed during W2.4): branchId `42` is in
+/// `b` but absent from `branchMap`. The parser emits a
+/// `BranchMismatch` diagnostic, skips THAT branch, and the rest of the
+/// scorecard still scores. Scenario 4.
+const ORPHAN_BRANCH_JSON: &str =
+    include_str!("fixtures/istanbul-broken/coverage-with-orphan-branch.json");
+
+// ── World ────────────────────────────────────────────────────────────
+
+#[derive(Debug, Default, World)]
+struct BranchWorld {
+    fixture: Option<(TempDir, PathBuf)>,
+    cov_path: Option<PathBuf>,
+    /// Table-format stdout (whitespace-collapsed in colour-stripped
+    /// form). Populated by the When-step's first invocation.
+    table_output: String,
+    /// `--format json --verbose` envelope, parsed.
+    envelope: Option<Envelope>,
+    /// `--format json --verbose` raw stdout — kept so step defs can do
+    /// substring checks that distinguish absent-field from `null` when
+    /// scenario 4's "`branchCoverage` is null" wording requires it.
+    json_raw: String,
+    stderr: String,
+}
+
+impl BranchWorld {
+    fn root(&mut self) -> PathBuf {
+        if self.fixture.is_none() {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let canonical = std::fs::canonicalize(tmp.path()).expect("canonicalize tempdir");
+            self.fixture = Some((tmp, canonical));
+        }
+        self.fixture.as_ref().unwrap().1.clone()
+    }
+
+    fn write(&mut self, name: &str, content: &str) {
+        let root = self.root();
+        std::fs::write(root.join(name), content).expect("write fixture file");
+    }
+
+    /// Look up the parsed envelope's row for `function` (panics with
+    /// the discovered set on miss — keeps walker-naming drift legible
+    /// in CI output).
+    fn function(&self, name: &str) -> &EnvelopeFn {
+        let env = self.envelope.as_ref().expect("envelope set by When step");
+        env.result
+            .functions
+            .iter()
+            .find(|f| f.scored.identity.qualified_name == name)
+            .unwrap_or_else(|| {
+                panic!(
+                    "function `{name}` not in the envelope; discovered: {:?}",
+                    env.result
+                        .functions
+                        .iter()
+                        .map(|f| f.scored.identity.qualified_name.as_str())
+                        .collect::<Vec<_>>(),
+                )
+            })
+    }
+}
+
+// ── Givens ───────────────────────────────────────────────────────────
+
+#[given("an Istanbul `coverage-final.json` whose entries include `b` and `branchMap` records")]
+fn given_branch_records_present(world: &mut BranchWorld) {
+    let root = world.root();
+    world.write("branch-heavy.ts", BRANCH_HEAVY_TS);
+    let payload =
+        COVERAGE_WITH_BRANCHES.replace("{SRC_ROOT}", &root.to_string_lossy().replace('\\', "/"));
+    let path = root.join("coverage-with-branches.json");
+    std::fs::write(&path, payload).expect("write coverage-with-branches.json");
+    world.cov_path = Some(path);
+}
+
+#[given("an Istanbul `coverage-final.json` whose entries have empty `b` and empty `branchMap`")]
+fn given_empty_branches(world: &mut BranchWorld) {
+    let root = world.root();
+    world.write("simple.ts", SIMPLE_TS);
+    // Hand-craft the empty-branches coverage entry calibrated to
+    // simple.ts's `add` function at line 3 (matches the W1.1 fixture's
+    // statementMap for simple.ts).
+    let abs = root.join("simple.ts").to_string_lossy().replace('\\', "/");
+    let payload = format!(
+        r#"{{"{abs}":{{"path":"{abs}","statementMap":{{"0":{{"start":{{"line":4,"column":2}},"end":{{"line":4,"column":15}}}}}},"s":{{"0":3}},"branchMap":{{}},"b":{{}},"fnMap":{{"0":{{"name":"add","decl":{{"start":{{"line":3,"column":16}},"end":{{"line":3,"column":19}}}},"loc":{{"start":{{"line":3,"column":51}},"end":{{"line":5,"column":1}}}},"line":3}}}},"f":{{"0":3}}}}}}"#,
+    );
+    let path = root.join("coverage-final.json");
+    std::fs::write(&path, payload).expect("write empty-branches coverage-final.json");
+    world.cov_path = Some(path);
+}
+
+#[given("a TypeScript function with cyclomatic complexity 3 (one if/else, one ternary)")]
+fn given_mixed_function(world: &mut BranchWorld) {
+    world.write("mixed.ts", MIXED_TS);
+}
+
+#[given("a coverage-final.json showing 4 of 6 branches hit (66% branch coverage)")]
+fn given_mixed_coverage(world: &mut BranchWorld) {
+    let root = world.root();
+    let payload =
+        MIXED_COVERAGE_JSON.replace("{SRC_ROOT}", &root.to_string_lossy().replace('\\', "/"));
+    let path = root.join("coverage-final.json");
+    std::fs::write(&path, payload).expect("write mixed coverage-final.json");
+    world.cov_path = Some(path);
+}
+
+#[given("the same function shows 100% line coverage in the `s` record")]
+fn given_full_line_coverage(_world: &mut BranchWorld) {
+    // The MIXED_COVERAGE_JSON template's `s` map covers every
+    // instrumented statement (all three statementMap entries have
+    // `s > 0`), so this Given just narrates the fixture state the
+    // previous step wrote.
+}
+
+#[given(
+    "an Istanbul `coverage-final.json` whose `b` references branchId `42` and `branchMap` omits `42`"
+)]
+fn given_orphan_branch(world: &mut BranchWorld) {
+    let root = world.root();
+    // The committed orphan-branch fixture targets `branch-heavy.ts` so
+    // the source tree must mirror it.
+    world.write("branch-heavy.ts", BRANCH_HEAVY_TS);
+    let payload =
+        ORPHAN_BRANCH_JSON.replace("{SRC_ROOT}", &root.to_string_lossy().replace('\\', "/"));
+    let path = root.join("coverage-with-orphan-branch.json");
+    std::fs::write(&path, payload).expect("write orphan-branch coverage-final.json");
+    world.cov_path = Some(path);
+}
+
+// ── When ─────────────────────────────────────────────────────────────
+
+#[when("the operator runs `crap4ts --coverage coverage-final.json --src src`")]
+fn when_run_crap4ts(world: &mut BranchWorld) {
+    let root = world.root();
+    let cov = world
+        .cov_path
+        .clone()
+        .expect("Given step must seed the coverage file");
+
+    // 1) Table run — `Branch%` column visibility tests live here.
+    let table_out = assert_cmd::Command::cargo_bin("crap4ts")
+        .expect("crap4ts binary discoverable")
+        .arg("--coverage")
+        .arg(&cov)
+        .arg("--src")
+        .arg(&root)
+        .args(["--format", "table", "--no-fail", "--color", "never"])
+        .output()
+        .expect("crap4ts (table run) executes");
+    assert!(
+        table_out.status.success(),
+        "crap4ts (table) exited non-zero: stderr=\n{}",
+        String::from_utf8_lossy(&table_out.stderr),
+    );
+    world.table_output = String::from_utf8_lossy(&table_out.stdout).into_owned();
+
+    // 2) JSON run with `--verbose` so diagnostics surface for the
+    //    BranchMismatch scenario.
+    let json_out = assert_cmd::Command::cargo_bin("crap4ts")
+        .expect("crap4ts binary discoverable")
+        .arg("--coverage")
+        .arg(&cov)
+        .arg("--src")
+        .arg(&root)
+        .args(["--format", "json", "--no-fail", "--verbose"])
+        .output()
+        .expect("crap4ts (json run) executes");
+    assert!(
+        json_out.status.success(),
+        "crap4ts (json) exited non-zero: stderr=\n{}",
+        String::from_utf8_lossy(&json_out.stderr),
+    );
+    world.json_raw = String::from_utf8_lossy(&json_out.stdout).into_owned();
+    world.stderr = String::from_utf8_lossy(&json_out.stderr).into_owned();
+    world.envelope = Some(serde_json::from_str(&world.json_raw).expect("envelope parses"));
+}
+
+#[when("the operator runs `crap4ts --coverage coverage-final.json --src src --format json`")]
+fn when_run_crap4ts_json(world: &mut BranchWorld) {
+    // Scenario 3 explicitly invokes `--format json`; share the same
+    // fixture/binary plumbing so the table + JSON outputs are both
+    // available to Then steps that compose across them.
+    when_run_crap4ts(world);
+}
+
+// ── Thens ────────────────────────────────────────────────────────────
+
+#[then("the report includes a branch-coverage column for every covered function")]
+fn then_branch_column_present(world: &mut BranchWorld) {
+    assert!(
+        world.table_output.contains("Branch%"),
+        "expected the table to render a `Branch%` column when branch data is present; got=\n{}",
+        world.table_output,
+    );
+    let env = world.envelope.as_ref().expect("envelope set");
+    assert!(
+        env.result
+            .functions
+            .iter()
+            .all(|f| f.scored.branch_coverage_percent.is_some()),
+        "expected every covered function to carry branch_coverage_percent; got: {:?}",
+        env.result
+            .functions
+            .iter()
+            .map(|f| (
+                f.scored.identity.qualified_name.as_str(),
+                f.scored.branch_coverage_percent
+            ))
+            .collect::<Vec<_>>(),
+    );
+}
+
+#[then("the branch-coverage entries are keyed by workspace-relative paths")]
+fn then_workspace_relative_paths(world: &mut BranchWorld) {
+    let env = world.envelope.as_ref().expect("envelope set");
+    // After `IstanbulCoverage::normalize_path`, file_path entries are
+    // relative to `--src` — no absolute path or tempdir prefix should
+    // appear in the envelope's per-function rows.
+    for f in &env.result.functions {
+        let p = &f.scored.identity.file_path;
+        assert!(
+            !p.starts_with('/') && !p.contains(":\\"),
+            "file_path `{p}` should be workspace-relative, not absolute",
+        );
+    }
+}
+
+#[then("every branch record in the input is paired with its `branchMap` entry")]
+fn then_branches_paired(world: &mut BranchWorld) {
+    // The branch-heavy fixture has every branchId in `branchMap`;
+    // a BranchMismatch diagnostic would be emitted on any orphan.
+    // The verbose envelope's diagnostics field would surface one if
+    // present — assert absence to confirm clean pairing.
+    let env = world.envelope.as_ref().expect("envelope set");
+    let saw_branch_mismatch = env
+        .diagnostics
+        .as_ref()
+        .map(|d| d.to_string().contains("branch-mismatch"))
+        .unwrap_or(false);
+    assert!(
+        !saw_branch_mismatch,
+        "expected zero branch-mismatch diagnostics on a clean fixture; envelope diagnostics=\n{:#?}",
+        env.diagnostics,
+    );
+}
+
+#[then("the scorecard renders with no branch-coverage column")]
+fn then_no_branch_column(world: &mut BranchWorld) {
+    assert!(
+        !world.table_output.contains("Branch%"),
+        "expected NO `Branch%` column when all rows have absent branch_coverage_percent; got=\n{}",
+        world.table_output,
+    );
+}
+
+#[then("the JSON envelope omits the `branches` field (or sets it to null)")]
+fn then_envelope_omits_or_nulls_branches(world: &mut BranchWorld) {
+    // Per #251 the wire shape uses `skip_serializing_if =
+    // "Option::is_none"`, so the field is absent on rows without
+    // branch data. Accept both `null` and absent to satisfy the
+    // scenario's "(or sets it to null)" alternative — the
+    // distinction is opaque at the JSON-text level.
+    let env = world.envelope.as_ref().expect("envelope set");
+    for f in &env.result.functions {
+        assert!(
+            f.scored.branch_coverage_percent.is_none(),
+            "function `{}` should have absent/null branch_coverage_percent on the empty-branches fixture; got {:?}",
+            f.scored.identity.qualified_name,
+            f.scored.branch_coverage_percent,
+        );
+    }
+}
+
+#[then(regex = r"^the function's `lineCoverage` is (\d+\.\d+)$")]
+fn then_function_line_coverage(world: &mut BranchWorld, expected: f64) {
+    let f = world.function("classify");
+    assert!(
+        (f.scored.coverage_percent - expected).abs() < 0.05,
+        "`classify` line coverage: expected {expected}, got {}",
+        f.scored.coverage_percent,
+    );
+}
+
+#[then(regex = r"^the function's `branchCoverage` is (\d+\.\d+) \(rounded one decimal\)$")]
+fn then_function_branch_coverage(world: &mut BranchWorld, expected: f64) {
+    let f = world.function("classify");
+    let actual = f
+        .scored
+        .branch_coverage_percent
+        .expect("expected branchCoverage to be populated for the mixed-coverage fixture");
+    // `expected` is the scenario's rounded value; the parser produces
+    // the un-rounded percent. Match on rounded-to-one-decimal equality
+    // to honour the scenario's "(rounded one decimal)" prose.
+    let rounded = (actual * 10.0).round() / 10.0;
+    assert!(
+        (rounded - expected).abs() < 0.05,
+        "`classify` branchCoverage rounded one decimal: expected {expected}, got {rounded} (raw {actual})",
+    );
+}
+
+#[then("both values appear in the JSON envelope's row for the function")]
+fn then_both_values_in_envelope_row(world: &mut BranchWorld) {
+    let f = world.function("classify");
+    assert!(f.scored.branch_coverage_percent.is_some());
+    assert!(f.scored.coverage_percent.is_finite());
+}
+
+#[then("the parser emits an `IstanbulParseDiagnostic` with kind `branch-mismatch`")]
+fn then_parser_emits_branch_mismatch(world: &mut BranchWorld) {
+    let env = world.envelope.as_ref().expect("envelope set");
+    let dx = env
+        .diagnostics
+        .as_ref()
+        .map(|d| d.to_string())
+        .unwrap_or_default();
+    assert!(
+        dx.contains("branch-mismatch"),
+        "expected a `branch-mismatch` diagnostic in the verbose envelope; diagnostics=\n{dx}",
+    );
+}
+
+#[then("the function's `branchCoverage` is `null` for the affected entry")]
+fn then_affected_branch_coverage_null(world: &mut BranchWorld) {
+    // The orphan fixture (`coverage-with-orphan-branch.json`) covers
+    // `branch-heavy.ts` with ONE valid branchId (`0`, at line 11 —
+    // inside `classify`'s span) and one orphan (`42`, dropped by the
+    // parser). With the orphan skipped, the per-function shape is:
+    //
+    //   classify (lines 10-16) — branch 0 falls in span, 2/2 arms
+    //                            taken → branch_coverage_percent = 100%
+    //   sign    (lines 18-20) — no branches in span → None (absent)
+    //   bucket  (lines 22-28) — no branches in span → None (absent)
+    //
+    // So the "is null for the affected entry" assertion lands sharply
+    // on `sign` AND `bucket`: at least one function MUST have the
+    // field absent (the JSON-text "null" sense — `Option<f64>::None`
+    // serializes as absent under `skip_serializing_if`). The
+    // assertion would fail (intentionally) if the orphan-skip
+    // somehow inflated every function row with stale branch data, or
+    // if the surfacing erroneously populated `Some(_)` for functions
+    // without branches in their span.
+    let env = world.envelope.as_ref().expect("envelope set");
+    let null_count = env
+        .result
+        .functions
+        .iter()
+        .filter(|f| f.scored.branch_coverage_percent.is_none())
+        .count();
+    assert!(
+        null_count >= 1,
+        "expected at least one function row to carry branchCoverage = null/absent under the orphan-branch fixture; got rows: {:?}",
+        env.result
+            .functions
+            .iter()
+            .map(|f| (
+                f.scored.identity.qualified_name.as_str(),
+                f.scored.branch_coverage_percent
+            ))
+            .collect::<Vec<_>>(),
+    );
+}
+
+#[then("the rest of the scorecard still produces line coverage for the file")]
+fn then_rest_still_scored(world: &mut BranchWorld) {
+    let env = world.envelope.as_ref().expect("envelope set");
+    assert!(
+        env.result
+            .functions
+            .iter()
+            .any(|f| f.scored.coverage_percent.is_finite()),
+        "expected at least one function with finite line coverage in the orphan-branch fixture; got=\n{:#?}",
+        env.result
+            .functions
+            .iter()
+            .map(|f| (
+                f.scored.identity.qualified_name.as_str(),
+                f.scored.coverage_percent
+            ))
+            .collect::<Vec<_>>(),
+    );
+}
+
+// ── Runner ───────────────────────────────────────────────────────────
+
+#[tokio::main]
+async fn main() {
+    BranchWorld::cucumber()
+        .with_writer(writer::Libtest::or_basic())
+        .with_default_cli()
+        .filter_run_and_exit("tests/features/branch_coverage.feature", |_, _, sc| {
+            sc.tags.iter().any(|t| t == "wired")
+        })
+        .await;
+}

--- a/crates/crap4ts/tests/features/branch_coverage.feature
+++ b/crates/crap4ts/tests/features/branch_coverage.feature
@@ -3,35 +3,36 @@ Feature: Istanbul branch coverage flows through to the scorecard
   I want crap4ts to surface per-function branch coverage alongside line coverage
   So that I can identify functions whose branches are tested but whose statements are not (or vice versa)
 
-  @unwired
+  @wired
   Scenario: A coverage-final.json with branch records populates ParseOutput.branches
-    # tracked: crap-rs#251 — branch coverage is parsed into ParseOutput.branches
-    # but not surfaced in the scorecard or JSON envelope, so the report/envelope
-    # assertions here are unwireable; the parser-side contract is pinned by
-    # istanbul_smoke.rs::w23_*
+    # Wired by `branch_coverage_cucumber.rs` (crap-rs#251) — the
+    # surface lift to per-function envelope rows + the conditional
+    # `Branch%` table column landed in the same PR.
     Given an Istanbul `coverage-final.json` whose entries include `b` and `branchMap` records
     When the operator runs `crap4ts --coverage coverage-final.json --src src`
     Then the report includes a branch-coverage column for every covered function
     And the branch-coverage entries are keyed by workspace-relative paths
     And every branch record in the input is paired with its `branchMap` entry
 
-  @unwired
+  @wired
   Scenario: A coverage-final.json with NO branch records leaves ParseOutput.branches as None
-    # tracked: crap-rs#251 — branch coverage is parsed into ParseOutput.branches
-    # but not surfaced in the scorecard or JSON envelope, so the report/envelope
-    # assertions here are unwireable; the parser-side contract is pinned by
-    # istanbul_smoke.rs::w23_*
+    # Wired by `branch_coverage_cucumber.rs` (crap-rs#251). The
+    # `Option<f64>` + `skip_serializing_if(None)` wire model means the
+    # "omits the field (or sets it to null)" alternative collapses to
+    # "absent" in practice; the harness accepts both shapes.
     Given an Istanbul `coverage-final.json` whose entries have empty `b` and empty `branchMap`
     When the operator runs `crap4ts --coverage coverage-final.json --src src`
     Then the scorecard renders with no branch-coverage column
     And the JSON envelope omits the `branches` field (or sets it to null)
 
-  @unwired
+  @wired
   Scenario: A function's branch coverage joins its line coverage in the report
-    # tracked: crap-rs#251 — branch coverage is parsed into ParseOutput.branches
-    # but not surfaced in the scorecard or JSON envelope, so the report/envelope
-    # assertions here are unwireable; the parser-side contract is pinned by
-    # istanbul_smoke.rs::w23_*
+    # Wired by `branch_coverage_cucumber.rs` (crap-rs#251). The "6
+    # branches" wording is Istanbul-arm-count narration (not the
+    # walker's CC primitive); the harness's authored fixture exercises
+    # two branchIds (a 2-arm if + a 4-arm switch-style group) with hit
+    # pattern `[1,1]` + `[1,0,1,0]` = 4 of 6 arms taken → 66.7%
+    # rounded one decimal.
     Given a TypeScript function with cyclomatic complexity 3 (one if/else, one ternary)
     And a coverage-final.json showing 4 of 6 branches hit (66% branch coverage)
     And the same function shows 100% line coverage in the `s` record
@@ -40,12 +41,14 @@ Feature: Istanbul branch coverage flows through to the scorecard
     And the function's `branchCoverage` is 66.7 (rounded one decimal)
     And both values appear in the JSON envelope's row for the function
 
-  @unwired
+  @wired
   Scenario: A b record references a branchId not in branchMap emits BranchMismatch
-    # tracked: crap-rs#251 — branch coverage is parsed into ParseOutput.branches
-    # but not surfaced in the scorecard or JSON envelope, so the report/envelope
-    # assertions here are unwireable; the parser-side contract is pinned by
-    # istanbul_smoke.rs::w23_*
+    # Wired by `branch_coverage_cucumber.rs` (crap-rs#251). The
+    # parser's "diagnostic + skip THAT branch, never abort first-
+    # record" contract (#187) means the function's row still scores
+    # against the non-orphaned branches in its span; the affected
+    # entry's `branchCoverage` is absent (null at the JSON-text level)
+    # only when the orphan was the function's sole branch.
     Given an Istanbul `coverage-final.json` whose `b` references branchId `42` and `branchMap` omits `42`
     When the operator runs `crap4ts --coverage coverage-final.json --src src`
     Then the parser emits an `IstanbulParseDiagnostic` with kind `branch-mismatch`

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -95,6 +95,7 @@ pre-push:
         --test istanbul_parser_cucumber
         --test arrow_function_coverage_cucumber
         --test file_extensions_cucumber
+        --test branch_coverage_cucumber
       timeout: 300s
     docs:
       env:


### PR DESCRIPTION
## Summary

W2.3 (#186) shipped Istanbul branch parsing — `IstanbulCoverage::parse`
populates `ParseOutput.branches` and `domain::matching::compute_branch_coverage`
computes a per-function `CoverageRatio` — but **no reporter or view
layer surfaced it**. This PR lifts that already-computed value through
the public surface (JSON envelope row + conditional table column) and
flips the 4 `branch_coverage.feature` scenarios `@unwired` → `@wired`.

## Acceptance criteria (all green)

- [x] `--format json` envelope per-function row carries `branch_coverage_percent: Option<f64>`, populated from `matching.rs`'s already-computed `branch_coverage`
- [x] Table reporter renders `Branch%` column when branch data is present, omits it when no row has it
- [x] Wire-envelope shape change is locked by a NEW snapshot canary — see "AC #3 interpretation" below
- [x] 4 `branch_coverage.feature` scenarios flipped `@unwired` → `@wired` against the new surface (closes the BDD gap left by #229)

## Surface changes

| Layer | File | Change |
|---|---|---|
| Domain | `crap-core/src/domain/types.rs` | New `ScoredFunction.branch_coverage_percent: Option<f64>` (#[serde(default, skip_serializing_if = "Option::is_none")]) — pre-#251 envelope preserved when None |
| Producer | `crap-core/src/core/mod.rs` (score_and_summarize) | Lifts `cov.branch_coverage.percent` onto the new field |
| JSON reporter | `crap-core/src/adapters/reporters/json.rs` | Auto via serde derive — no code change |
| Table reporter | `crap-core/src/adapters/reporters/table.rs` | Conditional `Branch%` column (any verdict has Some → column appears, "—" for rows without). Refactored row/cell construction into `build_function_table` / `build_function_row` / `format_branch_cell` helpers to keep `format_table_with_explain` CC under the self-CRAP strict-15 gate. |
| BDD | `crap4ts/tests/features/branch_coverage.feature` | 4 scenarios `@unwired` → `@wired` |
| BDD harness | `crap4ts/tests/branch_coverage_cucumber.rs` (NEW) | Binary-shell + dual-format (table + json --verbose) projection — mirrors `arrow_function_coverage_cucumber.rs` |
| Canary | `crap-core/tests/wire_envelope_crap4ts_branches.rs` (NEW) | Locks the branches-populated wire shape using W2.3's branch-rich fixture pair |
| CI | `.github/workflows/ci.yml`, `lefthook.yml`, `crap4ts/Cargo.toml` | Add `branch_coverage_cucumber` to every-harness-in-CI list + lefthook + [[test]] entry |

## AC #3 interpretation (worth a paragraph)

Acceptance criterion 3 reads "wire_envelope_crap4rs / wire_envelope_crap4ts
snapshots drift INTENTIONALLY." Under `skip_serializing_if(None)` + the
existing canaries' fixtures (LCOV / empty-`branchMap` jest), **neither
existing snapshot drifts** — the new field is absent on every row, so
the pre-#251 envelope is preserved byte-identically. That's the right
behavior for non-branch-aware runs.

To satisfy the spirit of AC #3 (lock the new wire shape with a
canary), this PR **adds** `wire_envelope_crap4ts_branches.rs` — a
third canary that exercises the branch-populated shape using W2.3's
committed `branch-heavy.ts` + `coverage-with-branches.json`. The new
snapshot bakes the `branch_coverage_percent: 100.0` field per row,
giving the wire shape a dedicated regression gate that will fail
loudly if the field's serialization drifts (typo in field name, lost
`skip_serializing_if`, dropped Option-ness, etc.).

This is a strictly-better outcome than mutating the existing canaries
would have been: Rust-only runs and jest-without-branches runs
preserve their pre-#251 envelope width (no `null` field per row), and
the new wire field has its own dedicated canary covering the
populated shape.

## What's NOT changed (per #251 strict-NOT list)

- Threshold gate stays **line-coverage-only**. Branch coverage is
  informational, not gating. If/when gating-on-branch is wanted,
  that's a separate ADR.
- No changes to `IstanbulCoverage::parse`, `ParseOutput.branches`, or
  `matching::compute_branch_coverage` — already shipped in #186.
- No new `ContributorKind` variants.
- No changes to `crap4ts` walker, oxc dispatch, or any adapter-side
  code.

## Local gate battery

- `cargo fmt --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo nextest run --workspace --all-targets` — 1097 tests, 0 failures ✅
- `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps` ✅
- `cargo +1.93 check --workspace --all-targets` ✅
- `cargo deny check` ✅
- 4-layer ast-purity grep on `crates/crap-core/src/` — clean ✅
- All 8 cucumber harnesses green ✅
- Self-CRAP-thrice (strict mode): all three crates PASS — `crap-core/src` (worst 13.0 < 15 after the row-builder extraction), `crap4rs/src` (worst 11.0), `crap4ts/src` (worst 12.0)
- `cargo insta test --workspace` ✅ (existing snapshots byte-identical; new branch canary accepted)

## Discovery resolutions

1. **Wire field naming** — Resolved to `branch_coverage_percent: Option<f64>` mirroring `coverage_percent: f64`. snake_case + `_percent` suffix for parallel naming.
2. **Conditional vs unconditional column** — Resolved to conditional, derived from `view.shown.any(|v| v.scored.branch_coverage_percent.is_some())`. No `branches_present: bool` threaded through the view layer.
3. **null vs absent** — Resolved to absent (via `skip_serializing_if(None)`). Step defs accept both null and absent at the JSON-text level (loose check). Tradeoff: the wire model can't distinguish "we tried, no usable signal" from "we didn't try" — both → absent — but that distinction isn't load-bearing for any downstream consumer today; an explicit `branch_coverage_available: bool` flag would over-engineer it.

Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)