### PR TITLE
#272 — align CRAP thresholds + risk tiers (8/15/25)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,19 +222,24 @@ jobs:
           echo "First 5 SF records in lcov.info:"
           head -200 lcov.info | grep '^SF:' | head -5 || true
           echo "Working directory: $PWD"
+      # --threshold 15 (the post-#272 `default` tier) is a temporary
+      # softening of the self-check while crap-rs#273 refactors the 23
+      # functions in (8, 15] CRAP back under the new --strict cutoff
+      # (cognitive 8). When #273 lands all three legs flip back to
+      # --strict and this comment + the tracked: marker can come out.
+      # tracked: crap-rs#273
       - name: Self-CRAP — crap-core
-        run: ./target/release/crap4rs --coverage lcov.info --src crates/crap-core/src --strict --color always
+        run: ./target/release/crap4rs --coverage lcov.info --src crates/crap-core/src --threshold 15 --color always
+      # tracked: crap-rs#273
       - name: Self-CRAP — crap4rs
-        run: ./target/release/crap4rs --coverage lcov.info --src crates/crap4rs/src --strict --color always
+        run: ./target/release/crap4rs --coverage lcov.info --src crates/crap4rs/src --threshold 15 --color always
       # crap4ts/src is Rust — analyzed by the crap4rs binary, NOT crap4ts
       # (which needs Istanbul JSON; there is no TS in crates/crap4ts/src).
-      # --strict (same as the two legs above) lowers the CRAP-score gate
-      # to 15 — i.e. every function must score CRAP <= 15. This is the
-      # CRAP-score cutoff, orthogonal to the cognitive-complexity metric
-      # default. Reuses the single ./target/release/crap4rs built once
-      # above (rust-cache warm) — no per-leg recompile.
+      # Reuses the single ./target/release/crap4rs built once above
+      # (rust-cache warm) — no per-leg recompile.
+      # tracked: crap-rs#273
       - name: Self-CRAP — crap4ts (Rust source)
-        run: ./target/release/crap4rs --coverage lcov.info --src crates/crap4ts/src --strict --color always
+        run: ./target/release/crap4rs --coverage lcov.info --src crates/crap4ts/src --threshold 15 --color always
 
   self-crap-view:
     name: domain/view.rs per-function CC <= 15

--- a/README.md
+++ b/README.md
@@ -22,23 +22,23 @@ Both adapters link the same `crap-core`, so Rust and TypeScript / JavaScript pro
 The CRAP metric combines **complexity** and **code coverage** into a single risk score:
 
 ```
-CRAP(complexity, coverage) = complexity^2 * (1 - coverage)^3 + complexity
+CRAP(complexity, coverage) = complexity² × (1 − coverage)³ + complexity
 ```
 
-High complexity + low coverage = high CRAP score = high risk of bugs when changed.
+where `coverage` is the fraction in `[0, 1]` (50% → `0.5`). High complexity + low coverage = high CRAP score = high risk of bugs when changed.
 
-### Risk classification (intrinsic)
+### Risk classification
 
-Every score lands in one of four risk levels. The classification is intrinsic to the score and drives the SARIF severity mapping — it is **not** the build gate.
+Every score lands in one of four risk levels:
 
 | CRAP Score | Risk Level |
 |------------|------------|
-| ≤ 5 | Low |
-| ≤ 8 | Acceptable |
-| ≤ 30 | Moderate |
-| > 30 | High |
+| ≤ 8        | Low        |
+| ≤ 15       | Acceptable |
+| ≤ 25       | Moderate   |
+| > 25       | High       |
 
-The build gate is a separate axis — see [Threshold (the gate)](#threshold-the-gate) below.
+These boundaries also anchor the threshold presets: `--strict` fires at the Low → Acceptable boundary, the default fires at Acceptable → Moderate, and `--lenient` fires at Moderate → High — so every preset corresponds to "gate at the next risk tier up." See [Threshold (the gate)](#threshold-the-gate) for how the gate works and how the two views relate.
 
 ## crap4rs — the Rust analyzer
 
@@ -54,42 +54,103 @@ cargo llvm-cov --lcov --output-path lcov.info
 crap4rs --src src/ --coverage lcov.info
 ```
 
+### Commands
+
+| Command | Purpose |
+|---------|---------|
+| `crap4rs` (no subcommand) | Run the analyzer. Requires `--coverage <FILE>`. |
+| `crap4rs init` | Generate a starter `crap4rs.toml` in the current directory. Interactive (pick a preset); pair with `--force` to overwrite. |
+| `crap4rs completions <SHELL>` | Print a shell completion script to stdout. See [Shell completions](#shell-completions). |
+| `crap4rs help [SUBCOMMAND]` | Long-form help for the binary or a subcommand. |
+
 ### Options
+
+Run `crap4rs --help` for the canonical full reference. Grouped here as in `--help` output:
+
+**Input**
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--src <path>` | `src` | Path to Rust source files |
-| `--coverage <path>` | required | Path to LCOV coverage file |
-| `--threshold <n>` | 25 | CRAP score threshold (exit 1 if exceeded) |
-| `--metric <type>` | cognitive | Complexity metric: `cognitive` or `cyclomatic` |
-| `--format <type>` | table | Output format: `table`, `json`, `markdown`, or `csv` |
-| `--exclude <glob>` | — | Exclude paths matching glob (repeatable) |
-| `--verbose` | — | Print analysis diagnostics to stderr |
-| `--breakdown` | — | Show per-contributor complexity breakdown for failing functions in table output |
-| `--explain` | — | With `--breakdown`, explain nested cognitive increments in table output |
-| `--only-failing` | — | Display only functions exceeding the threshold (full analysis still drives the gate) |
-| `--top <n>` | — | Truncate the report to the top `n` highest-CRAP rows (`--top 0` means no limit) |
-| `--min-coverage <pct>` | — | Drop functions whose `coverage_percent` falls below the bound |
-| `--max-coverage <pct>` | — | Drop functions whose `coverage_percent` exceeds the bound |
-| `--sort-by <key>` | `crap` | Reorder rows by `crap`, `coverage`, `complexity`, or `path` |
-| `--group-by <key>` | — | Aggregate the displayed view by a key. Today: `file` (per-file summaries). Under grouping, `--top` and `--sort-by` key at the file level. |
-| `--no-fail` | — | Always exit `0`; `result.passed` in JSON still reflects the truthful state |
+| `--coverage <FILE>` | required for analysis | Path to the LCOV coverage file. Not required for `completions`/`init`. |
+| `--src <DIR>` | `src` | Root directory of source files to analyze. |
+| `--metric <METRIC>` | `cognitive` | `cognitive` (default) or `cyclomatic`. |
+| `--config <FILE>` | auto-discovered | Explicit config file path; bypasses `crap4rs.toml` auto-discovery. |
+| `--view <NAME>` | — | Resolve a saved view preset from the config (see [Saved view presets](#saved-view-presets---view-name)). |
+| `--baseline <FILE>` | — | Compare against a previously-emitted JSON envelope (see [Comparing two analyses](#comparing-two-analyses---baseline-file)). |
+
+**Output**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--format <FORMAT[,…]>` | `table` | One or more output formats. Each entry is `FORMAT` (stdout) or `FORMAT:FILE` (write to file); a comma-separated list fans out a single analysis pass to multiple destinations (`json:env.json,markdown:report.md`). Supported formats: `table`, `json`, `markdown`, `csv`, `sarif`, `advice` (experimental), `scorecard-row`. Multi-format invocations require every entry to specify a file. |
+| `--threshold <N>` | metric-correct `default` preset (cognitive 15, cyclomatic 15 today) | CRAP score above which a function fails the check. The default is resolved against the effective metric, not a hard-coded scalar. |
+| `--strict` | — | Use the `strict` preset (cognitive 8, cyclomatic 8 today). Mutually exclusive with `--lenient`. |
+| `--lenient` | — | Use the `lenient` preset (cognitive 25, cyclomatic 25 today). |
+| `--no-fail` | — | Always exit `0`; `result.passed` in JSON still reflects truth. Composes with `--delta-gate` (overrides BOTH gates). |
+| `--delta-gate` | off | Fail the build (exit `1`) when `--baseline` introduces new threshold violations. |
+| `--minimal-view` | — | Omit `view.shown[]` from JSON output (payload-size escape hatch for large codebases). |
+| `--summary` | — | Emit a single-line analysis verdict instead of the full report; short-circuits `--format`. |
+
+**Filtering**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--exclude <GLOB>` | — | Exclude paths matching glob (repeatable). |
+| `--no-gitignore` | respect | Do NOT skip paths in `.gitignore`. |
+| `--diff <REF>` | — | Only analyze functions in files changed since `REF` (CI PR-gating). |
+| `--only-failing` | — | Display only functions exceeding the threshold (gate still ranges over everything). |
+| `--top <N>` | — | Truncate the displayed report to the top `N` highest-CRAP rows. |
+| `--min-coverage <PCT>` | — | Drop displayed rows whose coverage falls below `PCT`. |
+| `--max-coverage <PCT>` | — | Drop displayed rows whose coverage exceeds `PCT`. |
+| `--sort-by <KEY>` | `crap` | `crap` (default), `coverage`, `complexity`, or `path`. |
+| `--group-by <KEY>` | — | Today: `file` (per-file summaries). Under grouping, `--top` and `--sort-by` key at the file level. |
+| `--delta-top <N>` | — | Truncate the delta block to top `N` changes. |
+| `--delta-sort <KEY>` | `score-delta` | `score-delta`, `current-crap`, `baseline-crap`, or `path`. |
+| `--delta-only <KINDS>` | all | Comma-separated subset of `added`, `removed`, `modified`. |
+
+**Display**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--color <COLOR>` | `auto` | `auto`, `always`, or `never`. |
+| `-v`, `--verbose` | — | Show parse diagnostics and matching statistics. |
+| `-q`, `--quiet` | — | Suppress report output, only set exit code. |
+| `--breakdown` | — | Show per-contributor complexity breakdown for failing functions in table output. |
+| `--explain` | — | With `--breakdown`, explain nested cognitive increments in table output. |
+| `--md-full-table` | — | Append the full per-function table to markdown output (default markdown is a compact top-N summary). |
+| `--md-top <N>` | `10` | Number of rows in the markdown top-N table. |
 
 ### Threshold (the gate)
 
-`--threshold` is the line above which a function trips the build gate (exit `1` unless `--no-fail`). It is a separate axis from the risk classification — the gate is deliberately more aggressive than waiting for the `High` tier so functions surface before they cliff.
+`--threshold` is the line above which a function trips the build gate (exit `1` unless `--no-fail`). Tier presets are aligned with the [risk classification](#risk-classification) — each preset fires at the next risk-tier boundary:
 
-| Preset | Threshold | Where the gate sits relative to risk levels |
-|--------|-----------|---------------------------------------------|
-| `--strict` | `15` | Fires inside `Moderate` — flags borderline functions early |
-| default | `25` | Fires near the top of `Moderate` (just before `High` at 30) |
-| `--lenient` | `40` | Fires inside `High` — only catches genuinely-dangerous functions |
+| Preset      | Cognitive | Cyclomatic | Risk boundary it gates at |
+|-------------|-----------|------------|---------------------------|
+| `--strict`  | `8`       | `8`        | Low → Acceptable          |
+| default     | `15`      | `15`       | Acceptable → Moderate     |
+| `--lenient` | `25`      | `25`       | Moderate → High           |
 
-A function with CRAP `7` is `Acceptable` and never trips any preset. A function with CRAP `40` is `High` and trips every preset. A function with CRAP `20` is `Moderate` (the risk classification) but trips `--strict` (the gate); the two answers are independent.
+Cognitive and cyclomatic columns currently hold the same values. The dual-column infrastructure inside `crap-core` is preserved because the two metrics can diverge in magnitude for the same code (cognitive is nesting-weighted; cyclomatic counts decision points); a future per-metric recalibration is a one-line change without an API churn.
+
+A function with CRAP `5` is `Low` and never trips any preset. A function with CRAP `40` is `High` and trips every preset. A function with CRAP `12` is `Acceptable` (the risk classification) but trips `--strict` (the gate); the two views agree at boundaries but the gate moves earlier than risk reclassification.
 
 Risk classification feeds SARIF severity (`high → error`, `moderate → warning`, `acceptable/low → note`); threshold feeds the exit code. Scorecard-row status (`Red`/`Yellow`/`Green`) — see [docs/scorecard-row-contract.md](docs/scorecard-row-contract.md) — is minted from the threshold gate, not from risk classification.
 
-`crap4rs` and `crap4ts` share the CRAP formula and analysis concepts through `crap-core`, but threshold policy is language-specific — the two analyzers deliberately do not use identical thresholds.
+`crap4rs` and `crap4ts` share the CRAP formula and analysis concepts through `crap-core`; threshold policy is exposed per analyzer and may diverge in the future.
+
+#### Per-path threshold overrides
+
+`crap4rs.toml` accepts a `[thresholds]` block with per-glob overrides — useful when a directory has stricter or looser requirements than the project default. The most-specific (latest-matching) override wins:
+
+```toml
+# crap4rs.toml — domain/ must stay under the strict cutoff, even when
+# the project default is more permissive.
+preset = "default"   # global cutoff = cognitive 15
+
+[[thresholds.overrides]]
+pattern = "src/domain/**"
+threshold = 8        # gate at the strict tier inside domain/
+```
 
 ### Why cognitive by default?
 
@@ -186,19 +247,6 @@ The shaping flags `--delta-top`, `--delta-sort` (`score-delta` (default) | `curr
 
 `--format markdown` produces GitHub-flavored Markdown (pipe-syntax table plus a Summary block) — paste it into a PR comment, an issue body, or a doc page. `--format csv` produces RFC 4180 CSV with a fixed header row, suitable for piping into spreadsheets, BI tools, or `awk`/`jq` pipelines that prefer tabular input. Both honor every shaping flag (`--top`, `--sort-by`, `--only-failing`, `--min-coverage` / `--max-coverage`).
 
-### Scorecard row (`--format scorecard-row`)
-
-Emits a single `Row::CrapDelta` JSON object on stdout, conformant to the locked schema in [breezy-bays-labs/mokumo](https://github.com/breezy-bays-labs/mokumo) at `.config/scorecard/schema.json`. Designed for cross-tool aggregation: a fan-in workflow can run crap4rs alongside other per-gate emitters (mutation testing, BDD, dep-cruiser, coverage) and post one composed scorecard comment per PR.
-
-```bash
-# Producer mode — one Row per run, no envelope, no markdown noise
-crap4rs --coverage lcov.info --baseline baseline.json --format scorecard-row
-```
-
-Status (`Red`/`Yellow`/`Green`) is minted by crap4rs from the [threshold gate](#threshold-the-gate) and modified-function regressions, *not* from the intrinsic risk classification. See **[docs/scorecard-row-contract.md](docs/scorecard-row-contract.md)** for the full contract reference: wire shape, status policy, schema vendoring, producer-pattern overview, and the planned crap-core extraction path.
-
-The composite action at `.github/actions/scorecard` exposes the same JSON via `outputs.row-json` for downstream aggregator workflows.
-
 ### Agent advice (`--format advice`) — experimental
 
 `--format advice` emits the same JSON envelope as `--format json`, but with a populated `Diagnostic` on every over-threshold `view.shown[]` entry. The diagnostic is AST-derived — coverage gaps, complexity drivers, suggested actions, and a flat `root_cause` scalar — so coding agents can read findings and propose remediations without re-walking the source.
@@ -249,7 +297,7 @@ A grep-friendly stderr summary streams alongside stdout — one line per over-th
 | `acceptable`   | `note`        |
 | `low`          | `note`        |
 
-Severity is the [intrinsic risk classification](#risk-classification-intrinsic), not the threshold gate — a `Moderate` function is a SARIF `warning` regardless of which preset is in effect.
+Severity is the [risk classification](#risk-classification), not the threshold gate — a `Moderate` function is a SARIF `warning` regardless of which preset is in effect.
 
 Unlike the table / JSON / Markdown / CSV reporters, SARIF is a **gate translation**, not a display: it iterates the unshapeable analysis. `--top`, `--sort-by`, `--only-failing`, and `--baseline` do **not** alter SARIF output — PR annotations must reflect truth, not a presentation choice. `--no-fail` overrides the exit code only; the `results[]` array still lists every finding.
 

--- a/crates/crap-core/src/adapters/reporters/snapshots/crap_core__adapters__reporters__json__tests__full_json_snapshot.snap
+++ b/crates/crap-core/src/adapters/reporters/snapshots/crap_core__adapters__reporters__json__tests__full_json_snapshot.snap
@@ -1,5 +1,5 @@
 ---
-source: src/adapters/reporters/json.rs
+source: crates/crap-core/src/adapters/reporters/json.rs
 expression: v
 ---
 {
@@ -114,7 +114,7 @@ expression: v
       "exceeding_threshold": 0,
       "max_complexity": 5,
       "max_crap": {
-        "risk_level": "acceptable",
+        "risk_level": "low",
         "value": 5.16
       },
       "median_complexity": 5.0,

--- a/crates/crap-core/src/cli/init.rs
+++ b/crates/crap-core/src/cli/init.rs
@@ -15,7 +15,7 @@
 //!   3. Neither → fall back to `"src"` with a hint comment so users
 //!      see the toggle point.
 //!
-//! Threshold preset: defaults to `default` (25) non-interactively;
+//! Threshold preset: defaults to `default` (15) non-interactively;
 //! interactively reads one line from stdin and maps the first char
 //! (`s|S` → strict, `l|L` → lenient, anything else → default). No TTY
 //! detection — CI users pass `--non-interactive` to skip the prompt;
@@ -387,9 +387,9 @@ mod tests {
             "header line missing; got:\n{out}",
         );
         assert!(out.contains("Threshold preset"));
-        assert!(out.contains("strict (15)"));
-        assert!(out.contains("default (25)"));
-        assert!(out.contains("lenient (40)"));
+        assert!(out.contains("strict (8)"));
+        assert!(out.contains("default (15)"));
+        assert!(out.contains("lenient (25)"));
     }
 
     #[test]
@@ -412,19 +412,19 @@ mod tests {
 
     #[test]
     fn prompt_numbers_track_the_metric() {
-        // The interactive prompt must show the cutoffs calibrated for
-        // the adapter's metric — a cyclomatic adapter shows 8/16/30,
-        // never the cognitive 15/25/40. This is the same defect class
-        // as the generated-config comment: metric-blind numbers shown
-        // to the user.
+        // The interactive prompt must show the cutoffs that route via
+        // the adapter's metric. Both columns are flat-equal post-#272
+        // (8/15/25); the prompt still emits the cyclomatic-column
+        // values, proving the metric-keyed routing path is exercised
+        // even when columns agree.
         let mut stdin = Cursor::new(b"\n");
         let mut stderr: Vec<u8> = Vec::new();
         prompt_threshold_preset(ComplexityMetric::Cyclomatic, &mut stdin, &mut stderr).unwrap();
         let shown = String::from_utf8(stderr).unwrap();
         assert!(shown.contains("cyclomatic metric"), "prompt: {shown}");
         assert!(shown.contains("(s)trict  = 8"), "prompt: {shown}");
-        assert!(shown.contains("(d)efault = 16"), "prompt: {shown}");
-        assert!(shown.contains("(l)enient = 30"), "prompt: {shown}");
+        assert!(shown.contains("(d)efault = 15"), "prompt: {shown}");
+        assert!(shown.contains("(l)enient = 25"), "prompt: {shown}");
     }
 
     #[test]

--- a/crates/crap-core/src/cli/mod.rs
+++ b/crates/crap-core/src/cli/mod.rs
@@ -2238,48 +2238,45 @@ mod tests {
 
     #[test]
     fn merge_threshold_explicit_default_overrides_config() {
-        // User explicitly passes --threshold 8.0 (same as DEFAULT_THRESHOLD).
+        // User explicitly passes --threshold 15.0 (same as DEFAULT_THRESHOLD).
         // This MUST override the config file's threshold of 12.0.
-        let cli = parse(&["--coverage", "lcov.info", "--threshold", "8.0"]).unwrap();
+        let cli = parse(&["--coverage", "lcov.info", "--threshold", "15.0"]).unwrap();
         let file_config = Some(FileConfig {
             threshold: Some(12.0),
             ..FileConfig::default()
         });
         let (config, display) = merge_threshold(&cli, &file_config, ComplexityMetric::Cognitive);
         assert_eq!(
-            config.global, 8.0,
+            config.global, 15.0,
             "explicit CLI default must override config"
         );
-        assert_eq!(display, 8.0);
+        assert_eq!(display, 15.0);
     }
 
     #[test]
     fn merge_threshold_no_flag_default_is_metric_keyed() {
-        // Replaces the pre-fix `merge_threshold_no_cli_no_config_uses_hardcoded_default`.
-        // The no-flag/no-config fallthrough is the `Default` tier
-        // resolved against the effective metric — NOT a single shared
-        // scalar. Cognitive runs get 25; cyclomatic runs get 16. A
-        // cognitive-tuned 25 applied to cyclomatic scores would
-        // under-gate (the bug this keys against).
+        // No-flag/no-config fallthrough is the `Default` tier resolved
+        // against the effective metric. Both columns currently hold 15
+        // (post-#272 alignment); the metric-keyed routing path is
+        // exercised so a future per-metric divergence surfaces here.
         let cli = parse(&["--coverage", "lcov.info"]).unwrap();
         let (cog, cog_disp) = merge_threshold(&cli, &None, ComplexityMetric::Cognitive);
-        assert_eq!(cog.global, 25.0);
-        assert_eq!(cog_disp, 25.0);
+        assert_eq!(cog.global, 15.0);
+        assert_eq!(cog_disp, 15.0);
         let (cyc, cyc_disp) = merge_threshold(&cli, &None, ComplexityMetric::Cyclomatic);
-        assert_eq!(cyc.global, 16.0);
-        assert_eq!(cyc_disp, 16.0);
+        assert_eq!(cyc.global, 15.0);
+        assert_eq!(cyc_disp, 15.0);
     }
 
     #[test]
     fn merge_threshold_strict_lenient_are_metric_keyed() {
-        // `--strict` / `--lenient` were previously metric-blind (always
-        // the cognitive 15 / 40). They now resolve per metric too, so
-        // no preset path silently applies a cognitive cutoff to
-        // cyclomatic scores.
+        // `--strict` / `--lenient` resolve per metric. Columns are
+        // flat-equal post-#272; the metric-keyed routing path is still
+        // exercised so a future per-metric divergence surfaces here.
         let strict = parse(&["--coverage", "lcov.info", "--strict"]).unwrap();
         assert_eq!(
             merge_threshold(&strict, &None, ComplexityMetric::Cognitive).1,
-            15.0
+            8.0
         );
         assert_eq!(
             merge_threshold(&strict, &None, ComplexityMetric::Cyclomatic).1,
@@ -2288,11 +2285,11 @@ mod tests {
         let lenient = parse(&["--coverage", "lcov.info", "--lenient"]).unwrap();
         assert_eq!(
             merge_threshold(&lenient, &None, ComplexityMetric::Cognitive).1,
-            40.0
+            25.0
         );
         assert_eq!(
             merge_threshold(&lenient, &None, ComplexityMetric::Cyclomatic).1,
-            30.0
+            25.0
         );
     }
 
@@ -2740,7 +2737,7 @@ mod tests {
     fn merge_effective_inputs_default_threshold_follows_adapter_metric_cognitive() {
         // End-to-end wiring: an adapter whose default metric is
         // cognitive, with no `--threshold`/`--metric`/config, resolves
-        // the no-flag gate to the cognitive `Default` cutoff (25).
+        // the no-flag gate to the cognitive `Default` cutoff (15).
         let cli = parse(&["--coverage", "lcov.info"]).unwrap();
         let meta = AdapterMeta {
             default_metric: ComplexityMetric::Cognitive,
@@ -2748,15 +2745,15 @@ mod tests {
         };
         let inputs = merge_effective_inputs(&cli, &None, &meta);
         assert!(matches!(inputs.metric, ComplexityMetric::Cognitive));
-        assert_eq!(inputs.threshold, 25.0);
+        assert_eq!(inputs.threshold, 15.0);
     }
 
     #[test]
     fn merge_effective_inputs_default_threshold_follows_adapter_metric_cyclomatic() {
         // Mirror for a cyclomatic-default adapter (crap4ts): the no-flag
-        // gate must be the cyclomatic `Default` cutoff (16), not the
-        // cognitive 25 — a single shared default applied the wrong
-        // metric's cutoff before this fix.
+        // gate routes through the cyclomatic column. Columns are flat-
+        // equal post-#272 (both 15); the metric-keyed routing is what
+        // this test locks, not the numeric value.
         let cli = parse(&["--coverage", "lcov.info"]).unwrap();
         let meta = AdapterMeta {
             default_metric: ComplexityMetric::Cyclomatic,
@@ -2764,7 +2761,7 @@ mod tests {
         };
         let inputs = merge_effective_inputs(&cli, &None, &meta);
         assert!(matches!(inputs.metric, ComplexityMetric::Cyclomatic));
-        assert_eq!(inputs.threshold, 16.0);
+        assert_eq!(inputs.threshold, 15.0);
     }
 
     #[test]

--- a/crates/crap-core/src/domain/crap.rs
+++ b/crates/crap-core/src/domain/crap.rs
@@ -30,11 +30,11 @@ fn round_to_2(value: f64) -> f64 {
 }
 
 pub fn classify_risk(score: f64) -> RiskLevel {
-    if score <= 5.0 {
+    if score <= 8.0 {
         RiskLevel::Low
-    } else if score <= 8.0 {
+    } else if score <= 15.0 {
         RiskLevel::Acceptable
-    } else if score <= 30.0 {
+    } else if score <= 25.0 {
         RiskLevel::Moderate
     } else {
         RiskLevel::High
@@ -63,7 +63,7 @@ mod tests {
     fn complex_function_fully_covered() {
         let score = compute_crap(10, 100.0).unwrap();
         assert_eq!(score.value, 10.0);
-        assert_eq!(score.risk_level, RiskLevel::Moderate);
+        assert_eq!(score.risk_level, RiskLevel::Acceptable);
     }
 
     #[test]
@@ -78,26 +78,25 @@ mod tests {
         // CC=6, 80% coverage => 6² × 0.2³ + 6 = 36 × 0.008 + 6 = 6.288 → 6.29
         let score = compute_crap(6, 80.0).unwrap();
         assert_eq!(score.value, 6.29);
-        assert_eq!(score.risk_level, RiskLevel::Acceptable);
+        assert_eq!(score.risk_level, RiskLevel::Low);
     }
 
     #[test]
     fn threshold_boundary_low_acceptable() {
-        // Score exactly 5.0 should be Low
-        assert_eq!(classify_risk(5.0), RiskLevel::Low);
-        assert_eq!(classify_risk(5.01), RiskLevel::Acceptable);
+        assert_eq!(classify_risk(8.0), RiskLevel::Low);
+        assert_eq!(classify_risk(8.01), RiskLevel::Acceptable);
     }
 
     #[test]
     fn threshold_boundary_acceptable_moderate() {
-        assert_eq!(classify_risk(8.0), RiskLevel::Acceptable);
-        assert_eq!(classify_risk(8.01), RiskLevel::Moderate);
+        assert_eq!(classify_risk(15.0), RiskLevel::Acceptable);
+        assert_eq!(classify_risk(15.01), RiskLevel::Moderate);
     }
 
     #[test]
     fn threshold_boundary_moderate_high() {
-        assert_eq!(classify_risk(30.0), RiskLevel::Moderate);
-        assert_eq!(classify_risk(30.01), RiskLevel::High);
+        assert_eq!(classify_risk(25.0), RiskLevel::Moderate);
+        assert_eq!(classify_risk(25.01), RiskLevel::High);
     }
 
     #[test]
@@ -139,7 +138,7 @@ mod tests {
     fn crap4ts_oracle_moderate_half_covered() {
         let score = compute_crap(5, 50.0).unwrap();
         assert_eq!(score.value, 8.13);
-        assert_eq!(score.risk_level, RiskLevel::Moderate);
+        assert_eq!(score.risk_level, RiskLevel::Acceptable);
     }
 
     #[test]

--- a/crates/crap-core/src/domain/summary.rs
+++ b/crates/crap-core/src/domain/summary.rs
@@ -652,10 +652,10 @@ mod tests {
     #[test]
     fn distribution_counting() {
         let verdicts = vec![
-            make_verdict("a.rs", "low", 2.0, 30.0),        // Low (<=5)
-            make_verdict("a.rs", "acceptable", 6.0, 30.0), // Acceptable (<=8)
-            make_verdict("a.rs", "moderate", 15.0, 30.0),  // Moderate (<=30)
-            make_verdict("a.rs", "high", 50.0, 30.0),      // High (>30)
+            make_verdict("a.rs", "low", 2.0, 30.0),         // Low (<=8)
+            make_verdict("a.rs", "acceptable", 10.0, 30.0), // Acceptable (<=15)
+            make_verdict("a.rs", "moderate", 20.0, 30.0),   // Moderate (<=25)
+            make_verdict("a.rs", "high", 50.0, 30.0),       // High (>25)
         ];
         let summary = compute_summary(&verdicts);
         assert_eq!(summary.distribution.low, 1);
@@ -899,10 +899,10 @@ mod file_summary_tests {
     #[test]
     fn distribution_per_file() {
         let verdicts = vec![
-            vrd("a.rs", "low", 2.0, 25.0),        // Low (<=5)
-            vrd("a.rs", "acceptable", 6.0, 25.0), // Acceptable (<=8)
-            vrd("a.rs", "moderate", 15.0, 25.0),  // Moderate (<=30)
-            vrd("a.rs", "high", 50.0, 25.0),      // High (>30)
+            vrd("a.rs", "low", 2.0, 25.0),         // Low (<=8)
+            vrd("a.rs", "acceptable", 10.0, 25.0), // Acceptable (<=15)
+            vrd("a.rs", "moderate", 20.0, 25.0),   // Moderate (<=25)
+            vrd("a.rs", "high", 50.0, 25.0),       // High (>25)
         ];
         let summaries = compute_file_summaries(&verdicts);
         assert_eq!(summaries.len(), 1);

--- a/crates/crap-core/src/domain/threshold.rs
+++ b/crates/crap-core/src/domain/threshold.rs
@@ -2,54 +2,54 @@ use super::types::ComplexityMetric;
 
 // ── Threshold calibration table ──────────────────────────────────────
 //
-// CRAP thresholds are NOT metric-invariant. For the *same* function,
-// its cyclomatic count (decision points) and its cognitive count
-// (nesting-weighted structural complexity) differ in magnitude — a
-// function that is "moderately risky" scores ~16 cyclomatic but ~25
-// cognitive. So one scalar cutoff cannot serve both metrics: a cutoff
-// tuned for cognitive scores, applied to cyclomatic scores, lets
-// genuinely-risky functions pass (and vice versa).
-//
-// Each calibration *tier* (strict / default / lenient) therefore has a
-// distinct cutoff per metric:
+// CRAP thresholds are aligned with the intrinsic risk classification
+// in `crap.rs::classify_risk`: every preset fires at the next
+// risk-tier boundary up.
 //
 //                strict  default  lenient
-//   cyclomatic      8       16       30
-//   cognitive      15       25       40
+//   cyclomatic      8       15       25
+//   cognitive       8       15       25
 //
-// The bare-named constants are the cognitive column; the
-// `_CYCLOMATIC` siblings are the cyclomatic column.
+// Both metric columns currently hold the same values. The dual-column
+// infrastructure is preserved because cognitive and cyclomatic scores
+// can diverge in magnitude for the same code (cognitive is
+// nesting-weighted; cyclomatic counts decision points), and a future
+// recalibration may want to widen one column without touching the
+// other. Today the columns are flat-equal — the simplest defensible
+// position until corpus evidence motivates a split.
+//
 // `ThresholdPreset::threshold(metric)` is the single lookup that keys
-// a tier to the right column — every preset / `--strict` / `--lenient`
-// / no-flag-default resolution routes through it so no path applies a
-// metric's cutoff to the other metric's scores.
+// a tier to a column. Every preset / `--strict` / `--lenient` /
+// no-flag-default resolution routes through it, so a future per-metric
+// divergence is a one-line constant change with no API churn.
 
-/// Strict CRAP cutoff for the **cognitive** metric — high-quality or
-/// safety-critical code. Matches SonarSource S3776's cognitive
-/// complexity limit and eliminates false positives on well-tested
-/// idiomatic Rust (SeaORM-style large match arms). Cyclomatic
-/// equivalent: [`STRICT_THRESHOLD_CYCLOMATIC`].
-pub const STRICT_THRESHOLD: f64 = 15.0;
+/// Strict CRAP cutoff for the **cognitive** metric — gates at the
+/// Low → Acceptable risk boundary; for high-quality or safety-critical
+/// code. Cyclomatic equivalent: [`STRICT_THRESHOLD_CYCLOMATIC`].
+pub const STRICT_THRESHOLD: f64 = 8.0;
 
-/// Default CRAP cutoff for the **cognitive** metric — balanced for
-/// typical codebases. Cyclomatic equivalent: [`DEFAULT_THRESHOLD_CYCLOMATIC`].
-pub const DEFAULT_THRESHOLD: f64 = 25.0;
+/// Default CRAP cutoff for the **cognitive** metric — gates at the
+/// Acceptable → Moderate risk boundary; the balanced tier for typical
+/// codebases. Cyclomatic equivalent: [`DEFAULT_THRESHOLD_CYCLOMATIC`].
+pub const DEFAULT_THRESHOLD: f64 = 15.0;
 
-/// Lenient CRAP cutoff for the **cognitive** metric — legacy or
-/// transitional code. Cyclomatic equivalent: [`LENIENT_THRESHOLD_CYCLOMATIC`].
-pub const LENIENT_THRESHOLD: f64 = 40.0;
+/// Lenient CRAP cutoff for the **cognitive** metric — gates at the
+/// Moderate → High risk boundary; for legacy or transitional code.
+/// Cyclomatic equivalent: [`LENIENT_THRESHOLD_CYCLOMATIC`].
+pub const LENIENT_THRESHOLD: f64 = 25.0;
 
-/// Strict CRAP cutoff for the **cyclomatic** metric. ~half the
-/// cognitive strict value because cyclomatic scores run lower in
-/// magnitude for the same code.
+/// Strict CRAP cutoff for the **cyclomatic** metric. Currently flat-
+/// equal to the cognitive strict value; the constant is retained so a
+/// future per-metric recalibration is a one-line change.
 pub const STRICT_THRESHOLD_CYCLOMATIC: f64 = 8.0;
 
-/// Default CRAP cutoff for the **cyclomatic** metric — the balanced
-/// tier for cyclomatic-scored code.
-pub const DEFAULT_THRESHOLD_CYCLOMATIC: f64 = 16.0;
+/// Default CRAP cutoff for the **cyclomatic** metric. Currently flat-
+/// equal to the cognitive default; see column note above.
+pub const DEFAULT_THRESHOLD_CYCLOMATIC: f64 = 15.0;
 
-/// Lenient CRAP cutoff for the **cyclomatic** metric.
-pub const LENIENT_THRESHOLD_CYCLOMATIC: f64 = 30.0;
+/// Lenient CRAP cutoff for the **cyclomatic** metric. Currently flat-
+/// equal to the cognitive lenient; see column note above.
+pub const LENIENT_THRESHOLD_CYCLOMATIC: f64 = 25.0;
 
 /// Named threshold preset — a calibration *tier*, independent of
 /// metric. The concrete f64 cutoff is resolved per metric via
@@ -57,13 +57,15 @@ pub const LENIENT_THRESHOLD_CYCLOMATIC: f64 = 30.0;
 /// number for cyclomatic vs cognitive scores).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ThresholdPreset {
-    /// High-quality libraries, safety-critical code. Cognitive 15,
-    /// cyclomatic 8.
+    /// High-quality libraries, safety-critical code. Gates at the
+    /// Low → Acceptable risk boundary (cognitive 8, cyclomatic 8).
     Strict,
     /// Typical projects (balanced) — the tier used when no preset or
-    /// explicit threshold is given. Cognitive 25, cyclomatic 16.
+    /// explicit threshold is given. Gates at the Acceptable → Moderate
+    /// risk boundary (cognitive 15, cyclomatic 15).
     Default,
-    /// Legacy or transitional code. Cognitive 40, cyclomatic 30.
+    /// Legacy or transitional code. Gates at the Moderate → High risk
+    /// boundary (cognitive 25, cyclomatic 25).
     Lenient,
 }
 
@@ -158,28 +160,31 @@ mod tests {
 
     #[test]
     fn threshold_constants() {
-        // D5 calibration table (locked decision #5).
-        assert_eq!(STRICT_THRESHOLD, 15.0);
-        assert_eq!(DEFAULT_THRESHOLD, 25.0);
-        assert_eq!(LENIENT_THRESHOLD, 40.0);
+        // Aligned with classify_risk boundaries (Low ≤ 8, Acceptable ≤ 15,
+        // Moderate ≤ 25). Both metric columns flat-equal today; see the
+        // calibration-table comment at the top of this module for why
+        // the dual-column infrastructure is preserved.
+        assert_eq!(STRICT_THRESHOLD, 8.0);
+        assert_eq!(DEFAULT_THRESHOLD, 15.0);
+        assert_eq!(LENIENT_THRESHOLD, 25.0);
         assert_eq!(STRICT_THRESHOLD_CYCLOMATIC, 8.0);
-        assert_eq!(DEFAULT_THRESHOLD_CYCLOMATIC, 16.0);
-        assert_eq!(LENIENT_THRESHOLD_CYCLOMATIC, 30.0);
+        assert_eq!(DEFAULT_THRESHOLD_CYCLOMATIC, 15.0);
+        assert_eq!(LENIENT_THRESHOLD_CYCLOMATIC, 25.0);
     }
 
     #[test]
     fn preset_to_threshold_is_metric_keyed() {
         use ComplexityMetric::{Cognitive, Cyclomatic};
-        // Cognitive column (crap4rs).
-        assert_eq!(ThresholdPreset::Strict.threshold(Cognitive), 15.0);
-        assert_eq!(ThresholdPreset::Default.threshold(Cognitive), 25.0);
-        assert_eq!(ThresholdPreset::Lenient.threshold(Cognitive), 40.0);
-        // Cyclomatic column (crap4ts / crap4rs --metric cyclomatic) —
-        // the #218 fix: a tier resolves to the metric-correct cutoff,
-        // not the cognitive value applied blindly.
+        // Cognitive column (crap4rs default).
+        assert_eq!(ThresholdPreset::Strict.threshold(Cognitive), 8.0);
+        assert_eq!(ThresholdPreset::Default.threshold(Cognitive), 15.0);
+        assert_eq!(ThresholdPreset::Lenient.threshold(Cognitive), 25.0);
+        // Cyclomatic column (crap4ts / crap4rs --metric cyclomatic).
+        // Routing stays metric-keyed even with flat-equal values so a
+        // future per-metric recalibration is a one-line change.
         assert_eq!(ThresholdPreset::Strict.threshold(Cyclomatic), 8.0);
-        assert_eq!(ThresholdPreset::Default.threshold(Cyclomatic), 16.0);
-        assert_eq!(ThresholdPreset::Lenient.threshold(Cyclomatic), 30.0);
+        assert_eq!(ThresholdPreset::Default.threshold(Cyclomatic), 15.0);
+        assert_eq!(ThresholdPreset::Lenient.threshold(Cyclomatic), 25.0);
     }
 
     #[test]

--- a/crates/crap-core/tests/default_gate_threshold.rs
+++ b/crates/crap-core/tests/default_gate_threshold.rs
@@ -24,24 +24,25 @@
 //!
 //! ## What it locks (the calibration table, observed end-to-end)
 //!
-//! Threshold cutoffs are metric-keyed: for the same code, cyclomatic
-//! and cognitive scores differ in magnitude, so each tier maps to a
-//! different number per metric (strict/default/lenient = cyclomatic
-//! 8/16/30, cognitive 15/25/40):
+//! Threshold cutoffs are routed metric-by-metric through
+//! `ThresholdPreset::threshold`. Cognitive and cyclomatic columns
+//! currently hold the same values (strict/default/lenient = 8/15/25
+//! for both); the dual-column infrastructure is preserved so a future
+//! per-metric divergence is a one-line constant change.
 //!
 //! | invocation                              | metric    | tier    | expect |
 //! |-----------------------------------------|-----------|---------|--------|
-//! | `crap4ts` (no flags)                    | cyclomatic| default | 16     |
+//! | `crap4ts` (no flags)                    | cyclomatic| default | 15     |
 //! | `crap4ts --strict`                      | cyclomatic| strict  | 8      |
-//! | `crap4ts --lenient`                     | cyclomatic| lenient | 30     |
-//! | `crap4rs` (no flags)                    | cognitive | default | 25     |
-//! | `crap4rs --strict`                      | cognitive | strict  | 15     |
-//! | `crap4rs --metric cyclomatic`           | cyclomatic| default | 16     |
+//! | `crap4ts --lenient`                     | cyclomatic| lenient | 25     |
+//! | `crap4rs` (no flags)                    | cognitive | default | 15     |
+//! | `crap4rs --strict`                      | cognitive | strict  | 8      |
+//! | `crap4rs --metric cyclomatic`           | cyclomatic| default | 15     |
 //! | `crap4rs --metric cyclomatic --strict`  | cyclomatic| strict  | 8      |
 //!
-//! The crap4rs cognitive rows are regression guards: the
-//! `merge_threshold` signature change must not move the Rust adapter's
-//! long-standing cognitive defaults.
+//! Tests assert the metric-keyed routing path even when the columns
+//! agree, so if a future change splits the columns the regression
+//! surfaces here first.
 
 use std::path::PathBuf;
 
@@ -159,77 +160,73 @@ fn crap4rs_threshold(extra_args: &[&str]) -> f64 {
 // ── crap4ts: cyclomatic-metric adapter ───────────────────────────────
 
 #[test]
-fn default_gate_crap4ts_no_flag_is_cyclomatic_16() {
+fn default_gate_crap4ts_no_flag_is_cyclomatic_default() {
     assert_eq!(
         crap4ts_threshold(&[]),
-        16.0,
-        "crap4ts no-flag default must be the cyclomatic `default` cutoff \
-         (16), not the cognitive 25 — a single shared default applied a \
-         cognitive cutoff to cyclomatic scores"
+        15.0,
+        "crap4ts no-flag default must resolve to the cyclomatic \
+         `default` cutoff via metric-keyed routing"
     );
 }
 
 #[test]
-fn default_gate_crap4ts_strict_is_cyclomatic_8() {
+fn default_gate_crap4ts_strict_is_cyclomatic_strict() {
     assert_eq!(
         crap4ts_threshold(&["--strict"]),
         8.0,
-        "crap4ts --strict must be the cyclomatic `strict` cutoff (8), \
-         not the cognitive 15"
+        "crap4ts --strict must resolve to the cyclomatic `strict` cutoff"
     );
 }
 
 #[test]
-fn default_gate_crap4ts_lenient_is_cyclomatic_30() {
+fn default_gate_crap4ts_lenient_is_cyclomatic_lenient() {
     assert_eq!(
         crap4ts_threshold(&["--lenient"]),
-        30.0,
-        "crap4ts --lenient must be the cyclomatic `lenient` cutoff (30), \
-         not the cognitive 40"
+        25.0,
+        "crap4ts --lenient must resolve to the cyclomatic `lenient` cutoff"
     );
 }
 
 // ── crap4rs: cognitive-metric adapter (regression guards) ────────────
 
 #[test]
-fn default_gate_crap4rs_no_flag_stays_cognitive_25() {
+fn default_gate_crap4rs_no_flag_is_cognitive_default() {
     assert_eq!(
         crap4rs_threshold(&[]),
-        25.0,
-        "crap4rs no-flag default must stay the cognitive `default` \
-         cutoff (25) — the resolution refactor must not regress the \
-         Rust adapter"
+        15.0,
+        "crap4rs no-flag default must resolve to the cognitive \
+         `default` cutoff via metric-keyed routing"
     );
 }
 
 #[test]
-fn default_gate_crap4rs_strict_stays_cognitive_15() {
+fn default_gate_crap4rs_strict_is_cognitive_strict() {
     assert_eq!(
         crap4rs_threshold(&["--strict"]),
-        15.0,
-        "crap4rs --strict (cognitive metric) must stay 15"
+        8.0,
+        "crap4rs --strict (cognitive metric) must resolve to the \
+         cognitive `strict` cutoff"
     );
 }
 
 #[test]
-fn default_gate_crap4rs_metric_cyclomatic_no_flag_is_16() {
-    // The deeper instance of the same defect class: crap4rs *supports*
-    // cyclomatic too, and `--metric cyclomatic` with no threshold must
-    // resolve to the cyclomatic `default` (16), not the cognitive 25.
+fn default_gate_crap4rs_metric_cyclomatic_no_flag_is_default() {
+    // crap4rs *supports* cyclomatic too; --metric cyclomatic with no
+    // threshold must route through the cyclomatic column.
     assert_eq!(
         crap4rs_threshold(&["--metric", "cyclomatic"]),
-        16.0,
-        "crap4rs --metric cyclomatic no-flag default must be the \
-         cyclomatic cutoff (16), not the cognitive 25"
+        15.0,
+        "crap4rs --metric cyclomatic no-flag default must resolve to \
+         the cyclomatic `default` cutoff"
     );
 }
 
 #[test]
-fn default_gate_crap4rs_metric_cyclomatic_strict_is_8() {
+fn default_gate_crap4rs_metric_cyclomatic_strict_is_strict() {
     assert_eq!(
         crap4rs_threshold(&["--metric", "cyclomatic", "--strict"]),
         8.0,
-        "crap4rs --metric cyclomatic --strict must be the cyclomatic \
-         strict cutoff (8), not the cognitive 15"
+        "crap4rs --metric cyclomatic --strict must resolve to the \
+         cyclomatic `strict` cutoff"
     );
 }

--- a/crates/crap-core/tests/snapshots/wire_envelope_crap4rs__envelope.snap
+++ b/crates/crap-core/tests/snapshots/wire_envelope_crap4rs__envelope.snap
@@ -30,7 +30,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -49,7 +49,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -63,7 +63,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -87,7 +87,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -111,7 +111,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -130,7 +130,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -144,10 +144,10 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
-        "exceeds": false,
+        "exceeds": true,
         "scored": {
           "complexity": 4,
           "complexity_metric": "cognitive",
@@ -185,7 +185,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -209,7 +209,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -233,7 +233,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -257,7 +257,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -281,10 +281,10 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
-        "exceeds": false,
+        "exceeds": true,
         "scored": {
           "complexity": 3,
           "complexity_metric": "cognitive",
@@ -308,7 +308,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "moderate",
+            "risk_level": "acceptable",
             "value": 12.0
           },
           "identity": {
@@ -322,7 +322,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -341,7 +341,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -355,7 +355,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -379,7 +379,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": true,
@@ -428,7 +428,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -447,7 +447,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -461,10 +461,10 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
-        "exceeds": false,
+        "exceeds": true,
         "scored": {
           "complexity": 4,
           "complexity_metric": "cognitive",
@@ -502,7 +502,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -526,7 +526,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -550,7 +550,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -574,7 +574,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -598,7 +598,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -622,7 +622,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -646,7 +646,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -670,7 +670,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -689,7 +689,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -703,7 +703,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -727,7 +727,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -746,7 +746,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -760,7 +760,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -779,7 +779,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -793,7 +793,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -812,7 +812,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -826,7 +826,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": true,
@@ -875,10 +875,10 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
-        "exceeds": false,
+        "exceeds": true,
         "scored": {
           "complexity": 4,
           "complexity_metric": "cognitive",
@@ -916,7 +916,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": true,
@@ -973,7 +973,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -992,7 +992,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -1006,7 +1006,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -1025,7 +1025,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -1039,7 +1039,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -1058,7 +1058,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -1072,7 +1072,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -1096,7 +1096,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -1115,7 +1115,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -1129,7 +1129,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -1153,7 +1153,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -1177,7 +1177,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -1201,7 +1201,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -1225,7 +1225,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -1244,7 +1244,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -1258,10 +1258,10 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
-        "exceeds": false,
+        "exceeds": true,
         "scored": {
           "complexity": 3,
           "complexity_metric": "cognitive",
@@ -1285,7 +1285,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "moderate",
+            "risk_level": "acceptable",
             "value": 12.0
           },
           "identity": {
@@ -1299,10 +1299,10 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
-        "exceeds": false,
+        "exceeds": true,
         "scored": {
           "complexity": 4,
           "complexity_metric": "cognitive",
@@ -1340,10 +1340,10 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
-        "exceeds": false,
+        "exceeds": true,
         "scored": {
           "complexity": 3,
           "complexity_metric": "cognitive",
@@ -1367,7 +1367,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "moderate",
+            "risk_level": "acceptable",
             "value": 12.0
           },
           "identity": {
@@ -1381,7 +1381,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -1400,7 +1400,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -1414,7 +1414,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -1438,7 +1438,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -1462,7 +1462,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -1486,7 +1486,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -1505,7 +1505,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -1519,7 +1519,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -1543,7 +1543,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -1562,7 +1562,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -1576,7 +1576,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -1600,7 +1600,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -1624,7 +1624,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -1648,7 +1648,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -1672,7 +1672,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -1696,7 +1696,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -1720,7 +1720,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -1744,7 +1744,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -1768,7 +1768,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -1792,7 +1792,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -1816,7 +1816,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -1840,7 +1840,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -1864,7 +1864,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -1888,7 +1888,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -1912,7 +1912,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -1936,7 +1936,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -1960,7 +1960,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -1984,7 +1984,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -2008,7 +2008,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -2032,7 +2032,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -2056,7 +2056,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -2080,7 +2080,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -2104,7 +2104,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -2128,7 +2128,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -2152,7 +2152,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -2176,7 +2176,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -2200,7 +2200,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -2224,7 +2224,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -2248,7 +2248,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -2272,7 +2272,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -2296,7 +2296,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -2320,7 +2320,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -2344,7 +2344,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -2368,7 +2368,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -2392,7 +2392,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -2416,7 +2416,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -2440,7 +2440,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -2464,7 +2464,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -2488,7 +2488,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -2512,7 +2512,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -2536,7 +2536,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -2560,7 +2560,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -2584,7 +2584,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -2608,7 +2608,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -2632,7 +2632,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -2656,10 +2656,10 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
-        "exceeds": false,
+        "exceeds": true,
         "scored": {
           "complexity": 3,
           "complexity_metric": "cognitive",
@@ -2683,7 +2683,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "moderate",
+            "risk_level": "acceptable",
             "value": 12.0
           },
           "identity": {
@@ -2697,7 +2697,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -2721,7 +2721,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -2745,7 +2745,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -2764,7 +2764,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -2778,7 +2778,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -2802,7 +2802,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -2821,7 +2821,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -2835,7 +2835,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -2859,7 +2859,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -2883,7 +2883,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -2907,7 +2907,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -2926,7 +2926,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -2940,7 +2940,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -2964,7 +2964,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -2988,7 +2988,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -3012,7 +3012,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -3036,7 +3036,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -3060,7 +3060,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -3084,7 +3084,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -3108,7 +3108,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -3132,7 +3132,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -3156,7 +3156,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -3180,7 +3180,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -3204,7 +3204,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -3228,7 +3228,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -3252,7 +3252,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -3276,7 +3276,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -3300,7 +3300,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -3324,7 +3324,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -3348,7 +3348,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -3372,7 +3372,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -3396,7 +3396,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -3420,7 +3420,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -3444,7 +3444,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -3463,7 +3463,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -3477,7 +3477,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -3501,7 +3501,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -3525,7 +3525,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -3544,7 +3544,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -3558,7 +3558,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -3577,7 +3577,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -3591,7 +3591,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": true,
@@ -3672,10 +3672,10 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
-        "exceeds": false,
+        "exceeds": true,
         "scored": {
           "complexity": 4,
           "complexity_metric": "cognitive",
@@ -3721,7 +3721,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -3740,7 +3740,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -3754,10 +3754,10 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
-        "exceeds": false,
+        "exceeds": true,
         "scored": {
           "complexity": 3,
           "complexity_metric": "cognitive",
@@ -3781,7 +3781,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "moderate",
+            "risk_level": "acceptable",
             "value": 12.0
           },
           "identity": {
@@ -3795,10 +3795,10 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
-        "exceeds": false,
+        "exceeds": true,
         "scored": {
           "complexity": 3,
           "complexity_metric": "cognitive",
@@ -3822,7 +3822,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "moderate",
+            "risk_level": "acceptable",
             "value": 12.0
           },
           "identity": {
@@ -3836,7 +3836,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -3860,7 +3860,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": true,
@@ -3925,7 +3925,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": true,
@@ -4030,7 +4030,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -4049,7 +4049,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -4063,10 +4063,10 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
-        "exceeds": false,
+        "exceeds": true,
         "scored": {
           "complexity": 3,
           "complexity_metric": "cognitive",
@@ -4090,7 +4090,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "moderate",
+            "risk_level": "acceptable",
             "value": 12.0
           },
           "identity": {
@@ -4104,10 +4104,10 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
-        "exceeds": false,
+        "exceeds": true,
         "scored": {
           "complexity": 3,
           "complexity_metric": "cognitive",
@@ -4131,7 +4131,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "moderate",
+            "risk_level": "acceptable",
             "value": 12.0
           },
           "identity": {
@@ -4145,7 +4145,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -4169,7 +4169,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -4193,7 +4193,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -4212,7 +4212,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -4226,7 +4226,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -4250,7 +4250,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -4274,7 +4274,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -4298,7 +4298,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -4322,7 +4322,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -4346,7 +4346,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -4370,7 +4370,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -4394,7 +4394,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -4418,7 +4418,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -4442,7 +4442,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -4466,7 +4466,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -4490,7 +4490,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -4514,7 +4514,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -4538,7 +4538,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -4562,7 +4562,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -4586,7 +4586,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -4610,7 +4610,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -4634,7 +4634,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -4658,7 +4658,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -4682,7 +4682,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -4706,7 +4706,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -4730,7 +4730,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -4754,7 +4754,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -4778,7 +4778,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -4802,7 +4802,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -4826,7 +4826,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -4845,7 +4845,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -4859,7 +4859,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -4883,7 +4883,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -4907,7 +4907,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -4931,7 +4931,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -4950,7 +4950,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -4964,7 +4964,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -4988,7 +4988,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -5012,7 +5012,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -5036,7 +5036,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -5060,7 +5060,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -5084,7 +5084,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -5108,7 +5108,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -5132,7 +5132,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -5156,7 +5156,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -5180,7 +5180,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -5204,7 +5204,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -5228,7 +5228,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -5247,7 +5247,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -5261,7 +5261,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -5285,7 +5285,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -5309,7 +5309,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -5328,7 +5328,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -5342,7 +5342,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -5366,7 +5366,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -5390,7 +5390,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -5414,10 +5414,10 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
-        "exceeds": false,
+        "exceeds": true,
         "scored": {
           "complexity": 3,
           "complexity_metric": "cognitive",
@@ -5433,7 +5433,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "moderate",
+            "risk_level": "acceptable",
             "value": 12.0
           },
           "identity": {
@@ -5447,7 +5447,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -5471,7 +5471,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -5495,7 +5495,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -5519,7 +5519,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -5543,7 +5543,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -5562,7 +5562,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -5576,7 +5576,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -5600,7 +5600,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -5624,7 +5624,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -5648,7 +5648,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       }
     ],
     "passed": false,
@@ -5657,12 +5657,12 @@ expression: pretty
       "average_coverage": 0.0,
       "average_crap": 5.724137931034483,
       "distribution": {
-        "acceptable": 30,
+        "acceptable": 9,
         "high": 6,
-        "low": 153,
-        "moderate": 14
+        "low": 183,
+        "moderate": 5
       },
-      "exceeding_threshold": 6,
+      "exceeding_threshold": 20,
       "max_complexity": 11,
       "max_crap": {
         "risk_level": "high",
@@ -5687,7 +5687,7 @@ expression: pretty
     }
   },
   "schema_version": 2,
-  "threshold": 25.0,
+  "threshold": 8.0,
   "timestamp": "[STRIPPED:timestamp]",
   "tool_version": "[STRIPPED:tool_version]",
   "view": {
@@ -5797,7 +5797,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": true,
@@ -5878,7 +5878,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": true,
@@ -5935,7 +5935,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": true,
@@ -5984,7 +5984,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": true,
@@ -6033,7 +6033,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": true,
@@ -6098,10 +6098,10 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
-        "exceeds": false,
+        "exceeds": true,
         "scored": {
           "complexity": 4,
           "complexity_metric": "cognitive",
@@ -6139,10 +6139,10 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
-        "exceeds": false,
+        "exceeds": true,
         "scored": {
           "complexity": 4,
           "complexity_metric": "cognitive",
@@ -6180,10 +6180,10 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
-        "exceeds": false,
+        "exceeds": true,
         "scored": {
           "complexity": 4,
           "complexity_metric": "cognitive",
@@ -6221,10 +6221,10 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
-        "exceeds": false,
+        "exceeds": true,
         "scored": {
           "complexity": 4,
           "complexity_metric": "cognitive",
@@ -6262,10 +6262,10 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
-        "exceeds": false,
+        "exceeds": true,
         "scored": {
           "complexity": 4,
           "complexity_metric": "cognitive",
@@ -6311,10 +6311,10 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
-        "exceeds": false,
+        "exceeds": true,
         "scored": {
           "complexity": 3,
           "complexity_metric": "cognitive",
@@ -6338,7 +6338,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "moderate",
+            "risk_level": "acceptable",
             "value": 12.0
           },
           "identity": {
@@ -6352,10 +6352,10 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
-        "exceeds": false,
+        "exceeds": true,
         "scored": {
           "complexity": 3,
           "complexity_metric": "cognitive",
@@ -6379,7 +6379,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "moderate",
+            "risk_level": "acceptable",
             "value": 12.0
           },
           "identity": {
@@ -6393,10 +6393,10 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
-        "exceeds": false,
+        "exceeds": true,
         "scored": {
           "complexity": 3,
           "complexity_metric": "cognitive",
@@ -6420,7 +6420,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "moderate",
+            "risk_level": "acceptable",
             "value": 12.0
           },
           "identity": {
@@ -6434,10 +6434,10 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
-        "exceeds": false,
+        "exceeds": true,
         "scored": {
           "complexity": 3,
           "complexity_metric": "cognitive",
@@ -6461,7 +6461,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "moderate",
+            "risk_level": "acceptable",
             "value": 12.0
           },
           "identity": {
@@ -6475,10 +6475,10 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
-        "exceeds": false,
+        "exceeds": true,
         "scored": {
           "complexity": 3,
           "complexity_metric": "cognitive",
@@ -6502,7 +6502,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "moderate",
+            "risk_level": "acceptable",
             "value": 12.0
           },
           "identity": {
@@ -6516,10 +6516,10 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
-        "exceeds": false,
+        "exceeds": true,
         "scored": {
           "complexity": 3,
           "complexity_metric": "cognitive",
@@ -6543,7 +6543,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "moderate",
+            "risk_level": "acceptable",
             "value": 12.0
           },
           "identity": {
@@ -6557,10 +6557,10 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
-        "exceeds": false,
+        "exceeds": true,
         "scored": {
           "complexity": 3,
           "complexity_metric": "cognitive",
@@ -6584,7 +6584,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "moderate",
+            "risk_level": "acceptable",
             "value": 12.0
           },
           "identity": {
@@ -6598,10 +6598,10 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
-        "exceeds": false,
+        "exceeds": true,
         "scored": {
           "complexity": 3,
           "complexity_metric": "cognitive",
@@ -6625,7 +6625,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "moderate",
+            "risk_level": "acceptable",
             "value": 12.0
           },
           "identity": {
@@ -6639,10 +6639,10 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
-        "exceeds": false,
+        "exceeds": true,
         "scored": {
           "complexity": 3,
           "complexity_metric": "cognitive",
@@ -6658,7 +6658,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "moderate",
+            "risk_level": "acceptable",
             "value": 12.0
           },
           "identity": {
@@ -6672,7 +6672,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -6691,7 +6691,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -6705,7 +6705,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -6724,7 +6724,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -6738,7 +6738,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -6757,7 +6757,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -6771,7 +6771,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -6790,7 +6790,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -6804,7 +6804,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -6823,7 +6823,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -6837,7 +6837,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -6856,7 +6856,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -6870,7 +6870,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -6889,7 +6889,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -6903,7 +6903,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -6922,7 +6922,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -6936,7 +6936,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -6955,7 +6955,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -6969,7 +6969,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -6988,7 +6988,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -7002,7 +7002,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -7021,7 +7021,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -7035,7 +7035,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -7054,7 +7054,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -7068,7 +7068,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -7087,7 +7087,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -7101,7 +7101,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -7120,7 +7120,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -7134,7 +7134,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -7153,7 +7153,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -7167,7 +7167,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -7186,7 +7186,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -7200,7 +7200,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -7219,7 +7219,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -7233,7 +7233,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -7252,7 +7252,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -7266,7 +7266,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -7285,7 +7285,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -7299,7 +7299,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -7318,7 +7318,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -7332,7 +7332,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -7351,7 +7351,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -7365,7 +7365,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -7384,7 +7384,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -7398,7 +7398,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -7417,7 +7417,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -7431,7 +7431,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -7450,7 +7450,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -7464,7 +7464,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -7483,7 +7483,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -7497,7 +7497,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -7516,7 +7516,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -7530,7 +7530,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -7549,7 +7549,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -7563,7 +7563,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -7582,7 +7582,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -7596,7 +7596,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -7615,7 +7615,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -7629,7 +7629,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -7648,7 +7648,7 @@ expression: pretty
           ],
           "coverage_percent": 0.0,
           "crap": {
-            "risk_level": "acceptable",
+            "risk_level": "low",
             "value": 6.0
           },
           "identity": {
@@ -7662,7 +7662,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -7686,7 +7686,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -7710,7 +7710,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -7734,7 +7734,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -7758,7 +7758,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -7782,7 +7782,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -7806,7 +7806,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -7830,7 +7830,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -7854,7 +7854,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -7878,7 +7878,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -7902,7 +7902,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -7926,7 +7926,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -7950,7 +7950,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -7974,7 +7974,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -7998,7 +7998,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -8022,7 +8022,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -8046,7 +8046,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -8070,7 +8070,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -8094,7 +8094,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -8118,7 +8118,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -8142,7 +8142,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -8166,7 +8166,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -8190,7 +8190,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -8214,7 +8214,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -8238,7 +8238,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -8262,7 +8262,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -8286,7 +8286,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -8310,7 +8310,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -8334,7 +8334,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -8358,7 +8358,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -8382,7 +8382,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -8406,7 +8406,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -8430,7 +8430,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -8454,7 +8454,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -8478,7 +8478,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -8502,7 +8502,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -8526,7 +8526,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -8550,7 +8550,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -8574,7 +8574,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -8598,7 +8598,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -8622,7 +8622,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -8646,7 +8646,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -8670,7 +8670,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -8694,7 +8694,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -8718,7 +8718,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -8742,7 +8742,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -8766,7 +8766,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -8790,7 +8790,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -8814,7 +8814,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -8838,7 +8838,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -8862,7 +8862,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -8886,7 +8886,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -8910,7 +8910,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -8934,7 +8934,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -8958,7 +8958,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -8982,7 +8982,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -9006,7 +9006,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -9030,7 +9030,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -9054,7 +9054,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -9078,7 +9078,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -9102,7 +9102,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -9126,7 +9126,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -9150,7 +9150,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -9174,7 +9174,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -9198,7 +9198,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -9222,7 +9222,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -9246,7 +9246,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -9270,7 +9270,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -9294,7 +9294,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -9318,7 +9318,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -9342,7 +9342,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -9366,7 +9366,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -9390,7 +9390,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -9414,7 +9414,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -9438,7 +9438,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -9462,7 +9462,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -9486,7 +9486,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -9510,7 +9510,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -9534,7 +9534,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -9558,7 +9558,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -9582,7 +9582,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -9606,7 +9606,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -9630,7 +9630,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -9654,7 +9654,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -9678,7 +9678,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -9702,7 +9702,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -9726,7 +9726,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -9750,7 +9750,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -9774,7 +9774,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -9798,7 +9798,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -9822,7 +9822,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -9846,7 +9846,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -9870,7 +9870,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -9894,7 +9894,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -9918,7 +9918,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -9942,7 +9942,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -9966,7 +9966,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -9990,7 +9990,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -10014,7 +10014,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -10038,7 +10038,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -10062,7 +10062,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -10086,7 +10086,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -10110,7 +10110,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -10134,7 +10134,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -10158,7 +10158,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -10182,7 +10182,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -10206,7 +10206,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -10230,7 +10230,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -10254,7 +10254,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -10278,7 +10278,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -10302,7 +10302,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -10326,7 +10326,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -10350,7 +10350,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -10374,7 +10374,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -10398,7 +10398,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -10422,7 +10422,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -10446,7 +10446,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -10470,7 +10470,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -10494,7 +10494,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -10518,7 +10518,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -10542,7 +10542,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -10566,7 +10566,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -10590,7 +10590,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -10614,7 +10614,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -10638,7 +10638,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -10662,7 +10662,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -10686,7 +10686,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -10710,7 +10710,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -10734,7 +10734,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -10758,7 +10758,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -10782,7 +10782,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -10806,7 +10806,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -10830,7 +10830,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -10854,7 +10854,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -10878,7 +10878,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -10902,7 +10902,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -10926,7 +10926,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -10950,7 +10950,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -10974,7 +10974,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -10998,7 +10998,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -11022,7 +11022,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -11046,7 +11046,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -11070,7 +11070,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -11094,7 +11094,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -11118,7 +11118,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -11142,7 +11142,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -11166,7 +11166,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -11190,7 +11190,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -11214,7 +11214,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -11238,7 +11238,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -11262,7 +11262,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -11286,7 +11286,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -11310,7 +11310,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       },
       {
         "exceeds": false,
@@ -11334,7 +11334,7 @@ expression: pretty
             }
           }
         },
-        "threshold": 25.0
+        "threshold": 8.0
       }
     ],
     "shown_summary": {
@@ -11342,12 +11342,12 @@ expression: pretty
       "average_coverage": 0.0,
       "average_crap": 5.724137931034483,
       "distribution": {
-        "acceptable": 30,
+        "acceptable": 9,
         "high": 6,
-        "low": 153,
-        "moderate": 14
+        "low": 183,
+        "moderate": 5
       },
-      "exceeding_threshold": 6,
+      "exceeding_threshold": 20,
       "max_complexity": 11,
       "max_crap": {
         "risk_level": "high",

--- a/crates/crap-core/tests/wire_envelope_crap4rs.rs
+++ b/crates/crap-core/tests/wire_envelope_crap4rs.rs
@@ -67,8 +67,9 @@ fn strip_volatile(value: &mut Value) {
 fn envelope() {
     // Fixture: crap4rs's own LCOV against its own source. `--no-fail`
     // ensures the snapshot covers the threshold-exceeded branch
-    // (passed=false) since crap4rs-self.lcov has functions above
-    // threshold=25 — that's the realistic envelope shape.
+    // (passed=false). `--threshold 8` matches the post-#272 strict
+    // cutoff and exposes the crap4rs-self.lcov over-threshold
+    // functions — that's the realistic envelope shape.
     let output = Command::cargo_bin("crap4rs")
         .expect("crap4rs binary discoverable in workspace")
         .args([
@@ -77,7 +78,7 @@ fn envelope() {
             "--src",
             "../crap4rs/src",
             "--threshold",
-            "25",
+            "8",
             "--format",
             "json",
             "--no-fail",

--- a/crates/crap4rs/tests/features/cli_init.feature
+++ b/crates/crap4rs/tests/features/cli_init.feature
@@ -60,9 +60,9 @@ Feature: crap4rs init subcommand
     When the operator runs `crap4rs init --non-interactive`
     Then the config file contains "# crap4rs.toml"
     And the config file contains "Threshold preset"
-    And the config file contains "strict (15)"
-    And the config file contains "default (25)"
-    And the config file contains "lenient (40)"
+    And the config file contains "strict (8)"
+    And the config file contains "default (15)"
+    And the config file contains "lenient (25)"
 
   @wired
   Scenario: generated config round-trips through the loader

--- a/crates/crap4rs/tests/features/json_reporter.feature
+++ b/crates/crap4rs/tests/features/json_reporter.feature
@@ -42,7 +42,7 @@ Feature: JSON reporter
     And the entry contains "complexity" equal to 5
     And the entry contains "coverage_percent" equal to 80.0
     And the entry contains "crap" with "value" equal to 5.16
-    And the entry contains "crap" with "risk_level" equal to "acceptable"
+    And the entry contains "crap" with "risk_level" equal to "low"
     And the entry contains "exceeds" equal to false
 
   @wired

--- a/crates/crap4rs/tests/fixtures/scorecard/SOURCE.md
+++ b/crates/crap4rs/tests/fixtures/scorecard/SOURCE.md
@@ -1,7 +1,11 @@
 # Vendored mokumo scorecard schema
 
 `schema.json` is a verbatim copy of
-`breezy-bays-labs/mokumo:.config/scorecard/schema.json`.
+`breezy-bays-labs/mokumo:.config/scorecard/schema.json`, with one local
+deviation: the `definitions/CrateBreakout.properties.crate_name.description`
+example was changed from a project-specific crate name to the generic
+`"my-crate"`. A re-sync via `./regen.sh` must re-apply that sanitization
+(or land the same change upstream first).
 
 | Field | Value |
 |---|---|

--- a/crates/crap4rs/tests/fixtures/scorecard/schema.json
+++ b/crates/crap4rs/tests/fixtures/scorecard/schema.json
@@ -185,7 +185,7 @@
       ],
       "properties": {
         "crate_name": {
-          "description": "Crate name (e.g. `\"kikan\"`).",
+          "description": "Crate name (e.g. `\"my-crate\"`).",
           "type": "string"
         },
         "handlers": {

--- a/crates/crap4rs/tests/json_reporter_cucumber.rs
+++ b/crates/crap4rs/tests/json_reporter_cucumber.rs
@@ -261,11 +261,11 @@ fn given_one_function(
     coverage: f64,
     crap: f64,
 ) {
-    let risk = if crap < 5.0 {
+    let risk = if crap <= 8.0 {
         "low"
-    } else if crap < 10.0 {
+    } else if crap <= 15.0 {
         "acceptable"
-    } else if crap < 30.0 {
+    } else if crap <= 25.0 {
         "moderate"
     } else {
         "high"

--- a/crates/crap4ts/tests/features/cyclomatic_walker.feature
+++ b/crates/crap4ts/tests/features/cyclomatic_walker.feature
@@ -145,8 +145,8 @@ Feature: Cyclomatic complexity for TypeScript via the oxc walker
     And the contributors include exactly one `logical-operator` entry
 
   @wired
-  Scenario: Risk classification is metric-invariant per ADR D8
+  Scenario: Risk classification is metric-invariant
     Given a TypeScript function with cyclomatic complexity 4 and coverage 50%
     When the operator runs `crap4ts --coverage cov.json --src .`
     Then the function's CRAP score is 6.0
-    And the function's risk classification is `acceptable`
+    And the function's risk classification is `low`

--- a/crates/crap4ts/tests/features/parity_with_v1.feature
+++ b/crates/crap4ts/tests/features/parity_with_v1.feature
@@ -9,7 +9,7 @@ Feature: crap4ts@2 parity with crap4ts@1.x reference outputs
     And the captured v1.x reference outputs at `tests/fixtures/crap4ts-v1-reference.json`
     When the parity harness runs `crap4ts --src tests/fixtures/crap4ts-v1/src --coverage <v1-coverage>` and compares
     Then 95%+ of functions match cyclomatic complexity within ±0 (exact match)
-    And 100% of functions match risk-classification labels (Low/Acceptable/Moderate/High)
+    And every matched function's CRAP score is within tolerance (no unexplained regressions)
     And any divergence is reported per-function in the harness output
 
   @wired
@@ -25,11 +25,11 @@ Feature: crap4ts@2 parity with crap4ts@1.x reference outputs
     And the report shows v2 contributors: `2× if-branch`
 
   @wired
-  Scenario: Risk classification labels match across versions (D8 invariance check)
+  Scenario: Risk-tier recalibration is allowed; score parity is the contract
     Given the v1.x corpus + reference outputs
-    When the parity harness compares risk labels function-by-function
-    Then every function's risk classification matches v1.x to v2 exactly
-    And the cutoff boundaries (5/8/30) are NOT version-sensitive
+    When the parity harness compares scores function-by-function
+    Then every matched function's score is within tolerance (no unexplained regressions)
+    And risk-tier boundaries may be recalibrated across versions without tripping the gate
 
   @wired
   Scenario: Threshold-default difference is documented, not a parity failure

--- a/crates/crap4ts/tests/parity_helpers/mod.rs
+++ b/crates/crap4ts/tests/parity_helpers/mod.rs
@@ -15,23 +15,31 @@
 //! presupposes oracle contributor data the v1.x format does not carry;
 //! that is a documented surviving limitation, not a harness gap.
 //!
-//! ## Three-way classification (per the W3.1 fixture README)
+//! ## Classification (per the W3.1 fixture README, post-#272)
 //!
-//! Every matched function falls into exactly one bucket:
+//! Every matched function falls into exactly one bucket. Score parity
+//! is primary; the risk label is a *derived* attribute of the score
+//! (it lives in `classify_risk`) and is not pinned across the v1.x
+//! boundary — recalibrating risk tiers would otherwise force a new
+//! exemption bucket for every future move. Risk-label correctness is
+//! verified separately by unit tests of `classify_risk` itself.
 //!
-//! - **Match** — within tolerance, same risk class. Pass.
+//! - **Match** — score within tolerance (same CC, |Δcrap| ≤ 0.5,
+//!   coverage stable). Pass.
 //! - **ThresholdDefaultChange** — score unchanged, only the pass/fail
-//!   gate flips because the oracle used per-glob defaults (8/12) and
-//!   crap4ts@2 uses 16. Pass (an intentional calibration break, not a
-//!   regression).
+//!   gate flips because the oracle used per-glob defaults and
+//!   crap4ts@2 uses a different calibrated threshold. Pass (an
+//!   intentional calibration break, not a regression).
 //! - **Crap37Improvement** — v1.x reported 0% coverage where v2 reports
 //!   real coverage on the same complexity. This is the crap4ts#37 v1.x
 //!   span-overlap-ratio matcher bug; v2's strict line-range containment
-//!   is structurally immune. Pass, logged as an improvement. A risk
-//!   class that moves *because of* this also passes.
+//!   is structurally immune. Pass, logged as an improvement.
+//! - **Crap252Improvement** — v1.x's per-function rollup conflated
+//!   multi-statement source lines; v2's MIN aggregation reports the
+//!   true per-line coverage. Pass.
 //! - **ScoreRegression** — anything else: complexity differs, coverage
-//!   differs without being a #37 improvement, or |Δcrap| > 0.5 with no
-//!   benign explanation. Fail.
+//!   differs without being a #37/#252 improvement, or |Δcrap| > 0.5
+//!   with no benign explanation. Fail.
 
 use std::collections::BTreeMap;
 
@@ -229,10 +237,12 @@ pub fn parse_v2(json: &str) -> Vec<FnRecord> {
 /// Which bucket a matched (oracle, v2) pair falls into.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Class {
-    /// Within tolerance, same risk class.
+    /// Score within tolerance (same CC, |Δcrap| ≤ 0.5, coverage stable).
+    /// Risk label is derived from score and not pinned here.
     Match,
     /// Score unchanged; only the pass/fail gate flips (oracle 8/12 vs
-    /// crap4ts@2 16). Intentional calibration break — passes.
+    /// crap4ts@2's calibrated default). Intentional calibration break
+    /// — passes.
     ThresholdDefaultChange,
     /// v1.x reported 0% coverage on a function v2 covers (crap4ts#37
     /// v1.x matcher bug). Passes, logged as an improvement.
@@ -353,23 +363,24 @@ fn classify(v1: &FnRecord, v2: &FnRecord) -> Class {
     }
 
     if same_cc && cov_unchanged && crap_unchanged {
-        // Score is unchanged. If the gate verdict nonetheless flipped
-        // while the risk class held, that is purely the threshold
-        // default moving (oracle 8/12 → crap4ts@2 16), not a score
-        // drift. The `v1.risk == v2.risk` guard is load-bearing: the
-        // |Δcrap| ≤ 0.5 band can straddle a risk cutoff, so a
-        // same-score gate-flip that ALSO shifts risk class is a real
-        // divergence and must fall through to ScoreRegression rather
-        // than be absorbed here (README "risk hard-match" intent).
-        if v1.exceeds != v2.exceeds && v1.risk == v2.risk {
+        // Score is unchanged. The risk label is a *derived* attribute
+        // of the score — it lives in `classify_risk` and shifts when
+        // tier boundaries are recalibrated (e.g. #272). Pinning risk
+        // labels across the v1.x boundary would force a new exemption
+        // bucket for every future calibration; instead the parity
+        // contract treats score parity as primary and risk parity as
+        // downstream.
+        //
+        // If the gate verdict flipped while the score held, that is
+        // the threshold default moving (oracle 8/12 → crap4ts@2 15);
+        // a real regression would have moved the score too.
+        if v1.exceeds != v2.exceeds {
             return Class::ThresholdDefaultChange;
         }
-        // Score and risk both stable → clean parity. (A risk move with
-        // an otherwise-unchanged score is itself a divergence — fall
-        // through to ScoreRegression below.)
-        if v1.risk == v2.risk {
-            return Class::Match;
-        }
+        // Score stable → clean parity, regardless of derived risk
+        // label. Risk-label correctness is verified separately, by
+        // unit tests of `classify_risk` (see crap-core).
+        return Class::Match;
     }
 
     Class::ScoreRegression
@@ -418,10 +429,11 @@ impl ParityReport {
 
     /// The hierarchical tolerance gate (W3.1 README + CQO ADVISORY-4):
     /// every oracle function discovered, ≥95% exact CC, zero genuine
-    /// score-regressions. Risk hard-match is enforced *through* the
-    /// classifier — a risk move explained by an improvement or a
-    /// threshold change is not a regression; only an unexplained one
-    /// classifies as `ScoreRegression`.
+    /// score-regressions. Risk labels are derived from the score (via
+    /// `classify_risk`) and verified by that function's own unit tests
+    /// — they are not part of the cross-version parity contract, so a
+    /// tier recalibration that moves labels without moving scores does
+    /// not trip this gate.
     pub fn gate_passes(&self) -> bool {
         self.v1_only.is_empty()
             && self.exact_cc_rate() >= MIN_EXACT_CC_RATE

--- a/crates/crap4ts/tests/parity_v1.rs
+++ b/crates/crap4ts/tests/parity_v1.rs
@@ -186,18 +186,24 @@ fn scenario_divergence_shows_contributor_breakdown() {
     );
 }
 
-/// Scenario: risk classification labels match across versions (D8
-/// invariance) — when nothing diverges, every risk label matches and
-/// no risk-class divergence is emitted.
+/// Scenario: score parity is the only parity contract. When score
+/// matches across versions (same CC, |Δcrap| ≤ tolerance, coverage
+/// stable), the pair classifies as `Match` regardless of whether the
+/// derived risk label moved. Risk labels live in `classify_risk` and
+/// are unit-tested there; pinning them across the v1.x boundary
+/// would force a new exemption bucket for every future tier
+/// recalibration (e.g. #272).
 #[test]
-fn scenario_risk_labels_match_when_no_divergence() {
+fn scenario_score_parity_is_match_even_when_risk_label_moved() {
+    // Same score, same CC, same coverage; v1's label is the pre-#272
+    // tier label, v2's is the post-#272 label — score-derived only.
     let oracle = vec![
         rec("a", 1, 2, 100.0, 2.0, "low", false, &[]),
         rec("b", 9, 9, 90.0, 9.01, "moderate", true, &[]),
     ];
     let v2 = vec![
         rec("a", 1, 2, 100.0, 2.0, "low", false, &[]),
-        rec("b", 9, 9, 90.0, 9.01, "moderate", true, &[]),
+        rec("b", 9, 9, 90.0, 9.01, "acceptable", true, &[]),
     ];
     let r = diff(&oracle, &v2);
     assert!(r.gate_passes());

--- a/crates/crap4ts/tests/parity_with_v1_cucumber.rs
+++ b/crates/crap4ts/tests/parity_with_v1_cucumber.rs
@@ -207,8 +207,8 @@ fn when_run_real_corpus(world: &mut ParityWorld) {
     world.report = Some(real_parity().clone());
 }
 
-#[when("the parity harness compares risk labels function-by-function")]
-fn when_compare_risk_labels(world: &mut ParityWorld) {
+#[when("the parity harness compares scores function-by-function")]
+fn when_compare_scores(world: &mut ParityWorld) {
     world.report = Some(real_parity().clone());
 }
 
@@ -240,15 +240,16 @@ fn then_exact_cc_rate(world: &mut ParityWorld) {
     );
 }
 
-#[then("100% of functions match risk-classification labels (Low/Acceptable/Moderate/High)")]
-fn then_risk_labels_match(world: &mut ParityWorld) {
-    // Risk hard-match is enforced through the classifier: a risk move
-    // not absorbed by an improvement or a threshold change classifies
-    // as ScoreRegression. Zero regressions ⇒ every risk label matched.
+#[then("every matched function's CRAP score is within tolerance (no unexplained regressions)")]
+fn then_scores_within_tolerance(world: &mut ParityWorld) {
+    // Score parity is the parity contract. Risk labels are derived
+    // from the score by `classify_risk` and verified by that
+    // function's own unit tests; they are not pinned across the v1.x
+    // boundary so a tier recalibration does not surface here.
     let report = world.report();
     assert!(
         report.regressions().is_empty(),
-        "{} risk/score regression(s):\n{}",
+        "{} score regression(s):\n{}",
         report.regressions().len(),
         report.render(),
     );
@@ -263,21 +264,17 @@ fn then_divergence_reported_per_function(world: &mut ParityWorld) {
     );
 }
 
-#[then("every function's risk classification matches v1.x to v2 exactly")]
-fn then_every_risk_matches(world: &mut ParityWorld) {
-    then_risk_labels_match(world);
-}
-
-#[then("the cutoff boundaries (5/8/30) are NOT version-sensitive")]
-fn then_cutoffs_not_version_sensitive(world: &mut ParityWorld) {
-    // The 5/8/30 risk cutoffs live in crap_core::domain and are shared
-    // by both versions. A version-sensitive cutoff would surface as a
-    // same-score risk-class move — a ScoreRegression. None ⇒ the
-    // cutoffs held across the version boundary.
+#[then("risk-tier boundaries may be recalibrated across versions without tripping the gate")]
+fn then_risk_tier_recalibration_does_not_trip_gate(world: &mut ParityWorld) {
+    // Risk-tier boundaries live in `classify_risk`. They are allowed
+    // to move across versions (e.g. #272 aligned them with the
+    // threshold presets). Because the parity gate ranges over scores
+    // (not derived labels), a tier-only change does not flip
+    // `gate_passes`.
     let report = world.report();
     assert!(
         report.gate_passes(),
-        "a version-sensitive risk cutoff would fail the gate:\n{}",
+        "score parity should hold across a risk-tier recalibration:\n{}",
         report.render(),
     );
 }

--- a/docs/scorecard-row-contract.md
+++ b/docs/scorecard-row-contract.md
@@ -49,7 +49,7 @@ for offline-clean testing — see [Schema vendoring strategy](#schema-vendoring-
 | `label` | `string` | Display label, e.g. `"CRAP Δ"` |
 | `anchor` | `string` | URL-fragment anchor for the rendered row, e.g. `"crap-delta"` |
 | `status` | `"Red"` \| `"Yellow"` \| `"Green"` | Producer-minted verdict — see [Status policy](#status-policy-model-p) |
-| `threshold` | `u32` | The CRAP threshold the count is over (default `25`; tunable via `crap4rs.toml` or `--threshold`) |
+| `threshold` | `u32` | The CRAP threshold the count is over (default `15`, the metric-correct `default` preset; tunable via `crap4rs.toml` or `--threshold`) |
 | `delta_count` | `i32` | Signed delta in over-threshold function count vs. baseline |
 | `delta_text` | `string` | Producer-rendered display string, e.g. `"5 → 7 (+2)"`. The aggregator never reparses. |
 | `failure_detail_md` | `string?` | Markdown describing the new violations. **Required when `status == "Red"`** (Layer 2 schema enforcement); omitted otherwise. |
@@ -70,7 +70,7 @@ variants, new optional fields) bump `schema_version` on the envelope.
   "label": "CRAP Δ",
   "anchor": "crap-delta",
   "status": "Green",
-  "threshold": 25,
+  "threshold": 15,
   "delta_count": -1,
   "delta_text": "5 → 4 (-1)"
 }
@@ -85,7 +85,7 @@ variants, new optional fields) bump `schema_version` on the envelope.
   "label": "CRAP Δ",
   "anchor": "crap-delta",
   "status": "Yellow",
-  "threshold": 25,
+  "threshold": 15,
   "delta_count": 0,
   "delta_text": "5 → 5 (regressions on existing functions)"
 }
@@ -100,10 +100,10 @@ variants, new optional fields) bump `schema_version` on the envelope.
   "label": "CRAP Δ",
   "anchor": "crap-delta",
   "status": "Red",
-  "threshold": 25,
+  "threshold": 15,
   "delta_count": 2,
   "delta_text": "5 → 7 (+2)",
-  "failure_detail_md": "**New CRAP threshold violations (>25):**\n- `kikan::control_plane::users::handle_create` — `crates/kikan/src/control_plane/users.rs:142` — CRAP 28.4\n- `kikan::backup::run_backup` — `crates/kikan/src/backup.rs:88` — CRAP 31.1"
+  "failure_detail_md": "**New CRAP threshold violations (>15):**\n- `auth::login::handle_post` — `src/auth/login.rs:142` — CRAP 18.4\n- `backup::run_backup` — `src/backup.rs:88` — CRAP 21.1"
 }
 ```
 


### PR DESCRIPTION
## Summary

- Collapse the threshold-preset axis and the risk-classification axis onto a single set of cutoffs — **8 / 15 / 25** — so every preset gates exactly at a risk-tier boundary (`--strict` = Low → Acceptable, default = Acceptable → Moderate, `--lenient` = Moderate → High).
- Risk-classification boundaries shift from `5 / 8 / 30` to `8 / 15 / 25` to match. SARIF severity mapping, scorecard-row status, and `risk_level` fields in JSON envelopes all move with the new tiers.
- Cognitive and cyclomatic columns flatten to the same values for now; the dual-column infrastructure in `crap-core::domain::threshold` is preserved so a future per-metric divergence is a one-line constant change with no API churn.
- README rewritten end-to-end against the current `--help` surface (options grouped, subcommands documented, scorecard-row deduped, formula clarified, `[thresholds]` example added).

## Behavioural changes (breaking — wire-shape unchanged, values move)

| Score range | Pre-#272 risk | Post-#272 risk |
|-------------|---------------|----------------|
| `(5, 8]`    | Acceptable    | **Low**        |
| `(8, 15]`   | Moderate      | **Acceptable** |
| `(25, 30]`  | Moderate      | **High**       |

The wire schema (`schema_version`) does not change; only the values populated by `classify_risk` and the threshold-resolution defaults move. Downstream SARIF / scorecard / mokumo consumers receive different `level` / `risk_level` strings for the same source code without code changes.

## Self-check + #273 follow-up

Blast radius (measured against fresh workspace LCOV, `feat/threshold-tier-alignment`):

| Crate     | Total fns | Above 8 (new `--strict`) | Above 15 | Max CRAP |
|-----------|-----------|--------------------------|----------|----------|
| crap-core | 957       | 15                       | 0        | 13.0     |
| crap4rs   | 203       | 2                        | 0        | 11.0     |
| crap4ts   | 98        | 6                        | 0        | 12.0     |

The CI self-check (`.github/workflows/ci.yml`) is temporarily relaxed from `--strict` to `--threshold 15` with a `tracked: crap-rs#273` marker on each line. #273 tracks the per-crate refactor that brings the self-check back to `--strict`. Downstream users on their own codebases are unaffected by the CI relaxation.

## Parity classifier loosening

`crates/crap4ts/tests/parity_helpers/mod.rs` previously enforced a same-version hard-match on `risk_level` labels across the v1.x boundary. With tier boundaries now mobile, that contract would force a new exemption bucket for every recalibration. The classifier now treats risk labels as a derived attribute of the score (computed by `classify_risk`, unit-tested there) and gates parity on score parity alone. Behaviour change is documented in both `parity_helpers/mod.rs` and `parity_with_v1.feature`.

## Vendored mokumo schema

`crates/crap4rs/tests/fixtures/scorecard/schema.json` is a vendored verbatim copy of mokumo's scorecard schema. A single description-string example was sanitised to use a generic crate name; the deviation is noted in `tests/fixtures/scorecard/SOURCE.md` so the next `regen.sh` re-applies it.

## Test plan

- [x] `cargo nextest run --workspace` — 1110 passed
- [x] `cargo test --workspace --tests` — 1110 passed (cucumber harness propagates failures)
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo llvm-cov` re-run end-to-end without test failures
- [x] Snapshot diffs reviewed before `cargo insta accept` (risk-label shifts + new `--threshold 8` wire envelope baseline)
- [ ] CI green on this PR

Closes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)