### PR TITLE
fix(crap4ts): #253 — skip `.d.ts` declaration files via AdapterMeta::forced_excludes

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -33,7 +33,7 @@ Windows and Linux arm64 / musl are tracked for a later release.
 ### Why are my scores different?
 
 `crap4ts@2.x` scores can diverge from `crap4ts@1.x` scores on the same
-codebase. Two compounding reasons account for the gap (a third was
+codebase. Three compounding reasons account for the gap (a fourth was
 resolved in 2.0.0 — see below); each is documented so you can
 self-diagnose rather than chase a phantom regression:
 
@@ -48,6 +48,16 @@ self-diagnose rather than chase a phantom regression:
    against the `crap4ts@1.x` test corpus; until that completes, treat
    the gate as a guideline rather than a ground truth. Track at
    [`crap-rs`#173](https://github.com/breezy-bays-labs/crap-rs/issues/173).
+3. **`.d.ts` declaration files are skipped by default.** `crap4ts@2.x`
+   drops `**/*.d.ts` at the source-discovery boundary (declaration
+   files contain only ambient types — no executable code — so they
+   contribute zero useful CRAP signal). The skip is unconditional;
+   there is no opt-in to include them. If your v1.x scorecard listed
+   functions from `.d.ts` files (e.g. a `types.d.ts` entry with
+   suspicious 0% coverage), v2 will simply omit them — the function
+   count drops, the report is shorter, and the codebase-level summary
+   improves slightly. This matches the convention every other TS
+   tool (`eslint`, `tsc --noEmit`, `vitest`, …) already follows.
 
 **Resolved in 2.0.0 — arrow-function coverage now reads correctly.**
 v2's Istanbul adapter consumes `s` / `statementMap` (not `f` / `fnMap`,

--- a/crates/crap-core/src/cli/init.rs
+++ b/crates/crap-core/src/cli/init.rs
@@ -288,6 +288,11 @@ mod tests {
             rule_help_uri: "https://example.invalid",
             config_file_name: "fake-adapter.toml",
             default_excludes: &["tests/**", "benches/**", "examples/**"],
+            // `init` doesn't render forced_excludes (they're load-bearing
+            // at analysis time, not template scaffolding); empty here
+            // keeps the round-trip assertions focused on what `init`
+            // actually emits.
+            forced_excludes: &[],
             // Cognitive matches the pre-W2.5 fallthrough — init's
             // round-trip / comment-rendering assertions don't probe
             // the metric default; this keeps the field meaningful

--- a/crates/crap-core/src/cli/mod.rs
+++ b/crates/crap-core/src/cli/mod.rs
@@ -684,7 +684,27 @@ pub struct AdapterMeta {
     /// and ignorable artifacts live" differs per ecosystem. May be
     /// empty — init then emits the `# exclude = [ … ]` block without
     /// per-language entries.
+    ///
+    /// This field is **init-template only** — it does NOT affect the
+    /// analyzer's effective exclude list at runtime. The runtime
+    /// exclude list is built from `cli.filter.exclude` plus the user's
+    /// `crap4ts.toml`/`crap4rs.toml` `exclude` entries, with adapter-
+    /// mandated patterns prepended via `forced_excludes` (below).
     pub default_excludes: &'static [&'static str],
+    /// Adapter-mandated exclude patterns prepended to every analysis
+    /// run, regardless of CLI flags or user config. Use for files that
+    /// are **structurally never source** for the adapter's language —
+    /// e.g. crap4ts sets `&["**/*.d.ts"]` because TypeScript
+    /// declaration files contain only ambient types, never executable
+    /// code. crap4rs has no such suffix today and sets `&[]`.
+    ///
+    /// Distinct from `default_excludes` (above): forced excludes are
+    /// load-bearing at analysis time and cannot be turned off by the
+    /// operator, whereas `default_excludes` is init-template
+    /// scaffolding. If an operator genuinely needs `.d.ts` files in
+    /// their report, the path is forking the adapter or filing a
+    /// follow-up to add an opt-out — not a config knob (crap-rs#253).
+    pub forced_excludes: &'static [&'static str],
     /// The default complexity metric the adapter binary uses when
     /// neither CLI nor config file specifies one. crap4rs sets
     /// `Cognitive`; crap4ts sets `Cyclomatic` (the only metric crap4ts
@@ -1042,7 +1062,7 @@ fn merge_effective_inputs(
         .or_else(|| file_config.as_ref().and_then(|c| c.metric))
         .unwrap_or(meta.default_metric);
     let (threshold_config, threshold) = merge_threshold(cli, file_config, metric);
-    let exclude = merge_exclude(cli, file_config);
+    let exclude = merge_exclude(cli, file_config, meta);
     EffectiveInputs {
         src,
         metric,
@@ -1522,14 +1542,31 @@ fn merge_threshold(
     (config, global)
 }
 
-fn merge_exclude(cli: &Cli, file_config: &Option<FileConfig>) -> Vec<String> {
-    let mut exclude = cli.filter.exclude.clone();
+/// Build the effective exclude list applied to the source walker:
+/// `meta.forced_excludes` first (adapter-mandated, structural skips
+/// like `**/*.d.ts` for crap4ts — see `AdapterMeta::forced_excludes`),
+/// then CLI `--exclude` flags, then patterns from the user's config
+/// file. Duplicates are dropped so the override builder doesn't see
+/// the same pattern twice. Order matters because `ignore::overrides`
+/// is order-sensitive on shadowed patterns; forced excludes lead so a
+/// user can't accidentally re-include a structurally-skipped file.
+fn merge_exclude(cli: &Cli, file_config: &Option<FileConfig>, meta: &AdapterMeta) -> Vec<String> {
+    let mut exclude: Vec<String> = meta
+        .forced_excludes
+        .iter()
+        .map(|s| (*s).to_string())
+        .collect();
+    let mut seen: std::collections::HashSet<String> = exclude.iter().cloned().collect();
+    for pattern in &cli.filter.exclude {
+        if seen.insert(pattern.clone()) {
+            exclude.push(pattern.clone());
+        }
+    }
     if let Some(fc) = file_config
         && let Some(fc_exclude) = &fc.exclude
     {
-        let seen: std::collections::HashSet<String> = exclude.iter().cloned().collect();
         for pattern in fc_exclude {
-            if !seen.contains(pattern) {
+            if seen.insert(pattern.clone()) {
                 exclude.push(pattern.clone());
             }
         }
@@ -2266,7 +2303,7 @@ mod tests {
             exclude: Some(vec!["benches/**".to_string()]),
             ..FileConfig::default()
         });
-        let exclude = merge_exclude(&cli, &file_config);
+        let exclude = merge_exclude(&cli, &file_config, &fake_meta());
         assert_eq!(exclude, vec!["tests/**", "benches/**"]);
     }
 
@@ -2277,8 +2314,63 @@ mod tests {
             exclude: Some(vec!["tests/**".to_string()]),
             ..FileConfig::default()
         });
-        let exclude = merge_exclude(&cli, &file_config);
+        let exclude = merge_exclude(&cli, &file_config, &fake_meta());
         assert_eq!(exclude, vec!["tests/**"]);
+    }
+
+    /// `AdapterMeta::forced_excludes` patterns are prepended to the
+    /// effective exclude list at analysis time so an adapter can
+    /// structurally skip files that are never source code in its
+    /// language (`**/*.d.ts` for crap4ts — crap-rs#253). CLI flags and
+    /// config-file entries layer on top, with duplicates dropped.
+    #[test]
+    fn merge_exclude_prepends_forced_excludes_from_adapter_meta() {
+        let cli = parse(&["--coverage", "lcov.info", "--exclude", "tests/**"]).unwrap();
+        let file_config = Some(FileConfig {
+            exclude: Some(vec!["benches/**".to_string()]),
+            ..FileConfig::default()
+        });
+        let meta = AdapterMeta {
+            forced_excludes: &["**/*.d.ts"],
+            ..fake_meta()
+        };
+        let exclude = merge_exclude(&cli, &file_config, &meta);
+        assert_eq!(exclude, vec!["**/*.d.ts", "tests/**", "benches/**"]);
+    }
+
+    /// Empty `forced_excludes` (crap4rs's setting today) is a no-op —
+    /// the merge is identical to the pre-#253 behavior of CLI then
+    /// file-config patterns.
+    #[test]
+    fn merge_exclude_with_empty_forced_excludes_matches_legacy_behavior() {
+        let cli = parse(&["--coverage", "lcov.info", "--exclude", "tests/**"]).unwrap();
+        let file_config = Some(FileConfig {
+            exclude: Some(vec!["benches/**".to_string()]),
+            ..FileConfig::default()
+        });
+        let meta = AdapterMeta {
+            forced_excludes: &[],
+            ..fake_meta()
+        };
+        let exclude = merge_exclude(&cli, &file_config, &meta);
+        assert_eq!(exclude, vec!["tests/**", "benches/**"]);
+    }
+
+    /// A `forced_excludes` pattern already present in CLI flags is
+    /// deduplicated — appears once, in its forced-prefix position.
+    #[test]
+    fn merge_exclude_forced_excludes_deduplicates_against_cli_and_config() {
+        let cli = parse(&["--coverage", "lcov.info", "--exclude", "**/*.d.ts"]).unwrap();
+        let file_config = Some(FileConfig {
+            exclude: Some(vec!["**/*.d.ts".to_string(), "benches/**".to_string()]),
+            ..FileConfig::default()
+        });
+        let meta = AdapterMeta {
+            forced_excludes: &["**/*.d.ts"],
+            ..fake_meta()
+        };
+        let exclude = merge_exclude(&cli, &file_config, &meta);
+        assert_eq!(exclude, vec!["**/*.d.ts", "benches/**"]);
     }
 
     // ── --diff flag tests ───────────────────────────────────────────
@@ -2791,6 +2883,11 @@ mod tests {
             rule_help_uri: "https://example.invalid/fake-adapter#rules",
             config_file_name: "fake-adapter.toml",
             default_excludes: &["fixtures/**"],
+            // Empty in the shared fake so tests that don't care don't
+            // see an unexpected prefix; the two `merge_exclude` tests
+            // that DO care construct their own AdapterMeta with an
+            // explicit `forced_excludes`.
+            forced_excludes: &[],
             // `Cognitive` preserves the pre-W2.5 fallthrough semantics
             // for tests that don't care which default they get (the two
             // tests that DO care construct their own AdapterMeta with

--- a/crates/crap-core/src/core/walker.rs
+++ b/crates/crap-core/src/core/walker.rs
@@ -118,6 +118,36 @@ mod tests {
         );
     }
 
+    /// A `**/*.d.ts` glob in the exclude list drops TypeScript
+    /// declaration files while a sibling `app.ts` survives — pins the
+    /// `ignore::overrides` contract the crap4ts `forced_excludes`
+    /// wiring in `cli::merge_exclude` relies on (crap-rs#253). The
+    /// adapter passes `**/*.d.ts` via `AdapterMeta::forced_excludes`;
+    /// this test confirms the walker mechanism honors that glob shape.
+    #[test]
+    fn discover_source_files_dts_excluded_by_glob() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src");
+        fs::create_dir_all(src.join("sub")).unwrap();
+        fs::write(src.join("app.ts"), "").unwrap();
+        fs::write(src.join("types.d.ts"), "").unwrap();
+        fs::write(src.join("sub").join("nested.d.ts"), "").unwrap();
+        fs::write(src.join("sub").join("nested.ts"), "").unwrap();
+
+        let exclude = vec!["**/*.d.ts".to_string()];
+        let files =
+            discover_source_files(&src, &exclude, false, &["ts", "tsx", "js", "jsx"]).unwrap();
+        let names: Vec<_> = files
+            .iter()
+            .filter_map(|f| f.file_name().and_then(|n| n.to_str()))
+            .collect();
+        assert_eq!(names, vec!["app.ts", "nested.ts"]);
+        assert!(
+            !names.iter().any(|n| n.ends_with(".d.ts")),
+            "`**/*.d.ts` glob must drop every declaration file in the tree, including nested ones",
+        );
+    }
+
     /// Empty `extensions` returns no files — the only sane behavior
     /// when the caller forgot to set `AnalyzeOptions::extensions`.
     /// `core::ensure_source_files_found` then surfaces the diagnostic.

--- a/crates/crap-core/tests/snapshots/wire_envelope_crap4rs__envelope.snap
+++ b/crates/crap-core/tests/snapshots/wire_envelope_crap4rs__envelope.snap
@@ -5504,7 +5504,7 @@ expression: pretty
             "qualified_name": "main",
             "span": {
               "end_column": 1,
-              "end_line": 107,
+              "end_line": 111,
               "start_column": 1,
               "start_line": 78
             }
@@ -11190,7 +11190,7 @@ expression: pretty
             "qualified_name": "main",
             "span": {
               "end_column": 1,
-              "end_line": 107,
+              "end_line": 111,
               "start_column": 1,
               "start_line": 78
             }

--- a/crates/crap4rs/src/main.rs
+++ b/crates/crap4rs/src/main.rs
@@ -89,6 +89,10 @@ fn main() -> ExitCode {
         rule_help_uri: "https://github.com/breezy-bays-labs/crap-rs#crap-formula",
         config_file_name: "crap4rs.toml",
         default_excludes: DEFAULT_EXCLUDES,
+        // No Rust file suffix is "structurally never source" the way
+        // TypeScript's `.d.ts` is (crap-rs#253) — `mod.rs`, `lib.rs`,
+        // `build.rs`, etc. all carry executable code. Empty here.
+        forced_excludes: &[],
         // crap4rs supports both cognitive and cyclomatic. Cognitive
         // remains the default (locked decision #2) — explicit here so
         // the per-adapter default flows through `AdapterMeta` for both

--- a/crates/crap4ts/src/lib.rs
+++ b/crates/crap4ts/src/lib.rs
@@ -50,6 +50,17 @@ pub const EXTENSIONS: &[&str] = &["ts", "tsx", "js", "jsx", "mjs", "cjs"];
 /// `node_modules` (which, for the CLI, the config-merge step filters).
 pub const DEFAULT_EXCLUDES: &[&str] = &["node_modules/**", "dist/**", "coverage/**"];
 
+/// Adapter-mandated structural skips applied to every analysis run
+/// regardless of CLI flags or operator config. crap4ts skips
+/// TypeScript declaration files (`*.d.ts`) because they contain only
+/// ambient type declarations — never executable code — so they
+/// contribute zero useful complexity or coverage signal and showing
+/// them in a CRAP report is always misleading (crap-rs#253). Flowed
+/// through both the CLI path (`AdapterMeta::forced_excludes`) and the
+/// library / napi path ([`analyze_to_json`]) so a programmatic caller
+/// gets the same skip behavior as the CLI.
+pub const FORCED_EXCLUDES: &[&str] = &["**/*.d.ts"];
+
 /// Wire shape for the JSON returned by [`analyze_to_json`]. Mirrors
 /// `crap_core::core::AnalysisOutput<P>`'s `{ result, diagnostics }`
 /// shape verbatim. `#[serde(bound = "")]` suppresses serde's
@@ -78,6 +89,10 @@ struct AnalyzeWireOutput<'a, P: ParseDiagnostic> {
 ///
 /// [`DEFAULT_EXCLUDES`] is applied so a caller pointed at a project
 /// root does not walk into `node_modules`, `dist`, or `coverage`.
+/// [`FORCED_EXCLUDES`] is also applied so `.d.ts` declaration files
+/// are skipped on this path (the napi shim funnels through here);
+/// without it, programmatic callers would see ambient-type entries
+/// the CLI doesn't (crap-rs#253).
 ///
 /// Inputs are validated up front: `source_root` must resolve to an
 /// existing directory, and `threshold` — when set — must be a finite
@@ -125,7 +140,14 @@ pub fn analyze_to_json(
         },
         metric,
         extensions: EXTENSIONS.iter().map(|&s| s.to_string()).collect(),
-        exclude: DEFAULT_EXCLUDES.iter().map(|&s| s.to_string()).collect(),
+        // Forced excludes lead so a programmatic caller can't override
+        // structural skips (`*.d.ts` per crap-rs#253), DEFAULT_EXCLUDES
+        // follows for vendored / build / coverage paths.
+        exclude: FORCED_EXCLUDES
+            .iter()
+            .chain(DEFAULT_EXCLUDES.iter())
+            .map(|&s| s.to_string())
+            .collect(),
         ..AnalyzeOptions::default()
     };
 

--- a/crates/crap4ts/src/main.rs
+++ b/crates/crap4ts/src/main.rs
@@ -18,7 +18,7 @@ use crap_core::cli::AdapterMeta;
 use crap_core::domain::types::ComplexityMetric;
 use crap4ts::adapters::coverage::IstanbulCoverage;
 use crap4ts::adapters::walker::OxcWalker;
-use crap4ts::{DEFAULT_EXCLUDES, EXTENSIONS};
+use crap4ts::{DEFAULT_EXCLUDES, EXTENSIONS, FORCED_EXCLUDES};
 
 const ABOUT: &str = "CRAP score analyzer for TypeScript / JavaScript";
 const LONG_ABOUT: &str = "CRAP (Change Risk Anti-Patterns) score analyzer for TypeScript / \
@@ -54,6 +54,13 @@ fn main() -> ExitCode {
         rule_help_uri: "https://github.com/breezy-bays-labs/crap-rs#crap-formula",
         config_file_name: "crap4ts.toml",
         default_excludes: DEFAULT_EXCLUDES,
+        // `.d.ts` declaration files contain ambient types only (no
+        // executable code); skip them at the discovery boundary so
+        // they never reach the AST walker (crap-rs#253). Operators
+        // cannot opt back in via `crap4ts.toml` — if a corpus
+        // legitimately needs declaration-file CRAP, fork the adapter
+        // or file a follow-up to add an opt-out flag.
+        forced_excludes: FORCED_EXCLUDES,
         // crap4ts ships --metric cyclomatic as the only supported
         // metric in 2.0.0; cognitive returns CrapError::MetricNotSupported
         // from the walker (D5 + locked decision #2).

--- a/crates/crap4ts/tests/api_smoke.rs
+++ b/crates/crap4ts/tests/api_smoke.rs
@@ -164,6 +164,66 @@ fn analyze_to_json_nan_threshold_is_rejected() {
     );
 }
 
+/// `.d.ts` declaration files are skipped on the library / napi entry
+/// point the same way they're skipped on the CLI path (crap-rs#253).
+/// `analyze_to_json` populates `AnalyzeOptions.exclude` with
+/// `FORCED_EXCLUDES` (chained into `DEFAULT_EXCLUDES`), so a tempdir
+/// containing both a `.ts` file and a `.d.ts` file must produce only
+/// the `.ts` file's functions. Without this, programmatic (Node)
+/// callers would see ambient-type entries the CLI doesn't.
+#[test]
+fn analyze_to_json_skips_dts_declaration_files() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let canonical = std::fs::canonicalize(tmp.path()).expect("canonicalize tempdir");
+
+    // Two sibling files: a normal `.ts` carrying an executable
+    // function, and a `.d.ts` carrying an ambient declaration. Both
+    // syntactically parse with oxc; the `forced_excludes` skip stops
+    // discovery from feeding the `.d.ts` into the AST walker at all.
+    std::fs::write(
+        canonical.join("app.ts"),
+        "export function app() { return 1; }\n",
+    )
+    .expect("write app.ts");
+    std::fs::write(
+        canonical.join("types.d.ts"),
+        "export declare function ambient(): number;\n",
+    )
+    .expect("write types.d.ts");
+
+    // Coverage covers `app.ts` only — Istanbul never instruments
+    // declaration files (no statements to wrap), so omitting the
+    // `.d.ts` entry from the fixture mirrors what a real jest run
+    // produces.
+    let abs = canonical.to_string_lossy().replace('\\', "/");
+    let coverage_payload = format!(
+        r#"{{ "{abs}/app.ts": {{ "path": "{abs}/app.ts", "s": {{ "0": 1 }}, "statementMap": {{ "0": {{ "start": {{ "line": 1, "column": 0 }}, "end": {{ "line": 1, "column": 5 }} }} }} }} }}"#
+    );
+    let coverage = canonical.join("coverage-final.json");
+    std::fs::write(&coverage, coverage_payload).expect("write coverage-final.json");
+
+    let json = analyze_to_json(&canonical, &coverage, None, ComplexityMetric::Cyclomatic)
+        .expect("analyze_to_json succeeds on app.ts + types.d.ts");
+
+    let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+    let functions = parsed["result"]["functions"]
+        .as_array()
+        .expect("`result.functions` is an array");
+    let file_paths: Vec<&str> = functions
+        .iter()
+        .filter_map(|f| f["scored"]["identity"]["file_path"].as_str())
+        .collect();
+
+    assert!(
+        file_paths.contains(&"app.ts"),
+        "expected `app.ts` in report; got {file_paths:?}",
+    );
+    assert!(
+        !file_paths.iter().any(|p| p.ends_with(".d.ts")),
+        "no `.d.ts` file should appear in the report (crap-rs#253); got {file_paths:?}",
+    );
+}
+
 #[test]
 fn analyze_to_json_missing_source_root_is_rejected() {
     let (_tmp, root) = build_jest_fixture();

--- a/crates/crap4ts/tests/features/file_extensions.feature
+++ b/crates/crap4ts/tests/features/file_extensions.feature
@@ -20,10 +20,12 @@ Feature: TypeScript file extension discovery and parsing
       | .mjs      | `export function greet(name) { return 'hello ' + name; }`                            |
       | .cjs      | `module.exports.greet = function(name) { return 'hello ' + name; };`                 |
 
-  @unwired
+  @wired
   Scenario: A .d.ts file is skipped by default (declaration-only, no executable code)
-    # tracked: crap-rs#253 — crap4ts currently analyzes `.d.ts` declaration files
-    # instead of skipping them; this scenario waits on the discovery-walker skip
+    # crap-rs#253 — `**/*.d.ts` is in `AdapterMeta::forced_excludes` for crap4ts,
+    # so the source-discovery walker drops declaration files before they reach
+    # the AST walker. There is no opt-out: declaration files contribute zero
+    # useful CRAP signal (ambient types only, no executable code).
     Given a source tree under `src/` containing `types.d.ts` and `app.ts`
     And the operator's `crap4ts.toml` does NOT explicitly include `.d.ts`
     When the operator runs `crap4ts --coverage coverage-final.json --src src`

--- a/crates/crap4ts/tests/file_extensions_cucumber.rs
+++ b/crates/crap4ts/tests/file_extensions_cucumber.rs
@@ -7,9 +7,10 @@
 //! `--format json` and reads the per-function `file_path` set out of
 //! the envelope — mirroring `metric_unsupported_cucumber.rs`.
 //!
-//! Scenario "A .d.ts file is skipped by default" stays `@unwired`:
-//! crap4ts@2 currently analyzes `.d.ts` declaration files rather than
-//! skipping them — tracked at crap-rs#253.
+//! Scenario "A .d.ts file is skipped by default" is `@wired` post-
+//! crap-rs#253: `AdapterMeta::forced_excludes` carries `**/*.d.ts` for
+//! crap4ts, so declaration files are dropped by the source-discovery
+//! walker before they reach the AST walker.
 //!
 //! Named `*_cucumber` (suffix) so `.config/nextest.toml`'s
 //! `binary(/.*_cucumber$/)` filter excludes it from nextest probing.
@@ -170,6 +171,32 @@ fn given_app_and_notes(world: &mut FileExtWorld) {
     world.cov_path = Some(write_coverage(&root, &["app.ts"]));
 }
 
+#[given("a source tree under `src/` containing `types.d.ts` and `app.ts`")]
+fn given_dts_and_app(world: &mut FileExtWorld) {
+    // `types.d.ts` is a declaration file (ambient types only); `app.ts`
+    // carries an executable function so we can assert positive
+    // discovery alongside the negative-discovery assertion on
+    // `types.d.ts`. The walker can syntactically parse declaration
+    // files (oxc accepts `export declare function`); the
+    // `forced_excludes` skip happens at filesystem discovery so the
+    // AST walker never sees them.
+    world.write("types.d.ts", "export declare function ambient(): number;\n");
+    world.write("app.ts", "export function app() { return 1; }\n");
+    let root = world.root();
+    // Coverage covers `app.ts` only — Istanbul never emits coverage
+    // for `.d.ts` (no statements to instrument), so excluding it from
+    // the fixture mirrors what a real jest run produces.
+    world.cov_path = Some(write_coverage(&root, &["app.ts"]));
+}
+
+#[given("the operator's `crap4ts.toml` does NOT explicitly include `.d.ts`")]
+fn given_no_dts_include_in_config(_world: &mut FileExtWorld) {
+    // No `crap4ts.toml` is written; the default skip applies. There
+    // is no `include` flag for `.d.ts` today (crap-rs#253) — the skip
+    // is unconditional. This Given is narration that pins the
+    // contract for future readers.
+}
+
 #[given(
     "a source tree under `src/` containing `good.ts` (parses cleanly) and `broken.ts` (syntactically invalid)"
 )]
@@ -261,6 +288,22 @@ fn then_excludes_test(world: &mut FileExtWorld) {
         !world.files_with_functions().contains(&"app.test.ts"),
         "app.test.ts should be excluded by the crap4ts.toml glob; got {:?}",
         world.files_with_functions(),
+    );
+}
+
+#[then("the report does NOT include entries from `types.d.ts`")]
+fn then_excludes_dts_entries(world: &mut FileExtWorld) {
+    // The discovery walker drops `*.d.ts` via `forced_excludes`
+    // before the AST walker runs, so neither file paths nor function
+    // entries from declaration files reach the envelope.
+    let files = world.files_with_functions();
+    assert!(
+        !files.iter().any(|f| f.ends_with(".d.ts")),
+        "no .d.ts file should contribute a function entry; got {files:?}",
+    );
+    assert!(
+        !files.contains(&"types.d.ts"),
+        "`types.d.ts` must not appear in the report; got {files:?}",
     );
 }
 

--- a/crates/crap4ts/tests/file_extensions_cucumber.rs
+++ b/crates/crap4ts/tests/file_extensions_cucumber.rs
@@ -377,8 +377,12 @@ fn then_parse_failure_alone_does_not_gate(world: &mut FileExtWorld) {
 
 #[tokio::main]
 async fn main() {
-    // `@wired`-only filter (AGENTS.md rule 5) — the `.d.ts` scenario
-    // stays `@unwired` (crap-rs#253) and is skipped, not failed.
+    // `@wired`-only filter (AGENTS.md rule 5) — every scenario in this
+    // feature is wired post-crap-rs#253 (the `.d.ts` skip closed the
+    // last `@unwired` here), so the filter is currently a no-op pass-
+    // through. Kept for shape consistency with other crap4ts cucumber
+    // harnesses + so a future `@unwired` regression is mechanically
+    // gated out rather than silently passing as a skipped scenario.
     // `with_default_cli()` skips argv parsing so the `--skip` libtest
     // args `cargo mutants --package crap4ts` injects do not abort
     // cucumber's strict clap CLI (the crap-rs#224 gate-zeroing class).


### PR DESCRIPTION
## Summary

`crap4ts@2.x` was discovering and analyzing TypeScript declaration files (`*.d.ts`) as if they were source code, producing function entries for ambient-type declarations that contribute zero useful complexity or coverage signal. Surfaced during #229 BDD wiring when `file_extensions.feature` scenario 2 stayed `@unwired` (crap4ts returned an `ambient` function from a `types.d.ts` fixture).

Closes #253

## Fix

Add a load-bearing `forced_excludes: &'static [&'static str]` field to `AdapterMeta` (crap-core), prepended to the effective exclude list in `merge_exclude`:

- **crap4ts** sets `&["**/*.d.ts"]` via the new `crap4ts::FORCED_EXCLUDES` constant
- **crap4rs** sets `&[]` (no Rust suffix is structurally never source)
- The `ignore::overrides` glob mechanism already supports `**/*.d.ts` — zero walker code changes needed
- The napi / library path (`crap4ts::analyze_to_json`) also wires `FORCED_EXCLUDES` so programmatic (node) callers get the same skip behavior as the CLI

### Empirical verification

Hand-crafted fixture before fix:
```
functions discovered:
 - app.ts :: app
 - types.d.ts :: ambient    ← bug
```

After fix:
```
functions discovered:
 - app.ts :: app
```

## Design choice: unconditional skip, no opt-in

Issue AC bullet 3 asked whether the skip should be `crap4ts.toml`-overridable. Resolved as **unconditional**:

- Declaration files contribute zero useful CRAP signal (ambient types only, no executable code)
- The parallel `@wired` precedent in the same `.feature` file — "An unrecognized extension is silently skipped" for `notes.txt` — carries no opt-in either
- If a corpus genuinely needs declaration-file CRAP, the path is forking the adapter or filing a follow-up to add an opt-out flag

## `AdapterMeta::default_excludes` vs `AdapterMeta::forced_excludes`

Pre-existing `default_excludes` is **init-template only** — it seeds the commented-out `# exclude = [...]` block in `crap4ts init` / `crap4rs init` output but never reaches the analyzer. New `forced_excludes` is **load-bearing at analysis time**. Both fields' rustdoc now states this explicitly.

A `type:chore` follow-up may rename `default_excludes` → `init_template_excludes` for clarity; deferred to keep this PR focused.

## Cross-impact

- **Parity oracle (#190)**: zero impact. `find crap4ts-v1/src -name '*.d.ts'` returned empty — v1 corpus has no declaration files. Parity oracle test still passes.
- **Wire envelope canaries**:
  - `wire_envelope_crap4ts` — byte-identical (TS fixtures, no `.d.ts`)
  - `wire_envelope_crap4ts_branches` — byte-identical (same)
  - `wire_envelope_crap4rs` — **drifted by exactly +4 lines on `main`'s `end_line` (107→111)**. Expected structural drift: crap4rs analyzes its own source, which now includes the 4-line `forced_excludes: &[]` block I added in `crap4rs/src/main.rs`. No envelope shape change; only one function's span tracked the edit.
- **W2.2 plan (#185)**: explicitly anticipated this as a separate follow-up — this PR is that follow-up
- **MIGRATION.md**: added 4th compounding-reason under "Why are my scores different?" for v1 users whose corpora had `.d.ts` files

## Test coverage

| Test | Adds | Asserts |
|---|---|---|
| `discover_source_files_dts_excluded_by_glob` | walker.rs | `**/*.d.ts` glob drops every nested `.d.ts`, keeps `.ts` siblings |
| `merge_exclude_prepends_forced_excludes_from_adapter_meta` | cli/mod.rs | forced patterns lead, CLI+config follow |
| `merge_exclude_with_empty_forced_excludes_matches_legacy_behavior` | cli/mod.rs | crap4rs (empty forced) sees no behavior change |
| `merge_exclude_forced_excludes_deduplicates_against_cli_and_config` | cli/mod.rs | dedup is by string-equality across all three sources |
| `file_extensions.feature` scenario 2 | `@unwired` → `@wired` | step defs `given_dts_and_app` + `given_no_dts_include_in_config` + `then_excludes_dts_entries` |

All 11 file-extension scenarios pass (55/55 steps). All 9 cucumber harnesses workspace-wide green (88 scenarios, ~400 steps).

## Gate battery

- ✅ `cargo fmt --check`
- ✅ `cargo clippy --workspace --all-targets -- -D warnings`
- ✅ `cargo nextest run --workspace --all-targets` (1097 / 1097, was 1093 baseline + 4 new tests)
- ✅ `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- ✅ `cargo +1.93 check --workspace --all-targets`
- ✅ `cargo deny check`
- ✅ AST-purity (4 layers: syn / tree_sitter / swc / oxc) clean on `crates/crap-core/src/`
- ✅ Insta snapshot review (one accepted drift on `wire_envelope_crap4rs`, documented above)
- ✅ Parity oracle (`parity_v1`) green within tolerance band
- ✅ Self-CRAP-thrice (strict-15): crap-core 951/0/13.0 · crap4rs 202/0/11.0 · crap4ts 91/0/12.0 — ALL PASS

## Backlog position

Pre-GA backlog clearing under epic #173. Next up: #247 (mutants-skip lint, `priority:soon`). Then re-survey `priority:later` cluster before the GA chain (W4.1b #193 → W4.2 #194 → pipeline closeout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)