### PR TITLE
ci(crap-rs): #247 — enforce mutants.toml --skip coverage of adapter-bin-shelling tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -583,11 +583,24 @@ jobs:
     #
     # Mirrors the `lefthook.yml` pre-push step — single source of truth in
     # `scripts/mutants-skip-lint.py`.
+    #
+    # SHA pinning of `actions/checkout@v4` is deliberately deferred to the
+    # repo-wide hardening sweep tracked at crap-rs#233 (`type:chore`,
+    # `priority:later`) — pinning this one job in isolation would diverge
+    # from the rest of the workflow. The two cheap additions that DON'T
+    # require coordinated SHA selection — `permissions: contents: read`
+    # (least privilege) and `persist-credentials: false` (no GITHUB_TOKEN
+    # left in `.git/config` on the runner) — are applied here so the new
+    # job ships hardened by default and #233 only needs to flip the SHA.
     name: mutants-skip lint
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Lint .cargo/mutants.toml `--skip` coverage of adapter-bin-shelling tests
         run: python3 scripts/mutants-skip-lint.py
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -565,6 +565,32 @@ jobs:
           fi
           echo "crap-core adapter-name literals: clean (comment-only references allowed)"
 
+  mutants-skip-lint:
+    # Mechanical enforcement of the carry-forward rule documented at the top
+    # of `.cargo/mutants.toml`: every test that shells `cargo_bin("crap4rs"|
+    # "crap4ts")` under a scoped `cargo mutants` gate that doesn't build
+    # that bin must carry a `--skip` substring token in
+    # `additional_cargo_test_args`. #224's root cause was that rule being
+    # silently violated when `crap4rs_no_flag_default_cognitive_still_works`
+    # landed without the matching token, which aborted the entire `crap4ts`
+    # walker mutants run (`cargo mutants` exited 4, zero mutants tested,
+    # gate went silently dead). The rule was documented but not enforced;
+    # this job is the enforcement.
+    #
+    # See `scripts/mutants-skip-lint.py` for the limitation notes (literal
+    # `cargo_bin("X")` in `#[test]` fn body only; helper-mediated and
+    # parameterized-bin-name calls are out of scope).
+    #
+    # Mirrors the `lefthook.yml` pre-push step — single source of truth in
+    # `scripts/mutants-skip-lint.py`.
+    name: mutants-skip lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Lint .cargo/mutants.toml `--skip` coverage of adapter-bin-shelling tests
+        run: python3 scripts/mutants-skip-lint.py
+
   docs:
     name: cargo doc (warnings as errors)
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,3 +225,21 @@ mutants is scoped to mutants only; every PR's `Test (linux-x86)` /
 `Test (macos-arm)` / `Test (macos-x86)` job still runs both canaries
 via `cargo nextest run --workspace --all-targets`, which DOES build the
 bins first.
+
+The same rule applies to any other test that shells
+`cargo_bin("crap4rs"|"crap4ts")` from a `#[test]` fn body — without a
+matching `--skip` substring token in `additional_cargo_test_args`, the
+scoped mutants run's unmutated baseline panics on
+`CARGO_BIN_EXE_<bin>` being unset, cargo-mutants exits 4 ("cargo test
+failed in an unmutated tree"), and zero mutants get tested — the gate
+silently goes dead. This was #224's root cause: a new test landed
+without the token. The rule was documented but not enforced, so this
+repo now enforces it mechanically — the `mutants-skip-lint` job in
+`.github/workflows/ci.yml` and the matching `lefthook.yml` pre-push
+hook both run `scripts/mutants-skip-lint.py`, which fails the build
+if any in-scope `#[test]` fn shelling either adapter bin lacks a
+covering `--skip` substring. Add a new shelling test → either pick a
+fn name that an existing token already covers as a substring (cheap),
+or add a new token to `.cargo/mutants.toml` in the same PR (also
+cheap, just remember). The lint's failure message walks the
+contributor through the fix.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -40,6 +40,20 @@ pre-push:
           exit 1
         fi
       timeout: 30s
+    mutants-skip-lint:
+      # Mechanical enforcement of the carry-forward rule documented at
+      # the top of `.cargo/mutants.toml`: every test that shells
+      # `cargo_bin("crap4rs"|"crap4ts")` under a scoped `cargo mutants`
+      # gate that doesn't build that bin must carry a `--skip` substring
+      # token in `additional_cargo_test_args`. #224's root cause was that
+      # rule being silently violated when a new test landed without the
+      # token, aborting the whole walker mutants run (cargo-mutants exits
+      # 4, zero mutants tested). Documentation alone enforces nothing;
+      # this hook is the local-velocity layer of the same check that
+      # `.github/workflows/ci.yml`'s `mutants-skip-lint` job runs on
+      # every push. Single source of truth: `scripts/mutants-skip-lint.py`.
+      run: python3 scripts/mutants-skip-lint.py
+      timeout: 30s
     clippy:
       run: cargo clippy --workspace --all-targets -- -D warnings
       timeout: 300s

--- a/scripts/mutants-skip-lint.py
+++ b/scripts/mutants-skip-lint.py
@@ -18,19 +18,30 @@ Scope-by-directory (mirrors the two scoped mutants gates):
     walker per-merge gate). The `crap4ts` bin IS built, so only literal
     `cargo_bin("crap4rs")` calls require a `--skip`.
 
-Limitation: detects literal `cargo_bin("crap4rs"|"crap4ts")` calls that
-appear DIRECTLY inside a `#[test]` fn body. Literals nested inside
-helper fns (e.g. `fn crap4rs_threshold(...) { Command::cargo_bin("crap4rs")... }`
-in `default_gate_threshold.rs`) are SILENTLY SKIPPED — those helpers
-are dangerous only if they're called from a non-`--skip`'d test fn, and
-that requires call-graph analysis the lint does not perform. The pattern
-in scope today is "helper called exclusively from `--skip`'d tests"
-(verified empirically: the `crap4{rs,ts}_threshold` helpers in
-`default_gate_threshold.rs` are called only from `default_gate_*` tests
-covered by `--skip default_gate`). Helper-mediated calls with variable
-bin names (`run_bin("crap4rs", ...)` → internal `cargo_bin(name)`) are
-also out of scope. If either pattern produces a real regression, extend
-the lint to walk the call graph.
+Limitations (all verified empirically against the current codebase):
+
+* **Helper fns silently skipped.** Literals nested inside helper fns
+  (e.g. `fn crap4rs_threshold(...) { Command::cargo_bin("crap4rs")... }`
+  in `default_gate_threshold.rs`) are silently skipped — those helpers
+  are dangerous only if they're called from a non-`--skip`'d test fn,
+  and that requires call-graph analysis the lint does not perform. The
+  pattern in scope today is "helper called exclusively from `--skip`'d
+  tests" (the `crap4{rs,ts}_threshold` helpers in
+  `default_gate_threshold.rs` are called only from `default_gate_*`
+  tests covered by `--skip default_gate`).
+* **Parameterised helpers not detected.** Helper-mediated calls with
+  variable bin names (`run_bin("crap4rs", ...)` → internal
+  `cargo_bin(name)`) are not detected. None present today.
+* **Sync `#[test]` only.** `#[tokio::test]` / `#[async_std::test]` /
+  other test-runner attributes are not detected by `TEST_ATTR_RE`.
+  None present today; if introduced, extend the regex.
+* **Brace tracking is line-comment-aware but not string- or
+  block-comment-aware.** `//` line comments are stripped before
+  brace counting, but `/* { */` block comments and `{` inside
+  string literals can theoretically skew the fn range. No current
+  test file exhibits the pattern.
+
+If any of these gaps produces a real regression, extend the lint.
 """
 
 from __future__ import annotations
@@ -44,21 +55,34 @@ SCOPES: list[tuple[Path, str, frozenset[str]]] = [
     (Path("crates/crap4ts/tests"), "crap4ts", frozenset({"crap4rs"})),
 ]
 
-CARGO_BIN_RE = re.compile(r'cargo_bin\("(crap4rs|crap4ts)"\)')
+# DOTALL on CARGO_BIN_RE allows the literal to span lines — rustfmt
+# can wrap `cargo_bin("crap4rs")` across newlines if the surrounding
+# call gets long, often with a trailing comma:
+#   cargo_bin(
+#       "crap4rs",
+#   )
+# The line-by-line scan would have missed those. Trailing comma is
+# optional so both the formatted-wide and rustfmt-wrapped shapes match.
+CARGO_BIN_RE = re.compile(r'cargo_bin\(\s*"(crap4rs|crap4ts)"\s*,?\s*\)', re.DOTALL)
 TEST_ATTR_RE = re.compile(r"^\s*#\[test\]\s*$")
 FN_DECL_RE = re.compile(r"^\s*fn\s+([a-zA-Z_][a-zA-Z_0-9]*)\s*[(<]")
 
 
 def extract_skip_tokens(mutants_toml: Path) -> list[str]:
+    # Anchor at start-of-line (MULTILINE) so a commented-out
+    # `# additional_cargo_test_args = [...]` line does not match.
     body_match = re.search(
-        r"additional_cargo_test_args\s*=\s*\[(.*?)\]",
+        r"^additional_cargo_test_args\s*=\s*\[(.*?)\]",
         mutants_toml.read_text(),
-        re.DOTALL,
+        re.DOTALL | re.MULTILINE,
     )
     if not body_match:
         return []
     strings = re.findall(r'"([^"]+)"', body_match.group(1))
-    return [s for s in strings if s not in ("--", "--skip")]
+    # Reject any `-`-prefixed string so unrelated cargo-test flags
+    # (e.g. `--nocapture`, `--test-threads=1`) cannot accidentally
+    # be treated as `--skip` substring tokens.
+    return [s for s in strings if not s.startswith("-")]
 
 
 def find_test_fn_ranges(lines: list[str]) -> list[tuple[str, int, int]]:
@@ -86,7 +110,12 @@ def find_test_fn_ranges(lines: list[str]) -> list[tuple[str, int, int]]:
                     seen = False
                     end = j
                     for k in range(j, n):
-                        for c in lines[k]:
+                        # Strip `//` line comments before counting — a
+                        # comment containing `{` or `}` would otherwise
+                        # skew fn-range detection. Block comments and
+                        # string-literal braces are out of scope (see
+                        # module docstring "Limitations").
+                        for c in lines[k].split("//", 1)[0]:
                             if c == "{":
                                 depth += 1
                                 seen = True
@@ -126,37 +155,42 @@ def lint(repo_root: Path) -> int:
         if not abs_dir.exists():
             continue
         for rs_file in sorted(abs_dir.rglob("*.rs")):
-            lines = rs_file.read_text().splitlines()
+            text = rs_file.read_text()
+            lines = text.splitlines()
             ranges = find_test_fn_ranges(lines)
-            for lineno0, line in enumerate(lines):
-                for m in CARGO_BIN_RE.finditer(line):
-                    bin_name = m.group(1)
-                    if bin_name not in gate_bins:
-                        continue
-                    fn_name = next(
-                        (name for name, s, e in ranges if s <= lineno0 <= e),
-                        None,
-                    )
-                    if fn_name is None:
-                        # Literal in helper fn — see "Limitation" in module
-                        # docstring. Out of scope; silently skip.
-                        continue
-                    if is_covered(fn_name, tokens):
-                        continue
-                    rel = rs_file.relative_to(repo_root)
-                    print(
-                        f"\nmutants-skip-lint: uncovered adapter-bin shelling test\n"
-                        f"  {rel}:{lineno0 + 1}  fn {fn_name}\n"
-                        f'  shells cargo_bin("{bin_name}") under '
-                        f"`--package {scope}` mutants scope\n"
-                        f"  but `{fn_name}` is not covered by any --skip substring in\n"
-                        f"  .cargo/mutants.toml's additional_cargo_test_args.\n\n"
-                        f"  Fix: add a substring of `{fn_name}` (or the literal name) to\n"
-                        f"  that array. See the explanatory comment at the top of\n"
-                        f"  .cargo/mutants.toml for why.\n",
-                        file=sys.stderr,
-                    )
-                    errors += 1
+            # Scan whole-file text so the regex can match a
+            # `cargo_bin(...)` call split across lines by rustfmt
+            # (CARGO_BIN_RE is DOTALL). Recompute the line number
+            # from the match's character offset.
+            for m in CARGO_BIN_RE.finditer(text):
+                bin_name = m.group(1)
+                if bin_name not in gate_bins:
+                    continue
+                lineno0 = text.count("\n", 0, m.start())
+                fn_name = next(
+                    (name for name, s, e in ranges if s <= lineno0 <= e),
+                    None,
+                )
+                if fn_name is None:
+                    # Literal in helper fn — see "Limitations" in module
+                    # docstring. Out of scope; silently skip.
+                    continue
+                if is_covered(fn_name, tokens):
+                    continue
+                rel = rs_file.relative_to(repo_root)
+                print(
+                    f"\nmutants-skip-lint: uncovered adapter-bin shelling test\n"
+                    f"  {rel}:{lineno0 + 1}  fn {fn_name}\n"
+                    f'  shells cargo_bin("{bin_name}") under '
+                    f"`--package {scope}` mutants scope\n"
+                    f"  but `{fn_name}` is not covered by any --skip substring in\n"
+                    f"  .cargo/mutants.toml's additional_cargo_test_args.\n\n"
+                    f"  Fix: add a substring of `{fn_name}` (or the literal name) to\n"
+                    f"  that array. See the explanatory comment at the top of\n"
+                    f"  .cargo/mutants.toml for why.\n",
+                    file=sys.stderr,
+                )
+                errors += 1
 
     if errors > 0:
         print(

--- a/scripts/mutants-skip-lint.py
+++ b/scripts/mutants-skip-lint.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Mutants-skip lint — mechanical enforcement of the carry-forward rule that
+every test which shells `cargo_bin("crap4rs"|"crap4ts")` under a scoped
+`cargo mutants` gate that does NOT build that bin must carry a `--skip`
+substring token in `.cargo/mutants.toml`'s `additional_cargo_test_args`.
+
+The *why* lives in the top-of-file comment of `.cargo/mutants.toml`. This
+script is the *what*: replaces the documented rule (which #224 root-caused as
+silently violated by a new test that landed without the token) with a check
+CI and lefthook run on every push.
+
+Scope-by-directory (mirrors the two scoped mutants gates):
+
+  * `crates/crap-core/tests/**` is scanned under `--package crap-core`
+    (the `view.rs` per-PR gate). Neither `crap4rs` nor `crap4ts` bin is
+    built — both literal calls require a `--skip`.
+  * `crates/crap4ts/tests/**` is scanned under `--package crap4ts` (the
+    walker per-merge gate). The `crap4ts` bin IS built, so only literal
+    `cargo_bin("crap4rs")` calls require a `--skip`.
+
+Limitation: detects literal `cargo_bin("crap4rs"|"crap4ts")` calls that
+appear DIRECTLY inside a `#[test]` fn body. Literals nested inside
+helper fns (e.g. `fn crap4rs_threshold(...) { Command::cargo_bin("crap4rs")... }`
+in `default_gate_threshold.rs`) are SILENTLY SKIPPED — those helpers
+are dangerous only if they're called from a non-`--skip`'d test fn, and
+that requires call-graph analysis the lint does not perform. The pattern
+in scope today is "helper called exclusively from `--skip`'d tests"
+(verified empirically: the `crap4{rs,ts}_threshold` helpers in
+`default_gate_threshold.rs` are called only from `default_gate_*` tests
+covered by `--skip default_gate`). Helper-mediated calls with variable
+bin names (`run_bin("crap4rs", ...)` → internal `cargo_bin(name)`) are
+also out of scope. If either pattern produces a real regression, extend
+the lint to walk the call graph.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+SCOPES: list[tuple[Path, str, frozenset[str]]] = [
+    (Path("crates/crap-core/tests"), "crap-core", frozenset({"crap4rs", "crap4ts"})),
+    (Path("crates/crap4ts/tests"), "crap4ts", frozenset({"crap4rs"})),
+]
+
+CARGO_BIN_RE = re.compile(r'cargo_bin\("(crap4rs|crap4ts)"\)')
+TEST_ATTR_RE = re.compile(r"^\s*#\[test\]\s*$")
+FN_DECL_RE = re.compile(r"^\s*fn\s+([a-zA-Z_][a-zA-Z_0-9]*)\s*[(<]")
+
+
+def extract_skip_tokens(mutants_toml: Path) -> list[str]:
+    body_match = re.search(
+        r"additional_cargo_test_args\s*=\s*\[(.*?)\]",
+        mutants_toml.read_text(),
+        re.DOTALL,
+    )
+    if not body_match:
+        return []
+    strings = re.findall(r'"([^"]+)"', body_match.group(1))
+    return [s for s in strings if s not in ("--", "--skip")]
+
+
+def find_test_fn_ranges(lines: list[str]) -> list[tuple[str, int, int]]:
+    """Return [(fn_name, start_line, end_line)] for every #[test] fn in the
+    file. Line numbers are 0-indexed and `end_line` is inclusive (the line
+    containing the matching outer `}`)."""
+    ranges: list[tuple[str, int, int]] = []
+    n = len(lines)
+    i = 0
+    while i < n:
+        if TEST_ATTR_RE.match(lines[i]):
+            j = i + 1
+            while j < n:
+                line = lines[j]
+                stripped = line.strip()
+                if not stripped or stripped.startswith("//") or stripped.startswith("#"):
+                    j += 1
+                    continue
+                break
+            if j < n:
+                fn_match = FN_DECL_RE.match(lines[j])
+                if fn_match:
+                    fn_name = fn_match.group(1)
+                    depth = 0
+                    seen = False
+                    end = j
+                    for k in range(j, n):
+                        for c in lines[k]:
+                            if c == "{":
+                                depth += 1
+                                seen = True
+                            elif c == "}":
+                                depth -= 1
+                        if seen and depth == 0:
+                            end = k
+                            break
+                    ranges.append((fn_name, j, end))
+                    i = end + 1
+                    continue
+        i += 1
+    return ranges
+
+
+def is_covered(fn_name: str | None, tokens: list[str]) -> bool:
+    return fn_name is not None and any(tok in fn_name for tok in tokens)
+
+
+def lint(repo_root: Path) -> int:
+    mutants_toml = repo_root / ".cargo" / "mutants.toml"
+    if not mutants_toml.exists():
+        print(f"mutants-skip-lint: {mutants_toml} not found", file=sys.stderr)
+        return 1
+
+    tokens = extract_skip_tokens(mutants_toml)
+    if not tokens:
+        print(
+            "mutants-skip-lint: no --skip tokens in additional_cargo_test_args",
+            file=sys.stderr,
+        )
+        return 1
+
+    errors = 0
+    for test_dir, scope, gate_bins in SCOPES:
+        abs_dir = repo_root / test_dir
+        if not abs_dir.exists():
+            continue
+        for rs_file in sorted(abs_dir.rglob("*.rs")):
+            lines = rs_file.read_text().splitlines()
+            ranges = find_test_fn_ranges(lines)
+            for lineno0, line in enumerate(lines):
+                for m in CARGO_BIN_RE.finditer(line):
+                    bin_name = m.group(1)
+                    if bin_name not in gate_bins:
+                        continue
+                    fn_name = next(
+                        (name for name, s, e in ranges if s <= lineno0 <= e),
+                        None,
+                    )
+                    if fn_name is None:
+                        # Literal in helper fn — see "Limitation" in module
+                        # docstring. Out of scope; silently skip.
+                        continue
+                    if is_covered(fn_name, tokens):
+                        continue
+                    rel = rs_file.relative_to(repo_root)
+                    print(
+                        f"\nmutants-skip-lint: uncovered adapter-bin shelling test\n"
+                        f"  {rel}:{lineno0 + 1}  fn {fn_name}\n"
+                        f'  shells cargo_bin("{bin_name}") under '
+                        f"`--package {scope}` mutants scope\n"
+                        f"  but `{fn_name}` is not covered by any --skip substring in\n"
+                        f"  .cargo/mutants.toml's additional_cargo_test_args.\n\n"
+                        f"  Fix: add a substring of `{fn_name}` (or the literal name) to\n"
+                        f"  that array. See the explanatory comment at the top of\n"
+                        f"  .cargo/mutants.toml for why.\n",
+                        file=sys.stderr,
+                    )
+                    errors += 1
+
+    if errors > 0:
+        print(
+            f"mutants-skip-lint: {errors} uncovered test fn(s); see above",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"mutants-skip-lint: ok ({len(tokens)} --skip token(s) cover all "
+        f"adapter-bin shelling tests in scope)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(lint(Path(__file__).resolve().parent.parent))


### PR DESCRIPTION
## Summary

Replaces the documented carry-forward rule in `.cargo/mutants.toml` (every test that shells `cargo_bin("crap4rs"|"crap4ts")` under a scoped `cargo mutants` gate must carry a matching `--skip` substring in `additional_cargo_test_args`) with a CI + lefthook gate that runs `scripts/mutants-skip-lint.py` on every push. "Documentation rots; CI doesn't."

#224's root cause was that rule being silently violated when `crap4rs_no_flag_default_cognitive_still_works` landed via W2.5/#188 without the matching token. `cargo mutants --package crap4ts` exited 4 ("cargo test failed in an unmutated tree"), zero mutants got tested, and the walker mutation gate went silently dead. The same regression class is now structurally un-violable.

## What ships

| File | Change |
|---|---|
| `scripts/mutants-skip-lint.py` | New. Single source of truth for the check. Parses `additional_cargo_test_args` for `--skip` tokens, walks every `#[test]` fn in `crates/crap-core/tests/**` and `crates/crap4ts/tests/**`, fails if a fn whose body contains a literal `cargo_bin("crap4rs"|"crap4ts")` call is not covered by any token substring. |
| `.github/workflows/ci.yml` | New `mutants-skip-lint` job mirroring `ast-purity` shape; ubuntu-latest, 5min timeout, `python3 scripts/mutants-skip-lint.py`. |
| `lefthook.yml` | New `mutants-skip-lint` pre-push step running the same script — local-velocity layer of the CI gate. |
| `AGENTS.md` | Tightened "Why `additional_cargo_test_args = [...]`" section to forward-reference the lint. |

## Per-directory scope (matches the two scoped mutants gates)

- `crates/crap-core/tests/**` runs under `--package crap-core` (`view.rs` per-PR gate). Neither bin built → both `cargo_bin("crap4rs")` and `cargo_bin("crap4ts")` literals require a `--skip`.
- `crates/crap4ts/tests/**` runs under `--package crap4ts` (walker per-merge gate). `crap4ts` bin IS built → only `cargo_bin("crap4rs")` literals require a `--skip`.

## Limitations (documented in script header)

- Detects literal `cargo_bin("crap4rs"|"crap4ts")` calls inside `#[test]` fn bodies only.
- Literals nested in helper fns (current example: `crap4{rs,ts}_threshold` helpers in `default_gate_threshold.rs`) are silently skipped. Verified empirically: those helpers are called only from `default_gate_*` tests already covered by `--skip default_gate`, so the literals never execute.
- Helper-mediated calls with variable bin names (`run_bin("crap4rs", ...)` → `cargo_bin(name)`) are also out of scope. None present today.

Both limitations would require call-graph analysis. If a real helper-mediated regression ever materializes, extend the lint then.

## Verification rubric (load-bearing evidence)

Run on uncommitted edits, restored after each:

### (1) Remove `envelope` token → lint fails on all 3 wire-envelope tests

```
mutants-skip-lint: uncovered adapter-bin shelling test
  crates/crap-core/tests/wire_envelope_crap4rs.rs:72  fn envelope
  shells cargo_bin("crap4rs") under `--package crap-core` mutants scope
  but `envelope` is not covered by any --skip substring in
  .cargo/mutants.toml's additional_cargo_test_args.

  Fix: add a substring of `envelope` (or the literal name) to
  that array. See the explanatory comment at the top of
  .cargo/mutants.toml for why.


mutants-skip-lint: uncovered adapter-bin shelling test
  crates/crap-core/tests/wire_envelope_crap4ts.rs:180  fn envelope
  shells cargo_bin("crap4ts") under `--package crap-core` mutants scope
  but `envelope` is not covered by any --skip substring in
  .cargo/mutants.toml's additional_cargo_test_args.

  Fix: add a substring of `envelope` (or the literal name) to
  that array. See the explanatory comment at the top of
  .cargo/mutants.toml for why.


mutants-skip-lint: uncovered adapter-bin shelling test
  crates/crap-core/tests/wire_envelope_crap4ts_branches.rs:128  fn envelope
  shells cargo_bin("crap4ts") under `--package crap-core` mutants scope
  but `envelope` is not covered by any --skip substring in
  .cargo/mutants.toml's additional_cargo_test_args.

  Fix: add a substring of `envelope` (or the literal name) to
  that array. See the explanatory comment at the top of
  .cargo/mutants.toml for why.

mutants-skip-lint: 3 uncovered test fn(s); see above
```

Exit 1.

### (2) Add `#[test] fn uncovered_yolo_test_for_negative_lint_check() { cargo_bin("crap4rs")... }` → lint fails on that fn

```
mutants-skip-lint: uncovered adapter-bin shelling test
  crates/crap-core/tests/wire_envelope_crap4rs.rs:105  fn uncovered_yolo_test_for_negative_lint_check
  shells cargo_bin("crap4rs") under `--package crap-core` mutants scope
  but `uncovered_yolo_test_for_negative_lint_check` is not covered by any --skip substring in
  .cargo/mutants.toml's additional_cargo_test_args.

  Fix: add a substring of `uncovered_yolo_test_for_negative_lint_check` (or the literal name) to
  that array. See the explanatory comment at the top of
  .cargo/mutants.toml for why.

mutants-skip-lint: 1 uncovered test fn(s); see above
```

Exit 1.

### (3) Status quo on 916505e (origin/main HEAD at PR open) → green

```
mutants-skip-lint: ok (3 --skip token(s) cover all adapter-bin shelling tests in scope)
```

Exit 0.

## Wire envelope canaries

Byte-identical across all three canaries (`wire_envelope_crap4rs`, `wire_envelope_crap4ts`, `wire_envelope_crap4ts_branches`) — predicted and verified. No Rust source touched; the change is pure CI/lefthook/script wiring.

## Gate battery (all green locally)

| Gate | Result |
|---|---|
| `cargo fmt --all --check` | clean |
| `cargo clippy --workspace --all-targets -- -D warnings` | clean |
| `cargo +1.93 check --workspace --all-targets` | clean |
| `cargo nextest run --workspace --all-targets` | 1110 / 1110 pass |
| `cargo insta test --workspace --check --test-runner=nextest` | no snapshots to review (byte-identical) |
| `cargo deny check` | advisories ok, bans ok, licenses ok, sources ok |
| `cargo doc --workspace --no-deps` (RUSTDOCFLAGS=-D warnings) | clean |
| 4-layer ast-purity (leading-token / grouped / Cargo.toml / adapter-name literals) | all clean |
| 8 cucumber harnesses (`cargo test --test json_reporter_cucumber ...`) | exit 0 |
| `python3 scripts/mutants-skip-lint.py` (new) | green on this commit |

## Context

- Sibling pattern: `crap-rs/AGENTS.md` BDD hygiene rule 5 (`@unwired` / `# tracked:` lint, #180) — same shape of mechanical enforcement replacing a documented carry-forward rule. No existing #180-style lint in the repo yet; this PR is the first such mechanical-enforcement lint, picking `scripts/` as the location.
- Memory `feedback_documentation-rots-ci-doesnt` — textbook application.

Closes #247

Pipeline: `crap-rs/20260513-typescript-adapter` (epic #173), build phase, mid-pipeline backlog-clearing — NOT terminated. Next: re-survey `priority:later` cluster for GA-blocking judgement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated enforcement mechanisms in CI pipeline and pre-push hooks to ensure compliance with cargo-mutants testing rules.
  * Tests that invoke specific binaries must include required skip tokens in configuration to prevent test skipping.
  * Updated contributor documentation with new requirements and step-by-step guidance for resolving enforcement violations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/breezy-bays-labs/crap-rs/pull/259?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->