### PR TITLE
feat: #180 #196 #202 — BDD tracked-comment lint + delta.feature spec + colored set_override poison fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -658,6 +658,34 @@ jobs:
       - name: Lint .cargo/mutants.toml `--skip` coverage of adapter-bin-shelling tests
         run: python3 scripts/mutants-skip-lint.py
 
+  bdd-tracked-lint:
+    # Mechanical enforcement of AGENTS.md "BDD hygiene" Rule 2: every
+    # `@unwired` or `@wip` scenario across `crates/*/tests/features/`
+    # must carry a `# tracked: crap-rs#<n>` comment inside its
+    # scenario block, naming the issue that owns the wiring deferral.
+    # Without this gate, the rule was documented but unenforced —
+    # documentation rots; CI doesn't.
+    #
+    # See `scripts/bdd-tracked-lint.py` for the parser shape and
+    # limitations. Mirrors the `lefthook.yml` pre-push step — single
+    # source of truth in the script.
+    #
+    # Conventions follow the post-#264 supply-chain hardening: scoped
+    # `permissions: contents: read`, `persist-credentials: false` on
+    # checkout, no cache (the lint is pure-Python and finishes in
+    # under a second; caching is overhead, not savings).
+    name: bdd-tracked-lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - name: 'Lint `# tracked: crap-rs#<n>` comment coverage of @unwired/@wip scenarios'
+        run: python3 scripts/bdd-tracked-lint.py
+
   docs:
     name: cargo doc (warnings as errors)
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,11 @@ breezy-bays-labs/mokumo#370) can dogfood on us without false positives.
    File the tracking issue **before** the tag lands. Same rule for
    `@wip` (issue must name the in-flight PR).
 
+   Mechanical enforcement: `scripts/bdd-tracked-lint.py` (run from
+   `lefthook.yml` pre-push and the `bdd-tracked-lint` CI job)
+   rejects any `@unwired`/`@wip` scenario whose body lacks a
+   `# tracked: crap-rs#<n>` comment. Documentation rots; CI doesn't.
+
 3. **No no-op step definitions.** If a `Given`/`When`/`Then` in a
    scenario has no executable implementation, the scenario is
    `@unwired` — not "wired with empty step defs". Forced empty step

--- a/crates/crap-core/src/adapters/reporters/table.rs
+++ b/crates/crap-core/src/adapters/reporters/table.rs
@@ -489,8 +489,25 @@ fn crap_color(exceeds: bool, text: &str) -> String {
 /// All tests that call `set_override` must hold this lock to prevent
 /// races under `cargo test` (threaded). Nextest doesn't need this
 /// (process isolation) but the lock is harmless there.
+///
+/// Acquired via `acquire_color_lock()`, which recovers from
+/// `PoisonError` by extracting the inner guard rather than panicking.
+/// Without recovery, a single test panicking inside the locked region
+/// (historically: comfy-table width detection under non-PTY
+/// `cargo test`) cascades into 43+ unrelated failures as every
+/// subsequent `lock().unwrap()` re-panics on the poisoned mutex. The
+/// lock guards a flag flip, not invariant state — a poison from the
+/// previous holder doesn't leave behind inconsistent data, so
+/// recovering is safe and breaks the cascade. (crap-rs#202.)
 #[cfg(test)]
 static COLOR_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+#[cfg(test)]
+fn acquire_color_lock() -> std::sync::MutexGuard<'static, ()> {
+    COLOR_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
 
 #[cfg(test)]
 mod tests {
@@ -502,7 +519,7 @@ mod tests {
 
     #[test]
     fn test_empty_shows_no_functions() {
-        let _guard = COLOR_LOCK.lock().unwrap();
+        let _guard = acquire_color_lock();
         colored::control::set_override(false);
         let result = make_empty_result();
         let output = format_table(
@@ -520,7 +537,7 @@ mod tests {
 
     #[test]
     fn test_sorted_by_crap_descending() {
-        let _guard = COLOR_LOCK.lock().unwrap();
+        let _guard = acquire_color_lock();
         colored::control::set_override(false);
         let result = make_multi_function_result();
         let output = format_table(
@@ -552,7 +569,7 @@ mod tests {
 
     #[test]
     fn test_all_columns_present() {
-        let _guard = COLOR_LOCK.lock().unwrap();
+        let _guard = acquire_color_lock();
         colored::control::set_override(false);
         let result = make_single_function_result(
             "test_fn",
@@ -580,7 +597,7 @@ mod tests {
 
     #[test]
     fn test_function_details_in_columns() {
-        let _guard = COLOR_LOCK.lock().unwrap();
+        let _guard = acquire_color_lock();
         colored::control::set_override(false);
         let result = make_single_function_result(
             "parse_record",
@@ -607,7 +624,7 @@ mod tests {
 
     #[test]
     fn test_crap_two_decimal_places() {
-        let _guard = COLOR_LOCK.lock().unwrap();
+        let _guard = acquire_color_lock();
         colored::control::set_override(false);
         let result =
             make_single_function_result("f", "src/lib.rs", 1, 100.0, 5.0, RiskLevel::Low, 8.0);
@@ -623,7 +640,7 @@ mod tests {
 
     #[test]
     fn test_coverage_one_decimal_place() {
-        let _guard = COLOR_LOCK.lock().unwrap();
+        let _guard = acquire_color_lock();
         colored::control::set_override(false);
         let result =
             make_single_function_result("f", "src/lib.rs", 1, 85.0, 1.0, RiskLevel::Low, 8.0);
@@ -644,7 +661,7 @@ mod tests {
     /// absent from the header entirely.
     #[test]
     fn branch_column_omitted_when_no_branch_data() {
-        let _guard = COLOR_LOCK.lock().unwrap();
+        let _guard = acquire_color_lock();
         colored::control::set_override(false);
         let result = make_single_function_result(
             "no_branches",
@@ -673,7 +690,7 @@ mod tests {
     /// decimal — the same precision as the line `Cov%` column.
     #[test]
     fn branch_column_present_when_branch_data_some() {
-        let _guard = COLOR_LOCK.lock().unwrap();
+        let _guard = acquire_color_lock();
         colored::control::set_override(false);
         let mut result = make_single_function_result(
             "classify",
@@ -712,7 +729,7 @@ mod tests {
     /// show the `—` sentinel — visibly distinct from a genuine `0.0`.
     #[test]
     fn branch_column_dash_for_rows_without_branch_data() {
-        let _guard = COLOR_LOCK.lock().unwrap();
+        let _guard = acquire_color_lock();
         colored::control::set_override(false);
 
         // Two verdicts: one carries branch coverage, one doesn't.
@@ -773,7 +790,7 @@ mod tests {
 
     #[test]
     fn test_version_header() {
-        let _guard = COLOR_LOCK.lock().unwrap();
+        let _guard = acquire_color_lock();
         colored::control::set_override(false);
         let result = make_empty_result();
         // `tool_name` and `tool_version` are caller-supplied. In-crate
@@ -792,7 +809,7 @@ mod tests {
 
     #[test]
     fn test_summary_line_contents() {
-        let _guard = COLOR_LOCK.lock().unwrap();
+        let _guard = acquire_color_lock();
         colored::control::set_override(false);
         let result = make_multi_function_result();
         let output = format_table(
@@ -810,7 +827,7 @@ mod tests {
 
     #[test]
     fn test_summary_pass_variant() {
-        let _guard = COLOR_LOCK.lock().unwrap();
+        let _guard = acquire_color_lock();
         colored::control::set_override(false);
         let result =
             make_single_function_result("f", "src/lib.rs", 1, 100.0, 1.0, RiskLevel::Low, 8.0);
@@ -827,7 +844,7 @@ mod tests {
 
     #[test]
     fn test_summary_distribution() {
-        let _guard = COLOR_LOCK.lock().unwrap();
+        let _guard = acquire_color_lock();
         colored::control::set_override(false);
         let result = make_multi_function_result();
         let output = format_table(
@@ -883,7 +900,7 @@ mod tests {
 
     #[test]
     fn test_breakdown_off_no_sub_rows() {
-        let _guard = COLOR_LOCK.lock().unwrap();
+        let _guard = acquire_color_lock();
         colored::control::set_override(false);
         let verdict = make_verdict_with_contributors(
             make_verdict("my_fn", "src/lib.rs", 5, 30.0, 45.0, RiskLevel::High, 8.0),
@@ -913,7 +930,7 @@ mod tests {
 
     #[test]
     fn test_breakdown_on_exceeding_shows_sub_rows() {
-        let _guard = COLOR_LOCK.lock().unwrap();
+        let _guard = acquire_color_lock();
         colored::control::set_override(false);
         let verdict = make_verdict_with_contributors(
             make_verdict(
@@ -959,7 +976,7 @@ mod tests {
 
     #[test]
     fn test_breakdown_on_within_threshold_no_sub_rows() {
-        let _guard = COLOR_LOCK.lock().unwrap();
+        let _guard = acquire_color_lock();
         colored::control::set_override(false);
         let verdict = make_verdict_with_contributors(
             make_verdict("safe_fn", "src/lib.rs", 2, 90.0, 2.0, RiskLevel::Low, 8.0),
@@ -986,7 +1003,7 @@ mod tests {
 
     #[test]
     fn test_breakdown_tree_chars_last_uses_corner() {
-        let _guard = COLOR_LOCK.lock().unwrap();
+        let _guard = acquire_color_lock();
         colored::control::set_override(false);
         let verdict = make_verdict_with_contributors(
             make_verdict(
@@ -1022,7 +1039,7 @@ mod tests {
 
     #[test]
     fn test_breakdown_nesting_suffix() {
-        let _guard = COLOR_LOCK.lock().unwrap();
+        let _guard = acquire_color_lock();
         colored::control::set_override(false);
         let verdict = make_verdict_with_contributors(
             make_verdict(
@@ -1057,7 +1074,7 @@ mod tests {
 
     #[test]
     fn test_explain_adds_legend_for_nested_breakdown() {
-        let _guard = COLOR_LOCK.lock().unwrap();
+        let _guard = acquire_color_lock();
         colored::control::set_override(false);
         let verdict = make_verdict_with_contributors(
             make_verdict(
@@ -1094,7 +1111,7 @@ mod tests {
 
     #[test]
     fn test_explain_without_breakdown_is_inert() {
-        let _guard = COLOR_LOCK.lock().unwrap();
+        let _guard = acquire_color_lock();
         colored::control::set_override(false);
         let verdict = make_verdict_with_contributors(
             make_verdict(
@@ -1128,7 +1145,7 @@ mod tests {
 
     #[test]
     fn test_explain_suppressed_without_nested_contributors() {
-        let _guard = COLOR_LOCK.lock().unwrap();
+        let _guard = acquire_color_lock();
         colored::control::set_override(false);
         let verdict = make_verdict_with_contributors(
             make_verdict(
@@ -1169,7 +1186,7 @@ mod tests {
     #[test]
     fn test_breakdown_sorted_by_line() {
         use crate::domain::types::{ComplexityContributor, ContributorKind};
-        let _guard = COLOR_LOCK.lock().unwrap();
+        let _guard = acquire_color_lock();
         colored::control::set_override(false);
         // Contributors must be pre-sorted by (line, column) — as FunctionFinder guarantees.
         let verdict = make_verdict_with_contributors(
@@ -1227,7 +1244,7 @@ mod tests {
         // If one name is a prefix of another, both match the same table row.
         // Assert each function's contributors appear exactly once.
         use crate::domain::types::{ComplexityContributor, ContributorKind};
-        let _guard = COLOR_LOCK.lock().unwrap();
+        let _guard = acquire_color_lock();
         colored::control::set_override(false);
 
         let v1 = make_verdict_with_contributors(
@@ -1294,7 +1311,7 @@ mod tests {
         // next char is `/`, failing the word-boundary check and silently skipping
         // sub-row injection. The fix loops all occurrences until one passes.
         use crate::domain::types::{ComplexityContributor, ContributorKind};
-        let _guard = COLOR_LOCK.lock().unwrap();
+        let _guard = acquire_color_lock();
         colored::control::set_override(false);
 
         let v = make_verdict_with_contributors(
@@ -1338,7 +1355,7 @@ mod tests {
 
     #[test]
     fn test_varied_thresholds_detected() {
-        let _guard = COLOR_LOCK.lock().unwrap();
+        let _guard = acquire_color_lock();
         colored::control::set_override(false);
 
         let mut result = make_multi_function_result();
@@ -1362,7 +1379,7 @@ mod tests {
 
     #[test]
     fn test_uniform_thresholds_not_varied() {
-        let _guard = COLOR_LOCK.lock().unwrap();
+        let _guard = acquire_color_lock();
         colored::control::set_override(false);
 
         let result = make_multi_function_result();
@@ -1381,7 +1398,7 @@ mod tests {
 
     #[test]
     fn test_single_function_not_varied() {
-        let _guard = COLOR_LOCK.lock().unwrap();
+        let _guard = acquire_color_lock();
         colored::control::set_override(false);
 
         let result =
@@ -1400,7 +1417,7 @@ mod tests {
 
     #[test]
     fn test_risk_color_low_green() {
-        let _guard = COLOR_LOCK.lock().unwrap();
+        let _guard = acquire_color_lock();
         colored::control::set_override(true);
         let out = risk_color(&RiskLevel::Low, "low");
         assert!(out.contains("\x1b[32m"), "Expected green ANSI: {out:?}");
@@ -1408,7 +1425,7 @@ mod tests {
 
     #[test]
     fn test_risk_color_acceptable_no_color() {
-        let _guard = COLOR_LOCK.lock().unwrap();
+        let _guard = acquire_color_lock();
         colored::control::set_override(true);
         let out = risk_color(&RiskLevel::Acceptable, "acceptable");
         assert!(!out.contains("\x1b["), "Expected no ANSI escapes: {out:?}");
@@ -1417,7 +1434,7 @@ mod tests {
 
     #[test]
     fn test_risk_color_moderate_yellow() {
-        let _guard = COLOR_LOCK.lock().unwrap();
+        let _guard = acquire_color_lock();
         colored::control::set_override(true);
         let out = risk_color(&RiskLevel::Moderate, "moderate");
         assert!(out.contains("\x1b[33m"), "Expected yellow ANSI: {out:?}");
@@ -1425,7 +1442,7 @@ mod tests {
 
     #[test]
     fn test_risk_color_high_bold_red() {
-        let _guard = COLOR_LOCK.lock().unwrap();
+        let _guard = acquire_color_lock();
         colored::control::set_override(true);
         let out = risk_color(&RiskLevel::High, "high");
         // colored combines bold+red as \x1b[1;31m
@@ -1437,7 +1454,7 @@ mod tests {
 
     #[test]
     fn test_coverage_color_thresholds() {
-        let _guard = COLOR_LOCK.lock().unwrap();
+        let _guard = acquire_color_lock();
         colored::control::set_override(true);
         let low = coverage_color(30.0, "30.0");
         assert!(low.contains("\x1b[31m"), "Expected red for <50%: {low:?}");
@@ -1457,7 +1474,7 @@ mod tests {
 
     #[test]
     fn test_coverage_color_boundary_50() {
-        let _guard = COLOR_LOCK.lock().unwrap();
+        let _guard = acquire_color_lock();
         colored::control::set_override(true);
         let at_50 = coverage_color(50.0, "50.0");
         assert!(
@@ -1468,7 +1485,7 @@ mod tests {
 
     #[test]
     fn test_coverage_color_boundary_80() {
-        let _guard = COLOR_LOCK.lock().unwrap();
+        let _guard = acquire_color_lock();
         colored::control::set_override(true);
         let at_80 = coverage_color(80.0, "80.0");
         assert!(
@@ -1479,7 +1496,7 @@ mod tests {
 
     #[test]
     fn test_crap_exceeding_bold_red() {
-        let _guard = COLOR_LOCK.lock().unwrap();
+        let _guard = acquire_color_lock();
         colored::control::set_override(true);
         let out = crap_color(true, "15.00");
         assert!(
@@ -1490,7 +1507,7 @@ mod tests {
 
     #[test]
     fn test_crap_within_no_emphasis() {
-        let _guard = COLOR_LOCK.lock().unwrap();
+        let _guard = acquire_color_lock();
         colored::control::set_override(true);
         let out = crap_color(false, "5.00");
         assert!(!out.contains("\x1b["), "Expected no ANSI: {out:?}");
@@ -1499,7 +1516,7 @@ mod tests {
 
     #[test]
     fn test_full_table_snapshot() {
-        let _guard = COLOR_LOCK.lock().unwrap();
+        let _guard = acquire_color_lock();
         colored::control::set_override(false);
         let result = make_multi_function_result();
         let output = format_table(
@@ -1515,7 +1532,7 @@ mod tests {
     #[test]
     fn grouped_table_has_per_file_header() {
         use crate::domain::view::{self, GroupKey, ViewSpec};
-        let _guard = COLOR_LOCK.lock().unwrap();
+        let _guard = acquire_color_lock();
         colored::control::set_override(false);
         let result = make_multi_function_result();
         let view = view::apply(
@@ -1551,7 +1568,7 @@ mod tests {
     #[test]
     fn grouped_table_snapshot() {
         use crate::domain::view::{self, GroupKey, ViewSpec};
-        let _guard = COLOR_LOCK.lock().unwrap();
+        let _guard = acquire_color_lock();
         colored::control::set_override(false);
         let result = make_multi_function_result();
         let view = view::apply(
@@ -1569,7 +1586,7 @@ mod tests {
 
     #[test]
     fn delta_block_renders_header_and_summary_line() {
-        let _guard = COLOR_LOCK.lock().unwrap();
+        let _guard = acquire_color_lock();
         colored::control::set_override(false);
         let delta = make_sample_delta();
         let dview = make_delta_view_default(&delta);
@@ -1599,7 +1616,7 @@ mod tests {
 
     #[test]
     fn delta_block_includes_change_rows_with_kind_column() {
-        let _guard = COLOR_LOCK.lock().unwrap();
+        let _guard = acquire_color_lock();
         colored::control::set_override(false);
         let delta = make_sample_delta();
         let dview = make_delta_view_default(&delta);
@@ -1623,7 +1640,7 @@ mod tests {
 
     #[test]
     fn no_baseline_means_no_delta_block() {
-        let _guard = COLOR_LOCK.lock().unwrap();
+        let _guard = acquire_color_lock();
         colored::control::set_override(false);
         let result = make_multi_function_result();
         let output = format_table_with_explain(
@@ -1640,7 +1657,7 @@ mod tests {
 
     #[test]
     fn delta_block_full_snapshot() {
-        let _guard = COLOR_LOCK.lock().unwrap();
+        let _guard = acquire_color_lock();
         colored::control::set_override(false);
         let delta = make_sample_delta();
         let dview = make_delta_view_default(&delta);
@@ -1797,7 +1814,7 @@ mod proptests {
 
         #[test]
         fn prop_format_table_never_panics(result in arb_analysis_result()) {
-            let _guard = super::COLOR_LOCK.lock().unwrap();
+            let _guard = super::acquire_color_lock();
             colored::control::set_override(false);
             let _ = format_table(&make_view_default(&result), 8.0, false, TEST_TOOL_NAME, TEST_TOOL_VERSION);
         }
@@ -1807,7 +1824,7 @@ mod proptests {
             mut result in arb_analysis_result(),
             contributors in prop::collection::vec(arb_contributor(), 0..5),
         ) {
-            let _guard = super::COLOR_LOCK.lock().unwrap();
+            let _guard = super::acquire_color_lock();
             colored::control::set_override(false);
             // Inject contributors into the first exceeding function (if any)
             if let Some(v) = result.functions.iter_mut().find(|v| v.exceeds) {
@@ -1819,7 +1836,7 @@ mod proptests {
 
         #[test]
         fn prop_format_table_row_count(result in arb_analysis_result()) {
-            let _guard = super::COLOR_LOCK.lock().unwrap();
+            let _guard = super::acquire_color_lock();
             colored::control::set_override(false);
             let output = format_table(&make_view_default(&result), 8.0, false, TEST_TOOL_NAME, TEST_TOOL_VERSION);
             if result.functions.is_empty() {

--- a/crates/crap4rs/tests/features/delta.feature
+++ b/crates/crap4rs/tests/features/delta.feature
@@ -124,7 +124,7 @@ Feature: --baseline delta analysis (Bundle E, issue #81)
   Scenario: Default DeltaViewSpec is filter=all, sort=score_delta desc
     When `delta::apply(&delta, DeltaViewSpec::default())` runs
     Then `view.shown` contains every `FunctionChange` in `delta.changes`
-    And rows are ordered by `score_delta.abs()` descending
+    And rows are ordered by signed `score_delta` descending (regressions first, improvements last)
 
   Scenario: Filter by change_kinds=[added] returns only Added
     When `delta::apply` is called with `filters.change_kinds = Some({Added})`

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -92,19 +92,14 @@ pre-push:
       # documentation alone enforces the wire-snapshot contract;
       # "documentation rots, CI doesn't."
       #
-      # `--test-runner=nextest` is load-bearing — the default
-      # `cargo-test` backend runs tests in-process with thread
-      # parallelism, which interacts poorly with the
-      # `colored::set_override` global mutex used by the table
-      # reporter (see `~/.claude/projects/.../feedback_colored-set-
-      # override-mutex` memory). Under non-PTY environments (lefthook,
-      # CI) one test's width-detection panic poisons the mutex and
-      # cascades into 43+ unrelated failures. Nextest runs each test
-      # in its own process, so a panic in one test doesn't poison any
-      # other test's mutex state. This is the same runner the
-      # workspace's `test:` step above uses; switching insta to it
-      # keeps the two parallel testing layers consistent.
-      run: cargo insta test --workspace --check --test-runner=nextest
+      # Note: this step previously pinned `--test-runner=nextest` as
+      # a workaround for the `colored::set_override` mutex-poison
+      # cascade in the table reporter test suite (crap-rs#202). The
+      # cascade is now structurally broken by `acquire_color_lock()`
+      # in `crates/crap-core/src/adapters/reporters/table.rs`, which
+      # recovers from `PoisonError` instead of re-panicking. The
+      # default backend is safe again, so the override is removed.
+      run: cargo insta test --workspace --check
       timeout: 180s
     cucumber:
       # cucumber-rs harness=false targets bypass libtest's

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -54,6 +54,16 @@ pre-push:
       # every push. Single source of truth: `scripts/mutants-skip-lint.py`.
       run: python3 scripts/mutants-skip-lint.py
       timeout: 30s
+    bdd-tracked-lint:
+      # Mechanical enforcement of AGENTS.md "BDD hygiene" Rule 2: every
+      # `@unwired` or `@wip` scenario across `crates/*/tests/features/`
+      # must carry a `# tracked: crap-rs#<n>` comment inside its
+      # scenario block, naming the issue that owns the wiring deferral.
+      # Local-velocity layer of the same check that
+      # `.github/workflows/ci.yml`'s `bdd-tracked-lint` job runs on
+      # every push. Single source of truth: `scripts/bdd-tracked-lint.py`.
+      run: python3 scripts/bdd-tracked-lint.py
+      timeout: 30s
     clippy:
       run: cargo clippy --workspace --all-targets -- -D warnings
       timeout: 300s

--- a/scripts/bdd-tracked-lint.py
+++ b/scripts/bdd-tracked-lint.py
@@ -59,12 +59,20 @@ from pathlib import Path
 STATUS_TAG_RE = re.compile(r"(?:^|\s)@(unwired|wip)(?=\s|$)")
 TAG_LINE_RE = re.compile(r"^\s*@")
 SCENARIO_LINE_RE = re.compile(r"^\s*Scenario(?::|\s+Outline:)\s*(.*)$")
-TRACKED_RE = re.compile(r"#\s*tracked:\s*crap-rs#\d+")
+# Enforce the AGENTS.md "BDD hygiene" Rule 2 example shape exactly:
+#   # tracked: crap-rs#<digits> — <one-line non-empty reason>
+# `^\s*#` so the comment must be a true Gherkin comment line (not an
+# inline trailing comment in a step). The em-dash is U+2014 (the exact
+# glyph the AGENTS.md example uses); ASCII `--` is rejected. The
+# reason must contain at least one non-space character so an empty
+# trailer (`crap-rs#123 — `) cannot pass.
+TRACKED_RE = re.compile(r"^\s*#\s*tracked:\s*crap-rs#\d+\s+—\s+\S.*$")
 
-FEATURE_DIRS = (
-    Path("crates/crap4rs/tests/features"),
-    Path("crates/crap4ts/tests/features"),
-)
+# Dynamic discovery — every `crates/*/tests/features/` directory is in
+# scope. Hard-coding `crap4rs` + `crap4ts` worked today but silently
+# omits any future adapter crate (e.g. a `crap4py`); the glob keeps the
+# lint future-proof without per-crate maintenance.
+FEATURE_DIR_GLOB = "crates/*/tests/features"
 
 
 @dataclass
@@ -154,9 +162,8 @@ def lint(repo_root: Path) -> int:
     scanned = 0
     deferred = 0
 
-    for feat_dir in FEATURE_DIRS:
-        abs_dir = repo_root / feat_dir
-        if not abs_dir.exists():
+    for abs_dir in sorted(repo_root.glob(FEATURE_DIR_GLOB)):
+        if not abs_dir.is_dir():
             continue
         for feature_path in sorted(abs_dir.rglob("*.feature")):
             for block in parse_blocks(feature_path):

--- a/scripts/bdd-tracked-lint.py
+++ b/scripts/bdd-tracked-lint.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""BDD tracked-comment lint — mechanical enforcement of the AGENTS.md
+"BDD hygiene" Rule 2: every `@unwired` or `@wip` scenario must carry a
+`# tracked: crap-rs#<n>` comment inside its scenario block, naming the
+issue that captures the wiring deferral.
+
+The *why* lives in `AGENTS.md` ("BDD hygiene" → Rule 2 → "@unwired and
+@wip require a tracking comment"). This script is the *what*: replaces
+the documented rule with a CI + lefthook gate so a future agent cannot
+land a deferred scenario without naming the deferral's owning issue.
+
+Same mechanical-enforcement pattern as `scripts/mutants-skip-lint.py`
+(documentation rots; CI doesn't). Single source of truth in this
+script; `.github/workflows/ci.yml` and `lefthook.yml` both invoke it.
+
+Scope: every `*.feature` file under `crates/*/tests/features/`.
+
+Algorithm:
+
+  1. Parse each `.feature` file into scenario blocks. A block bundles
+     the contiguous tag line(s) immediately preceding a `Scenario:` or
+     `Scenario Outline:` header with that header and its body
+     (everything up to the next tag-line / scenario-header / EOF).
+  2. For each block, if any tag line carries `@unwired` or `@wip`,
+     scan the body lines for a `# tracked: crap-rs#<n>` comment.
+  3. Report (file, scenario line, scenario title, tag) for every
+     missing tracked-comment. Exit 1 on any miss, 0 otherwise.
+
+Limitations:
+
+* **Block tracking is comment-aware but assumes well-formed Gherkin.**
+  Tag lines must start with `@` (Gherkin spec); the lint trusts that.
+  Pathological inputs (commented-out scenario headers inside an
+  `Examples:` table cell, etc.) are out of scope — no current
+  `.feature` file exhibits the pattern.
+* **Tracked-comment form is fixed.** The regex matches `# tracked:
+  crap-rs#<digits>`. Other shapes (e.g. `# tracked: org/repo#N`,
+  `tracked:` without leading `#`) are not recognized. The
+  fixed-shape rule keeps grep / audit cheap.
+* **Examples-table semantics:** the body of a `Scenario Outline:`
+  includes its `Examples:` table; the lint sees that as a body line
+  like any other, so a tracked-comment may live either above the
+  `Examples:` keyword or anywhere inside the table — both pass.
+
+If any of these gaps produces a real regression, extend the lint.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+# A status tag MUST appear on its own tag line (Gherkin convention),
+# leading whitespace allowed, followed by `@unwired` or `@wip` as a
+# discrete token (separated by whitespace from other tags on the same
+# line, if any).
+STATUS_TAG_RE = re.compile(r"(?:^|\s)@(unwired|wip)(?=\s|$)")
+TAG_LINE_RE = re.compile(r"^\s*@")
+SCENARIO_LINE_RE = re.compile(r"^\s*Scenario(?::|\s+Outline:)\s*(.*)$")
+TRACKED_RE = re.compile(r"#\s*tracked:\s*crap-rs#\d+")
+
+FEATURE_DIRS = (
+    Path("crates/crap4rs/tests/features"),
+    Path("crates/crap4ts/tests/features"),
+)
+
+
+@dataclass
+class ScenarioBlock:
+    file: Path
+    header_line: int  # 1-indexed line of the `Scenario:` header
+    tag_lines: list[tuple[int, str]]  # 1-indexed; line text
+    body_lines: list[tuple[int, str]]  # 1-indexed; line text
+    title: str
+
+    def status_tag(self) -> str | None:
+        for _, txt in self.tag_lines:
+            m = STATUS_TAG_RE.search(txt)
+            if m:
+                return f"@{m.group(1)}"
+        return None
+
+    def has_tracked_comment(self) -> bool:
+        return any(TRACKED_RE.search(txt) for _, txt in self.body_lines)
+
+
+def parse_blocks(feature_path: Path) -> list[ScenarioBlock]:
+    """Walk `feature_path` line-by-line. Group contiguous tag lines with
+    the next `Scenario:`/`Scenario Outline:` header; treat everything
+    up to the next tag-line, scenario-header, or EOF as that scenario's
+    body."""
+    lines = feature_path.read_text().splitlines()
+    blocks: list[ScenarioBlock] = []
+
+    i = 0
+    pending_tags: list[tuple[int, str]] = []
+    n = len(lines)
+    while i < n:
+        line = lines[i]
+        stripped = line.strip()
+
+        if TAG_LINE_RE.match(line):
+            pending_tags.append((i + 1, line))
+            i += 1
+            continue
+
+        sc_match = SCENARIO_LINE_RE.match(line)
+        if sc_match:
+            header_line = i + 1
+            title = sc_match.group(1).strip()
+            body: list[tuple[int, str]] = []
+            j = i + 1
+            while j < n:
+                next_line = lines[j]
+                # End of scenario when we hit the next scenario's tag
+                # block OR a bare `Scenario:`/`Scenario Outline:`
+                # without preceding tags.
+                if TAG_LINE_RE.match(next_line) or SCENARIO_LINE_RE.match(next_line):
+                    break
+                body.append((j + 1, next_line))
+                j += 1
+
+            blocks.append(
+                ScenarioBlock(
+                    file=feature_path,
+                    header_line=header_line,
+                    tag_lines=pending_tags,
+                    body_lines=body,
+                    title=title,
+                )
+            )
+            pending_tags = []
+            i = j
+            continue
+
+        # Non-tag, non-scenario line outside a scenario block (e.g.
+        # `Feature:` keyword, freeform prose, `Background:` body).
+        # Anything dangling in `pending_tags` belongs to a structural
+        # block we don't enforce here — drop and move on. (A tag block
+        # left dangling without a following scenario is malformed
+        # Gherkin; cucumber would already reject it, so no point
+        # double-reporting.)
+        if stripped and not stripped.startswith("#"):
+            pending_tags = []
+        i += 1
+
+    return blocks
+
+
+def lint(repo_root: Path) -> int:
+    errors: list[str] = []
+    scanned = 0
+    deferred = 0
+
+    for feat_dir in FEATURE_DIRS:
+        abs_dir = repo_root / feat_dir
+        if not abs_dir.exists():
+            continue
+        for feature_path in sorted(abs_dir.rglob("*.feature")):
+            for block in parse_blocks(feature_path):
+                scanned += 1
+                status = block.status_tag()
+                if status not in ("@unwired", "@wip"):
+                    continue
+                deferred += 1
+                if block.has_tracked_comment():
+                    continue
+                rel = feature_path.relative_to(repo_root)
+                errors.append(
+                    f"\nbdd-tracked-lint: missing tracked-comment on "
+                    f"{status} scenario\n"
+                    f"  {rel}:{block.header_line}  Scenario: {block.title}\n"
+                    f"  carries `{status}` but no `# tracked: crap-rs#<n>` "
+                    f"comment in its body.\n\n"
+                    f"  Fix: add a comment of the exact shape\n"
+                    f"    # tracked: crap-rs#<n> — <one-line reason>\n"
+                    f"  inside the scenario block (between the `Scenario:` "
+                    f"header and the next scenario). Open or reuse a "
+                    f"tracking issue first; see AGENTS.md \"BDD hygiene\" "
+                    f"Rule 2 for why."
+                )
+
+    if errors:
+        for msg in errors:
+            print(msg, file=sys.stderr)
+        print(
+            f"\nbdd-tracked-lint: {len(errors)} uncovered {('scenario' if len(errors) == 1 else 'scenarios')}; "
+            f"see above ({scanned} scanned, {deferred} deferred)",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"bdd-tracked-lint: ok ({deferred} deferred scenarios all carry "
+        f"a `# tracked: crap-rs#<n>` comment; {scanned} scanned)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(lint(Path(__file__).resolve().parent.parent))


### PR DESCRIPTION
## Summary

PR 4 of 7-PR pre-GA backlog-clearing roadmap. Quality hygiene + BDD lint + comfy-table-cascade root cause:

- **#180** — `scripts/bdd-tracked-lint.py` (new) + `ci.yml` job + `lefthook.yml` pre-push hook + AGENTS.md cross-ref. Mechanical enforcement of AGENTS.md "BDD hygiene" Rule 2: every `@unwired`/`@wip` scenario must carry a `# tracked: crap-rs#<n>` comment in its scenario block. "Documentation rots; CI doesn't." Single source of truth in the script, mirrors the `scripts/mutants-skip-lint.py` shape. Scenario-block-scoped (not file-scoped).
- **#196** — `delta.feature:127` flipped from `score_delta.abs()` (magnitude) to signed `score_delta` (regressions-first), aligning the Gherkin with `cmp_by_score_delta_desc`'s actual behavior. The function's own rustdoc says "Signed-impact ordering: regressions and risky additions sort to the top" — code is the conscious product choice. One-line spec fix; scenario stays `@unwired` (no harness pins delta.feature today).
- **#202** — `acquire_color_lock()` helper recovers from `PoisonError` so a single test panicking inside the locked region (historically: comfy-table width detection under non-PTY) no longer cascades into 43+ unrelated failures via re-panicking `unwrap()` calls. The lock guards a flag flip, not invariant state — recovery is safe. ~45 callsites swapped from `COLOR_LOCK.lock().unwrap()` to `acquire_color_lock()`. `lefthook.yml` `--test-runner=nextest` override on the `insta:` step (the workaround that masked the symptom) is removed; default cargo-test backend stays green under non-PTY conditions.

Closes #180 #196 #202

## Discovery notes

- **#202 cascade did NOT reproduce on current `main`** (637 crap-core lib tests + 1110 workspace nextest tests + `cargo insta test --workspace --check < /dev/null` all green pre-fix). The lefthook nextest workaround had been hiding it since #201 (W1.3). The fix is therefore defensive — `PoisonError` recovery makes the cascade structurally impossible regardless of whether the original trigger comes back.
- **#196 ordering decision** — verified by reading `cmp_by_score_delta_desc`'s rustdoc + `signed_impact` impl. The "regressions sort to the top" UX is intentional. Spec lost; fixed.

## Wire-envelope canary

Per-issue prediction (all matched):
- **#180**: byte-identical (CI/script-only addition).
- **#196**: byte-identical (Gherkin spec text change only; code unchanged).
- **#202**: byte-identical (test-only mutex acquisition pattern change; production code paths unchanged).

`cargo insta test --workspace --check` green on all three snapshots (`wire_envelope_crap4rs`, `wire_envelope_crap4ts`, `wire_envelope_crap4ts_branches`).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace --all-targets` (1110 tests, all green)
- [x] `cargo insta test --workspace --check < /dev/null` (default cargo-test backend, non-PTY — the original #202 cascade condition)
- [x] `cargo +1.93 check --workspace --all-targets`
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps`
- [x] `cargo deny check`
- [x] AST-purity grep on `crates/crap-core/src/` clean
- [x] All 8 cucumber harnesses green
- [x] `pipx run 'zizmor>=1.5,<2' .github/` exits 0 (No findings to report)
- [x] New `bdd-tracked-lint`: 244 deferred scenarios scanned (out of 365 total), all carry tracked comments; injected violation test fails-as-expected
- [x] `mutants-skip-lint` still green
- [ ] CI green on PR push (all ~17 checks)

After PR 4 merges → start PR 5 (#139 + #114 composite action + scorecard-row parity) on a fresh worktree. **#270 (release-plz adoption) stays parallel-eligible** — can run alongside any of PR 5/6/7/8 in a separate worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure to recover from lock failures, reducing cascading test failures.

* **Chores**
  * Added CI enforcement for BDD scenario tracking comments on draft scenarios.
  * Updated pre-push hooks to enforce tracking requirements locally.
  * Updated documentation with scenario tracking guidelines.

* **Bug Fixes**
  * Corrected delta sorting to prioritize regressions over improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/breezy-bays-labs/crap-rs/pull/279?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->