### PR TITLE
chore(crap-core): #178 #179 — port-surface cleanup (CrapError rename + CoveragePort::parse to &Path)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,36 @@ differ for the three compounding reasons documented there.
   resolving a preset to a numeric cutoff must pass the effective
   metric. crap-core minor-bumped `0.2.0` → `0.3.0`; no external
   consumers. (#218)
+- `CoveragePort::parse` now takes `&Path` instead of `&str` so each
+  adapter owns its slurp-vs-stream decision internally. The shared
+  pre-read in `crap_core::core::Analyzer::parse_coverage` is removed,
+  eliminating the double-read trap where the orchestrator slurped a
+  100 MB LCOV file before handing the buffer to a parser that could
+  have streamed. `LcovParser` and `IstanbulCoverage` both slurp via
+  `std::fs::read_to_string` internally (size ceilings well below
+  peak-RSS concern); future streaming adapters drop in unchanged.
+  External `CoveragePort` impls — likely none today, the port has
+  been internal — migrate by changing the `parse` signature to
+  `fn parse(&self, path: &Path) -> Result<…>` and adding a slurp
+  or stream at the top of the body. Each impl owns its read
+  strategy; the trait makes no commitment. (#179)
+- `CrapError::LcovParse(String)` renamed to
+  `CrapError::CoverageParse(String)`. The variant was always
+  adapter-agnostic in intent — both the LCOV and Istanbul parsers
+  today either succeed (emitting per-record issues as non-fatal
+  `ParseOutput.diagnostics`) or fail via `CrapError::SourceParse`
+  for malformed top-level structure, so the rename has no
+  user-facing impact on current adapters. The variant stays as the
+  stable error surface for future adapter-format parse failures
+  that don't fit either bucket; tool-prefixed messages
+  (`"lcov: …"` / `"istanbul: …"`) render at construction sites.
+  `CrapError` remains `#[non_exhaustive]` so external matchers with
+  `_ => …` arms continue to compile; explicit
+  `CrapError::LcovParse(_)` matches need a one-line rename.
+  Mirrors the same anti-pattern class that closed #161. (#178)
+
+crap-core minor-bumped `0.3.0` → `0.4.0` to cover both breaking
+changes above in a single migration window.
 
 ## [0.5.0] - 2026-05-10
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,7 +356,7 @@ checksum = "417bef24afe1460300965a25ff4a24b8b45ad011948302ec221e8a0a81eb2c79"
 
 [[package]]
 name = "crap-core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ authors = ["Christopher Bays <cmbays@breezybayslabs.com>"]
 # Rust adapter. Future siblings (`crap4ts`) inherit the same pins.
 [workspace.dependencies]
 # ── In-workspace crates ──
-crap-core = { path = "crates/crap-core", version = "0.3.0" }
+crap-core = { path = "crates/crap-core", version = "0.4.0" }
 
 # ── CLI (crap4rs only today) ──
 clap = { version = "4", features = ["derive", "string"] }

--- a/crates/crap-core/Cargo.toml
+++ b/crates/crap-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crap-core"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/crap-core/src/cli/mod.rs
+++ b/crates/crap-core/src/cli/mod.rs
@@ -2510,7 +2510,7 @@ mod tests {
 
         fn parse(
             &self,
-            _data: &str,
+            _path: &std::path::Path,
         ) -> Result<crate::ports::ParseOutput<Self::Diagnostic>, crate::domain::types::CrapError>
         {
             unreachable!("preflight tests never invoke parse")

--- a/crates/crap-core/src/core/mod.rs
+++ b/crates/crap-core/src/core/mod.rs
@@ -272,15 +272,30 @@ impl<'a, P: ParseDiagnostic> AnalysisContext<'a, P> {
     }
 
     fn parse_coverage(&self) -> Result<ParseOutput<P>> {
-        let coverage_data = std::fs::read_to_string(&self.options.coverage).with_context(|| {
-            format!(
-                "failed to read coverage file: {}",
-                self.options.coverage.display()
-            )
-        })?;
+        // `CoveragePort::parse` takes `&Path` post-#179 — each adapter
+        // owns its slurp-vs-stream decision internally (LCOV slurps;
+        // Istanbul slurps; `validate` streams in the LCOV case). The
+        // orchestrator no longer pre-reads, eliminating the double-read
+        // trap that motivated `feedback_trait_io_input_path_over_str`.
+        //
+        // The pre-#179 implementation slurped here and wrapped any
+        // open/read failure with `"failed to read coverage file: <path>"`
+        // via `with_context`. The path-aware context is still load-
+        // bearing (test contract + user-facing error UX), so we
+        // re-add it at the orchestrator boundary — only when the
+        // adapter surfaces an I/O failure (the path-doesn't-exist
+        // case), letting per-adapter parse errors (malformed JSON,
+        // etc.) flow through their own messages.
         self.coverage
-            .parse(&coverage_data)
-            .map_err(|e| anyhow::anyhow!("{e}"))
+            .parse(&self.options.coverage)
+            .map_err(|e| match e {
+                crate::domain::types::CrapError::Io(io_err) => anyhow::anyhow!(
+                    "failed to read coverage file: {}: {}",
+                    self.options.coverage.display(),
+                    io_err
+                ),
+                other => anyhow::anyhow!("{other}"),
+            })
     }
 
     fn extract_complexities(&self, source_files: &[PathBuf]) -> Result<ExtractedComplexities> {

--- a/crates/crap-core/src/core/mod.rs
+++ b/crates/crap-core/src/core/mod.rs
@@ -286,15 +286,21 @@ impl<'a, P: ParseDiagnostic> AnalysisContext<'a, P> {
         // adapter surfaces an I/O failure (the path-doesn't-exist
         // case), letting per-adapter parse errors (malformed JSON,
         // etc.) flow through their own messages.
+        //
+        // Uses `anyhow::Error::new(e).context(...)` (not
+        // `anyhow!("{e}")`) so the underlying `CrapError` / `io::Error`
+        // chain is preserved for `err.source()` / `err.root_cause()`
+        // walks. `err.to_string()` still returns the top context
+        // message (`"failed to read coverage file: <path>"`), keeping
+        // the analyze-pipeline test contract green.
         self.coverage
             .parse(&self.options.coverage)
             .map_err(|e| match e {
-                crate::domain::types::CrapError::Io(io_err) => anyhow::anyhow!(
-                    "failed to read coverage file: {}: {}",
-                    self.options.coverage.display(),
-                    io_err
-                ),
-                other => anyhow::anyhow!("{other}"),
+                crate::domain::types::CrapError::Io(_) => anyhow::Error::new(e).context(format!(
+                    "failed to read coverage file: {}",
+                    self.options.coverage.display()
+                )),
+                other => anyhow::Error::new(other),
             })
     }
 

--- a/crates/crap-core/src/domain/types.rs
+++ b/crates/crap-core/src/domain/types.rs
@@ -641,8 +641,20 @@ pub enum CrapError {
     #[error("Invalid coverage percentage: {0}. Must be finite.")]
     InvalidCoverage(f64),
 
-    #[error("Failed to parse LCOV data: {0}")]
-    LcovParse(String),
+    /// Coverage payload parse failure.
+    ///
+    /// Adapter-agnostic by design — the source format (LCOV, Istanbul
+    /// JSON, future formats) renders at the construction site via a
+    /// tool-prefixed message (`"lcov: …"` / `"istanbul: …"`) rather
+    /// than being baked into the variant name. Today no adapter
+    /// returns this variant — both the LCOV and Istanbul parsers
+    /// either succeed (emitting per-record issues as non-fatal
+    /// `ParseOutput.diagnostics`) or fail via
+    /// [`CrapError::SourceParse`] for malformed top-level structure.
+    /// The variant remains as the stable error surface for future
+    /// adapter-format-parse failures that don't fit either bucket.
+    #[error("Failed to parse coverage data: {0}")]
+    CoverageParse(String),
 
     /// The walker was asked to compute a metric the adapter does not
     /// (yet) support. The variant is metric-named, not adapter-named —

--- a/crates/crap-core/src/ports/mod.rs
+++ b/crates/crap-core/src/ports/mod.rs
@@ -56,7 +56,20 @@ pub struct ParseOutput<P: ParseDiagnostic> {
 /// See ADR D9 for the mixed-dispatch rationale.
 pub trait CoveragePort {
     type Diagnostic: ParseDiagnostic;
-    fn parse(&self, data: &str) -> Result<ParseOutput<Self::Diagnostic>, CrapError>;
+
+    /// Parse the coverage file at `path` into per-file line / branch
+    /// hit data.
+    ///
+    /// Takes `&Path` (not `&str`) so each impl owns its read strategy:
+    /// LCOV stays free to stream line-by-line via `BufReader`, Istanbul
+    /// JSON slurps once and hands the buffer to `serde_json`. Forcing
+    /// the caller to pre-read into a `String` would (a) require slurp
+    /// universally even when streaming is viable and (b) double peak
+    /// RSS on every invocation since [`Self::validate`] already takes
+    /// `&Path` and may stream the same file. Per the
+    /// `feedback_trait_io_input_path_over_str` operational rule, port
+    /// methods that gate on file content take `&Path`.
+    fn parse(&self, path: &Path) -> Result<ParseOutput<Self::Diagnostic>, CrapError>;
 
     /// Adapter-aware pre-flight check: does the file at `path` contain
     /// at least one usable coverage record? Runs before the analyzer
@@ -69,13 +82,13 @@ pub trait CoveragePort {
     /// LCOV format easily exceeds 100 MB on large workspaces and
     /// loading the whole file into memory twice (once here, once in
     /// `parse`) would double peak RSS for no semantic gain. Adapters
-    /// that need random access (Istanbul JSON, post-implementation)
-    /// can still slurp via `read_to_string` internally.
+    /// that need random access (Istanbul JSON) can still slurp via
+    /// `read_to_string` internally.
     ///
     /// Default implementation returns `Ok(())` (skip validation) —
     /// adapters with a cheap structural signature override. The LCOV
     /// adapter checks for `SF:` + `DA:` records; the Istanbul adapter
-    /// will check for non-empty `statementMap` once implemented.
+    /// checks for at least one entry with a non-empty `statementMap`.
     ///
     /// The returned `Err(String)` is the structural reason
     /// (e.g., `"no SF/DA records"`); the CLI layer pairs it with the

--- a/crates/crap-core/tests/snapshots/wire_envelope_crap4rs__envelope.snap
+++ b/crates/crap-core/tests/snapshots/wire_envelope_crap4rs__envelope.snap
@@ -3535,10 +3535,43 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 65,
+              "end_line": 71,
               "increment": 1,
               "kind": "for-loop",
-              "line": 63,
+              "line": 69,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 0.0,
+          "crap": {
+            "risk_level": "acceptable",
+            "value": 6.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "LcovParser::parse_str",
+            "span": {
+              "end_column": 5,
+              "end_line": 75,
+              "start_column": 5,
+              "start_line": 58
+            }
+          }
+        },
+        "threshold": 25.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 2,
+          "complexity_metric": "cognitive",
+          "contributors": [
+            {
+              "column": 72,
+              "end_line": 94,
+              "increment": 1,
+              "kind": "try",
+              "line": 94,
               "nesting_depth": 0
             }
           ],
@@ -3552,9 +3585,9 @@ expression: pretty
             "qualified_name": "LcovParser::parse",
             "span": {
               "end_column": 5,
-              "end_line": 69,
+              "end_line": 96,
               "start_column": 5,
-              "start_line": 60
+              "start_line": 81
             }
           }
         },
@@ -3568,58 +3601,58 @@ expression: pretty
           "contributors": [
             {
               "column": 73,
-              "end_line": 84,
+              "end_line": 111,
               "increment": 1,
               "kind": "try",
-              "line": 84,
+              "line": 111,
               "nesting_depth": 0
             },
             {
               "column": 9,
-              "end_line": 101,
+              "end_line": 128,
               "increment": 1,
               "kind": "for-loop",
-              "line": 87,
+              "line": 114,
               "nesting_depth": 0
             },
             {
               "column": 68,
-              "end_line": 88,
+              "end_line": 115,
               "increment": 1,
               "kind": "try",
-              "line": 88,
+              "line": 115,
               "nesting_depth": 1
             },
             {
               "column": 13,
-              "end_line": 92,
+              "end_line": 119,
               "increment": 2,
               "kind": "if-branch",
-              "line": 89,
+              "line": 116,
               "nesting_depth": 1
             },
             {
               "column": 17,
-              "end_line": 91,
+              "end_line": 118,
               "increment": 1,
               "kind": "continue",
-              "line": 91,
+              "line": 118,
               "nesting_depth": 2
             },
             {
               "column": 13,
-              "end_line": 100,
+              "end_line": 127,
               "increment": 2,
               "kind": "if-branch",
-              "line": 93,
+              "line": 120,
               "nesting_depth": 1
             },
             {
               "column": 17,
-              "end_line": 94,
+              "end_line": 121,
               "increment": 1,
               "kind": "logical-operator",
-              "line": 94,
+              "line": 121,
               "nesting_depth": 1
             }
           ],
@@ -3633,9 +3666,9 @@ expression: pretty
             "qualified_name": "LcovParser::validate",
             "span": {
               "end_column": 5,
-              "end_line": 103,
+              "end_line": 130,
               "start_column": 5,
-              "start_line": 71
+              "start_line": 98
             }
           }
         },
@@ -3649,26 +3682,26 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 110,
+              "end_line": 137,
               "increment": 1,
               "kind": "if-branch",
-              "line": 107,
+              "line": 134,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 115,
+              "end_line": 142,
               "increment": 1,
               "kind": "if-branch",
-              "line": 112,
+              "line": 139,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 119,
+              "end_line": 146,
               "increment": 1,
               "kind": "if-branch",
-              "line": 117,
+              "line": 144,
               "nesting_depth": 0
             }
           ],
@@ -3682,9 +3715,9 @@ expression: pretty
             "qualified_name": "handle_parse_line",
             "span": {
               "end_column": 1,
-              "end_line": 120,
+              "end_line": 147,
               "start_column": 1,
-              "start_line": 106
+              "start_line": 133
             }
           }
         },
@@ -3698,10 +3731,10 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 132,
+              "end_line": 159,
               "increment": 1,
               "kind": "if-branch",
-              "line": 125,
+              "line": 152,
               "nesting_depth": 0
             }
           ],
@@ -3715,9 +3748,9 @@ expression: pretty
             "qualified_name": "start_source_file",
             "span": {
               "end_column": 1,
-              "end_line": 133,
+              "end_line": 160,
               "start_column": 1,
-              "start_line": 122
+              "start_line": 149
             }
           }
         },
@@ -3731,18 +3764,18 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 138,
+              "end_line": 165,
               "increment": 1,
               "kind": "if-branch",
-              "line": 136,
+              "line": 163,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 143,
+              "end_line": 170,
               "increment": 1,
               "kind": "match",
-              "line": 140,
+              "line": 167,
               "nesting_depth": 0
             }
           ],
@@ -3756,9 +3789,9 @@ expression: pretty
             "qualified_name": "record_da",
             "span": {
               "end_column": 1,
-              "end_line": 144,
+              "end_line": 171,
               "start_column": 1,
-              "start_line": 135
+              "start_line": 162
             }
           }
         },
@@ -3772,18 +3805,18 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 149,
+              "end_line": 176,
               "increment": 1,
               "kind": "if-branch",
-              "line": 147,
+              "line": 174,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 156,
+              "end_line": 183,
               "increment": 1,
               "kind": "match",
-              "line": 151,
+              "line": 178,
               "nesting_depth": 0
             }
           ],
@@ -3797,9 +3830,9 @@ expression: pretty
             "qualified_name": "record_brda",
             "span": {
               "end_column": 1,
-              "end_line": 157,
+              "end_line": 184,
               "start_column": 1,
-              "start_line": 146
+              "start_line": 173
             }
           }
         },
@@ -3821,9 +3854,9 @@ expression: pretty
             "qualified_name": "push_malformed_record",
             "span": {
               "end_column": 1,
-              "end_line": 166,
+              "end_line": 193,
               "start_column": 1,
-              "start_line": 159
+              "start_line": 186
             }
           }
         },
@@ -3837,42 +3870,42 @@ expression: pretty
           "contributors": [
             {
               "column": 56,
-              "end_line": 171,
+              "end_line": 198,
               "increment": 1,
               "kind": "try",
-              "line": 171,
+              "line": 198,
               "nesting_depth": 0
             },
             {
               "column": 52,
-              "end_line": 173,
+              "end_line": 200,
               "increment": 1,
               "kind": "try",
-              "line": 173,
+              "line": 200,
               "nesting_depth": 0
             },
             {
               "column": 58,
-              "end_line": 174,
+              "end_line": 201,
               "increment": 1,
               "kind": "try",
-              "line": 174,
+              "line": 201,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 177,
+              "end_line": 204,
               "increment": 1,
               "kind": "if-branch",
-              "line": 175,
+              "line": 202,
               "nesting_depth": 0
             },
             {
               "column": 53,
-              "end_line": 178,
+              "end_line": 205,
               "increment": 1,
               "kind": "try",
-              "line": 178,
+              "line": 205,
               "nesting_depth": 0
             }
           ],
@@ -3886,9 +3919,9 @@ expression: pretty
             "qualified_name": "parse_da",
             "span": {
               "end_column": 1,
-              "end_line": 180,
+              "end_line": 207,
               "start_column": 1,
-              "start_line": 168
+              "start_line": 195
             }
           }
         },
@@ -3902,82 +3935,82 @@ expression: pretty
           "contributors": [
             {
               "column": 42,
-              "end_line": 187,
+              "end_line": 214,
               "increment": 1,
               "kind": "try",
-              "line": 187,
+              "line": 214,
               "nesting_depth": 0
             },
             {
               "column": 43,
-              "end_line": 188,
+              "end_line": 215,
               "increment": 1,
               "kind": "try",
-              "line": 188,
+              "line": 215,
               "nesting_depth": 0
             },
             {
               "column": 44,
-              "end_line": 189,
+              "end_line": 216,
               "increment": 1,
               "kind": "try",
-              "line": 189,
+              "line": 216,
               "nesting_depth": 0
             },
             {
               "column": 43,
-              "end_line": 190,
+              "end_line": 217,
               "increment": 1,
               "kind": "try",
-              "line": 190,
+              "line": 217,
               "nesting_depth": 0
             },
             {
               "column": 58,
-              "end_line": 192,
+              "end_line": 219,
               "increment": 1,
               "kind": "try",
-              "line": 192,
+              "line": 219,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 195,
+              "end_line": 222,
               "increment": 1,
               "kind": "if-branch",
-              "line": 193,
+              "line": 220,
               "nesting_depth": 0
             },
             {
               "column": 55,
-              "end_line": 196,
+              "end_line": 223,
               "increment": 1,
               "kind": "try",
-              "line": 196,
+              "line": 223,
               "nesting_depth": 0
             },
             {
               "column": 57,
-              "end_line": 197,
+              "end_line": 224,
               "increment": 1,
               "kind": "try",
-              "line": 197,
+              "line": 224,
               "nesting_depth": 0
             },
             {
               "column": 17,
-              "end_line": 202,
+              "end_line": 229,
               "increment": 1,
               "kind": "if-branch",
-              "line": 198,
+              "line": 225,
               "nesting_depth": 0
             },
             {
               "column": 54,
-              "end_line": 201,
+              "end_line": 228,
               "increment": 1,
               "kind": "try",
-              "line": 201,
+              "line": 228,
               "nesting_depth": 1
             }
           ],
@@ -3991,9 +4024,9 @@ expression: pretty
             "qualified_name": "parse_brda",
             "span": {
               "end_column": 1,
-              "end_line": 205,
+              "end_line": 232,
               "start_column": 1,
-              "start_line": 182
+              "start_line": 209
             }
           }
         },
@@ -4007,10 +4040,10 @@ expression: pretty
           "contributors": [
             {
               "column": 52,
-              "end_line": 211,
+              "end_line": 238,
               "increment": 1,
               "kind": "let-else",
-              "line": 208,
+              "line": 235,
               "nesting_depth": 0
             }
           ],
@@ -4024,9 +4057,9 @@ expression: pretty
             "qualified_name": "flush_block",
             "span": {
               "end_column": 1,
-              "end_line": 216,
+              "end_line": 243,
               "start_column": 1,
-              "start_line": 207
+              "start_line": 234
             }
           }
         },
@@ -4040,18 +4073,18 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 225,
+              "end_line": 252,
               "increment": 1,
               "kind": "if-branch",
-              "line": 223,
+              "line": 250,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 230,
+              "end_line": 257,
               "increment": 1,
               "kind": "for-loop",
-              "line": 228,
+              "line": 255,
               "nesting_depth": 0
             }
           ],
@@ -4065,9 +4098,9 @@ expression: pretty
             "qualified_name": "merge_line_block",
             "span": {
               "end_column": 1,
-              "end_line": 231,
+              "end_line": 258,
               "start_column": 1,
-              "start_line": 218
+              "start_line": 245
             }
           }
         },
@@ -4081,18 +4114,18 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 240,
+              "end_line": 267,
               "increment": 1,
               "kind": "if-branch",
-              "line": 238,
+              "line": 265,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 245,
+              "end_line": 272,
               "increment": 1,
               "kind": "for-loop",
-              "line": 243,
+              "line": 270,
               "nesting_depth": 0
             }
           ],
@@ -4106,9 +4139,9 @@ expression: pretty
             "qualified_name": "merge_branch_block",
             "span": {
               "end_column": 1,
-              "end_line": 246,
+              "end_line": 273,
               "start_column": 1,
-              "start_line": 233
+              "start_line": 260
             }
           }
         },
@@ -4130,9 +4163,9 @@ expression: pretty
             "qualified_name": "merge_hits",
             "span": {
               "end_column": 1,
-              "end_line": 253,
+              "end_line": 280,
               "start_column": 1,
-              "start_line": 248
+              "start_line": 275
             }
           }
         },
@@ -4154,9 +4187,9 @@ expression: pretty
             "qualified_name": "merge_branch_value",
             "span": {
               "end_column": 1,
-              "end_line": 264,
+              "end_line": 291,
               "start_column": 1,
-              "start_line": 255
+              "start_line": 282
             }
           }
         },
@@ -4170,10 +4203,10 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 272,
+              "end_line": 299,
               "increment": 1,
               "kind": "match",
-              "line": 267,
+              "line": 294,
               "nesting_depth": 0
             }
           ],
@@ -4187,9 +4220,9 @@ expression: pretty
             "qualified_name": "merge_taken",
             "span": {
               "end_column": 1,
-              "end_line": 273,
+              "end_line": 300,
               "start_column": 1,
-              "start_line": 266
+              "start_line": 293
             }
           }
         },
@@ -4211,9 +4244,9 @@ expression: pretty
             "qualified_name": "clear_current_block",
             "span": {
               "end_column": 1,
-              "end_line": 278,
+              "end_line": 305,
               "start_column": 1,
-              "start_line": 275
+              "start_line": 302
             }
           }
         },
@@ -4235,9 +4268,9 @@ expression: pretty
             "qualified_name": "build_parse_output",
             "span": {
               "end_column": 1,
-              "end_line": 306,
+              "end_line": 333,
               "start_column": 1,
-              "start_line": 280
+              "start_line": 307
             }
           }
         },
@@ -4259,9 +4292,9 @@ expression: pretty
             "qualified_name": "to_line_coverage",
             "span": {
               "end_column": 1,
-              "end_line": 313,
+              "end_line": 340,
               "start_column": 1,
-              "start_line": 308
+              "start_line": 335
             }
           }
         },
@@ -4283,9 +4316,9 @@ expression: pretty
             "qualified_name": "parser",
             "span": {
               "end_column": 5,
-              "end_line": 322,
+              "end_line": 349,
               "start_column": 5,
-              "start_line": 320
+              "start_line": 347
             }
           }
         },
@@ -4307,9 +4340,9 @@ expression: pretty
             "qualified_name": "parse",
             "span": {
               "end_column": 5,
-              "end_line": 326,
+              "end_line": 353,
               "start_column": 5,
-              "start_line": 324
+              "start_line": 351
             }
           }
         },
@@ -4331,9 +4364,9 @@ expression: pretty
             "qualified_name": "empty_input_returns_empty_output",
             "span": {
               "end_column": 5,
-              "end_line": 333,
+              "end_line": 360,
               "start_column": 5,
-              "start_line": 328
+              "start_line": 355
             }
           }
         },
@@ -4355,9 +4388,9 @@ expression: pretty
             "qualified_name": "validate_str",
             "span": {
               "end_column": 5,
-              "end_line": 347,
+              "end_line": 374,
               "start_column": 5,
-              "start_line": 337
+              "start_line": 364
             }
           }
         },
@@ -4379,9 +4412,9 @@ expression: pretty
             "qualified_name": "validate_empty_input_rejected",
             "span": {
               "end_column": 5,
-              "end_line": 352,
+              "end_line": 379,
               "start_column": 5,
-              "start_line": 349
+              "start_line": 376
             }
           }
         },
@@ -4403,9 +4436,9 @@ expression: pretty
             "qualified_name": "validate_no_da_lines_rejected",
             "span": {
               "end_column": 5,
-              "end_line": 357,
+              "end_line": 384,
               "start_column": 5,
-              "start_line": 354
+              "start_line": 381
             }
           }
         },
@@ -4427,9 +4460,9 @@ expression: pretty
             "qualified_name": "validate_da_outside_sf_block_rejected",
             "span": {
               "end_column": 5,
-              "end_line": 362,
+              "end_line": 389,
               "start_column": 5,
-              "start_line": 359
+              "start_line": 386
             }
           }
         },
@@ -4451,9 +4484,9 @@ expression: pretty
             "qualified_name": "validate_malformed_da_rejected",
             "span": {
               "end_column": 5,
-              "end_line": 367,
+              "end_line": 394,
               "start_column": 5,
-              "start_line": 364
+              "start_line": 391
             }
           }
         },
@@ -4475,9 +4508,9 @@ expression: pretty
             "qualified_name": "validate_single_da_inside_sf_block_passes",
             "span": {
               "end_column": 5,
-              "end_line": 372,
+              "end_line": 399,
               "start_column": 5,
-              "start_line": 369
+              "start_line": 396
             }
           }
         },
@@ -4499,9 +4532,9 @@ expression: pretty
             "qualified_name": "validate_first_da_in_second_block_passes",
             "span": {
               "end_column": 5,
-              "end_line": 382,
+              "end_line": 409,
               "start_column": 5,
-              "start_line": 374
+              "start_line": 401
             }
           }
         },
@@ -4523,9 +4556,9 @@ expression: pretty
             "qualified_name": "validate_missing_path_returns_open_error",
             "span": {
               "end_column": 5,
-              "end_line": 394,
+              "end_line": 421,
               "start_column": 5,
-              "start_line": 384
+              "start_line": 411
             }
           }
         },
@@ -4547,9 +4580,9 @@ expression: pretty
             "qualified_name": "single_file_single_da",
             "span": {
               "end_column": 5,
-              "end_line": 404,
+              "end_line": 431,
               "start_column": 5,
-              "start_line": 396
+              "start_line": 423
             }
           }
         },
@@ -4571,9 +4604,9 @@ expression: pretty
             "qualified_name": "multiple_da_lines",
             "span": {
               "end_column": 5,
-              "end_line": 414,
+              "end_line": 441,
               "start_column": 5,
-              "start_line": 406
+              "start_line": 433
             }
           }
         },
@@ -4595,9 +4628,9 @@ expression: pretty
             "qualified_name": "multiple_source_files",
             "span": {
               "end_column": 5,
-              "end_line": 423,
+              "end_line": 450,
               "start_column": 5,
-              "start_line": 416
+              "start_line": 443
             }
           }
         },
@@ -4619,9 +4652,9 @@ expression: pretty
             "qualified_name": "hit_count_preservation",
             "span": {
               "end_column": 5,
-              "end_line": 431,
+              "end_line": 458,
               "start_column": 5,
-              "start_line": 425
+              "start_line": 452
             }
           }
         },
@@ -4643,9 +4676,9 @@ expression: pretty
             "qualified_name": "path_normalization_strips_prefix",
             "span": {
               "end_column": 5,
-              "end_line": 437,
+              "end_line": 464,
               "start_column": 5,
-              "start_line": 433
+              "start_line": 460
             }
           }
         },
@@ -4667,9 +4700,9 @@ expression: pretty
             "qualified_name": "non_matching_path_passes_through",
             "span": {
               "end_column": 5,
-              "end_line": 443,
+              "end_line": 470,
               "start_column": 5,
-              "start_line": 439
+              "start_line": 466
             }
           }
         },
@@ -4691,9 +4724,9 @@ expression: pretty
             "qualified_name": "backslash_normalized_to_forward_slash",
             "span": {
               "end_column": 5,
-              "end_line": 450,
+              "end_line": 477,
               "start_column": 5,
-              "start_line": 445
+              "start_line": 472
             }
           }
         },
@@ -4715,9 +4748,9 @@ expression: pretty
             "qualified_name": "path_boundary_not_confused_by_prefix_substring",
             "span": {
               "end_column": 5,
-              "end_line": 456,
+              "end_line": 483,
               "start_column": 5,
-              "start_line": 452
+              "start_line": 479
             }
           }
         },
@@ -4739,9 +4772,9 @@ expression: pretty
             "qualified_name": "repeated_sf_blocks_merge_coverage",
             "span": {
               "end_column": 5,
-              "end_line": 470,
+              "end_line": 497,
               "start_column": 5,
-              "start_line": 458
+              "start_line": 485
             }
           }
         },
@@ -4763,9 +4796,9 @@ expression: pretty
             "qualified_name": "duplicate_da_lines_sum_hits",
             "span": {
               "end_column": 5,
-              "end_line": 479,
+              "end_line": 506,
               "start_column": 5,
-              "start_line": 472
+              "start_line": 499
             }
           }
         },
@@ -4787,9 +4820,9 @@ expression: pretty
             "qualified_name": "duplicate_da_multiple_lines_sum_correctly",
             "span": {
               "end_column": 5,
-              "end_line": 491,
+              "end_line": 518,
               "start_column": 5,
-              "start_line": 481
+              "start_line": 508
             }
           }
         },
@@ -4803,10 +4836,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 507,
+              "end_line": 534,
               "increment": 1,
               "kind": "match",
-              "line": 498,
+              "line": 525,
               "nesting_depth": 0
             }
           ],
@@ -4820,9 +4853,9 @@ expression: pretty
             "qualified_name": "malformed_da_produces_diagnostic",
             "span": {
               "end_column": 5,
-              "end_line": 508,
+              "end_line": 535,
               "start_column": 5,
-              "start_line": 493
+              "start_line": 520
             }
           }
         },
@@ -4844,9 +4877,9 @@ expression: pretty
             "qualified_name": "malformed_da_does_not_stop_parsing",
             "span": {
               "end_column": 5,
-              "end_line": 516,
+              "end_line": 543,
               "start_column": 5,
-              "start_line": 510
+              "start_line": 537
             }
           }
         },
@@ -4868,9 +4901,9 @@ expression: pretty
             "qualified_name": "da_missing_hit_count_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 526,
+              "end_line": 553,
               "start_column": 5,
-              "start_line": 518
+              "start_line": 545
             }
           }
         },
@@ -4892,9 +4925,9 @@ expression: pretty
             "qualified_name": "da_negative_hit_count_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 536,
+              "end_line": 563,
               "start_column": 5,
-              "start_line": 528
+              "start_line": 555
             }
           }
         },
@@ -4908,10 +4941,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 551,
+              "end_line": 578,
               "increment": 1,
               "kind": "match",
-              "line": 542,
+              "line": 569,
               "nesting_depth": 0
             }
           ],
@@ -4925,9 +4958,9 @@ expression: pretty
             "qualified_name": "da_line_zero_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 552,
+              "end_line": 579,
               "start_column": 5,
-              "start_line": 538
+              "start_line": 565
             }
           }
         },
@@ -4949,9 +4982,9 @@ expression: pretty
             "qualified_name": "end_of_record_is_ignored",
             "span": {
               "end_column": 5,
-              "end_line": 563,
+              "end_line": 590,
               "start_column": 5,
-              "start_line": 554
+              "start_line": 581
             }
           }
         },
@@ -4973,9 +5006,9 @@ expression: pretty
             "qualified_name": "unterminated_final_block_emits_data",
             "span": {
               "end_column": 5,
-              "end_line": 570,
+              "end_line": 597,
               "start_column": 5,
-              "start_line": 565
+              "start_line": 592
             }
           }
         },
@@ -4997,9 +5030,9 @@ expression: pretty
             "qualified_name": "empty_sf_path_emits_diagnostic",
             "span": {
               "end_column": 5,
-              "end_line": 581,
+              "end_line": 608,
               "start_column": 5,
-              "start_line": 572
+              "start_line": 599
             }
           }
         },
@@ -5021,9 +5054,9 @@ expression: pretty
             "qualified_name": "da_with_checksum_field_is_accepted",
             "span": {
               "end_column": 5,
-              "end_line": 590,
+              "end_line": 617,
               "start_column": 5,
-              "start_line": 583
+              "start_line": 610
             }
           }
         },
@@ -5045,9 +5078,9 @@ expression: pretty
             "qualified_name": "non_coverage_records_are_ignored",
             "span": {
               "end_column": 5,
-              "end_line": 604,
+              "end_line": 631,
               "start_column": 5,
-              "start_line": 592
+              "start_line": 619
             }
           }
         },
@@ -5069,9 +5102,9 @@ expression: pretty
             "qualified_name": "brda_and_da_records_parsed",
             "span": {
               "end_column": 5,
-              "end_line": 616,
+              "end_line": 643,
               "start_column": 5,
-              "start_line": 608
+              "start_line": 635
             }
           }
         },
@@ -5093,9 +5126,9 @@ expression: pretty
             "qualified_name": "brda_dash_maps_to_none",
             "span": {
               "end_column": 5,
-              "end_line": 623,
+              "end_line": 650,
               "start_column": 5,
-              "start_line": 618
+              "start_line": 645
             }
           }
         },
@@ -5117,9 +5150,9 @@ expression: pretty
             "qualified_name": "brda_numeric_maps_to_some",
             "span": {
               "end_column": 5,
-              "end_line": 630,
+              "end_line": 657,
               "start_column": 5,
-              "start_line": 625
+              "start_line": 652
             }
           }
         },
@@ -5141,9 +5174,9 @@ expression: pretty
             "qualified_name": "brda_zero_maps_to_some_zero",
             "span": {
               "end_column": 5,
-              "end_line": 637,
+              "end_line": 664,
               "start_column": 5,
-              "start_line": 632
+              "start_line": 659
             }
           }
         },
@@ -5165,9 +5198,9 @@ expression: pretty
             "qualified_name": "duplicate_brda_sum_taken",
             "span": {
               "end_column": 5,
-              "end_line": 647,
+              "end_line": 674,
               "start_column": 5,
-              "start_line": 639
+              "start_line": 666
             }
           }
         },
@@ -5189,9 +5222,9 @@ expression: pretty
             "qualified_name": "brda_dash_and_numeric_merge",
             "span": {
               "end_column": 5,
-              "end_line": 655,
+              "end_line": 682,
               "start_column": 5,
-              "start_line": 649
+              "start_line": 676
             }
           }
         },
@@ -5205,10 +5238,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 670,
+              "end_line": 697,
               "increment": 1,
               "kind": "match",
-              "line": 661,
+              "line": 688,
               "nesting_depth": 0
             }
           ],
@@ -5222,9 +5255,9 @@ expression: pretty
             "qualified_name": "malformed_brda_produces_diagnostic",
             "span": {
               "end_column": 5,
-              "end_line": 671,
+              "end_line": 698,
               "start_column": 5,
-              "start_line": 657
+              "start_line": 684
             }
           }
         },
@@ -5246,9 +5279,9 @@ expression: pretty
             "qualified_name": "brda_missing_fields_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 682,
+              "end_line": 709,
               "start_column": 5,
-              "start_line": 673
+              "start_line": 700
             }
           }
         },
@@ -5270,9 +5303,9 @@ expression: pretty
             "qualified_name": "brda_missing_taken_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 693,
+              "end_line": 720,
               "start_column": 5,
-              "start_line": 684
+              "start_line": 711
             }
           }
         },
@@ -5286,10 +5319,10 @@ expression: pretty
           "contributors": [
             {
               "column": 13,
-              "end_line": 712,
+              "end_line": 739,
               "increment": 1,
               "kind": "for-loop",
-              "line": 710,
+              "line": 737,
               "nesting_depth": 0
             }
           ],
@@ -5303,9 +5336,9 @@ expression: pretty
             "qualified_name": "repeated_sf_blocks_merge_branch_coverage",
             "span": {
               "end_column": 5,
-              "end_line": 722,
+              "end_line": 749,
               "start_column": 5,
-              "start_line": 695
+              "start_line": 722
             }
           }
         },
@@ -5327,9 +5360,9 @@ expression: pretty
             "qualified_name": "brda_line_zero_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 732,
+              "end_line": 759,
               "start_column": 5,
-              "start_line": 724
+              "start_line": 751
             }
           }
         },
@@ -5351,9 +5384,9 @@ expression: pretty
             "qualified_name": "no_brda_produces_none_branches",
             "span": {
               "end_column": 5,
-              "end_line": 738,
+              "end_line": 765,
               "start_column": 5,
-              "start_line": 734
+              "start_line": 761
             }
           }
         },
@@ -5375,9 +5408,9 @@ expression: pretty
             "qualified_name": "arb_da_line",
             "span": {
               "end_column": 5,
-              "end_line": 748,
+              "end_line": 775,
               "start_column": 5,
-              "start_line": 746
+              "start_line": 773
             }
           }
         },
@@ -5391,10 +5424,10 @@ expression: pretty
           "contributors": [
             {
               "column": 13,
-              "end_line": 756,
+              "end_line": 783,
               "increment": 2,
               "kind": "for-loop",
-              "line": 753,
+              "line": 780,
               "nesting_depth": 1
             }
           ],
@@ -5408,9 +5441,9 @@ expression: pretty
             "qualified_name": "arb_lcov_block",
             "span": {
               "end_column": 5,
-              "end_line": 760,
+              "end_line": 787,
               "start_column": 5,
-              "start_line": 750
+              "start_line": 777
             }
           }
         },
@@ -5432,9 +5465,9 @@ expression: pretty
             "qualified_name": "arb_lcov_input",
             "span": {
               "end_column": 5,
-              "end_line": 764,
+              "end_line": 791,
               "start_column": 5,
-              "start_line": 762
+              "start_line": 789
             }
           }
         },
@@ -5620,11 +5653,11 @@ expression: pretty
     ],
     "passed": false,
     "summary": {
-      "average_complexity": 1.5198019801980198,
+      "average_complexity": 1.522167487684729,
       "average_coverage": 0.0,
-      "average_crap": 5.7227722772277225,
+      "average_crap": 5.724137931034483,
       "distribution": {
-        "acceptable": 29,
+        "acceptable": 30,
         "high": 6,
         "low": 153,
         "moderate": 14
@@ -5640,15 +5673,15 @@ expression: pretty
       "median_crap": 2.0,
       "min_coverage": 0.0,
       "total_files": 5,
-      "total_functions": 202,
+      "total_functions": 203,
       "worst_function": {
         "file_path": "adapters/coverage/mod.rs",
         "qualified_name": "parse_brda",
         "span": {
           "end_column": 1,
-          "end_line": 205,
+          "end_line": 232,
           "start_column": 1,
-          "start_line": 182
+          "start_line": 209
         }
       }
     }
@@ -5658,7 +5691,7 @@ expression: pretty
   "timestamp": "[STRIPPED:timestamp]",
   "tool_version": "[STRIPPED:tool_version]",
   "view": {
-    "eligible_count": 202,
+    "eligible_count": 203,
     "grouped": null,
     "shown": [
       {
@@ -5669,82 +5702,82 @@ expression: pretty
           "contributors": [
             {
               "column": 42,
-              "end_line": 187,
+              "end_line": 214,
               "increment": 1,
               "kind": "try",
-              "line": 187,
+              "line": 214,
               "nesting_depth": 0
             },
             {
               "column": 43,
-              "end_line": 188,
+              "end_line": 215,
               "increment": 1,
               "kind": "try",
-              "line": 188,
+              "line": 215,
               "nesting_depth": 0
             },
             {
               "column": 44,
-              "end_line": 189,
+              "end_line": 216,
               "increment": 1,
               "kind": "try",
-              "line": 189,
+              "line": 216,
               "nesting_depth": 0
             },
             {
               "column": 43,
-              "end_line": 190,
+              "end_line": 217,
               "increment": 1,
               "kind": "try",
-              "line": 190,
+              "line": 217,
               "nesting_depth": 0
             },
             {
               "column": 58,
-              "end_line": 192,
+              "end_line": 219,
               "increment": 1,
               "kind": "try",
-              "line": 192,
+              "line": 219,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 195,
+              "end_line": 222,
               "increment": 1,
               "kind": "if-branch",
-              "line": 193,
+              "line": 220,
               "nesting_depth": 0
             },
             {
               "column": 55,
-              "end_line": 196,
+              "end_line": 223,
               "increment": 1,
               "kind": "try",
-              "line": 196,
+              "line": 223,
               "nesting_depth": 0
             },
             {
               "column": 57,
-              "end_line": 197,
+              "end_line": 224,
               "increment": 1,
               "kind": "try",
-              "line": 197,
+              "line": 224,
               "nesting_depth": 0
             },
             {
               "column": 17,
-              "end_line": 202,
+              "end_line": 229,
               "increment": 1,
               "kind": "if-branch",
-              "line": 198,
+              "line": 225,
               "nesting_depth": 0
             },
             {
               "column": 54,
-              "end_line": 201,
+              "end_line": 228,
               "increment": 1,
               "kind": "try",
-              "line": 201,
+              "line": 228,
               "nesting_depth": 1
             }
           ],
@@ -5758,9 +5791,9 @@ expression: pretty
             "qualified_name": "parse_brda",
             "span": {
               "end_column": 1,
-              "end_line": 205,
+              "end_line": 232,
               "start_column": 1,
-              "start_line": 182
+              "start_line": 209
             }
           }
         },
@@ -5774,58 +5807,58 @@ expression: pretty
           "contributors": [
             {
               "column": 73,
-              "end_line": 84,
+              "end_line": 111,
               "increment": 1,
               "kind": "try",
-              "line": 84,
+              "line": 111,
               "nesting_depth": 0
             },
             {
               "column": 9,
-              "end_line": 101,
+              "end_line": 128,
               "increment": 1,
               "kind": "for-loop",
-              "line": 87,
+              "line": 114,
               "nesting_depth": 0
             },
             {
               "column": 68,
-              "end_line": 88,
+              "end_line": 115,
               "increment": 1,
               "kind": "try",
-              "line": 88,
+              "line": 115,
               "nesting_depth": 1
             },
             {
               "column": 13,
-              "end_line": 92,
+              "end_line": 119,
               "increment": 2,
               "kind": "if-branch",
-              "line": 89,
+              "line": 116,
               "nesting_depth": 1
             },
             {
               "column": 17,
-              "end_line": 91,
+              "end_line": 118,
               "increment": 1,
               "kind": "continue",
-              "line": 91,
+              "line": 118,
               "nesting_depth": 2
             },
             {
               "column": 13,
-              "end_line": 100,
+              "end_line": 127,
               "increment": 2,
               "kind": "if-branch",
-              "line": 93,
+              "line": 120,
               "nesting_depth": 1
             },
             {
               "column": 17,
-              "end_line": 94,
+              "end_line": 121,
               "increment": 1,
               "kind": "logical-operator",
-              "line": 94,
+              "line": 121,
               "nesting_depth": 1
             }
           ],
@@ -5839,9 +5872,9 @@ expression: pretty
             "qualified_name": "LcovParser::validate",
             "span": {
               "end_column": 5,
-              "end_line": 103,
+              "end_line": 130,
               "start_column": 5,
-              "start_line": 71
+              "start_line": 98
             }
           }
         },
@@ -6010,42 +6043,42 @@ expression: pretty
           "contributors": [
             {
               "column": 56,
-              "end_line": 171,
+              "end_line": 198,
               "increment": 1,
               "kind": "try",
-              "line": 171,
+              "line": 198,
               "nesting_depth": 0
             },
             {
               "column": 52,
-              "end_line": 173,
+              "end_line": 200,
               "increment": 1,
               "kind": "try",
-              "line": 173,
+              "line": 200,
               "nesting_depth": 0
             },
             {
               "column": 58,
-              "end_line": 174,
+              "end_line": 201,
               "increment": 1,
               "kind": "try",
-              "line": 174,
+              "line": 201,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 177,
+              "end_line": 204,
               "increment": 1,
               "kind": "if-branch",
-              "line": 175,
+              "line": 202,
               "nesting_depth": 0
             },
             {
               "column": 53,
-              "end_line": 178,
+              "end_line": 205,
               "increment": 1,
               "kind": "try",
-              "line": 178,
+              "line": 205,
               "nesting_depth": 0
             }
           ],
@@ -6059,9 +6092,9 @@ expression: pretty
             "qualified_name": "parse_da",
             "span": {
               "end_column": 1,
-              "end_line": 180,
+              "end_line": 207,
               "start_column": 1,
-              "start_line": 168
+              "start_line": 195
             }
           }
         },
@@ -6239,26 +6272,26 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 110,
+              "end_line": 137,
               "increment": 1,
               "kind": "if-branch",
-              "line": 107,
+              "line": 134,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 115,
+              "end_line": 142,
               "increment": 1,
               "kind": "if-branch",
-              "line": 112,
+              "line": 139,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 119,
+              "end_line": 146,
               "increment": 1,
               "kind": "if-branch",
-              "line": 117,
+              "line": 144,
               "nesting_depth": 0
             }
           ],
@@ -6272,9 +6305,9 @@ expression: pretty
             "qualified_name": "handle_parse_line",
             "span": {
               "end_column": 1,
-              "end_line": 120,
+              "end_line": 147,
               "start_column": 1,
-              "start_line": 106
+              "start_line": 133
             }
           }
         },
@@ -6452,18 +6485,18 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 138,
+              "end_line": 165,
               "increment": 1,
               "kind": "if-branch",
-              "line": 136,
+              "line": 163,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 143,
+              "end_line": 170,
               "increment": 1,
               "kind": "match",
-              "line": 140,
+              "line": 167,
               "nesting_depth": 0
             }
           ],
@@ -6477,9 +6510,9 @@ expression: pretty
             "qualified_name": "record_da",
             "span": {
               "end_column": 1,
-              "end_line": 144,
+              "end_line": 171,
               "start_column": 1,
-              "start_line": 135
+              "start_line": 162
             }
           }
         },
@@ -6493,18 +6526,18 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 149,
+              "end_line": 176,
               "increment": 1,
               "kind": "if-branch",
-              "line": 147,
+              "line": 174,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 156,
+              "end_line": 183,
               "increment": 1,
               "kind": "match",
-              "line": 151,
+              "line": 178,
               "nesting_depth": 0
             }
           ],
@@ -6518,9 +6551,9 @@ expression: pretty
             "qualified_name": "record_brda",
             "span": {
               "end_column": 1,
-              "end_line": 157,
+              "end_line": 184,
               "start_column": 1,
-              "start_line": 146
+              "start_line": 173
             }
           }
         },
@@ -6534,18 +6567,18 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 225,
+              "end_line": 252,
               "increment": 1,
               "kind": "if-branch",
-              "line": 223,
+              "line": 250,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 230,
+              "end_line": 257,
               "increment": 1,
               "kind": "for-loop",
-              "line": 228,
+              "line": 255,
               "nesting_depth": 0
             }
           ],
@@ -6559,9 +6592,9 @@ expression: pretty
             "qualified_name": "merge_line_block",
             "span": {
               "end_column": 1,
-              "end_line": 231,
+              "end_line": 258,
               "start_column": 1,
-              "start_line": 218
+              "start_line": 245
             }
           }
         },
@@ -6575,18 +6608,18 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 240,
+              "end_line": 267,
               "increment": 1,
               "kind": "if-branch",
-              "line": 238,
+              "line": 265,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 245,
+              "end_line": 272,
               "increment": 1,
               "kind": "for-loop",
-              "line": 243,
+              "line": 270,
               "nesting_depth": 0
             }
           ],
@@ -6600,9 +6633,9 @@ expression: pretty
             "qualified_name": "merge_branch_block",
             "span": {
               "end_column": 1,
-              "end_line": 246,
+              "end_line": 273,
               "start_column": 1,
-              "start_line": 233
+              "start_line": 260
             }
           }
         },
@@ -6616,10 +6649,10 @@ expression: pretty
           "contributors": [
             {
               "column": 13,
-              "end_line": 756,
+              "end_line": 783,
               "increment": 2,
               "kind": "for-loop",
-              "line": 753,
+              "line": 780,
               "nesting_depth": 1
             }
           ],
@@ -6633,9 +6666,9 @@ expression: pretty
             "qualified_name": "arb_lcov_block",
             "span": {
               "end_column": 5,
-              "end_line": 760,
+              "end_line": 787,
               "start_column": 5,
-              "start_line": 750
+              "start_line": 777
             }
           }
         },
@@ -7309,10 +7342,43 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 65,
+              "end_line": 71,
               "increment": 1,
               "kind": "for-loop",
-              "line": 63,
+              "line": 69,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 0.0,
+          "crap": {
+            "risk_level": "acceptable",
+            "value": 6.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "LcovParser::parse_str",
+            "span": {
+              "end_column": 5,
+              "end_line": 75,
+              "start_column": 5,
+              "start_line": 58
+            }
+          }
+        },
+        "threshold": 25.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 2,
+          "complexity_metric": "cognitive",
+          "contributors": [
+            {
+              "column": 72,
+              "end_line": 94,
+              "increment": 1,
+              "kind": "try",
+              "line": 94,
               "nesting_depth": 0
             }
           ],
@@ -7326,9 +7392,9 @@ expression: pretty
             "qualified_name": "LcovParser::parse",
             "span": {
               "end_column": 5,
-              "end_line": 69,
+              "end_line": 96,
               "start_column": 5,
-              "start_line": 60
+              "start_line": 81
             }
           }
         },
@@ -7342,10 +7408,10 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 132,
+              "end_line": 159,
               "increment": 1,
               "kind": "if-branch",
-              "line": 125,
+              "line": 152,
               "nesting_depth": 0
             }
           ],
@@ -7359,9 +7425,9 @@ expression: pretty
             "qualified_name": "start_source_file",
             "span": {
               "end_column": 1,
-              "end_line": 133,
+              "end_line": 160,
               "start_column": 1,
-              "start_line": 122
+              "start_line": 149
             }
           }
         },
@@ -7375,10 +7441,10 @@ expression: pretty
           "contributors": [
             {
               "column": 52,
-              "end_line": 211,
+              "end_line": 238,
               "increment": 1,
               "kind": "let-else",
-              "line": 208,
+              "line": 235,
               "nesting_depth": 0
             }
           ],
@@ -7392,9 +7458,9 @@ expression: pretty
             "qualified_name": "flush_block",
             "span": {
               "end_column": 1,
-              "end_line": 216,
+              "end_line": 243,
               "start_column": 1,
-              "start_line": 207
+              "start_line": 234
             }
           }
         },
@@ -7408,10 +7474,10 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 272,
+              "end_line": 299,
               "increment": 1,
               "kind": "match",
-              "line": 267,
+              "line": 294,
               "nesting_depth": 0
             }
           ],
@@ -7425,9 +7491,9 @@ expression: pretty
             "qualified_name": "merge_taken",
             "span": {
               "end_column": 1,
-              "end_line": 273,
+              "end_line": 300,
               "start_column": 1,
-              "start_line": 266
+              "start_line": 293
             }
           }
         },
@@ -7441,10 +7507,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 507,
+              "end_line": 534,
               "increment": 1,
               "kind": "match",
-              "line": 498,
+              "line": 525,
               "nesting_depth": 0
             }
           ],
@@ -7458,9 +7524,9 @@ expression: pretty
             "qualified_name": "malformed_da_produces_diagnostic",
             "span": {
               "end_column": 5,
-              "end_line": 508,
+              "end_line": 535,
               "start_column": 5,
-              "start_line": 493
+              "start_line": 520
             }
           }
         },
@@ -7474,10 +7540,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 551,
+              "end_line": 578,
               "increment": 1,
               "kind": "match",
-              "line": 542,
+              "line": 569,
               "nesting_depth": 0
             }
           ],
@@ -7491,9 +7557,9 @@ expression: pretty
             "qualified_name": "da_line_zero_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 552,
+              "end_line": 579,
               "start_column": 5,
-              "start_line": 538
+              "start_line": 565
             }
           }
         },
@@ -7507,10 +7573,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 670,
+              "end_line": 697,
               "increment": 1,
               "kind": "match",
-              "line": 661,
+              "line": 688,
               "nesting_depth": 0
             }
           ],
@@ -7524,9 +7590,9 @@ expression: pretty
             "qualified_name": "malformed_brda_produces_diagnostic",
             "span": {
               "end_column": 5,
-              "end_line": 671,
+              "end_line": 698,
               "start_column": 5,
-              "start_line": 657
+              "start_line": 684
             }
           }
         },
@@ -7540,10 +7606,10 @@ expression: pretty
           "contributors": [
             {
               "column": 13,
-              "end_line": 712,
+              "end_line": 739,
               "increment": 1,
               "kind": "for-loop",
-              "line": 710,
+              "line": 737,
               "nesting_depth": 0
             }
           ],
@@ -7557,9 +7623,9 @@ expression: pretty
             "qualified_name": "repeated_sf_blocks_merge_branch_coverage",
             "span": {
               "end_column": 5,
-              "end_line": 722,
+              "end_line": 749,
               "start_column": 5,
-              "start_line": 695
+              "start_line": 722
             }
           }
         },
@@ -9990,9 +10056,9 @@ expression: pretty
             "qualified_name": "push_malformed_record",
             "span": {
               "end_column": 1,
-              "end_line": 166,
+              "end_line": 193,
               "start_column": 1,
-              "start_line": 159
+              "start_line": 186
             }
           }
         },
@@ -10014,9 +10080,9 @@ expression: pretty
             "qualified_name": "merge_hits",
             "span": {
               "end_column": 1,
-              "end_line": 253,
+              "end_line": 280,
               "start_column": 1,
-              "start_line": 248
+              "start_line": 275
             }
           }
         },
@@ -10038,9 +10104,9 @@ expression: pretty
             "qualified_name": "merge_branch_value",
             "span": {
               "end_column": 1,
-              "end_line": 264,
+              "end_line": 291,
               "start_column": 1,
-              "start_line": 255
+              "start_line": 282
             }
           }
         },
@@ -10062,9 +10128,9 @@ expression: pretty
             "qualified_name": "clear_current_block",
             "span": {
               "end_column": 1,
-              "end_line": 278,
+              "end_line": 305,
               "start_column": 1,
-              "start_line": 275
+              "start_line": 302
             }
           }
         },
@@ -10086,9 +10152,9 @@ expression: pretty
             "qualified_name": "build_parse_output",
             "span": {
               "end_column": 1,
-              "end_line": 306,
+              "end_line": 333,
               "start_column": 1,
-              "start_line": 280
+              "start_line": 307
             }
           }
         },
@@ -10110,9 +10176,9 @@ expression: pretty
             "qualified_name": "to_line_coverage",
             "span": {
               "end_column": 1,
-              "end_line": 313,
+              "end_line": 340,
               "start_column": 1,
-              "start_line": 308
+              "start_line": 335
             }
           }
         },
@@ -10134,9 +10200,9 @@ expression: pretty
             "qualified_name": "parser",
             "span": {
               "end_column": 5,
-              "end_line": 322,
+              "end_line": 349,
               "start_column": 5,
-              "start_line": 320
+              "start_line": 347
             }
           }
         },
@@ -10158,9 +10224,9 @@ expression: pretty
             "qualified_name": "parse",
             "span": {
               "end_column": 5,
-              "end_line": 326,
+              "end_line": 353,
               "start_column": 5,
-              "start_line": 324
+              "start_line": 351
             }
           }
         },
@@ -10182,9 +10248,9 @@ expression: pretty
             "qualified_name": "empty_input_returns_empty_output",
             "span": {
               "end_column": 5,
-              "end_line": 333,
+              "end_line": 360,
               "start_column": 5,
-              "start_line": 328
+              "start_line": 355
             }
           }
         },
@@ -10206,9 +10272,9 @@ expression: pretty
             "qualified_name": "validate_str",
             "span": {
               "end_column": 5,
-              "end_line": 347,
+              "end_line": 374,
               "start_column": 5,
-              "start_line": 337
+              "start_line": 364
             }
           }
         },
@@ -10230,9 +10296,9 @@ expression: pretty
             "qualified_name": "validate_empty_input_rejected",
             "span": {
               "end_column": 5,
-              "end_line": 352,
+              "end_line": 379,
               "start_column": 5,
-              "start_line": 349
+              "start_line": 376
             }
           }
         },
@@ -10254,9 +10320,9 @@ expression: pretty
             "qualified_name": "validate_no_da_lines_rejected",
             "span": {
               "end_column": 5,
-              "end_line": 357,
+              "end_line": 384,
               "start_column": 5,
-              "start_line": 354
+              "start_line": 381
             }
           }
         },
@@ -10278,9 +10344,9 @@ expression: pretty
             "qualified_name": "validate_da_outside_sf_block_rejected",
             "span": {
               "end_column": 5,
-              "end_line": 362,
+              "end_line": 389,
               "start_column": 5,
-              "start_line": 359
+              "start_line": 386
             }
           }
         },
@@ -10302,9 +10368,9 @@ expression: pretty
             "qualified_name": "validate_malformed_da_rejected",
             "span": {
               "end_column": 5,
-              "end_line": 367,
+              "end_line": 394,
               "start_column": 5,
-              "start_line": 364
+              "start_line": 391
             }
           }
         },
@@ -10326,9 +10392,9 @@ expression: pretty
             "qualified_name": "validate_single_da_inside_sf_block_passes",
             "span": {
               "end_column": 5,
-              "end_line": 372,
+              "end_line": 399,
               "start_column": 5,
-              "start_line": 369
+              "start_line": 396
             }
           }
         },
@@ -10350,9 +10416,9 @@ expression: pretty
             "qualified_name": "validate_first_da_in_second_block_passes",
             "span": {
               "end_column": 5,
-              "end_line": 382,
+              "end_line": 409,
               "start_column": 5,
-              "start_line": 374
+              "start_line": 401
             }
           }
         },
@@ -10374,9 +10440,9 @@ expression: pretty
             "qualified_name": "validate_missing_path_returns_open_error",
             "span": {
               "end_column": 5,
-              "end_line": 394,
+              "end_line": 421,
               "start_column": 5,
-              "start_line": 384
+              "start_line": 411
             }
           }
         },
@@ -10398,9 +10464,9 @@ expression: pretty
             "qualified_name": "single_file_single_da",
             "span": {
               "end_column": 5,
-              "end_line": 404,
+              "end_line": 431,
               "start_column": 5,
-              "start_line": 396
+              "start_line": 423
             }
           }
         },
@@ -10422,9 +10488,9 @@ expression: pretty
             "qualified_name": "multiple_da_lines",
             "span": {
               "end_column": 5,
-              "end_line": 414,
+              "end_line": 441,
               "start_column": 5,
-              "start_line": 406
+              "start_line": 433
             }
           }
         },
@@ -10446,9 +10512,9 @@ expression: pretty
             "qualified_name": "multiple_source_files",
             "span": {
               "end_column": 5,
-              "end_line": 423,
+              "end_line": 450,
               "start_column": 5,
-              "start_line": 416
+              "start_line": 443
             }
           }
         },
@@ -10470,9 +10536,9 @@ expression: pretty
             "qualified_name": "hit_count_preservation",
             "span": {
               "end_column": 5,
-              "end_line": 431,
+              "end_line": 458,
               "start_column": 5,
-              "start_line": 425
+              "start_line": 452
             }
           }
         },
@@ -10494,9 +10560,9 @@ expression: pretty
             "qualified_name": "path_normalization_strips_prefix",
             "span": {
               "end_column": 5,
-              "end_line": 437,
+              "end_line": 464,
               "start_column": 5,
-              "start_line": 433
+              "start_line": 460
             }
           }
         },
@@ -10518,9 +10584,9 @@ expression: pretty
             "qualified_name": "non_matching_path_passes_through",
             "span": {
               "end_column": 5,
-              "end_line": 443,
+              "end_line": 470,
               "start_column": 5,
-              "start_line": 439
+              "start_line": 466
             }
           }
         },
@@ -10542,9 +10608,9 @@ expression: pretty
             "qualified_name": "backslash_normalized_to_forward_slash",
             "span": {
               "end_column": 5,
-              "end_line": 450,
+              "end_line": 477,
               "start_column": 5,
-              "start_line": 445
+              "start_line": 472
             }
           }
         },
@@ -10566,9 +10632,9 @@ expression: pretty
             "qualified_name": "path_boundary_not_confused_by_prefix_substring",
             "span": {
               "end_column": 5,
-              "end_line": 456,
+              "end_line": 483,
               "start_column": 5,
-              "start_line": 452
+              "start_line": 479
             }
           }
         },
@@ -10590,9 +10656,9 @@ expression: pretty
             "qualified_name": "repeated_sf_blocks_merge_coverage",
             "span": {
               "end_column": 5,
-              "end_line": 470,
+              "end_line": 497,
               "start_column": 5,
-              "start_line": 458
+              "start_line": 485
             }
           }
         },
@@ -10614,9 +10680,9 @@ expression: pretty
             "qualified_name": "duplicate_da_lines_sum_hits",
             "span": {
               "end_column": 5,
-              "end_line": 479,
+              "end_line": 506,
               "start_column": 5,
-              "start_line": 472
+              "start_line": 499
             }
           }
         },
@@ -10638,9 +10704,9 @@ expression: pretty
             "qualified_name": "duplicate_da_multiple_lines_sum_correctly",
             "span": {
               "end_column": 5,
-              "end_line": 491,
+              "end_line": 518,
               "start_column": 5,
-              "start_line": 481
+              "start_line": 508
             }
           }
         },
@@ -10662,9 +10728,9 @@ expression: pretty
             "qualified_name": "malformed_da_does_not_stop_parsing",
             "span": {
               "end_column": 5,
-              "end_line": 516,
+              "end_line": 543,
               "start_column": 5,
-              "start_line": 510
+              "start_line": 537
             }
           }
         },
@@ -10686,9 +10752,9 @@ expression: pretty
             "qualified_name": "da_missing_hit_count_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 526,
+              "end_line": 553,
               "start_column": 5,
-              "start_line": 518
+              "start_line": 545
             }
           }
         },
@@ -10710,9 +10776,9 @@ expression: pretty
             "qualified_name": "da_negative_hit_count_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 536,
+              "end_line": 563,
               "start_column": 5,
-              "start_line": 528
+              "start_line": 555
             }
           }
         },
@@ -10734,9 +10800,9 @@ expression: pretty
             "qualified_name": "end_of_record_is_ignored",
             "span": {
               "end_column": 5,
-              "end_line": 563,
+              "end_line": 590,
               "start_column": 5,
-              "start_line": 554
+              "start_line": 581
             }
           }
         },
@@ -10758,9 +10824,9 @@ expression: pretty
             "qualified_name": "unterminated_final_block_emits_data",
             "span": {
               "end_column": 5,
-              "end_line": 570,
+              "end_line": 597,
               "start_column": 5,
-              "start_line": 565
+              "start_line": 592
             }
           }
         },
@@ -10782,9 +10848,9 @@ expression: pretty
             "qualified_name": "empty_sf_path_emits_diagnostic",
             "span": {
               "end_column": 5,
-              "end_line": 581,
+              "end_line": 608,
               "start_column": 5,
-              "start_line": 572
+              "start_line": 599
             }
           }
         },
@@ -10806,9 +10872,9 @@ expression: pretty
             "qualified_name": "da_with_checksum_field_is_accepted",
             "span": {
               "end_column": 5,
-              "end_line": 590,
+              "end_line": 617,
               "start_column": 5,
-              "start_line": 583
+              "start_line": 610
             }
           }
         },
@@ -10830,9 +10896,9 @@ expression: pretty
             "qualified_name": "non_coverage_records_are_ignored",
             "span": {
               "end_column": 5,
-              "end_line": 604,
+              "end_line": 631,
               "start_column": 5,
-              "start_line": 592
+              "start_line": 619
             }
           }
         },
@@ -10854,9 +10920,9 @@ expression: pretty
             "qualified_name": "brda_and_da_records_parsed",
             "span": {
               "end_column": 5,
-              "end_line": 616,
+              "end_line": 643,
               "start_column": 5,
-              "start_line": 608
+              "start_line": 635
             }
           }
         },
@@ -10878,9 +10944,9 @@ expression: pretty
             "qualified_name": "brda_dash_maps_to_none",
             "span": {
               "end_column": 5,
-              "end_line": 623,
+              "end_line": 650,
               "start_column": 5,
-              "start_line": 618
+              "start_line": 645
             }
           }
         },
@@ -10902,9 +10968,9 @@ expression: pretty
             "qualified_name": "brda_numeric_maps_to_some",
             "span": {
               "end_column": 5,
-              "end_line": 630,
+              "end_line": 657,
               "start_column": 5,
-              "start_line": 625
+              "start_line": 652
             }
           }
         },
@@ -10926,9 +10992,9 @@ expression: pretty
             "qualified_name": "brda_zero_maps_to_some_zero",
             "span": {
               "end_column": 5,
-              "end_line": 637,
+              "end_line": 664,
               "start_column": 5,
-              "start_line": 632
+              "start_line": 659
             }
           }
         },
@@ -10950,9 +11016,9 @@ expression: pretty
             "qualified_name": "duplicate_brda_sum_taken",
             "span": {
               "end_column": 5,
-              "end_line": 647,
+              "end_line": 674,
               "start_column": 5,
-              "start_line": 639
+              "start_line": 666
             }
           }
         },
@@ -10974,9 +11040,9 @@ expression: pretty
             "qualified_name": "brda_dash_and_numeric_merge",
             "span": {
               "end_column": 5,
-              "end_line": 655,
+              "end_line": 682,
               "start_column": 5,
-              "start_line": 649
+              "start_line": 676
             }
           }
         },
@@ -10998,9 +11064,9 @@ expression: pretty
             "qualified_name": "brda_missing_fields_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 682,
+              "end_line": 709,
               "start_column": 5,
-              "start_line": 673
+              "start_line": 700
             }
           }
         },
@@ -11022,9 +11088,9 @@ expression: pretty
             "qualified_name": "brda_missing_taken_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 693,
+              "end_line": 720,
               "start_column": 5,
-              "start_line": 684
+              "start_line": 711
             }
           }
         },
@@ -11046,9 +11112,9 @@ expression: pretty
             "qualified_name": "brda_line_zero_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 732,
+              "end_line": 759,
               "start_column": 5,
-              "start_line": 724
+              "start_line": 751
             }
           }
         },
@@ -11070,9 +11136,9 @@ expression: pretty
             "qualified_name": "no_brda_produces_none_branches",
             "span": {
               "end_column": 5,
-              "end_line": 738,
+              "end_line": 765,
               "start_column": 5,
-              "start_line": 734
+              "start_line": 761
             }
           }
         },
@@ -11094,9 +11160,9 @@ expression: pretty
             "qualified_name": "arb_da_line",
             "span": {
               "end_column": 5,
-              "end_line": 748,
+              "end_line": 775,
               "start_column": 5,
-              "start_line": 746
+              "start_line": 773
             }
           }
         },
@@ -11118,9 +11184,9 @@ expression: pretty
             "qualified_name": "arb_lcov_input",
             "span": {
               "end_column": 5,
-              "end_line": 764,
+              "end_line": 791,
               "start_column": 5,
-              "start_line": 762
+              "start_line": 789
             }
           }
         },
@@ -11272,11 +11338,11 @@ expression: pretty
       }
     ],
     "shown_summary": {
-      "average_complexity": 1.5198019801980198,
+      "average_complexity": 1.522167487684729,
       "average_coverage": 0.0,
-      "average_crap": 5.7227722772277225,
+      "average_crap": 5.724137931034483,
       "distribution": {
-        "acceptable": 29,
+        "acceptable": 30,
         "high": 6,
         "low": 153,
         "moderate": 14
@@ -11292,15 +11358,15 @@ expression: pretty
       "median_crap": 2.0,
       "min_coverage": 0.0,
       "total_files": 5,
-      "total_functions": 202,
+      "total_functions": 203,
       "worst_function": {
         "file_path": "adapters/coverage/mod.rs",
         "qualified_name": "parse_brda",
         "span": {
           "end_column": 1,
-          "end_line": 205,
+          "end_line": 232,
           "start_column": 1,
-          "start_line": 182
+          "start_line": 209
         }
       }
     },

--- a/crates/crap-core/tests/snapshots/wire_envelope_crap4rs__envelope.snap
+++ b/crates/crap-core/tests/snapshots/wire_envelope_crap4rs__envelope.snap
@@ -3568,10 +3568,10 @@ expression: pretty
           "contributors": [
             {
               "column": 72,
-              "end_line": 94,
+              "end_line": 112,
               "increment": 1,
               "kind": "try",
-              "line": 94,
+              "line": 112,
               "nesting_depth": 0
             }
           ],
@@ -3585,7 +3585,7 @@ expression: pretty
             "qualified_name": "LcovParser::parse",
             "span": {
               "end_column": 5,
-              "end_line": 96,
+              "end_line": 114,
               "start_column": 5,
               "start_line": 81
             }
@@ -3601,58 +3601,58 @@ expression: pretty
           "contributors": [
             {
               "column": 73,
-              "end_line": 111,
+              "end_line": 129,
               "increment": 1,
               "kind": "try",
-              "line": 111,
+              "line": 129,
               "nesting_depth": 0
             },
             {
               "column": 9,
-              "end_line": 128,
+              "end_line": 146,
               "increment": 1,
               "kind": "for-loop",
-              "line": 114,
+              "line": 132,
               "nesting_depth": 0
             },
             {
               "column": 68,
-              "end_line": 115,
+              "end_line": 133,
               "increment": 1,
               "kind": "try",
-              "line": 115,
+              "line": 133,
               "nesting_depth": 1
             },
             {
               "column": 13,
-              "end_line": 119,
+              "end_line": 137,
               "increment": 2,
               "kind": "if-branch",
-              "line": 116,
+              "line": 134,
               "nesting_depth": 1
             },
             {
               "column": 17,
-              "end_line": 118,
+              "end_line": 136,
               "increment": 1,
               "kind": "continue",
-              "line": 118,
+              "line": 136,
               "nesting_depth": 2
             },
             {
               "column": 13,
-              "end_line": 127,
+              "end_line": 145,
               "increment": 2,
               "kind": "if-branch",
-              "line": 120,
+              "line": 138,
               "nesting_depth": 1
             },
             {
               "column": 17,
-              "end_line": 121,
+              "end_line": 139,
               "increment": 1,
               "kind": "logical-operator",
-              "line": 121,
+              "line": 139,
               "nesting_depth": 1
             }
           ],
@@ -3666,9 +3666,9 @@ expression: pretty
             "qualified_name": "LcovParser::validate",
             "span": {
               "end_column": 5,
-              "end_line": 130,
+              "end_line": 148,
               "start_column": 5,
-              "start_line": 98
+              "start_line": 116
             }
           }
         },
@@ -3682,26 +3682,26 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 137,
+              "end_line": 155,
               "increment": 1,
               "kind": "if-branch",
-              "line": 134,
+              "line": 152,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 142,
+              "end_line": 160,
               "increment": 1,
               "kind": "if-branch",
-              "line": 139,
+              "line": 157,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 146,
+              "end_line": 164,
               "increment": 1,
               "kind": "if-branch",
-              "line": 144,
+              "line": 162,
               "nesting_depth": 0
             }
           ],
@@ -3715,9 +3715,9 @@ expression: pretty
             "qualified_name": "handle_parse_line",
             "span": {
               "end_column": 1,
-              "end_line": 147,
+              "end_line": 165,
               "start_column": 1,
-              "start_line": 133
+              "start_line": 151
             }
           }
         },
@@ -3731,10 +3731,10 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 159,
+              "end_line": 177,
               "increment": 1,
               "kind": "if-branch",
-              "line": 152,
+              "line": 170,
               "nesting_depth": 0
             }
           ],
@@ -3748,9 +3748,9 @@ expression: pretty
             "qualified_name": "start_source_file",
             "span": {
               "end_column": 1,
-              "end_line": 160,
+              "end_line": 178,
               "start_column": 1,
-              "start_line": 149
+              "start_line": 167
             }
           }
         },
@@ -3764,18 +3764,18 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 165,
+              "end_line": 183,
               "increment": 1,
               "kind": "if-branch",
-              "line": 163,
+              "line": 181,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 170,
+              "end_line": 188,
               "increment": 1,
               "kind": "match",
-              "line": 167,
+              "line": 185,
               "nesting_depth": 0
             }
           ],
@@ -3789,9 +3789,9 @@ expression: pretty
             "qualified_name": "record_da",
             "span": {
               "end_column": 1,
-              "end_line": 171,
+              "end_line": 189,
               "start_column": 1,
-              "start_line": 162
+              "start_line": 180
             }
           }
         },
@@ -3805,18 +3805,18 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 176,
+              "end_line": 194,
               "increment": 1,
               "kind": "if-branch",
-              "line": 174,
+              "line": 192,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 183,
+              "end_line": 201,
               "increment": 1,
               "kind": "match",
-              "line": 178,
+              "line": 196,
               "nesting_depth": 0
             }
           ],
@@ -3830,9 +3830,9 @@ expression: pretty
             "qualified_name": "record_brda",
             "span": {
               "end_column": 1,
-              "end_line": 184,
+              "end_line": 202,
               "start_column": 1,
-              "start_line": 173
+              "start_line": 191
             }
           }
         },
@@ -3854,9 +3854,9 @@ expression: pretty
             "qualified_name": "push_malformed_record",
             "span": {
               "end_column": 1,
-              "end_line": 193,
+              "end_line": 211,
               "start_column": 1,
-              "start_line": 186
+              "start_line": 204
             }
           }
         },
@@ -3870,87 +3870,6 @@ expression: pretty
           "contributors": [
             {
               "column": 56,
-              "end_line": 198,
-              "increment": 1,
-              "kind": "try",
-              "line": 198,
-              "nesting_depth": 0
-            },
-            {
-              "column": 52,
-              "end_line": 200,
-              "increment": 1,
-              "kind": "try",
-              "line": 200,
-              "nesting_depth": 0
-            },
-            {
-              "column": 58,
-              "end_line": 201,
-              "increment": 1,
-              "kind": "try",
-              "line": 201,
-              "nesting_depth": 0
-            },
-            {
-              "column": 5,
-              "end_line": 204,
-              "increment": 1,
-              "kind": "if-branch",
-              "line": 202,
-              "nesting_depth": 0
-            },
-            {
-              "column": 53,
-              "end_line": 205,
-              "increment": 1,
-              "kind": "try",
-              "line": 205,
-              "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "high",
-            "value": 42.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "parse_da",
-            "span": {
-              "end_column": 1,
-              "end_line": 207,
-              "start_column": 1,
-              "start_line": 195
-            }
-          }
-        },
-        "threshold": 25.0
-      },
-      {
-        "exceeds": true,
-        "scored": {
-          "complexity": 11,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 42,
-              "end_line": 214,
-              "increment": 1,
-              "kind": "try",
-              "line": 214,
-              "nesting_depth": 0
-            },
-            {
-              "column": 43,
-              "end_line": 215,
-              "increment": 1,
-              "kind": "try",
-              "line": 215,
-              "nesting_depth": 0
-            },
-            {
-              "column": 44,
               "end_line": 216,
               "increment": 1,
               "kind": "try",
@@ -3958,11 +3877,11 @@ expression: pretty
               "nesting_depth": 0
             },
             {
-              "column": 43,
-              "end_line": 217,
+              "column": 52,
+              "end_line": 218,
               "increment": 1,
               "kind": "try",
-              "line": 217,
+              "line": 218,
               "nesting_depth": 0
             },
             {
@@ -3982,35 +3901,116 @@ expression: pretty
               "nesting_depth": 0
             },
             {
-              "column": 55,
+              "column": 53,
               "end_line": 223,
               "increment": 1,
               "kind": "try",
               "line": 223,
               "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 0.0,
+          "crap": {
+            "risk_level": "high",
+            "value": 42.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "parse_da",
+            "span": {
+              "end_column": 1,
+              "end_line": 225,
+              "start_column": 1,
+              "start_line": 213
+            }
+          }
+        },
+        "threshold": 25.0
+      },
+      {
+        "exceeds": true,
+        "scored": {
+          "complexity": 11,
+          "complexity_metric": "cognitive",
+          "contributors": [
+            {
+              "column": 42,
+              "end_line": 232,
+              "increment": 1,
+              "kind": "try",
+              "line": 232,
+              "nesting_depth": 0
+            },
+            {
+              "column": 43,
+              "end_line": 233,
+              "increment": 1,
+              "kind": "try",
+              "line": 233,
+              "nesting_depth": 0
+            },
+            {
+              "column": 44,
+              "end_line": 234,
+              "increment": 1,
+              "kind": "try",
+              "line": 234,
+              "nesting_depth": 0
+            },
+            {
+              "column": 43,
+              "end_line": 235,
+              "increment": 1,
+              "kind": "try",
+              "line": 235,
+              "nesting_depth": 0
+            },
+            {
+              "column": 58,
+              "end_line": 237,
+              "increment": 1,
+              "kind": "try",
+              "line": 237,
+              "nesting_depth": 0
+            },
+            {
+              "column": 5,
+              "end_line": 240,
+              "increment": 1,
+              "kind": "if-branch",
+              "line": 238,
+              "nesting_depth": 0
+            },
+            {
+              "column": 55,
+              "end_line": 241,
+              "increment": 1,
+              "kind": "try",
+              "line": 241,
+              "nesting_depth": 0
             },
             {
               "column": 57,
-              "end_line": 224,
+              "end_line": 242,
               "increment": 1,
               "kind": "try",
-              "line": 224,
+              "line": 242,
               "nesting_depth": 0
             },
             {
               "column": 17,
-              "end_line": 229,
+              "end_line": 247,
               "increment": 1,
               "kind": "if-branch",
-              "line": 225,
+              "line": 243,
               "nesting_depth": 0
             },
             {
               "column": 54,
-              "end_line": 228,
+              "end_line": 246,
               "increment": 1,
               "kind": "try",
-              "line": 228,
+              "line": 246,
               "nesting_depth": 1
             }
           ],
@@ -4024,9 +4024,9 @@ expression: pretty
             "qualified_name": "parse_brda",
             "span": {
               "end_column": 1,
-              "end_line": 232,
+              "end_line": 250,
               "start_column": 1,
-              "start_line": 209
+              "start_line": 227
             }
           }
         },
@@ -4040,10 +4040,10 @@ expression: pretty
           "contributors": [
             {
               "column": 52,
-              "end_line": 238,
+              "end_line": 256,
               "increment": 1,
               "kind": "let-else",
-              "line": 235,
+              "line": 253,
               "nesting_depth": 0
             }
           ],
@@ -4057,9 +4057,9 @@ expression: pretty
             "qualified_name": "flush_block",
             "span": {
               "end_column": 1,
-              "end_line": 243,
+              "end_line": 261,
               "start_column": 1,
-              "start_line": 234
+              "start_line": 252
             }
           }
         },
@@ -4073,18 +4073,18 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 252,
+              "end_line": 270,
               "increment": 1,
               "kind": "if-branch",
-              "line": 250,
+              "line": 268,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 257,
+              "end_line": 275,
               "increment": 1,
               "kind": "for-loop",
-              "line": 255,
+              "line": 273,
               "nesting_depth": 0
             }
           ],
@@ -4098,9 +4098,9 @@ expression: pretty
             "qualified_name": "merge_line_block",
             "span": {
               "end_column": 1,
-              "end_line": 258,
+              "end_line": 276,
               "start_column": 1,
-              "start_line": 245
+              "start_line": 263
             }
           }
         },
@@ -4114,18 +4114,18 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 267,
+              "end_line": 285,
               "increment": 1,
               "kind": "if-branch",
-              "line": 265,
+              "line": 283,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 272,
+              "end_line": 290,
               "increment": 1,
               "kind": "for-loop",
-              "line": 270,
+              "line": 288,
               "nesting_depth": 0
             }
           ],
@@ -4139,9 +4139,9 @@ expression: pretty
             "qualified_name": "merge_branch_block",
             "span": {
               "end_column": 1,
-              "end_line": 273,
+              "end_line": 291,
               "start_column": 1,
-              "start_line": 260
+              "start_line": 278
             }
           }
         },
@@ -4163,9 +4163,9 @@ expression: pretty
             "qualified_name": "merge_hits",
             "span": {
               "end_column": 1,
-              "end_line": 280,
+              "end_line": 298,
               "start_column": 1,
-              "start_line": 275
+              "start_line": 293
             }
           }
         },
@@ -4187,9 +4187,9 @@ expression: pretty
             "qualified_name": "merge_branch_value",
             "span": {
               "end_column": 1,
-              "end_line": 291,
+              "end_line": 309,
               "start_column": 1,
-              "start_line": 282
+              "start_line": 300
             }
           }
         },
@@ -4203,10 +4203,10 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 299,
+              "end_line": 317,
               "increment": 1,
               "kind": "match",
-              "line": 294,
+              "line": 312,
               "nesting_depth": 0
             }
           ],
@@ -4220,9 +4220,9 @@ expression: pretty
             "qualified_name": "merge_taken",
             "span": {
               "end_column": 1,
-              "end_line": 300,
+              "end_line": 318,
               "start_column": 1,
-              "start_line": 293
+              "start_line": 311
             }
           }
         },
@@ -4244,9 +4244,9 @@ expression: pretty
             "qualified_name": "clear_current_block",
             "span": {
               "end_column": 1,
-              "end_line": 305,
+              "end_line": 323,
               "start_column": 1,
-              "start_line": 302
+              "start_line": 320
             }
           }
         },
@@ -4268,9 +4268,9 @@ expression: pretty
             "qualified_name": "build_parse_output",
             "span": {
               "end_column": 1,
-              "end_line": 333,
+              "end_line": 351,
               "start_column": 1,
-              "start_line": 307
+              "start_line": 325
             }
           }
         },
@@ -4292,9 +4292,9 @@ expression: pretty
             "qualified_name": "to_line_coverage",
             "span": {
               "end_column": 1,
-              "end_line": 340,
+              "end_line": 358,
               "start_column": 1,
-              "start_line": 335
+              "start_line": 353
             }
           }
         },
@@ -4316,9 +4316,9 @@ expression: pretty
             "qualified_name": "parser",
             "span": {
               "end_column": 5,
-              "end_line": 349,
+              "end_line": 367,
               "start_column": 5,
-              "start_line": 347
+              "start_line": 365
             }
           }
         },
@@ -4340,9 +4340,9 @@ expression: pretty
             "qualified_name": "parse",
             "span": {
               "end_column": 5,
-              "end_line": 353,
+              "end_line": 371,
               "start_column": 5,
-              "start_line": 351
+              "start_line": 369
             }
           }
         },
@@ -4364,9 +4364,9 @@ expression: pretty
             "qualified_name": "empty_input_returns_empty_output",
             "span": {
               "end_column": 5,
-              "end_line": 360,
+              "end_line": 378,
               "start_column": 5,
-              "start_line": 355
+              "start_line": 373
             }
           }
         },
@@ -4388,9 +4388,9 @@ expression: pretty
             "qualified_name": "validate_str",
             "span": {
               "end_column": 5,
-              "end_line": 374,
+              "end_line": 392,
               "start_column": 5,
-              "start_line": 364
+              "start_line": 382
             }
           }
         },
@@ -4412,9 +4412,9 @@ expression: pretty
             "qualified_name": "validate_empty_input_rejected",
             "span": {
               "end_column": 5,
-              "end_line": 379,
+              "end_line": 397,
               "start_column": 5,
-              "start_line": 376
+              "start_line": 394
             }
           }
         },
@@ -4436,9 +4436,9 @@ expression: pretty
             "qualified_name": "validate_no_da_lines_rejected",
             "span": {
               "end_column": 5,
-              "end_line": 384,
+              "end_line": 402,
               "start_column": 5,
-              "start_line": 381
+              "start_line": 399
             }
           }
         },
@@ -4460,9 +4460,9 @@ expression: pretty
             "qualified_name": "validate_da_outside_sf_block_rejected",
             "span": {
               "end_column": 5,
-              "end_line": 389,
+              "end_line": 407,
               "start_column": 5,
-              "start_line": 386
+              "start_line": 404
             }
           }
         },
@@ -4484,9 +4484,9 @@ expression: pretty
             "qualified_name": "validate_malformed_da_rejected",
             "span": {
               "end_column": 5,
-              "end_line": 394,
+              "end_line": 412,
               "start_column": 5,
-              "start_line": 391
+              "start_line": 409
             }
           }
         },
@@ -4508,9 +4508,9 @@ expression: pretty
             "qualified_name": "validate_single_da_inside_sf_block_passes",
             "span": {
               "end_column": 5,
-              "end_line": 399,
+              "end_line": 417,
               "start_column": 5,
-              "start_line": 396
+              "start_line": 414
             }
           }
         },
@@ -4532,9 +4532,9 @@ expression: pretty
             "qualified_name": "validate_first_da_in_second_block_passes",
             "span": {
               "end_column": 5,
-              "end_line": 409,
+              "end_line": 427,
               "start_column": 5,
-              "start_line": 401
+              "start_line": 419
             }
           }
         },
@@ -4556,9 +4556,9 @@ expression: pretty
             "qualified_name": "validate_missing_path_returns_open_error",
             "span": {
               "end_column": 5,
-              "end_line": 421,
+              "end_line": 439,
               "start_column": 5,
-              "start_line": 411
+              "start_line": 429
             }
           }
         },
@@ -4580,9 +4580,9 @@ expression: pretty
             "qualified_name": "single_file_single_da",
             "span": {
               "end_column": 5,
-              "end_line": 431,
+              "end_line": 449,
               "start_column": 5,
-              "start_line": 423
+              "start_line": 441
             }
           }
         },
@@ -4604,9 +4604,9 @@ expression: pretty
             "qualified_name": "multiple_da_lines",
             "span": {
               "end_column": 5,
-              "end_line": 441,
+              "end_line": 459,
               "start_column": 5,
-              "start_line": 433
+              "start_line": 451
             }
           }
         },
@@ -4628,9 +4628,9 @@ expression: pretty
             "qualified_name": "multiple_source_files",
             "span": {
               "end_column": 5,
-              "end_line": 450,
+              "end_line": 468,
               "start_column": 5,
-              "start_line": 443
+              "start_line": 461
             }
           }
         },
@@ -4652,9 +4652,9 @@ expression: pretty
             "qualified_name": "hit_count_preservation",
             "span": {
               "end_column": 5,
-              "end_line": 458,
+              "end_line": 476,
               "start_column": 5,
-              "start_line": 452
+              "start_line": 470
             }
           }
         },
@@ -4676,9 +4676,9 @@ expression: pretty
             "qualified_name": "path_normalization_strips_prefix",
             "span": {
               "end_column": 5,
-              "end_line": 464,
+              "end_line": 482,
               "start_column": 5,
-              "start_line": 460
+              "start_line": 478
             }
           }
         },
@@ -4700,9 +4700,9 @@ expression: pretty
             "qualified_name": "non_matching_path_passes_through",
             "span": {
               "end_column": 5,
-              "end_line": 470,
+              "end_line": 488,
               "start_column": 5,
-              "start_line": 466
+              "start_line": 484
             }
           }
         },
@@ -4724,9 +4724,9 @@ expression: pretty
             "qualified_name": "backslash_normalized_to_forward_slash",
             "span": {
               "end_column": 5,
-              "end_line": 477,
+              "end_line": 495,
               "start_column": 5,
-              "start_line": 472
+              "start_line": 490
             }
           }
         },
@@ -4748,9 +4748,9 @@ expression: pretty
             "qualified_name": "path_boundary_not_confused_by_prefix_substring",
             "span": {
               "end_column": 5,
-              "end_line": 483,
+              "end_line": 501,
               "start_column": 5,
-              "start_line": 479
+              "start_line": 497
             }
           }
         },
@@ -4772,9 +4772,9 @@ expression: pretty
             "qualified_name": "repeated_sf_blocks_merge_coverage",
             "span": {
               "end_column": 5,
-              "end_line": 497,
+              "end_line": 515,
               "start_column": 5,
-              "start_line": 485
+              "start_line": 503
             }
           }
         },
@@ -4796,9 +4796,9 @@ expression: pretty
             "qualified_name": "duplicate_da_lines_sum_hits",
             "span": {
               "end_column": 5,
-              "end_line": 506,
+              "end_line": 524,
               "start_column": 5,
-              "start_line": 499
+              "start_line": 517
             }
           }
         },
@@ -4820,9 +4820,9 @@ expression: pretty
             "qualified_name": "duplicate_da_multiple_lines_sum_correctly",
             "span": {
               "end_column": 5,
-              "end_line": 518,
+              "end_line": 536,
               "start_column": 5,
-              "start_line": 508
+              "start_line": 526
             }
           }
         },
@@ -4836,10 +4836,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 534,
+              "end_line": 552,
               "increment": 1,
               "kind": "match",
-              "line": 525,
+              "line": 543,
               "nesting_depth": 0
             }
           ],
@@ -4853,9 +4853,9 @@ expression: pretty
             "qualified_name": "malformed_da_produces_diagnostic",
             "span": {
               "end_column": 5,
-              "end_line": 535,
+              "end_line": 553,
               "start_column": 5,
-              "start_line": 520
+              "start_line": 538
             }
           }
         },
@@ -4877,9 +4877,9 @@ expression: pretty
             "qualified_name": "malformed_da_does_not_stop_parsing",
             "span": {
               "end_column": 5,
-              "end_line": 543,
+              "end_line": 561,
               "start_column": 5,
-              "start_line": 537
+              "start_line": 555
             }
           }
         },
@@ -4901,9 +4901,9 @@ expression: pretty
             "qualified_name": "da_missing_hit_count_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 553,
+              "end_line": 571,
               "start_column": 5,
-              "start_line": 545
+              "start_line": 563
             }
           }
         },
@@ -4925,9 +4925,9 @@ expression: pretty
             "qualified_name": "da_negative_hit_count_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 563,
+              "end_line": 581,
               "start_column": 5,
-              "start_line": 555
+              "start_line": 573
             }
           }
         },
@@ -4941,10 +4941,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 578,
+              "end_line": 596,
               "increment": 1,
               "kind": "match",
-              "line": 569,
+              "line": 587,
               "nesting_depth": 0
             }
           ],
@@ -4958,9 +4958,9 @@ expression: pretty
             "qualified_name": "da_line_zero_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 579,
+              "end_line": 597,
               "start_column": 5,
-              "start_line": 565
+              "start_line": 583
             }
           }
         },
@@ -4980,54 +4980,6 @@ expression: pretty
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
             "qualified_name": "end_of_record_is_ignored",
-            "span": {
-              "end_column": 5,
-              "end_line": 590,
-              "start_column": 5,
-              "start_line": 581
-            }
-          }
-        },
-        "threshold": 25.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "unterminated_final_block_emits_data",
-            "span": {
-              "end_column": 5,
-              "end_line": 597,
-              "start_column": 5,
-              "start_line": 592
-            }
-          }
-        },
-        "threshold": 25.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "empty_sf_path_emits_diagnostic",
             "span": {
               "end_column": 5,
               "end_line": 608,
@@ -5051,12 +5003,60 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "unterminated_final_block_emits_data",
+            "span": {
+              "end_column": 5,
+              "end_line": 615,
+              "start_column": 5,
+              "start_line": 610
+            }
+          }
+        },
+        "threshold": 25.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 0.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "empty_sf_path_emits_diagnostic",
+            "span": {
+              "end_column": 5,
+              "end_line": 626,
+              "start_column": 5,
+              "start_line": 617
+            }
+          }
+        },
+        "threshold": 25.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 0.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
             "qualified_name": "da_with_checksum_field_is_accepted",
             "span": {
               "end_column": 5,
-              "end_line": 617,
+              "end_line": 635,
               "start_column": 5,
-              "start_line": 610
+              "start_line": 628
             }
           }
         },
@@ -5078,9 +5078,9 @@ expression: pretty
             "qualified_name": "non_coverage_records_are_ignored",
             "span": {
               "end_column": 5,
-              "end_line": 631,
+              "end_line": 649,
               "start_column": 5,
-              "start_line": 619
+              "start_line": 637
             }
           }
         },
@@ -5102,9 +5102,9 @@ expression: pretty
             "qualified_name": "brda_and_da_records_parsed",
             "span": {
               "end_column": 5,
-              "end_line": 643,
+              "end_line": 661,
               "start_column": 5,
-              "start_line": 635
+              "start_line": 653
             }
           }
         },
@@ -5126,9 +5126,9 @@ expression: pretty
             "qualified_name": "brda_dash_maps_to_none",
             "span": {
               "end_column": 5,
-              "end_line": 650,
+              "end_line": 668,
               "start_column": 5,
-              "start_line": 645
+              "start_line": 663
             }
           }
         },
@@ -5150,9 +5150,9 @@ expression: pretty
             "qualified_name": "brda_numeric_maps_to_some",
             "span": {
               "end_column": 5,
-              "end_line": 657,
+              "end_line": 675,
               "start_column": 5,
-              "start_line": 652
+              "start_line": 670
             }
           }
         },
@@ -5174,9 +5174,9 @@ expression: pretty
             "qualified_name": "brda_zero_maps_to_some_zero",
             "span": {
               "end_column": 5,
-              "end_line": 664,
+              "end_line": 682,
               "start_column": 5,
-              "start_line": 659
+              "start_line": 677
             }
           }
         },
@@ -5198,9 +5198,9 @@ expression: pretty
             "qualified_name": "duplicate_brda_sum_taken",
             "span": {
               "end_column": 5,
-              "end_line": 674,
+              "end_line": 692,
               "start_column": 5,
-              "start_line": 666
+              "start_line": 684
             }
           }
         },
@@ -5222,9 +5222,9 @@ expression: pretty
             "qualified_name": "brda_dash_and_numeric_merge",
             "span": {
               "end_column": 5,
-              "end_line": 682,
+              "end_line": 700,
               "start_column": 5,
-              "start_line": 676
+              "start_line": 694
             }
           }
         },
@@ -5238,10 +5238,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 697,
+              "end_line": 715,
               "increment": 1,
               "kind": "match",
-              "line": 688,
+              "line": 706,
               "nesting_depth": 0
             }
           ],
@@ -5255,9 +5255,9 @@ expression: pretty
             "qualified_name": "malformed_brda_produces_diagnostic",
             "span": {
               "end_column": 5,
-              "end_line": 698,
+              "end_line": 716,
               "start_column": 5,
-              "start_line": 684
+              "start_line": 702
             }
           }
         },
@@ -5279,9 +5279,9 @@ expression: pretty
             "qualified_name": "brda_missing_fields_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 709,
+              "end_line": 727,
               "start_column": 5,
-              "start_line": 700
+              "start_line": 718
             }
           }
         },
@@ -5303,9 +5303,9 @@ expression: pretty
             "qualified_name": "brda_missing_taken_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 720,
+              "end_line": 738,
               "start_column": 5,
-              "start_line": 711
+              "start_line": 729
             }
           }
         },
@@ -5319,10 +5319,10 @@ expression: pretty
           "contributors": [
             {
               "column": 13,
-              "end_line": 739,
+              "end_line": 757,
               "increment": 1,
               "kind": "for-loop",
-              "line": 737,
+              "line": 755,
               "nesting_depth": 0
             }
           ],
@@ -5336,9 +5336,9 @@ expression: pretty
             "qualified_name": "repeated_sf_blocks_merge_branch_coverage",
             "span": {
               "end_column": 5,
-              "end_line": 749,
+              "end_line": 767,
               "start_column": 5,
-              "start_line": 722
+              "start_line": 740
             }
           }
         },
@@ -5360,9 +5360,9 @@ expression: pretty
             "qualified_name": "brda_line_zero_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 759,
+              "end_line": 777,
               "start_column": 5,
-              "start_line": 751
+              "start_line": 769
             }
           }
         },
@@ -5384,9 +5384,9 @@ expression: pretty
             "qualified_name": "no_brda_produces_none_branches",
             "span": {
               "end_column": 5,
-              "end_line": 765,
+              "end_line": 783,
               "start_column": 5,
-              "start_line": 761
+              "start_line": 779
             }
           }
         },
@@ -5408,9 +5408,9 @@ expression: pretty
             "qualified_name": "arb_da_line",
             "span": {
               "end_column": 5,
-              "end_line": 775,
+              "end_line": 793,
               "start_column": 5,
-              "start_line": 773
+              "start_line": 791
             }
           }
         },
@@ -5424,10 +5424,10 @@ expression: pretty
           "contributors": [
             {
               "column": 13,
-              "end_line": 783,
+              "end_line": 801,
               "increment": 2,
               "kind": "for-loop",
-              "line": 780,
+              "line": 798,
               "nesting_depth": 1
             }
           ],
@@ -5441,9 +5441,9 @@ expression: pretty
             "qualified_name": "arb_lcov_block",
             "span": {
               "end_column": 5,
-              "end_line": 787,
+              "end_line": 805,
               "start_column": 5,
-              "start_line": 777
+              "start_line": 795
             }
           }
         },
@@ -5465,9 +5465,9 @@ expression: pretty
             "qualified_name": "arb_lcov_input",
             "span": {
               "end_column": 5,
-              "end_line": 791,
+              "end_line": 809,
               "start_column": 5,
-              "start_line": 789
+              "start_line": 807
             }
           }
         },
@@ -5679,9 +5679,9 @@ expression: pretty
         "qualified_name": "parse_brda",
         "span": {
           "end_column": 1,
-          "end_line": 232,
+          "end_line": 250,
           "start_column": 1,
-          "start_line": 209
+          "start_line": 227
         }
       }
     }
@@ -5702,82 +5702,82 @@ expression: pretty
           "contributors": [
             {
               "column": 42,
-              "end_line": 214,
+              "end_line": 232,
               "increment": 1,
               "kind": "try",
-              "line": 214,
+              "line": 232,
               "nesting_depth": 0
             },
             {
               "column": 43,
-              "end_line": 215,
+              "end_line": 233,
               "increment": 1,
               "kind": "try",
-              "line": 215,
+              "line": 233,
               "nesting_depth": 0
             },
             {
               "column": 44,
-              "end_line": 216,
+              "end_line": 234,
               "increment": 1,
               "kind": "try",
-              "line": 216,
+              "line": 234,
               "nesting_depth": 0
             },
             {
               "column": 43,
-              "end_line": 217,
+              "end_line": 235,
               "increment": 1,
               "kind": "try",
-              "line": 217,
+              "line": 235,
               "nesting_depth": 0
             },
             {
               "column": 58,
-              "end_line": 219,
+              "end_line": 237,
               "increment": 1,
               "kind": "try",
-              "line": 219,
+              "line": 237,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 222,
+              "end_line": 240,
               "increment": 1,
               "kind": "if-branch",
-              "line": 220,
+              "line": 238,
               "nesting_depth": 0
             },
             {
               "column": 55,
-              "end_line": 223,
+              "end_line": 241,
               "increment": 1,
               "kind": "try",
-              "line": 223,
+              "line": 241,
               "nesting_depth": 0
             },
             {
               "column": 57,
-              "end_line": 224,
+              "end_line": 242,
               "increment": 1,
               "kind": "try",
-              "line": 224,
+              "line": 242,
               "nesting_depth": 0
             },
             {
               "column": 17,
-              "end_line": 229,
+              "end_line": 247,
               "increment": 1,
               "kind": "if-branch",
-              "line": 225,
+              "line": 243,
               "nesting_depth": 0
             },
             {
               "column": 54,
-              "end_line": 228,
+              "end_line": 246,
               "increment": 1,
               "kind": "try",
-              "line": 228,
+              "line": 246,
               "nesting_depth": 1
             }
           ],
@@ -5791,9 +5791,9 @@ expression: pretty
             "qualified_name": "parse_brda",
             "span": {
               "end_column": 1,
-              "end_line": 232,
+              "end_line": 250,
               "start_column": 1,
-              "start_line": 209
+              "start_line": 227
             }
           }
         },
@@ -5807,58 +5807,58 @@ expression: pretty
           "contributors": [
             {
               "column": 73,
-              "end_line": 111,
+              "end_line": 129,
               "increment": 1,
               "kind": "try",
-              "line": 111,
+              "line": 129,
               "nesting_depth": 0
             },
             {
               "column": 9,
-              "end_line": 128,
+              "end_line": 146,
               "increment": 1,
               "kind": "for-loop",
-              "line": 114,
+              "line": 132,
               "nesting_depth": 0
             },
             {
               "column": 68,
-              "end_line": 115,
+              "end_line": 133,
               "increment": 1,
               "kind": "try",
-              "line": 115,
+              "line": 133,
               "nesting_depth": 1
             },
             {
               "column": 13,
-              "end_line": 119,
+              "end_line": 137,
               "increment": 2,
               "kind": "if-branch",
-              "line": 116,
+              "line": 134,
               "nesting_depth": 1
             },
             {
               "column": 17,
-              "end_line": 118,
+              "end_line": 136,
               "increment": 1,
               "kind": "continue",
-              "line": 118,
+              "line": 136,
               "nesting_depth": 2
             },
             {
               "column": 13,
-              "end_line": 127,
+              "end_line": 145,
               "increment": 2,
               "kind": "if-branch",
-              "line": 120,
+              "line": 138,
               "nesting_depth": 1
             },
             {
               "column": 17,
-              "end_line": 121,
+              "end_line": 139,
               "increment": 1,
               "kind": "logical-operator",
-              "line": 121,
+              "line": 139,
               "nesting_depth": 1
             }
           ],
@@ -5872,9 +5872,9 @@ expression: pretty
             "qualified_name": "LcovParser::validate",
             "span": {
               "end_column": 5,
-              "end_line": 130,
+              "end_line": 148,
               "start_column": 5,
-              "start_line": 98
+              "start_line": 116
             }
           }
         },
@@ -6043,42 +6043,42 @@ expression: pretty
           "contributors": [
             {
               "column": 56,
-              "end_line": 198,
+              "end_line": 216,
               "increment": 1,
               "kind": "try",
-              "line": 198,
+              "line": 216,
               "nesting_depth": 0
             },
             {
               "column": 52,
-              "end_line": 200,
+              "end_line": 218,
               "increment": 1,
               "kind": "try",
-              "line": 200,
+              "line": 218,
               "nesting_depth": 0
             },
             {
               "column": 58,
-              "end_line": 201,
+              "end_line": 219,
               "increment": 1,
               "kind": "try",
-              "line": 201,
+              "line": 219,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 204,
+              "end_line": 222,
               "increment": 1,
               "kind": "if-branch",
-              "line": 202,
+              "line": 220,
               "nesting_depth": 0
             },
             {
               "column": 53,
-              "end_line": 205,
+              "end_line": 223,
               "increment": 1,
               "kind": "try",
-              "line": 205,
+              "line": 223,
               "nesting_depth": 0
             }
           ],
@@ -6092,9 +6092,9 @@ expression: pretty
             "qualified_name": "parse_da",
             "span": {
               "end_column": 1,
-              "end_line": 207,
+              "end_line": 225,
               "start_column": 1,
-              "start_line": 195
+              "start_line": 213
             }
           }
         },
@@ -6272,26 +6272,26 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 137,
+              "end_line": 155,
               "increment": 1,
               "kind": "if-branch",
-              "line": 134,
+              "line": 152,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 142,
+              "end_line": 160,
               "increment": 1,
               "kind": "if-branch",
-              "line": 139,
+              "line": 157,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 146,
+              "end_line": 164,
               "increment": 1,
               "kind": "if-branch",
-              "line": 144,
+              "line": 162,
               "nesting_depth": 0
             }
           ],
@@ -6305,9 +6305,9 @@ expression: pretty
             "qualified_name": "handle_parse_line",
             "span": {
               "end_column": 1,
-              "end_line": 147,
+              "end_line": 165,
               "start_column": 1,
-              "start_line": 133
+              "start_line": 151
             }
           }
         },
@@ -6485,18 +6485,18 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 165,
+              "end_line": 183,
               "increment": 1,
               "kind": "if-branch",
-              "line": 163,
+              "line": 181,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 170,
+              "end_line": 188,
               "increment": 1,
               "kind": "match",
-              "line": 167,
+              "line": 185,
               "nesting_depth": 0
             }
           ],
@@ -6510,9 +6510,9 @@ expression: pretty
             "qualified_name": "record_da",
             "span": {
               "end_column": 1,
-              "end_line": 171,
+              "end_line": 189,
               "start_column": 1,
-              "start_line": 162
+              "start_line": 180
             }
           }
         },
@@ -6526,18 +6526,18 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 176,
+              "end_line": 194,
               "increment": 1,
               "kind": "if-branch",
-              "line": 174,
+              "line": 192,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 183,
+              "end_line": 201,
               "increment": 1,
               "kind": "match",
-              "line": 178,
+              "line": 196,
               "nesting_depth": 0
             }
           ],
@@ -6551,9 +6551,9 @@ expression: pretty
             "qualified_name": "record_brda",
             "span": {
               "end_column": 1,
-              "end_line": 184,
+              "end_line": 202,
               "start_column": 1,
-              "start_line": 173
+              "start_line": 191
             }
           }
         },
@@ -6567,18 +6567,18 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 252,
+              "end_line": 270,
               "increment": 1,
               "kind": "if-branch",
-              "line": 250,
+              "line": 268,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 257,
+              "end_line": 275,
               "increment": 1,
               "kind": "for-loop",
-              "line": 255,
+              "line": 273,
               "nesting_depth": 0
             }
           ],
@@ -6592,9 +6592,9 @@ expression: pretty
             "qualified_name": "merge_line_block",
             "span": {
               "end_column": 1,
-              "end_line": 258,
+              "end_line": 276,
               "start_column": 1,
-              "start_line": 245
+              "start_line": 263
             }
           }
         },
@@ -6608,18 +6608,18 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 267,
+              "end_line": 285,
               "increment": 1,
               "kind": "if-branch",
-              "line": 265,
+              "line": 283,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 272,
+              "end_line": 290,
               "increment": 1,
               "kind": "for-loop",
-              "line": 270,
+              "line": 288,
               "nesting_depth": 0
             }
           ],
@@ -6633,9 +6633,9 @@ expression: pretty
             "qualified_name": "merge_branch_block",
             "span": {
               "end_column": 1,
-              "end_line": 273,
+              "end_line": 291,
               "start_column": 1,
-              "start_line": 260
+              "start_line": 278
             }
           }
         },
@@ -6649,10 +6649,10 @@ expression: pretty
           "contributors": [
             {
               "column": 13,
-              "end_line": 783,
+              "end_line": 801,
               "increment": 2,
               "kind": "for-loop",
-              "line": 780,
+              "line": 798,
               "nesting_depth": 1
             }
           ],
@@ -6666,9 +6666,9 @@ expression: pretty
             "qualified_name": "arb_lcov_block",
             "span": {
               "end_column": 5,
-              "end_line": 787,
+              "end_line": 805,
               "start_column": 5,
-              "start_line": 777
+              "start_line": 795
             }
           }
         },
@@ -7375,10 +7375,10 @@ expression: pretty
           "contributors": [
             {
               "column": 72,
-              "end_line": 94,
+              "end_line": 112,
               "increment": 1,
               "kind": "try",
-              "line": 94,
+              "line": 112,
               "nesting_depth": 0
             }
           ],
@@ -7392,7 +7392,7 @@ expression: pretty
             "qualified_name": "LcovParser::parse",
             "span": {
               "end_column": 5,
-              "end_line": 96,
+              "end_line": 114,
               "start_column": 5,
               "start_line": 81
             }
@@ -7408,10 +7408,10 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 159,
+              "end_line": 177,
               "increment": 1,
               "kind": "if-branch",
-              "line": 152,
+              "line": 170,
               "nesting_depth": 0
             }
           ],
@@ -7425,9 +7425,9 @@ expression: pretty
             "qualified_name": "start_source_file",
             "span": {
               "end_column": 1,
-              "end_line": 160,
+              "end_line": 178,
               "start_column": 1,
-              "start_line": 149
+              "start_line": 167
             }
           }
         },
@@ -7441,10 +7441,10 @@ expression: pretty
           "contributors": [
             {
               "column": 52,
-              "end_line": 238,
+              "end_line": 256,
               "increment": 1,
               "kind": "let-else",
-              "line": 235,
+              "line": 253,
               "nesting_depth": 0
             }
           ],
@@ -7458,9 +7458,9 @@ expression: pretty
             "qualified_name": "flush_block",
             "span": {
               "end_column": 1,
-              "end_line": 243,
+              "end_line": 261,
               "start_column": 1,
-              "start_line": 234
+              "start_line": 252
             }
           }
         },
@@ -7474,10 +7474,10 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 299,
+              "end_line": 317,
               "increment": 1,
               "kind": "match",
-              "line": 294,
+              "line": 312,
               "nesting_depth": 0
             }
           ],
@@ -7491,9 +7491,9 @@ expression: pretty
             "qualified_name": "merge_taken",
             "span": {
               "end_column": 1,
-              "end_line": 300,
+              "end_line": 318,
               "start_column": 1,
-              "start_line": 293
+              "start_line": 311
             }
           }
         },
@@ -7507,10 +7507,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 534,
+              "end_line": 552,
               "increment": 1,
               "kind": "match",
-              "line": 525,
+              "line": 543,
               "nesting_depth": 0
             }
           ],
@@ -7524,9 +7524,9 @@ expression: pretty
             "qualified_name": "malformed_da_produces_diagnostic",
             "span": {
               "end_column": 5,
-              "end_line": 535,
+              "end_line": 553,
               "start_column": 5,
-              "start_line": 520
+              "start_line": 538
             }
           }
         },
@@ -7540,10 +7540,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 578,
+              "end_line": 596,
               "increment": 1,
               "kind": "match",
-              "line": 569,
+              "line": 587,
               "nesting_depth": 0
             }
           ],
@@ -7557,9 +7557,9 @@ expression: pretty
             "qualified_name": "da_line_zero_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 579,
+              "end_line": 597,
               "start_column": 5,
-              "start_line": 565
+              "start_line": 583
             }
           }
         },
@@ -7573,10 +7573,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 697,
+              "end_line": 715,
               "increment": 1,
               "kind": "match",
-              "line": 688,
+              "line": 706,
               "nesting_depth": 0
             }
           ],
@@ -7590,9 +7590,9 @@ expression: pretty
             "qualified_name": "malformed_brda_produces_diagnostic",
             "span": {
               "end_column": 5,
-              "end_line": 698,
+              "end_line": 716,
               "start_column": 5,
-              "start_line": 684
+              "start_line": 702
             }
           }
         },
@@ -7606,10 +7606,10 @@ expression: pretty
           "contributors": [
             {
               "column": 13,
-              "end_line": 739,
+              "end_line": 757,
               "increment": 1,
               "kind": "for-loop",
-              "line": 737,
+              "line": 755,
               "nesting_depth": 0
             }
           ],
@@ -7623,9 +7623,9 @@ expression: pretty
             "qualified_name": "repeated_sf_blocks_merge_branch_coverage",
             "span": {
               "end_column": 5,
-              "end_line": 749,
+              "end_line": 767,
               "start_column": 5,
-              "start_line": 722
+              "start_line": 740
             }
           }
         },
@@ -10056,9 +10056,9 @@ expression: pretty
             "qualified_name": "push_malformed_record",
             "span": {
               "end_column": 1,
-              "end_line": 193,
+              "end_line": 211,
               "start_column": 1,
-              "start_line": 186
+              "start_line": 204
             }
           }
         },
@@ -10080,9 +10080,9 @@ expression: pretty
             "qualified_name": "merge_hits",
             "span": {
               "end_column": 1,
-              "end_line": 280,
+              "end_line": 298,
               "start_column": 1,
-              "start_line": 275
+              "start_line": 293
             }
           }
         },
@@ -10104,9 +10104,9 @@ expression: pretty
             "qualified_name": "merge_branch_value",
             "span": {
               "end_column": 1,
-              "end_line": 291,
+              "end_line": 309,
               "start_column": 1,
-              "start_line": 282
+              "start_line": 300
             }
           }
         },
@@ -10128,9 +10128,9 @@ expression: pretty
             "qualified_name": "clear_current_block",
             "span": {
               "end_column": 1,
-              "end_line": 305,
+              "end_line": 323,
               "start_column": 1,
-              "start_line": 302
+              "start_line": 320
             }
           }
         },
@@ -10152,9 +10152,9 @@ expression: pretty
             "qualified_name": "build_parse_output",
             "span": {
               "end_column": 1,
-              "end_line": 333,
+              "end_line": 351,
               "start_column": 1,
-              "start_line": 307
+              "start_line": 325
             }
           }
         },
@@ -10176,9 +10176,9 @@ expression: pretty
             "qualified_name": "to_line_coverage",
             "span": {
               "end_column": 1,
-              "end_line": 340,
+              "end_line": 358,
               "start_column": 1,
-              "start_line": 335
+              "start_line": 353
             }
           }
         },
@@ -10200,9 +10200,9 @@ expression: pretty
             "qualified_name": "parser",
             "span": {
               "end_column": 5,
-              "end_line": 349,
+              "end_line": 367,
               "start_column": 5,
-              "start_line": 347
+              "start_line": 365
             }
           }
         },
@@ -10224,9 +10224,9 @@ expression: pretty
             "qualified_name": "parse",
             "span": {
               "end_column": 5,
-              "end_line": 353,
+              "end_line": 371,
               "start_column": 5,
-              "start_line": 351
+              "start_line": 369
             }
           }
         },
@@ -10248,9 +10248,9 @@ expression: pretty
             "qualified_name": "empty_input_returns_empty_output",
             "span": {
               "end_column": 5,
-              "end_line": 360,
+              "end_line": 378,
               "start_column": 5,
-              "start_line": 355
+              "start_line": 373
             }
           }
         },
@@ -10272,9 +10272,9 @@ expression: pretty
             "qualified_name": "validate_str",
             "span": {
               "end_column": 5,
-              "end_line": 374,
+              "end_line": 392,
               "start_column": 5,
-              "start_line": 364
+              "start_line": 382
             }
           }
         },
@@ -10296,9 +10296,9 @@ expression: pretty
             "qualified_name": "validate_empty_input_rejected",
             "span": {
               "end_column": 5,
-              "end_line": 379,
+              "end_line": 397,
               "start_column": 5,
-              "start_line": 376
+              "start_line": 394
             }
           }
         },
@@ -10320,9 +10320,9 @@ expression: pretty
             "qualified_name": "validate_no_da_lines_rejected",
             "span": {
               "end_column": 5,
-              "end_line": 384,
+              "end_line": 402,
               "start_column": 5,
-              "start_line": 381
+              "start_line": 399
             }
           }
         },
@@ -10344,9 +10344,9 @@ expression: pretty
             "qualified_name": "validate_da_outside_sf_block_rejected",
             "span": {
               "end_column": 5,
-              "end_line": 389,
+              "end_line": 407,
               "start_column": 5,
-              "start_line": 386
+              "start_line": 404
             }
           }
         },
@@ -10368,9 +10368,9 @@ expression: pretty
             "qualified_name": "validate_malformed_da_rejected",
             "span": {
               "end_column": 5,
-              "end_line": 394,
+              "end_line": 412,
               "start_column": 5,
-              "start_line": 391
+              "start_line": 409
             }
           }
         },
@@ -10392,9 +10392,9 @@ expression: pretty
             "qualified_name": "validate_single_da_inside_sf_block_passes",
             "span": {
               "end_column": 5,
-              "end_line": 399,
+              "end_line": 417,
               "start_column": 5,
-              "start_line": 396
+              "start_line": 414
             }
           }
         },
@@ -10416,9 +10416,9 @@ expression: pretty
             "qualified_name": "validate_first_da_in_second_block_passes",
             "span": {
               "end_column": 5,
-              "end_line": 409,
+              "end_line": 427,
               "start_column": 5,
-              "start_line": 401
+              "start_line": 419
             }
           }
         },
@@ -10440,9 +10440,9 @@ expression: pretty
             "qualified_name": "validate_missing_path_returns_open_error",
             "span": {
               "end_column": 5,
-              "end_line": 421,
+              "end_line": 439,
               "start_column": 5,
-              "start_line": 411
+              "start_line": 429
             }
           }
         },
@@ -10464,9 +10464,9 @@ expression: pretty
             "qualified_name": "single_file_single_da",
             "span": {
               "end_column": 5,
-              "end_line": 431,
+              "end_line": 449,
               "start_column": 5,
-              "start_line": 423
+              "start_line": 441
             }
           }
         },
@@ -10488,9 +10488,9 @@ expression: pretty
             "qualified_name": "multiple_da_lines",
             "span": {
               "end_column": 5,
-              "end_line": 441,
+              "end_line": 459,
               "start_column": 5,
-              "start_line": 433
+              "start_line": 451
             }
           }
         },
@@ -10512,9 +10512,9 @@ expression: pretty
             "qualified_name": "multiple_source_files",
             "span": {
               "end_column": 5,
-              "end_line": 450,
+              "end_line": 468,
               "start_column": 5,
-              "start_line": 443
+              "start_line": 461
             }
           }
         },
@@ -10536,9 +10536,9 @@ expression: pretty
             "qualified_name": "hit_count_preservation",
             "span": {
               "end_column": 5,
-              "end_line": 458,
+              "end_line": 476,
               "start_column": 5,
-              "start_line": 452
+              "start_line": 470
             }
           }
         },
@@ -10560,9 +10560,9 @@ expression: pretty
             "qualified_name": "path_normalization_strips_prefix",
             "span": {
               "end_column": 5,
-              "end_line": 464,
+              "end_line": 482,
               "start_column": 5,
-              "start_line": 460
+              "start_line": 478
             }
           }
         },
@@ -10584,9 +10584,9 @@ expression: pretty
             "qualified_name": "non_matching_path_passes_through",
             "span": {
               "end_column": 5,
-              "end_line": 470,
+              "end_line": 488,
               "start_column": 5,
-              "start_line": 466
+              "start_line": 484
             }
           }
         },
@@ -10608,9 +10608,9 @@ expression: pretty
             "qualified_name": "backslash_normalized_to_forward_slash",
             "span": {
               "end_column": 5,
-              "end_line": 477,
+              "end_line": 495,
               "start_column": 5,
-              "start_line": 472
+              "start_line": 490
             }
           }
         },
@@ -10632,9 +10632,9 @@ expression: pretty
             "qualified_name": "path_boundary_not_confused_by_prefix_substring",
             "span": {
               "end_column": 5,
-              "end_line": 483,
+              "end_line": 501,
               "start_column": 5,
-              "start_line": 479
+              "start_line": 497
             }
           }
         },
@@ -10656,9 +10656,9 @@ expression: pretty
             "qualified_name": "repeated_sf_blocks_merge_coverage",
             "span": {
               "end_column": 5,
-              "end_line": 497,
+              "end_line": 515,
               "start_column": 5,
-              "start_line": 485
+              "start_line": 503
             }
           }
         },
@@ -10680,9 +10680,9 @@ expression: pretty
             "qualified_name": "duplicate_da_lines_sum_hits",
             "span": {
               "end_column": 5,
-              "end_line": 506,
+              "end_line": 524,
               "start_column": 5,
-              "start_line": 499
+              "start_line": 517
             }
           }
         },
@@ -10704,9 +10704,9 @@ expression: pretty
             "qualified_name": "duplicate_da_multiple_lines_sum_correctly",
             "span": {
               "end_column": 5,
-              "end_line": 518,
+              "end_line": 536,
               "start_column": 5,
-              "start_line": 508
+              "start_line": 526
             }
           }
         },
@@ -10728,9 +10728,9 @@ expression: pretty
             "qualified_name": "malformed_da_does_not_stop_parsing",
             "span": {
               "end_column": 5,
-              "end_line": 543,
+              "end_line": 561,
               "start_column": 5,
-              "start_line": 537
+              "start_line": 555
             }
           }
         },
@@ -10752,9 +10752,9 @@ expression: pretty
             "qualified_name": "da_missing_hit_count_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 553,
+              "end_line": 571,
               "start_column": 5,
-              "start_line": 545
+              "start_line": 563
             }
           }
         },
@@ -10776,9 +10776,9 @@ expression: pretty
             "qualified_name": "da_negative_hit_count_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 563,
+              "end_line": 581,
               "start_column": 5,
-              "start_line": 555
+              "start_line": 573
             }
           }
         },
@@ -10798,54 +10798,6 @@ expression: pretty
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
             "qualified_name": "end_of_record_is_ignored",
-            "span": {
-              "end_column": 5,
-              "end_line": 590,
-              "start_column": 5,
-              "start_line": 581
-            }
-          }
-        },
-        "threshold": 25.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "unterminated_final_block_emits_data",
-            "span": {
-              "end_column": 5,
-              "end_line": 597,
-              "start_column": 5,
-              "start_line": 592
-            }
-          }
-        },
-        "threshold": 25.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "empty_sf_path_emits_diagnostic",
             "span": {
               "end_column": 5,
               "end_line": 608,
@@ -10869,12 +10821,60 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "unterminated_final_block_emits_data",
+            "span": {
+              "end_column": 5,
+              "end_line": 615,
+              "start_column": 5,
+              "start_line": 610
+            }
+          }
+        },
+        "threshold": 25.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 0.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "empty_sf_path_emits_diagnostic",
+            "span": {
+              "end_column": 5,
+              "end_line": 626,
+              "start_column": 5,
+              "start_line": 617
+            }
+          }
+        },
+        "threshold": 25.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 0.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
             "qualified_name": "da_with_checksum_field_is_accepted",
             "span": {
               "end_column": 5,
-              "end_line": 617,
+              "end_line": 635,
               "start_column": 5,
-              "start_line": 610
+              "start_line": 628
             }
           }
         },
@@ -10896,9 +10896,9 @@ expression: pretty
             "qualified_name": "non_coverage_records_are_ignored",
             "span": {
               "end_column": 5,
-              "end_line": 631,
+              "end_line": 649,
               "start_column": 5,
-              "start_line": 619
+              "start_line": 637
             }
           }
         },
@@ -10920,9 +10920,9 @@ expression: pretty
             "qualified_name": "brda_and_da_records_parsed",
             "span": {
               "end_column": 5,
-              "end_line": 643,
+              "end_line": 661,
               "start_column": 5,
-              "start_line": 635
+              "start_line": 653
             }
           }
         },
@@ -10944,9 +10944,9 @@ expression: pretty
             "qualified_name": "brda_dash_maps_to_none",
             "span": {
               "end_column": 5,
-              "end_line": 650,
+              "end_line": 668,
               "start_column": 5,
-              "start_line": 645
+              "start_line": 663
             }
           }
         },
@@ -10968,9 +10968,9 @@ expression: pretty
             "qualified_name": "brda_numeric_maps_to_some",
             "span": {
               "end_column": 5,
-              "end_line": 657,
+              "end_line": 675,
               "start_column": 5,
-              "start_line": 652
+              "start_line": 670
             }
           }
         },
@@ -10992,9 +10992,9 @@ expression: pretty
             "qualified_name": "brda_zero_maps_to_some_zero",
             "span": {
               "end_column": 5,
-              "end_line": 664,
+              "end_line": 682,
               "start_column": 5,
-              "start_line": 659
+              "start_line": 677
             }
           }
         },
@@ -11016,9 +11016,9 @@ expression: pretty
             "qualified_name": "duplicate_brda_sum_taken",
             "span": {
               "end_column": 5,
-              "end_line": 674,
+              "end_line": 692,
               "start_column": 5,
-              "start_line": 666
+              "start_line": 684
             }
           }
         },
@@ -11040,9 +11040,9 @@ expression: pretty
             "qualified_name": "brda_dash_and_numeric_merge",
             "span": {
               "end_column": 5,
-              "end_line": 682,
+              "end_line": 700,
               "start_column": 5,
-              "start_line": 676
+              "start_line": 694
             }
           }
         },
@@ -11064,9 +11064,9 @@ expression: pretty
             "qualified_name": "brda_missing_fields_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 709,
+              "end_line": 727,
               "start_column": 5,
-              "start_line": 700
+              "start_line": 718
             }
           }
         },
@@ -11088,9 +11088,9 @@ expression: pretty
             "qualified_name": "brda_missing_taken_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 720,
+              "end_line": 738,
               "start_column": 5,
-              "start_line": 711
+              "start_line": 729
             }
           }
         },
@@ -11112,9 +11112,9 @@ expression: pretty
             "qualified_name": "brda_line_zero_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 759,
+              "end_line": 777,
               "start_column": 5,
-              "start_line": 751
+              "start_line": 769
             }
           }
         },
@@ -11136,9 +11136,9 @@ expression: pretty
             "qualified_name": "no_brda_produces_none_branches",
             "span": {
               "end_column": 5,
-              "end_line": 765,
+              "end_line": 783,
               "start_column": 5,
-              "start_line": 761
+              "start_line": 779
             }
           }
         },
@@ -11160,9 +11160,9 @@ expression: pretty
             "qualified_name": "arb_da_line",
             "span": {
               "end_column": 5,
-              "end_line": 775,
+              "end_line": 793,
               "start_column": 5,
-              "start_line": 773
+              "start_line": 791
             }
           }
         },
@@ -11184,9 +11184,9 @@ expression: pretty
             "qualified_name": "arb_lcov_input",
             "span": {
               "end_column": 5,
-              "end_line": 791,
+              "end_line": 809,
               "start_column": 5,
-              "start_line": 789
+              "start_line": 807
             }
           }
         },
@@ -11364,9 +11364,9 @@ expression: pretty
         "qualified_name": "parse_brda",
         "span": {
           "end_column": 1,
-          "end_line": 232,
+          "end_line": 250,
           "start_column": 1,
-          "start_line": 209
+          "start_line": 227
         }
       }
     },

--- a/crates/crap4rs/src/adapters/coverage/mod.rs
+++ b/crates/crap4rs/src/adapters/coverage/mod.rs
@@ -54,10 +54,16 @@ impl LcovParser {
     }
 }
 
-impl CoveragePort for LcovParser {
-    type Diagnostic = LcovParseDiagnostic;
-
-    fn parse(&self, data: &str) -> Result<ParseOutput<LcovParseDiagnostic>, CrapError> {
+impl LcovParser {
+    /// Parse already-loaded LCOV text. Pure, no I/O — the public
+    /// [`CoveragePort::parse`] impl slurps the file and delegates here
+    /// so the parsing logic stays testable without writing every
+    /// fixture to a tempfile.
+    ///
+    /// Kept `pub(crate)` so the in-tree test module can exercise the
+    /// parser against string literals; external callers always go
+    /// through the port.
+    pub(crate) fn parse_str(&self, data: &str) -> ParseOutput<LcovParseDiagnostic> {
         let mut state = ParseState::default();
 
         for (line, line_number) in data.lines().zip(1usize..) {
@@ -65,7 +71,28 @@ impl CoveragePort for LcovParser {
         }
 
         flush_block(&mut state);
-        Ok(build_parse_output(state))
+        build_parse_output(state)
+    }
+}
+
+impl CoveragePort for LcovParser {
+    type Diagnostic = LcovParseDiagnostic;
+
+    /// Slurp the LCOV file at `path` and parse it.
+    ///
+    /// **Slurp choice**: LCOV emitted by `cargo-llvm-cov --lcov` for a
+    /// typical Rust workspace stays well under 100 MB even on
+    /// workspaces with thousands of files — the format is line-oriented
+    /// text without expansion. A full read keeps the parser linear in
+    /// input size with predictable allocations; streaming would
+    /// complicate the single-pass block accumulator (`flush_block` and
+    /// its surrounding state machine) for a memory ceiling no observed
+    /// workload approaches. [`Self::validate`] still streams via
+    /// `BufReader` since pre-flight returns on the first match —
+    /// short-circuit semantics dominate cost there, not peak RSS.
+    fn parse(&self, path: &Path) -> Result<ParseOutput<LcovParseDiagnostic>, CrapError> {
+        let data = std::fs::read_to_string(path).map_err(CrapError::Io)?;
+        Ok(self.parse_str(&data))
     }
 
     /// LCOV-flavoured pre-flight: stream the file line-by-line via
@@ -322,7 +349,7 @@ mod tests {
     }
 
     fn parse(input: &str) -> ParseOutput<LcovParseDiagnostic> {
-        parser().parse(input).unwrap()
+        parser().parse_str(input)
     }
 
     #[test]
@@ -445,7 +472,7 @@ mod tests {
     #[test]
     fn backslash_normalized_to_forward_slash() {
         let p = LcovParser::new(PathBuf::from("C:\\project"));
-        let output = p.parse("SF:C:\\project\\src\\main.rs\nDA:1,1\n").unwrap();
+        let output = p.parse_str("SF:C:\\project\\src\\main.rs\nDA:1,1\n");
         assert!(output.coverage.contains_key("src/main.rs"));
     }
 
@@ -769,19 +796,19 @@ mod proptests {
         #[test]
         fn no_panic_on_structured_input(input in arb_lcov_input()) {
             let parser = LcovParser::new(PathBuf::from("/project"));
-            let _ = parser.parse(&input);
+            let _ = parser.parse_str(&input);
         }
 
         #[test]
         fn no_panic_on_arbitrary_input(input in ".*") {
             let parser = LcovParser::new(PathBuf::from("/project"));
-            let _ = parser.parse(&input);
+            let _ = parser.parse_str(&input);
         }
 
         #[test]
         fn all_line_numbers_are_positive(input in arb_lcov_input()) {
             let parser = LcovParser::new(PathBuf::from("/project"));
-            let output = parser.parse(&input).unwrap();
+            let output = parser.parse_str(&input);
             for lines in output.coverage.values() {
                 for lc in lines {
                     prop_assert!(lc.line > 0);
@@ -793,7 +820,7 @@ mod proptests {
         fn no_panic_on_arbitrary_brda(input in "BRDA:.*") {
             let lcov = format!("SF:/project/src/test.rs\n{input}\nend_of_record\n");
             let parser = LcovParser::new(PathBuf::from("/project"));
-            let _ = parser.parse(&lcov);
+            let _ = parser.parse_str(&lcov);
         }
 
         #[test]
@@ -812,7 +839,7 @@ mod proptests {
             input.push_str("end_of_record\n");
 
             let parser = LcovParser::new(PathBuf::from("/project"));
-            let output = parser.parse(&input).unwrap();
+            let output = parser.parse_str(&input);
 
             if let Some(a_coverage) = output.coverage.get("src/a.rs") {
                 for lc in a_coverage {

--- a/crates/crap4rs/src/adapters/coverage/mod.rs
+++ b/crates/crap4rs/src/adapters/coverage/mod.rs
@@ -80,16 +80,34 @@ impl CoveragePort for LcovParser {
 
     /// Slurp the LCOV file at `path` and parse it.
     ///
-    /// **Slurp choice**: LCOV emitted by `cargo-llvm-cov --lcov` for a
-    /// typical Rust workspace stays well under 100 MB even on
-    /// workspaces with thousands of files — the format is line-oriented
-    /// text without expansion. A full read keeps the parser linear in
-    /// input size with predictable allocations; streaming would
-    /// complicate the single-pass block accumulator (`flush_block` and
-    /// its surrounding state machine) for a memory ceiling no observed
-    /// workload approaches. [`Self::validate`] still streams via
-    /// `BufReader` since pre-flight returns on the first match —
-    /// short-circuit semantics dominate cost there, not peak RSS.
+    /// **Slurp choice (vs streaming via `BufReader`)**: deliberate
+    /// tradeoff. The slurp holds the file in memory once as a `String`,
+    /// then iterates `&str::lines()` which yields borrowed `&str`
+    /// slices with **zero per-line allocations**. A streaming
+    /// `BufReader::lines()` rewrite would bound peak memory at one line
+    /// — but each yielded `Result<String>` allocates a fresh `String`
+    /// per line. On the LCOV files this adapter sees (workspace
+    /// coverage from `cargo-llvm-cov --lcov`), files are line-oriented
+    /// text without expansion and stay well under any concerning
+    /// memory ceiling; a 1 M-line file would buy ~50 MB of avoided
+    /// peak RSS at the cost of 1 M small heap allocations, a trade
+    /// that's net-negative on every workload we measure. The
+    /// single-pass block accumulator (`flush_block` and its state
+    /// machine in this module) was also designed around `&str`
+    /// borrowing — refactoring to `impl BufRead` would force the
+    /// accumulator to own each line.
+    ///
+    /// [`Self::validate`] is a separate story and streams via
+    /// `BufReader` because it short-circuits on the first match —
+    /// for an early-exit gate, the per-line allocation cost is
+    /// dominated by the I/O-skipped tail, so streaming is the right
+    /// call there.
+    ///
+    /// If a future workload surfaces a multi-GB LCOV file, the
+    /// streaming refactor is tracked separately rather than blanket-
+    /// applied here — see follow-up issue for the abstraction (taking
+    /// `impl BufRead` so production streams and tests slice strings
+    /// via `.as_bytes()`).
     fn parse(&self, path: &Path) -> Result<ParseOutput<LcovParseDiagnostic>, CrapError> {
         let data = std::fs::read_to_string(path).map_err(CrapError::Io)?;
         Ok(self.parse_str(&data))

--- a/crates/crap4ts/src/adapters/coverage/mod.rs
+++ b/crates/crap4ts/src/adapters/coverage/mod.rs
@@ -606,11 +606,22 @@ impl CoveragePort for IstanbulCoverage {
     /// Slurp the Istanbul JSON file at `path` and parse it into per-file
     /// `LineCoverage` + `BranchCoverage` records.
     ///
-    /// **Slurp choice**: `serde_json` needs the whole document in
-    /// memory to deserialize, so streaming is not applicable here.
-    /// `coverage-final.json` files emitted by jest / vitest / nyc on
-    /// real-world TypeScript projects sit comfortably under 10 MB; a
-    /// single read is the correct tradeoff. Pre-flight
+    /// **Slurp choice (vs `serde_json::from_reader`)**: deliberate, and
+    /// matches `serde_json`'s own documented recommendation. The
+    /// `from_reader` family is explicitly slower for files — the
+    /// `serde_json::de::from_reader` docs note that "*it can be more
+    /// efficient to read the entire input into a String and then call
+    /// `from_str` on it*" because `from_reader` does not buffer
+    /// internally and incurs per-call syscall overhead. The classic
+    /// "raw string + parsed tree both in memory" objection holds only
+    /// if the string is much larger than the parsed `Value`; for
+    /// Istanbul payloads it's the opposite (the parsed `HashMap<String,
+    /// IstanbulCoverageFile>` is the dominant resident structure once
+    /// the source string is dropped, which happens at the close of
+    /// [`Self::parse_str`]). `coverage-final.json` files emitted by
+    /// jest / vitest / nyc on real-world TypeScript projects sit
+    /// comfortably under 10 MB; the duplicate transient memory is
+    /// negligible against the parsed tree's footprint. Pre-flight
     /// [`Self::validate`] also slurps for the same reason.
     ///
     /// **Top-level shape tolerance (W2.4)** — implemented by

--- a/crates/crap4ts/src/adapters/coverage/mod.rs
+++ b/crates/crap4ts/src/adapters/coverage/mod.rs
@@ -537,31 +537,17 @@ impl IstanbulCoverage {
     }
 }
 
-impl CoveragePort for IstanbulCoverage {
-    type Diagnostic = IstanbulParseDiagnostic;
-
-    /// Parse a `coverage-final.json` payload into per-file
-    /// `LineCoverage` + `BranchCoverage` records.
-    ///
-    /// **Top-level shape tolerance (W2.4)**:
-    ///
-    /// 1. Try the flat `{[path]: entry}` shape first (jest, vitest,
-    ///    nyc baseline).
-    /// 2. If that fails, parse as `serde_json::Value` and try a
-    ///    single-level unwrap (`{"coverage-final": {...flat...}}`).
-    /// 3. If neither matches, emit a `SchemaUnrecognized` diagnostic
-    ///    (with detected top-level keys) and return an empty
-    ///    `ParseOutput` carrying that diagnostic — the scorecard's
-    ///    downstream "no functions extracted" path then surfaces a
-    ///    non-zero exit. Never abort first-record.
-    /// 4. If the input is not valid JSON at all,
-    ///    `Err(CrapError::SourceParse("istanbul: ..."))` propagates
-    ///    (fatal — no recovery path).
-    ///
-    /// Per-entry errors (`PathUnresolved`, `MissingField`,
-    /// `BranchMismatch`) push an `IstanbulParseDiagnostic` and skip
-    /// the entry / branch; other entries still parse cleanly.
-    fn parse(&self, data: &str) -> Result<ParseOutput<IstanbulParseDiagnostic>, CrapError> {
+impl IstanbulCoverage {
+    /// Parse already-loaded Istanbul JSON text. Pure, no I/O — the
+    /// public [`CoveragePort::parse`] impl slurps the file and
+    /// delegates here so the parser can be exercised against string
+    /// literals (in-tree unit tests and the `crap4ts/tests/istanbul_smoke.rs`
+    /// integration suite) without materializing every fixture to a
+    /// tempfile. Public because the integration suite lives in a
+    /// separate crate; production callers should go through the port
+    /// (`<IstanbulCoverage as CoveragePort>::parse`) so the slurp
+    /// choice stays centralized.
+    pub fn parse_str(&self, data: &str) -> Result<ParseOutput<IstanbulParseDiagnostic>, CrapError> {
         // Path 1: flat-shape fast path.
         if let Ok(raw) = serde_json::from_str::<HashMap<String, IstanbulCoverageFile>>(data) {
             return Ok(self.build_parse_output(raw));
@@ -611,6 +597,44 @@ impl CoveragePort for IstanbulCoverage {
                 line: None,
             }],
         })
+    }
+}
+
+impl CoveragePort for IstanbulCoverage {
+    type Diagnostic = IstanbulParseDiagnostic;
+
+    /// Slurp the Istanbul JSON file at `path` and parse it into per-file
+    /// `LineCoverage` + `BranchCoverage` records.
+    ///
+    /// **Slurp choice**: `serde_json` needs the whole document in
+    /// memory to deserialize, so streaming is not applicable here.
+    /// `coverage-final.json` files emitted by jest / vitest / nyc on
+    /// real-world TypeScript projects sit comfortably under 10 MB; a
+    /// single read is the correct tradeoff. Pre-flight
+    /// [`Self::validate`] also slurps for the same reason.
+    ///
+    /// **Top-level shape tolerance (W2.4)** — implemented by
+    /// [`Self::parse_str`]:
+    ///
+    /// 1. Try the flat `{[path]: entry}` shape first (jest, vitest,
+    ///    nyc baseline).
+    /// 2. If that fails, parse as `serde_json::Value` and try a
+    ///    single-level unwrap (`{"coverage-final": {...flat...}}`).
+    /// 3. If neither matches, emit a `SchemaUnrecognized` diagnostic
+    ///    (with detected top-level keys) and return an empty
+    ///    `ParseOutput` carrying that diagnostic — the scorecard's
+    ///    downstream "no functions extracted" path then surfaces a
+    ///    non-zero exit. Never abort first-record.
+    /// 4. If the input is not valid JSON at all,
+    ///    `Err(CrapError::SourceParse("istanbul: ..."))` propagates
+    ///    (fatal — no recovery path).
+    ///
+    /// Per-entry errors (`PathUnresolved`, `MissingField`,
+    /// `BranchMismatch`) push an `IstanbulParseDiagnostic` and skip
+    /// the entry / branch; other entries still parse cleanly.
+    fn parse(&self, path: &Path) -> Result<ParseOutput<IstanbulParseDiagnostic>, CrapError> {
+        let data = std::fs::read_to_string(path).map_err(CrapError::Io)?;
+        self.parse_str(&data)
     }
 
     /// Pre-flight structural check: parse the file as Istanbul JSON and
@@ -674,7 +698,7 @@ mod tests {
     #[test]
     fn parse_empty_object_returns_ok_with_no_coverage() {
         let c = IstanbulCoverage::new(PathBuf::from("/tmp"));
-        let out = c.parse("{}").expect("empty JSON object parses cleanly");
+        let out = c.parse_str("{}").expect("empty JSON object parses cleanly");
         assert!(out.coverage.is_empty());
         assert!(out.diagnostics.is_empty());
         assert!(out.branches.is_none());
@@ -683,7 +707,7 @@ mod tests {
     #[test]
     fn parse_malformed_json_returns_source_parse_with_istanbul_prefix() {
         let c = IstanbulCoverage::new(PathBuf::from("/tmp"));
-        let err = c.parse("{not json").unwrap_err();
+        let err = c.parse_str("{not json").unwrap_err();
         match err {
             CrapError::SourceParse(msg) => {
                 assert!(msg.starts_with("istanbul: "), "msg: {msg}");

--- a/crates/crap4ts/tests/istanbul_parser_cucumber.rs
+++ b/crates/crap4ts/tests/istanbul_parser_cucumber.rs
@@ -105,10 +105,15 @@ impl IstanbulWorld {
     }
 
     /// Parse `payload` under `root` and stash the outcome.
+    ///
+    /// Uses `IstanbulCoverage::parse_str` (the pure-string entry point)
+    /// rather than `<IstanbulCoverage as CoveragePort>::parse(&Path)` so
+    /// scenarios can feed JSON literals directly without staging every
+    /// payload to a tempfile. Production callers go through the port.
     fn run_parse(&mut self) {
         let payload = self.payload.clone().expect("a Given must set the payload");
         let parser = IstanbulCoverage::new(self.root());
-        self.parsed = Some(parser.parse(&payload));
+        self.parsed = Some(parser.parse_str(&payload));
     }
 
     fn ok(&self) -> &ParseOutput<IstanbulParseDiagnostic> {

--- a/crates/crap4ts/tests/istanbul_smoke.rs
+++ b/crates/crap4ts/tests/istanbul_smoke.rs
@@ -111,7 +111,7 @@ fn hits_at(lines: &[LineCoverage], line: usize) -> u64 {
 fn parses_jest_fixture_with_all_five_files() {
     let (_tmp, canonical, payload) = build_fixture();
     let parser = IstanbulCoverage::new(canonical);
-    let out = parser.parse(&payload).expect("happy path parses");
+    let out = parser.parse_str(&payload).expect("happy path parses");
 
     // All five fixture files surface in the coverage map.
     let keys: Vec<_> = out.coverage.keys().cloned().collect();
@@ -171,7 +171,9 @@ fn validate_returns_err_on_bad_shape() {
 #[test]
 fn parse_malformed_json_returns_source_parse_with_istanbul_prefix() {
     let parser = IstanbulCoverage::new(PathBuf::from("/tmp"));
-    let err = parser.parse("{ not json").expect_err("malformed rejected");
+    let err = parser
+        .parse_str("{ not json")
+        .expect_err("malformed rejected");
     match err {
         CrapError::SourceParse(msg) => {
             assert!(
@@ -198,7 +200,7 @@ fn parse_emits_path_unresolved_for_out_of_tree_entries() {
     }"#;
     let parser = IstanbulCoverage::new(canonical);
     let out = parser
-        .parse(stray)
+        .parse_str(stray)
         .expect("stray entry parses but diagnoses");
 
     assert!(
@@ -236,7 +238,7 @@ fn parse_emits_path_unresolved_for_out_of_tree_entries() {
 fn arrow_ac_5a_square_covered_cube_uncovered() {
     let (_tmp, canonical, payload) = build_fixture();
     let parser = IstanbulCoverage::new(canonical);
-    let out = parser.parse(&payload).expect("happy path");
+    let out = parser.parse_str(&payload).expect("happy path");
 
     let arrow = lines_for(&out, "arrow.ts");
 
@@ -284,7 +286,7 @@ fn arrow_ac_5a_square_covered_cube_uncovered() {
 fn arrow_ac_5b_button_and_use_callback_handle_both_100() {
     let (_tmp, canonical, payload) = build_fixture();
     let parser = IstanbulCoverage::new(canonical);
-    let out = parser.parse(&payload).expect("happy path");
+    let out = parser.parse_str(&payload).expect("happy path");
 
     let button = lines_for(&out, "Button.tsx");
 
@@ -322,7 +324,7 @@ fn arrow_ac_5b_button_and_use_callback_handle_both_100() {
 fn arrow_ac_5c_inner_map_arrow_covered() {
     let (_tmp, canonical, payload) = build_fixture();
     let parser = IstanbulCoverage::new(canonical);
-    let out = parser.parse(&payload).expect("happy path");
+    let out = parser.parse_str(&payload).expect("happy path");
 
     let map = lines_for(&out, "map.ts");
 
@@ -360,7 +362,7 @@ fn arrow_ac_5c_inner_map_arrow_covered() {
 fn arrow_ac_5d_mixed_bodies_all_covered() {
     let (_tmp, canonical, payload) = build_fixture();
     let parser = IstanbulCoverage::new(canonical);
-    let out = parser.parse(&payload).expect("happy path");
+    let out = parser.parse_str(&payload).expect("happy path");
 
     let mixed = lines_for(&out, "mixed.ts");
 
@@ -459,7 +461,7 @@ fn build_three_file_fixture(payload_template: &str) -> (TempDir, PathBuf, String
 fn w23_branches_populated_when_b_records_present() {
     let (_tmp, canonical, payload) = build_branch_heavy_fixture(BRANCHES_FIXTURE);
     let parser = IstanbulCoverage::new(canonical);
-    let out = parser.parse(&payload).expect("branch-heavy parses");
+    let out = parser.parse_str(&payload).expect("branch-heavy parses");
 
     let branches = out
         .branches
@@ -490,7 +492,7 @@ fn w23_branches_populated_when_b_records_present() {
 fn w23_branch_arms_fan_to_per_arm_rows_not_summed() {
     let (_tmp, canonical, payload) = build_branch_heavy_fixture(BRANCHES_FIXTURE);
     let parser = IstanbulCoverage::new(canonical);
-    let out = parser.parse(&payload).expect("branch-heavy parses");
+    let out = parser.parse_str(&payload).expect("branch-heavy parses");
 
     let branches = out.branches.unwrap();
     let file_branches = branches.get("branch-heavy.ts").unwrap();
@@ -522,7 +524,7 @@ fn w23_branch_arms_fan_to_per_arm_rows_not_summed() {
 fn w23_orphan_branch_id_emits_branch_mismatch_and_skips_only_that_branch() {
     let (_tmp, canonical, payload) = build_branch_heavy_fixture(ORPHAN_BRANCH_FIXTURE);
     let parser = IstanbulCoverage::new(canonical);
-    let out = parser.parse(&payload).expect("orphan-branch parses");
+    let out = parser.parse_str(&payload).expect("orphan-branch parses");
 
     // Exactly one `BranchMismatch` diagnostic — for branchId 42.
     let mismatches: Vec<_> = out
@@ -568,7 +570,7 @@ fn w23_orphan_branch_id_emits_branch_mismatch_and_skips_only_that_branch() {
 fn w23_regression_no_b_records_leaves_branches_none() {
     let (_tmp, canonical, payload) = build_fixture();
     let parser = IstanbulCoverage::new(canonical);
-    let out = parser.parse(&payload).expect("happy path");
+    let out = parser.parse_str(&payload).expect("happy path");
     assert!(
         out.branches.is_none(),
         "W1.1 jest fixture has `\"b\": {{}}` for every entry — branches must stay None"
@@ -583,7 +585,7 @@ fn w23_regression_no_b_records_leaves_branches_none() {
 fn w24_vitest_shape_parses_with_no_diagnostics() {
     let (_tmp, canonical, payload) = build_three_file_fixture(VITEST_FIXTURE);
     let parser = IstanbulCoverage::new(canonical);
-    let out = parser.parse(&payload).expect("vitest parses");
+    let out = parser.parse_str(&payload).expect("vitest parses");
 
     let keys: Vec<_> = out.coverage.keys().cloned().collect();
     assert!(keys.contains(&"simple.ts".to_string()), "keys: {keys:?}");
@@ -617,7 +619,7 @@ fn w24_vitest_null_columns_parse_without_bailing() {
 
     let parser = IstanbulCoverage::new(canonical);
     let out = parser
-        .parse(&payload)
+        .parse_str(&payload)
         .expect("null-column fixture parses successfully (regression for #211)");
 
     let keys: Vec<_> = out.coverage.keys().cloned().collect();
@@ -648,7 +650,7 @@ fn w24_vitest_null_columns_parse_without_bailing() {
 fn w24_nyc_absolute_paths_normalize_via_strip_prefix() {
     let (_tmp, canonical, payload) = build_three_file_fixture(NYC_FIXTURE);
     let parser = IstanbulCoverage::new(canonical);
-    let out = parser.parse(&payload).expect("nyc parses");
+    let out = parser.parse_str(&payload).expect("nyc parses");
 
     let keys: Vec<_> = out.coverage.keys().cloned().collect();
     assert!(keys.contains(&"simple.ts".to_string()), "keys: {keys:?}");
@@ -676,7 +678,9 @@ fn w24_wrapped_shape_parses_via_single_level_unwrap() {
     let payload = WRAPPED_FIXTURE.replace("{SRC_ROOT}", &canonical.to_string_lossy());
 
     let parser = IstanbulCoverage::new(canonical);
-    let out = parser.parse(&payload).expect("wrapped parses via unwrap");
+    let out = parser
+        .parse_str(&payload)
+        .expect("wrapped parses via unwrap");
 
     let keys: Vec<_> = out.coverage.keys().cloned().collect();
     assert!(keys.contains(&"simple.ts".to_string()), "keys: {keys:?}");
@@ -692,7 +696,7 @@ fn w24_wrapped_shape_parses_via_single_level_unwrap() {
 fn w24_unrecognized_shape_emits_schema_unrecognized_with_detected_keys() {
     let parser = IstanbulCoverage::new(PathBuf::from("/tmp"));
     let out = parser
-        .parse(r#"{"foo": "bar", "baz": 42}"#)
+        .parse_str(r#"{"foo": "bar", "baz": 42}"#)
         .expect("parse returns Ok with diagnostic; downstream produces non-zero exit");
 
     assert!(out.coverage.is_empty(), "no coverage on unrecognized shape");
@@ -718,7 +722,7 @@ fn w24_unrecognized_shape_emits_schema_unrecognized_with_detected_keys() {
 fn w24_orphan_path_emits_path_unresolved_and_valid_entries_still_parse() {
     let (_tmp, canonical, payload) = build_branch_heavy_fixture(ORPHAN_PATH_FIXTURE);
     let parser = IstanbulCoverage::new(canonical);
-    let out = parser.parse(&payload).expect("orphan-path parses");
+    let out = parser.parse_str(&payload).expect("orphan-path parses");
 
     let unresolved: Vec<_> = out
         .diagnostics
@@ -752,7 +756,7 @@ fn w24_orphan_path_emits_path_unresolved_and_valid_entries_still_parse() {
 fn w24_missing_field_emits_diagnostic_and_skips_only_that_entry() {
     let (_tmp, canonical, payload) = build_branch_heavy_fixture(MISSING_FIELD_FIXTURE);
     let parser = IstanbulCoverage::new(canonical);
-    let out = parser.parse(&payload).expect("missing-field parses");
+    let out = parser.parse_str(&payload).expect("missing-field parses");
 
     let missing: Vec<_> = out
         .diagnostics
@@ -780,7 +784,7 @@ fn w24_missing_field_emits_diagnostic_and_skips_only_that_entry() {
 #[test]
 fn w24_truly_malformed_json_still_returns_source_parse_error() {
     let parser = IstanbulCoverage::new(PathBuf::from("/tmp"));
-    let err = parser.parse("{not json at all").unwrap_err();
+    let err = parser.parse_str("{not json at all").unwrap_err();
     match err {
         CrapError::SourceParse(msg) => assert!(msg.starts_with("istanbul: "), "msg: {msg}"),
         other => panic!("expected SourceParse, got {other:?}"),
@@ -814,7 +818,7 @@ fn w24_validate_accepts_wrapped_shape_for_cli_parity_with_parse() {
 fn w24_top_level_array_emits_schema_unrecognized() {
     let parser = IstanbulCoverage::new(PathBuf::from("/tmp"));
     let out = parser
-        .parse(r#"["not", "istanbul"]"#)
+        .parse_str(r#"["not", "istanbul"]"#)
         .expect("returns Ok with diagnostic");
     assert_eq!(out.diagnostics.len(), 1);
     assert_eq!(
@@ -874,7 +878,7 @@ fn fix215_foreign_prefix_absolute_path_resolves_via_suffix_fallback() {
 
     let parser = IstanbulCoverage::new(canonical);
     let out = parser
-        .parse(&payload)
+        .parse_str(&payload)
         .expect("foreign-prefix absolute path parses via suffix fallback");
 
     assert!(
@@ -915,7 +919,7 @@ fn fix215_no_matching_suffix_still_emits_path_unresolved() {
     );
 
     let parser = IstanbulCoverage::new(canonical);
-    let out = parser.parse(&payload).expect("parses with diagnostic");
+    let out = parser.parse_str(&payload).expect("parses with diagnostic");
 
     let unresolved: Vec<_> = out
         .diagnostics
@@ -961,7 +965,7 @@ fn fix215_ambiguous_suffix_longest_wins_deterministically() {
 
     let parser = IstanbulCoverage::new(canonical);
     let out = parser
-        .parse(&payload)
+        .parse_str(&payload)
         .expect("ambiguous-suffix path parses");
 
     assert!(out.diagnostics.is_empty(), "{:?}", out.diagnostics);
@@ -1084,7 +1088,7 @@ fn fix216_parentdir_traversal_does_not_resolve_outside_effective_src() {
 
     let parser = IstanbulCoverage::new(src_root);
     let out = parser
-        .parse(&payload)
+        .parse_str(&payload)
         .expect("traversal path parses (with diagnostic), no panic");
 
     let unresolved: Vec<_> = out
@@ -1210,7 +1214,7 @@ fn assert_producer_well_formed(
 fn producer_jest29_parses_clean() {
     let (_t, c, p) = build_producer_fixture(PRODUCER_JEST);
     let out = IstanbulCoverage::new(c)
-        .parse(&p)
+        .parse_str(&p)
         .expect("jest 29 captured fixture parses");
     assert_producer_well_formed(&out);
     assert!(
@@ -1231,7 +1235,7 @@ fn producer_vitest4_parses_clean_with_null_columns() {
         "vitest4 fixture must carry null columns — that is the variance under test"
     );
     let out = IstanbulCoverage::new(c)
-        .parse(&p)
+        .parse_str(&p)
         .expect("vitest 4.x captured fixture parses despite null columns");
     assert_producer_well_formed(&out);
 }
@@ -1242,7 +1246,7 @@ fn producer_vitest4_parses_clean_with_null_columns() {
 fn producer_nyc17_parses_clean() {
     let (_t, c, p) = build_producer_fixture(PRODUCER_NYC);
     let out = IstanbulCoverage::new(c)
-        .parse(&p)
+        .parse_str(&p)
         .expect("nyc 17 captured fixture parses");
     assert_producer_well_formed(&out);
 }
@@ -1254,7 +1258,7 @@ fn producer_nyc17_parses_clean() {
 fn producer_c8_parses_clean() {
     let (_t, c, p) = build_producer_fixture(PRODUCER_C8);
     let out = IstanbulCoverage::new(c)
-        .parse(&p)
+        .parse_str(&p)
         .expect("c8 captured fixture parses");
     assert_producer_well_formed(&out);
 }


### PR DESCRIPTION
## Summary

Combined port-surface cleanup closing crap-rs#178 + crap-rs#179. One coordinated bump (crap-core 0.3.0 → 0.4.0) covers both breaking changes; one CHANGELOG migration entry covers the full external-impl recipe.

- **#178** — Renames `CrapError::LcovParse(String)` → `CoverageParse(String)`, eliminating the adapter-name leak in the domain layer. The variant was always dormant (no adapter constructs it today) and adapter-agnostic by intent. Mirrors the same anti-pattern class that closed #161. `CrapError` stays `#[non_exhaustive]` so external matchers with `_ => …` arms continue to compile; explicit matches on the renamed variant need a one-line update.
- **#179** — Evolves `CoveragePort::parse(&self, data: &str)` → `parse(&self, path: &Path)`. Each adapter owns its slurp-vs-stream decision internally. The shared pre-read in `Analyzer::parse_coverage` is removed, closing the double-read trap that motivated `feedback_trait_io_input_path_over_str`. The orchestrator re-adds the `"failed to read coverage file: <path>: …"` context at the `Io` match arm only, preserving the user-facing error UX and the existing test contract.

Closes #178
Closes #179

## What changed

- **`crap-core/src/domain/types.rs`** — variant renamed; `#[error]` attribute updated to source-neutral wording. Added a rustdoc paragraph explaining the dormant-by-design / tool-prefix-at-construction-site convention.
- **`crap-core/src/ports/mod.rs`** — `CoveragePort::parse` signature changes to `&Path`. New rustdoc explains the slurp-vs-stream contract and cites `feedback_trait_io_input_path_over_str` as the operational rule.
- **`crap4rs/src/adapters/coverage/mod.rs`** — `LcovParser::parse_str(&str)` (`pub(crate)`) carries the existing pure parsing logic. `<LcovParser as CoveragePort>::parse(&Path)` slurps via `std::fs::read_to_string` and delegates. Rustdoc explains why slurp is appropriate (LCOV files emitted by `cargo-llvm-cov --lcov` stay well under any peak-RSS concern). In-tree tests and proptests now call `parse_str` directly.
- **`crap4ts/src/adapters/coverage/mod.rs`** — same refactor for `IstanbulCoverage`. `parse_str(&str)` is `pub` (not `pub(crate)`) because the `crap4ts/tests/istanbul_smoke.rs` integration suite lives in a separate crate and exercises parser internals (schema variance, MIN aggregation) directly against string literals. The cucumber harness `tests/istanbul_parser_cucumber.rs` also routes through `parse_str` for the same reason.
- **`crap-core/src/core/mod.rs`** — `Analyzer::parse_coverage` removes the pre-read; passes the `&Path` directly to the port. The `Io` variant gets wrapped with the `"failed to read coverage file: <path>"` context (preserves the test contract at `crap4rs/tests/analyze_pipeline_tests.rs:311`).
- **`crap-core/src/cli/mod.rs`** — `StubCoveragePort` test stub updated to match the new trait signature.
- **`crap4ts/tests/istanbul_smoke.rs`** + **`crap4ts/tests/istanbul_parser_cucumber.rs`** — bulk-renamed `.parse(<str>)` → `.parse_str(<str>)`. No semantic change.
- **`crap-core/Cargo.toml`** — version `0.3.0` → `0.4.0`. **`Cargo.toml`** workspace dep declaration bumped to match.
- **`CHANGELOG.md`** — single entry under `[Unreleased]` covering both changes with a migration recipe for any external `CoveragePort` impls (likely none today, but recipe documents the contract).

## Wire-envelope canary

- **`wire_envelope_crap4rs`** — **deliberate drift**, accepted. The analyzer's self-report sees `LcovParser::parse_str` as a new function (the pure parsing logic split out of the original `parse`) and surrounding line numbers shift from new rustdoc. The structural change is intentional; the wire canary correctly tracked the source-position movement. No semantic change in any function's CRAP score, complexity, or contributors beyond the new `parse_str` row.
- **`wire_envelope_crap4ts`** — byte-identical (TS source unchanged; the crap4ts envelope analyses TS fixtures, not the Rust adapter source).
- **`wire_envelope_crap4ts_branches`** — byte-identical (same reason).

Original prediction was "byte-identical on all three." The crap4rs drift is the kind of structural drift the canary exists to catch — accepted with explanation.

## ast-purity layer-4 extension — deferred

The optional layer-4 extension to ban adapter-vocabulary string literals (`"LCOV"`, `"Istanbul"`, `"TypeScript"`) in `crates/crap-core/src/` is deferred to **#261** (filed as a sub-issue of epic #173, `type:chore` + `priority:soon`). Reasons:

- The variant rename alone closes the immediate domain-layer leak.
- The lint needs careful regex design to avoid false-positives on the many legitimate rustdoc cross-references like ``LcovParseDiagnostic` (in `crap4rs`)`` that exist in `crap-core/src/`.
- Tighter PR scope here = faster review.

The follow-up issue captures the design discovery items (PCRE2 lookbehinds, banlist scope, regex strategy).

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo nextest run --workspace --all-targets` — 1110/1110 passed
- [x] `cargo doc --workspace --no-deps` with `RUSTDOCFLAGS="-D warnings"` — clean
- [x] `cargo +1.93 check --workspace --all-targets` — clean (MSRV)
- [x] `cargo deny check` — clean
- [x] ast-purity layer 1–3 (leading-token imports, grouped imports, direct crate deps) — clean
- [x] `cargo insta test --check` — no pending snapshots (the crap4rs envelope drift is committed)
- [x] `grep -r 'LcovParse' crates/` returns zero hits in source files (snapshot history strings retained as `LcovParser::*` function names, which are unrelated method-name identifiers)
- [x] `grep -rn 'read_to_string' crates/crap-core/src/` shows no pre-coverage-port read remains (the remaining hits are init template tests and config file reading, unrelated to coverage parsing)

Cucumber harnesses run via `lefthook cucumber:` pre-push (same step that runs `json_reporter_cucumber` and the 7 other harnesses) — green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
