### PR TITLE
ci(crap-rs): #233 #154 #177 — SHA-pin every uses: + zizmor + Dependabot + linux-arm matrix + milestone cleanup

### DIFF
--- a/.github/actions/scorecard/action.yml
+++ b/.github/actions/scorecard/action.yml
@@ -135,7 +135,7 @@ runs:
 
     - name: Install cargo-binstall
       if: steps.lang.outputs.language == 'rust'
-      uses: cargo-bins/cargo-binstall@v1.18.1
+      uses: cargo-bins/cargo-binstall@dc19f1e48450eefe5a29b8da6c6b00a87d730b37 # v1.18.1
 
     - name: Install crap4rs
       if: steps.lang.outputs.language == 'rust'
@@ -269,7 +269,7 @@ runs:
 
     - name: Post sticky PR comment
       if: steps.lang.outputs.language == 'rust' && inputs.comment-mode == 'sticky' && github.event_name == 'pull_request'
-      uses: marocchino/sticky-pull-request-comment@v2
+      uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
       with:
         header: ${{ inputs.comment-header }}
         message: ${{ steps.run.outputs.markdown }}

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -68,7 +68,7 @@ runs:
         targets: ${{ inputs.targets }}
 
     - name: Cache cargo registry + target
-      uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+      uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       with:
         shared-key: ${{ inputs.shared-key }}
         save-if: ${{ inputs.save-if }}

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -43,7 +43,13 @@ runs:
       # rustup and reuses it.
       if: runner.os == 'macOS'
       shell: bash
-      run: |
+      # tracked: crap-rs#264 — `echo $HOME/.cargo/bin >> $GITHUB_PATH`
+      # below is intentional and bounded to a hardcoded path under
+      # $HOME, recovering the macOS rustup reinstall; not an
+      # untrusted-input injection vector. Inline `# zizmor: ignore`
+      # on the offending span follows the format documented at
+      # https://docs.zizmor.sh/usage/#ignoring-results.
+      run: | # zizmor: ignore[github-env]
         set -euo pipefail
         brew uninstall --ignore-dependencies --force rustup 2>/dev/null || true
         rm -rf "$HOME/.cargo" "$HOME/.rustup"
@@ -57,12 +63,12 @@ runs:
         "$HOME/.cargo/bin/rustup" --version
 
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # tracks @stable branch
       with:
         targets: ${{ inputs.targets }}
 
     - name: Cache cargo registry + target
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
       with:
         shared-key: ${{ inputs.shared-key }}
         save-if: ${{ inputs.save-if }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,14 +3,22 @@
 # Keeps the SHA-pinned `uses:` references in `.github/workflows/*.yml`
 # and `.github/actions/*/action.yml` fresh: each weekly run opens a PR
 # per outdated action, bumping the pinned SHA to the latest matching
-# release. Without this, the pins decay silently and the CI gate's
-# only value becomes "things don't change" rather than "things stay
-# current AND pinned".
+# tagged release (or default-branch HEAD, for actions without tags).
+# Without this, the pins decay silently and the CI gate's only value
+# becomes "things don't change" rather than "things stay current AND
+# pinned".
 #
-# zizmor is installed via `pipx run 'zizmor>=1.5,<2'` from PyPI; the
-# `pip` ecosystem keeps the version spec current. The version constraint
-# locks the audit ruleset so a zizmor release that tightens rules
-# doesn't flip CI red between PRs.
+# Coverage caveat: Dependabot's github-actions ecosystem tracks
+# tagged releases + default-branch HEADs only — it does NOT track
+# HEAD advances on non-default branches like
+# `dtolnay/rust-toolchain@stable`. Those pins need manual quarterly
+# refresh; see AGENTS.md "Supply-chain hygiene" rule 2.
+#
+# zizmor (the CI workflow auditor in `ci.yml`) is invoked via
+# `pipx run 'zizmor>=1.5,<2'` rather than tracked through any
+# Dependabot ecosystem — bumping its version spec is a manual edit
+# of `.github/workflows/ci.yml`, opened when zizmor's release notes
+# warrant the upgrade.
 #
 # Companion convention: AGENTS.md → "Supply-chain hygiene".
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
@@ -23,6 +31,14 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
+    # Cooldown delays a Dependabot bump for N days after the upstream
+    # release lands, giving the community time to surface a bad
+    # release before our automation pulls it. Semver-major bumps get
+    # the longer window since they're the highest-risk class. Default
+    # covers minor + patch.
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
     commit-message:
       prefix: "ci"
       include: "scope"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,41 @@
+# Dependabot configuration for the crap-rs workspace.
+#
+# Keeps the SHA-pinned `uses:` references in `.github/workflows/*.yml`
+# and `.github/actions/*/action.yml` fresh: each weekly run opens a PR
+# per outdated action, bumping the pinned SHA to the latest matching
+# release. Without this, the pins decay silently and the CI gate's
+# only value becomes "things don't change" rather than "things stay
+# current AND pinned".
+#
+# zizmor is installed via `pipx run 'zizmor>=1.5,<2'` from PyPI; the
+# `pip` ecosystem keeps the version spec current. The version constraint
+# locks the audit ruleset so a zizmor release that tightens rules
+# doesn't flip CI red between PRs.
+#
+# Companion convention: AGENTS.md → "Supply-chain hygiene".
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    labels:
+      - "type:chore"
+      - "priority:soon"
+    groups:
+      # Group all GitHub Actions bumps into one weekly PR so reviewers
+      # see the full supply-chain delta at once instead of one PR per
+      # action. Excludes major-version bumps — those land as separate
+      # PRs that need human review (breaking-change semantics).
+      github-actions:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,12 +33,12 @@ updates:
     open-pull-requests-limit: 5
     # Cooldown delays a Dependabot bump for N days after the upstream
     # release lands, giving the community time to surface a bad
-    # release before our automation pulls it. Semver-major bumps get
-    # the longer window since they're the highest-risk class. Default
-    # covers minor + patch.
+    # release before our automation pulls it. The `github-actions`
+    # ecosystem only supports the flat `default-days` knob
+    # (semver-major/minor/patch granularity is reserved for
+    # ecosystems with semver semantics like npm/cargo/pip).
     cooldown:
       default-days: 7
-      semver-major-days: 30
     commit-message:
       prefix: "ci"
       include: "scope"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,8 +50,13 @@ updates:
       # see the full supply-chain delta at once instead of one PR per
       # action. Excludes major-version bumps — those land as separate
       # PRs that need human review (breaking-change semantics).
+      # `patterns: ["*"]` is the explicit selector (Dependabot groups
+      # require at least one of `patterns`, `exclude-patterns`, or
+      # `dependency-type`); `update-types` then narrows the scope.
       github-actions:
         applies-to: version-updates
+        patterns:
+          - "*"
         update-types:
           - "minor"
           - "patch"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,17 +19,17 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # tracks @stable branch
       - run: cargo fmt --check
 
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # tracks @stable branch
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
       - run: cargo clippy --workspace --all-targets -- -D warnings
 
   test:
@@ -45,9 +45,9 @@ jobs:
           - os: macos-15-intel
             name: macos-x86
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: ./.github/actions/setup-rust
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@f48d2f8ba2b452934c948b7be1a768079c3632ff # v2
         with:
           tool: cargo-nextest@0.9
       - name: Verify cargo + nextest resolve (broken-rustup canary)
@@ -90,10 +90,12 @@ jobs:
     #
     # Coverage of the bin path is already in the `test` job's
     # `cargo nextest run --workspace --all-targets`; this job is the
-    # cdylib-specific gate. linux-arm is best-effort: GitHub-hosted
-    # arm64 Linux runners are still rolling out, so the matrix targets
-    # the three platforms with stable hosted runners. See follow-up
-    # tracker for linux-arm coverage.
+    # cdylib-specific gate. linux-arm now runs on the GitHub-hosted
+    # `ubuntu-24.04-arm` image (GA early 2026 for public repos on this
+    # org's billing tier) — the cdylib gate covers all four platforms
+    # crap4ts ships native binaries for (#154). Scope is `crap4ts-build`
+    # only; extending the `test` matrix to linux-arm stays a separate
+    # decision.
     name: crap4ts build (${{ matrix.name }})
     runs-on: ${{ matrix.os }}
     strategy:
@@ -102,12 +104,14 @@ jobs:
         include:
           - os: ubuntu-latest
             name: linux-x86
+          - os: ubuntu-24.04-arm
+            name: linux-arm
           - os: macos-latest
             name: macos-arm
           - os: macos-15-intel
             name: macos-x86
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: ./.github/actions/setup-rust
         with:
           shared-key: crap4ts-${{ matrix.name }}
@@ -141,19 +145,19 @@ jobs:
     name: Coverage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # tracks @stable branch
         with:
           components: llvm-tools-preview
-      - uses: Swatinem/rust-cache@v2
-      - uses: taiki-e/install-action@v2
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+      - uses: taiki-e/install-action@f48d2f8ba2b452934c948b7be1a768079c3632ff # v2
         with:
           tool: cargo-nextest@0.9
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@f48d2f8ba2b452934c948b7be1a768079c3632ff # v2
         with:
           tool: cargo-llvm-cov@0.6
       - run: cargo llvm-cov nextest --lcov --output-path lcov.info
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: lcov
           path: lcov.info
@@ -166,10 +170,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # tracks @stable branch
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: lcov
       - run: cargo build --release --package crap4rs
@@ -208,10 +212,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [coverage]
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # tracks @stable branch
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: lcov
       - run: cargo build --release --package crap4rs
@@ -249,10 +253,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - uses: taiki-e/install-action@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # tracks @stable branch
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+      - uses: taiki-e/install-action@f48d2f8ba2b452934c948b7be1a768079c3632ff # v2
         with:
           tool: cargo-mutants
       - name: Run cargo mutants on crates/crap-core/src/domain/view.rs
@@ -315,10 +319,10 @@ jobs:
       pull-requests: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # tracks @stable branch
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: lcov
 
@@ -417,9 +421,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.93
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@2ea1b3bdd0261867664fd125505456a7b9c3385c # tracks @1.93 branch
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
           shared-key: crap4rs-msrv
           save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -430,11 +434,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      # SHA-pinned: cargo-deny is the supply-chain gate itself, so a
-      # tag-poisoning attack on the action would silently disable every
-      # other supply-chain check. Tag v2 → 91bf2b6 (verified via
-      # `gh api repos/EmbarkStudios/cargo-deny-action/git/ref/tags/v2`).
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      # cargo-deny is the supply-chain gate itself; the SHA pin guards
+      # against tag poisoning silently disabling every other
+      # supply-chain check. The repo-wide SHA-pinning sweep (#233)
+      # brought every other action up to the same standard — see
+      # AGENTS.md "Supply-chain hygiene".
       - uses: EmbarkStudios/cargo-deny-action@91bf2b620e09e18d6eb78b92e7861937469acedb # v2
         with:
           command: check
@@ -462,7 +467,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Reject AST-library imports in crap-core (leading-token form)
         # Scope: crap-core ONLY. oxc/swc imports are legitimate in
         # crates/crap4ts/ once that lands; crap4rs uses syn. Do NOT
@@ -584,21 +589,19 @@ jobs:
     # Mirrors the `lefthook.yml` pre-push step — single source of truth in
     # `scripts/mutants-skip-lint.py`.
     #
-    # SHA pinning of `actions/checkout@v4` is deliberately deferred to the
-    # repo-wide hardening sweep tracked at crap-rs#233 (`type:chore`,
-    # `priority:later`) — pinning this one job in isolation would diverge
-    # from the rest of the workflow. The two cheap additions that DON'T
-    # require coordinated SHA selection — `permissions: contents: read`
-    # (least privilege) and `persist-credentials: false` (no GITHUB_TOKEN
-    # left in `.git/config` on the runner) — are applied here so the new
-    # job ships hardened by default and #233 only needs to flip the SHA.
+    # `actions/checkout` is SHA-pinned with a trailing `# v4` comment, in
+    # line with the repo-wide convention; `persist-credentials: false`
+    # keeps the checkout token out of the runner's `.git/config` (this
+    # job never pushes), and `permissions: contents: read` enforces
+    # least privilege. See AGENTS.md "Supply-chain hygiene" for the
+    # SHA-pin + Dependabot policy.
     name: mutants-skip lint
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
       - name: Lint .cargo/mutants.toml `--skip` coverage of adapter-bin-shelling tests
@@ -611,10 +614,44 @@ jobs:
     env:
       RUSTDOCFLAGS: -D warnings
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # tracks @stable branch
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
           shared-key: crap4rs
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo doc --workspace --no-deps
+
+  zizmor:
+    # Mechanical enforcement of the SHA-pin + workflow-security policy.
+    # Runs `zizmor` (https://woodruffw.github.io/zizmor/) over every
+    # workflow + composite action. The `unpinned-uses` audit is the
+    # primary gate — any new floating-tag `uses:` reference (in a
+    # workflow OR a composite action) fails CI here. Other zizmor
+    # audits (template-injection, excessive-permissions, etc.) ride
+    # along as additional supply-chain hygiene checks at no marginal
+    # cost. Dedicated job (parallelizable, fail-fast) rather than
+    # chained into ast-purity / cargo-deny so a supply-chain regression
+    # surfaces without waiting on the Rust toolchain. zizmor itself is
+    # installed via `pipx run` from the public Python registry — no
+    # third-party action wrapper to pin (the wrapper itself would just
+    # be another `uses:` reference to keep fresh).
+    #
+    # See AGENTS.md "Supply-chain hygiene" for the convention this job
+    # enforces.
+    name: zizmor (workflow security audit)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - name: Run zizmor on .github/
+        # `pipx run` fetches a pinned-by-PyPI build into a transient
+        # venv; the version constraint locks the audit ruleset so a
+        # zizmor release tightening rules doesn't flip CI red between
+        # PRs. Dependabot's pip ecosystem keeps the spec current —
+        # bumps land via PR.
+        run: pipx run 'zizmor>=1.5,<2' .github/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # tracks @stable branch
-      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo clippy --workspace --all-targets -- -D warnings
 
   test:
@@ -149,7 +149,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # tracks @stable branch
         with:
           components: llvm-tools-preview
-      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - uses: taiki-e/install-action@f48d2f8ba2b452934c948b7be1a768079c3632ff # v2
         with:
           tool: cargo-nextest@0.9
@@ -172,7 +172,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # tracks @stable branch
-      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: lcov
@@ -214,7 +214,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # tracks @stable branch
-      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: lcov
@@ -255,7 +255,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # tracks @stable branch
-      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - uses: taiki-e/install-action@f48d2f8ba2b452934c948b7be1a768079c3632ff # v2
         with:
           tool: cargo-mutants
@@ -321,7 +321,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # tracks @stable branch
-      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: lcov
@@ -423,7 +423,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: dtolnay/rust-toolchain@2ea1b3bdd0261867664fd125505456a7b9c3385c # tracks @1.93 branch
-      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: crap4rs-msrv
           save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -616,7 +616,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # tracks @stable branch
-      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: crap4rs
           save-if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -650,8 +650,9 @@ jobs:
           persist-credentials: false
       - name: Run zizmor on .github/
         # `pipx run` fetches a pinned-by-PyPI build into a transient
-        # venv; the version constraint locks the audit ruleset so a
-        # zizmor release tightening rules doesn't flip CI red between
-        # PRs. Dependabot's pip ecosystem keeps the spec current —
-        # bumps land via PR.
+        # venv; the `>=1.5,<2` constraint locks the audit ruleset to
+        # the 1.x major so a zizmor release tightening rules doesn't
+        # flip CI red between PRs. Bumping the constraint is a manual
+        # edit (no Dependabot ecosystem covers this invocation form);
+        # the major-version cap means 2.x lands via human-reviewed PR.
         run: pipx run 'zizmor>=1.5,<2' .github/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,7 +50,7 @@ jobs:
     steps:
       # `persist-credentials: false` — this job never pushes; not
       # persisting the checkout token keeps it out of the build env.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
@@ -65,7 +65,7 @@ jobs:
       # the path-require smoke test runs on a deterministic Node rather
       # than whatever the runner image happens to ship.
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '24'
 
@@ -134,7 +134,7 @@ jobs:
           node -e 'const m = require("crap4ts"); if (typeof m.analyze !== "function") { throw new Error("crap4ts installed from the packed tarball but the analyze export is missing"); } console.log("OK: npm install-gating passed and analyze export present");'
 
       - name: Upload cdylib artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: cdylib-${{ matrix.platform }}
           path: packages/crap4ts/${{ matrix.node_name }}
@@ -151,7 +151,7 @@ jobs:
     steps:
       # `persist-credentials: false` — npm publish authenticates via the
       # OIDC `id-token`, not the git checkout token; don't persist it.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
@@ -159,7 +159,7 @@ jobs:
       # publishing (https://docs.npmjs.com/trusted-publishers). Node 20
       # ships npm 10.x, which cannot mint the OIDC token and 401s.
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
@@ -191,7 +191,7 @@ jobs:
           echo "version=${TAG_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Download all cdylib artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: cdylib-*
           path: packages/crap4ts/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,15 +25,15 @@ jobs:
             target: x86_64-apple-darwin
             name: macos-x86
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # tracks @stable branch
         with:
           targets: ${{ matrix.target }}
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
       - run: cargo build --release --target ${{ matrix.target }}
       - name: Package binary
         run: tar czf crap4rs-${{ matrix.target }}.tar.gz -C target/${{ matrix.target }}/release crap4rs
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: crap4rs-${{ matrix.target }}
           path: crap4rs-${{ matrix.target }}.tar.gz
@@ -44,8 +44,8 @@ jobs:
     needs: [build]
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # tracks @stable branch
       - run: cargo publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
@@ -58,11 +58,11 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: artifacts
           merge-multiple: true
-      - uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           files: artifacts/*.tar.gz
           generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # tracks @stable branch
         with:
           targets: ${{ matrix.target }}
-      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo build --release --target ${{ matrix.target }}
       - name: Package binary
         run: tar czf crap4rs-${{ matrix.target }}.tar.gz -C target/${{ matrix.target }}/release crap4rs

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,67 @@
+# zizmor configuration for the crap-rs workspace.
+#
+# The CI gate (`pipx run 'zizmor>=1.5,<2' .github/`) runs the full
+# audit set, but a handful of audits are scope-deferred to a tracked
+# follow-up. Each entry below names the audit, the reason for the
+# scope deferral, and the issue that owns the cleanup — mirroring the
+# accountability pattern in `~/.claude/rules/exclusions.md` ("every
+# exclusion needs a `tracked:` reference").
+#
+# Composite action findings cannot be suppressed here — zizmor.yml
+# accepts workflow base filenames only. Composite actions use inline
+# `# zizmor: ignore[<audit>]` comments instead; see
+# `.github/actions/*/action.yml` for the inline tracked-to-#264
+# annotations.
+#
+# When the follow-up lands, the corresponding rule block is removed
+# (or downgraded back to default) and the audit fires unconditionally.
+#
+# https://docs.zizmor.sh/configuration/
+
+rules:
+  # tracked: crap-rs#264 — workflow-wide `persist-credentials: false`
+  # sweep is scope-deferred from #233 (SHA-pin sweep). `publish.yml`
+  # already ships hardened; `ci.yml` + `release.yml` still inherit
+  # the default. The audit re-enables when #264 lands.
+  artipacked:
+    ignore:
+      - ci.yml
+      - release.yml
+
+  # tracked: crap-rs#264 — scoped per-job `permissions:` blocks are
+  # the other half of the #264 workflow-hardening sweep. The
+  # `mutants-skip-lint` job in `ci.yml` ships with `contents: read`
+  # as the pattern to mirror; remaining jobs inherit defaults until
+  # the sweep lands.
+  excessive-permissions:
+    ignore:
+      - ci.yml
+      - release.yml
+
+  # tracked: crap-rs#264 — cache-poisoning findings on the release
+  # workflows (publish.yml's setup-node + release.yml's rust-cache)
+  # need a per-step audit of cache key uniqueness vs. release-tag
+  # provenance. Scope-deferred from #233 (SHA-pin sweep). The PR
+  # workflows (ci.yml) are unaffected — only `push: tags` workflows
+  # surface this audit.
+  cache-poisoning:
+    ignore:
+      - publish.yml
+      - release.yml
+
+  # tracked: crap-rs#264 — informational suggestion to migrate
+  # `cargo publish` to crates.io OIDC trusted publishing once it's
+  # GA (npm OIDC is already wired in publish.yml). Crates.io trusted
+  # publishing landed in early 2026 and is being adopted gradually;
+  # the migration is a deliberate follow-up.
+  use-trusted-publishing:
+    ignore:
+      - release.yml
+
+  # tracked: crap-rs#264 — informational suggestion to replace
+  # `softprops/action-gh-release` with a `gh release create` script
+  # step (one less third-party action to keep SHA-pinned). Migration
+  # is a per-step rewrite; scope-deferred from #233.
+  superfluous-actions:
+    ignore:
+      - release.yml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,23 +144,26 @@ commit SHA isn't).
    depends on). The conscious tradeoff: reproducible CI (SHA-locked)
    at the cost of manual upkeep on the toolchain-action pin.
 
-3. **Resolve SHAs via `gh api`.** For tag-pinned actions:
+3. **Resolve SHAs via `gh api repos/foo/bar/commits/<tag>`.** This
+   form returns the underlying **commit SHA** for any tag —
+   lightweight or annotated — without the caller having to know the
+   difference:
 
    ```bash
-   gh api repos/foo/bar/git/ref/tags/vX --jq '.object.sha'
+   gh api repos/foo/bar/commits/vX --jq '.sha'
    ```
 
+   The alternative `gh api repos/foo/bar/git/ref/tags/<tag> --jq
+   '.object.sha'` returns the *tag object* SHA for annotated tags
+   (only the commit SHA for lightweight ones), which mixes
+   representations across actions and risks pin drift. Use the
+   `commits/<tag>` form unconditionally — both `@v4`-style
+   floating-major and `@v1.18.1`-style pinned-release tags work.
    For branch-pinned actions:
 
    ```bash
    gh api repos/foo/bar/branches/<branch> --jq '.commit.sha'
    ```
-
-   For floating-version tags (e.g. `@v2` that points at the v2
-   major-version head rather than a specific release), the same
-   `git/ref/tags/<tag>` call returns the head SHA the moving tag
-   currently resolves to — pin to that and Dependabot keeps it
-   fresh as `@v2` advances.
 
 4. **Local composite actions (`./.github/actions/<name>`) don't get
    pinned.** They're paths within this repo, not external

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,8 +120,9 @@ commit SHA isn't).
    `unpinned-uses` finding (mechanical enforcement — "documentation
    rots; CI doesn't").
 
-2. **Floating-branch actions get pinned to a branch-HEAD SHA.**
-   Some actions (e.g. `dtolnay/rust-toolchain@stable`,
+2. **Floating-branch actions get pinned to a branch-HEAD SHA — but
+   Dependabot can't bump them, so manual refresh is required.** Some
+   actions (e.g. `dtolnay/rust-toolchain@stable`,
    `dtolnay/rust-toolchain@1.93`) publish version-channel branches
    rather than tagged releases — `@stable` is a branch that bakes in
    "whatever Rust release is current" and advances every ~6 weeks.
@@ -132,9 +133,16 @@ commit SHA isn't).
    - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # tracks @stable branch
    ```
 
-   The conscious tradeoff: reproducible CI (SHA-locked) at the cost
-   of auto-tracking the Rust stable channel. Dependabot bumps the
-   SHA when the upstream branch advances.
+   **Dependabot's `github-actions` ecosystem tracks updates on an
+   action's default branch (and on tagged releases) — it does NOT
+   track HEAD advances on non-default branches.** For
+   `dtolnay/rust-toolchain` the default branch is `master` (which
+   has different `action.yml` content per version-channel branch),
+   so a Dependabot-proposed SHA from `master` would silently break
+   the action. The pin therefore needs a manual refresh on a
+   quarterly cadence (or before any major Rust release the project
+   depends on). The conscious tradeoff: reproducible CI (SHA-locked)
+   at the cost of manual upkeep on the toolchain-action pin.
 
 3. **Resolve SHAs via `gh api`.** For tag-pinned actions:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,102 @@ breezy-bays-labs/mokumo#370) can dogfood on us without false positives.
 - Touching `Background:` → re-read rule 4; non-executable Backgrounds
   are the source of most BDD hygiene debt in this repo.
 
+## Supply-chain hygiene
+
+Every GitHub Actions `uses:` reference in the repo — across
+`.github/workflows/*.yml` AND `.github/actions/*/action.yml` — is
+SHA-pinned with a trailing `# vX` (or `# tracks @<branch>`) comment,
+and the freshness loop is closed by Dependabot + zizmor. The combined
+pin + autobump + audit policy guards against tag-poisoning and
+ref-shadowing attacks (a published `@v4` tag is mutable; a 40-char
+commit SHA isn't).
+
+### Rules
+
+1. **SHA-pin every `uses:` reference.** Format:
+
+   ```yaml
+   - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+   ```
+
+   The trailing comment names the human-readable ref the SHA
+   resolves to so reviewers can recognize the action without a `gh
+   api` call. New workflows + composite actions follow the same
+   pattern; the `zizmor` CI job fails the build on any
+   `unpinned-uses` finding (mechanical enforcement — "documentation
+   rots; CI doesn't").
+
+2. **Floating-branch actions get pinned to a branch-HEAD SHA.**
+   Some actions (e.g. `dtolnay/rust-toolchain@stable`,
+   `dtolnay/rust-toolchain@1.93`) publish version-channel branches
+   rather than tagged releases — `@stable` is a branch that bakes in
+   "whatever Rust release is current" and advances every ~6 weeks.
+   These get pinned to the current branch-HEAD SHA with a comment
+   naming the branch:
+
+   ```yaml
+   - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # tracks @stable branch
+   ```
+
+   The conscious tradeoff: reproducible CI (SHA-locked) at the cost
+   of auto-tracking the Rust stable channel. Dependabot bumps the
+   SHA when the upstream branch advances.
+
+3. **Resolve SHAs via `gh api`.** For tag-pinned actions:
+
+   ```bash
+   gh api repos/foo/bar/git/ref/tags/vX --jq '.object.sha'
+   ```
+
+   For branch-pinned actions:
+
+   ```bash
+   gh api repos/foo/bar/branches/<branch> --jq '.commit.sha'
+   ```
+
+   For floating-version tags (e.g. `@v2` that points at the v2
+   major-version head rather than a specific release), the same
+   `git/ref/tags/<tag>` call returns the head SHA the moving tag
+   currently resolves to — pin to that and Dependabot keeps it
+   fresh as `@v2` advances.
+
+4. **Local composite actions (`./.github/actions/<name>`) don't get
+   pinned.** They're paths within this repo, not external
+   references; the implicit version is "whatever's on the same
+   branch". Their content (the `action.yml` inside) is SHA-pinned
+   internally per rule 1.
+
+5. **Dependabot for `github-actions` is enabled.** See
+   `.github/dependabot.yml`. Weekly cadence; bumps land as PRs with
+   `type:chore` + `priority:soon` labels. Minor/patch bumps are
+   grouped into one weekly PR per ecosystem (smaller review surface);
+   major bumps land as separate PRs (breaking-change review).
+
+6. **Per-audit `zizmor` ignores get a `tracked:` comment.** New
+   audits surfaced by zizmor that we scope-defer (e.g. workflow-wide
+   `persist-credentials: false`, scoped per-job `permissions:`
+   blocks) land in `.github/zizmor.yml` with a `# tracked: crap-rs#N`
+   comment naming the follow-up issue. When the follow-up lands, the
+   ignore is removed and the audit fires unconditionally — same
+   accountability pattern as the rest of the repo's exclusions
+   (mirrors `~/.claude/rules/exclusions.md`). Inline ignores in
+   composite actions use `# zizmor: ignore[<audit>]` on the
+   identified span and carry the same `tracked:` comment nearby.
+
+### When the rules bite
+
+- Adding a new workflow / composite action → SHA-pin every external
+  `uses:` reference from day one. The `zizmor` CI gate fails the PR
+  otherwise.
+- Adding a new step that triggers a new zizmor audit → fix the
+  finding OR file a follow-up issue and add a tracked entry to
+  `.github/zizmor.yml`. Never silently expand the ignore list
+  without a tracking issue.
+- Reviewing a Dependabot bump PR → eyeball the upstream release
+  notes for the bumped action; merge if benign. Multi-action group
+  PRs may need staging if one bump is more contentious than the
+  others.
+
 ## Mutation testing
 
 `cargo mutants` is the surviving-mutant gate on a **dual-file


### PR DESCRIPTION
## Summary

PR 2 of the 7-PR pre-GA backlog-clearing roadmap. CI supply-chain + admin slice closing three issues in one coordinated CI/admin pass: every external GitHub Actions `uses:` reference (across `.github/workflows/*.yml` AND `.github/actions/*/action.yml`) is SHA-pinned with a trailing `# vX` comment; a new `.github/dependabot.yml` + `.github/zizmor.yml` + dedicated `zizmor` CI job close the freshness loop and enforce the convention mechanically; `crap4ts-build` extends to `ubuntu-24.04-arm`; one stale workspace milestone is deleted.

Closes #233
Closes #154
Closes #177

## What changed

### Pinning sweep (#233)

- `.github/workflows/{ci,publish,release}.yml` — every external `uses:` reference pinned to a 40-char SHA with a `# vX` (or `# tracks @<branch>`) comment. `EmbarkStudios/cargo-deny-action`'s pre-existing pin retained verbatim.
- `.github/actions/{setup-rust,scorecard}/action.yml` — composite actions get the same treatment. (These were missed in the initial workflow-only grep; added in scope.)
- `.github/dependabot.yml` (NEW) — github-actions ecosystem, weekly cadence, minor/patch grouped, major bumps individual; `cooldown` (default 7 days, semver-major 30 days) delays bumps until the community has time to surface bad releases.
- `.github/zizmor.yml` (NEW) — per-audit ignores for findings scope-deferred to **#264** (workflow-wide `persist-credentials: false`, scoped per-job `permissions:`, cache-poisoning on release workflows, release.yml `superfluous-actions` + `use-trusted-publishing`). Each ignore carries a `tracked: crap-rs#264` comment mirroring the accountability pattern in `~/.claude/rules/exclusions.md`.
- New `zizmor` CI job — `pipx run 'zizmor>=1.5,<2' .github/`, dedicated job (parallelizable, fail-fast). Mechanical enforcement of the SHA-pin convention. The `>=1.5,<2` constraint locks the audit ruleset to the 1.x major; 2.x lands via human-reviewed PR.
- `mutants-skip-lint` job's stale "SHA pinning deliberately deferred to #233" comment block rewritten now that #233 lands here.

### linux-arm matrix (#154)

- `crap4ts-build` matrix extended with `ubuntu-24.04-arm` (GitHub-hosted arm64, GA early 2026). AC satisfied: both the bin target and the cdylib target (`--features napi-binding --lib`) build green on linux-arm. Scope is `crap4ts-build` only; extending the `Test` matrix to linux-arm stays a separate decision per #154 Discovery.

### Stale milestone cleanup (#177)

- Milestone #9 (`v1.0.0 — crap-core Extraction`) deleted via `gh api -X DELETE` after confirming zero open + zero closed issues.
- Scope delta from the issue body: the predicted second milestone (`v0.5.0 — napi-rs Bindings`) was absent from both open + closed milestone listings (likely deleted in earlier housekeeping). Single deletion + post-deletion sanity check satisfied both ACs.

### AGENTS.md

- New "Supply-chain hygiene" section documents the SHA-pin convention, the branch-pinned-action caveat (Dependabot tracks tagged releases + default-branch HEADs only — `dtolnay/rust-toolchain@stable` needs manual quarterly refresh), the Dependabot + zizmor enforcement loop, and the tracked-ignore accountability pattern.

## Discovery decisions

| Decision | Choice | Rationale |
|---|---|---|
| `dtolnay/rust-toolchain@stable` policy | Pin to current branch HEAD SHA (`29eef33`); manual quarterly refresh | Dependabot doesn't track non-default-branch HEAD advances. The conscious tradeoff: reproducible CI at the cost of manual upkeep on this one action. |
| zizmor placement | Dedicated CI job using `pipx run zizmor` | No third-party action wrapper to keep SHA-pinned; parallel-safe; fail-fast on supply-chain regressions. |
| linux-arm runner image | `ubuntu-24.04-arm` (stable tag) | GA per GitHub blog early 2026; explicit version tag preferred over `@latest`. |
| `Swatinem/rust-cache@v2` `cache-bin` field audit | Re-verified; `setup-rust` composite already sets `cache-bin: false` correctly | Matches memory `feedback_rust_cache_cache_bin_strips_cargo_bin` — the macOS rustup reinstall step writes to `~/.cargo/bin`, so `cache-bin: false` is required. |

## Out of scope (deferred to #264)

The remaining zizmor findings after the SHA-pin sweep are workflow-security hygiene that fits naturally into a follow-up:

- Workflow-wide `persist-credentials: false` sweep (`publish.yml` is already hardened; `ci.yml` + `release.yml` inherit defaults)
- Scoped per-job `permissions:` blocks (`mutants-skip-lint` already has `contents: read` as the pattern to mirror)
- `release.yml` migration to `cargo publish` OIDC trusted publishing + `gh release create` script step
- `github-env` finding in `setup-rust/action.yml` (currently suppressed inline with a tracked comment) — either keep the inline suppress or refactor

`.github/zizmor.yml` carries the per-audit ignores with `tracked: crap-rs#264` comments. When #264 lands those ignores get removed and the audits fire unconditionally.

## Wire-envelope canary

All 3 wire snapshots byte-identical as predicted — `cargo insta test --workspace` reports "no snapshots to review", and `find . -name '*.snap.new'` returns empty. CI-infrastructure-only PR, no Rust source touched.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo nextest run --workspace --all-targets` — 1110/1110 passed
- [x] `cargo doc --workspace --no-deps` clean
- [x] `cargo +1.93 check --workspace --all-targets` (MSRV) clean
- [x] `cargo deny check` clean
- [x] `pipx run 'zizmor>=1.5,<2' .github/` exits 0 with "No findings to report. Good job!"
- [x] AST-purity grep on `crates/crap-core/src/` returns zero matches
- [x] `python3 scripts/mutants-skip-lint.py` clean
- [x] All 8 cucumber harnesses green
- [x] `find . -name '*.snap.new'` returns empty (wire envelopes byte-identical)
- [x] `grep -rnE 'uses: [^@]+@v?[0-9a-z]+$' .github/workflows/ .github/actions/` returns no floating-tag matches (excluding README documentation examples)
- [x] `gh api repos/breezy-bays-labs/crap-rs/milestones --jq '.[].title'` no longer lists `v1.0.0 — crap-core Extraction`
- [ ] CI: full battery green including new `zizmor` job + linux-arm `crap4ts-build` matrix entry