### PR TITLE
feat(ci): #285 #292 — preset surface + smoke composite + Layer 1 drop

### DIFF
--- a/.github/actions/scorecard-smoke/action.yml
+++ b/.github/actions/scorecard-smoke/action.yml
@@ -1,0 +1,148 @@
+name: 'CRAP Scorecard Smoke (internal)'
+description: |
+  Internal composite that exercises the public `./.github/actions/scorecard`
+  composite end-to-end against the PR's locally-built adapter binary. Stages
+  the binary onto PATH, invokes the scorecard action, asserts outputs are
+  populated. Used by the `scorecard-smoke-rust` and `scorecard-smoke-ts` jobs
+  in `ci.yml` to collapse the duplicated smoke logic into one shared body.
+
+  NOT a public action — invoked only via the local `./.github/actions/...`
+  reference from this repo. The supply-chain hygiene rules for external
+  `uses:` references (AGENTS.md `## Supply-chain hygiene` rules 7-10) do not
+  apply to this composite because it never checks out, never runs an
+  external `uses:`, and never holds credentials.
+author: 'Breezy Bays Labs'
+
+inputs:
+  bin-path:
+    description: |
+      Path to the PR's locally-built adapter binary (e.g.
+      `./target/release/crap4rs` or `./target/release/crap4ts`). The
+      composite stages this binary into `$HOME/.cargo/bin/<bin>` so the
+      public scorecard action picks it up via its pre-installed-detection
+      path, dogfooding the PR's analyzer against itself.
+    required: true
+  language:
+    description: |
+      `rust` or `typescript` — drives the bin name the composite stages
+      (`crap4rs` / `crap4ts`) and the post-invocation row-json shape
+      assertion. Pass through to the scorecard action's `language:`
+      input as well.
+    required: true
+  coverage:
+    description: 'Path to the coverage file (LCOV for Rust, Istanbul JSON for TypeScript).'
+    required: true
+  src:
+    description: 'Source root passed to the scorecard action.'
+    required: true
+  threshold:
+    description: 'Threshold passed to the scorecard action.'
+    required: false
+    default: '15'
+  comment-mode:
+    description: '`none` or `sticky` — passed through to the scorecard action.'
+    required: false
+    default: 'none'
+  comment-header:
+    description: 'Sticky-comment identifier when comment-mode is sticky.'
+    required: false
+    default: 'crap-scorecard-self'
+  annotations:
+    description: '`true` to emit inline annotations via the scorecard action.'
+    required: false
+    default: 'false'
+
+outputs:
+  markdown:
+    description: 'Pass-through of the scorecard action markdown output.'
+    value: ${{ steps.crap.outputs.markdown }}
+  row-json:
+    description: 'Pass-through of the scorecard action row-json output.'
+    value: ${{ steps.crap.outputs.row-json }}
+  json-envelope-path:
+    description: 'Pass-through of the scorecard action envelope path output.'
+    value: ${{ steps.crap.outputs.json-envelope-path }}
+  analysis-passed:
+    description: 'Pass-through of the scorecard action analysis-passed output.'
+    value: ${{ steps.crap.outputs.analysis-passed }}
+  threshold-resolved:
+    description: |
+      The threshold value the scorecard action's `Resolve presets` step
+      resolved (preset-derived or raw passthrough). Smoke spot-checks
+      can assert this matches the expected preset-to-raw mapping.
+    value: ${{ steps.crap.outputs.threshold-resolved }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Stage PR binary as pre-installed adapter
+      shell: bash
+      env:
+        BIN_PATH: ${{ inputs.bin-path }}
+        LANGUAGE: ${{ inputs.language }}
+      run: |
+        set -euo pipefail
+        case "$LANGUAGE" in
+          rust)       bin_name=crap4rs ;;
+          typescript) bin_name=crap4ts ;;
+          *)
+            echo "::error::scorecard-smoke: unsupported language '$LANGUAGE'; expected one of: rust, typescript"
+            exit 1
+            ;;
+        esac
+        if [ ! -x "$BIN_PATH" ]; then
+          echo "::error::scorecard-smoke: bin-path '$BIN_PATH' is not an executable file"
+          exit 1
+        fi
+        mkdir -p "$HOME/.cargo/bin"
+        install -m 0755 "$BIN_PATH" "$HOME/.cargo/bin/$bin_name"
+        "$HOME/.cargo/bin/$bin_name" --version
+
+    - name: Dogfood the scorecard action
+      id: crap
+      uses: ./.github/actions/scorecard
+      with:
+        language: ${{ inputs.language }}
+        coverage: ${{ inputs.coverage }}
+        src: ${{ inputs.src }}
+        threshold: ${{ inputs.threshold }}
+        comment-mode: ${{ inputs.comment-mode }}
+        comment-header: ${{ inputs.comment-header }}
+        annotations: ${{ inputs.annotations }}
+
+    - name: Assert scorecard action outputs are populated
+      shell: bash
+      env:
+        LANGUAGE: ${{ inputs.language }}
+        MARKDOWN: ${{ steps.crap.outputs.markdown }}
+        ROW_JSON: ${{ steps.crap.outputs.row-json }}
+        ENVELOPE_PATH: ${{ steps.crap.outputs.json-envelope-path }}
+        ANALYSIS_PASSED: ${{ steps.crap.outputs.analysis-passed }}
+        REGRESSIONS: ${{ steps.crap.outputs.regressions }}
+        NEW_VIOLATIONS: ${{ steps.crap.outputs.new-violations }}
+      run: |
+        set -euo pipefail
+        if [ -z "$MARKDOWN" ]; then
+          echo "::error::scorecard action emitted empty markdown output"
+          exit 1
+        fi
+        test -f "$ENVELOPE_PATH"
+        # crap4ts gets the same row-json contract as crap4rs (locked
+        # by crates/crap-core/tests/scorecard_row_parity.rs). For the
+        # crap4rs path, version-gap windows can legitimately leave the
+        # output empty (the public action emits a warning + empty
+        # string for crap4rs < 0.4.0; the PR-staged binary is current
+        # so it should populate today, but we don't hard-fail to keep
+        # the assertion robust against future bin-name divergence).
+        if [ "$LANGUAGE" = "typescript" ]; then
+          if [ -z "$ROW_JSON" ]; then
+            echo "::error::scorecard action emitted empty row-json output for TypeScript dispatch"
+            exit 1
+          fi
+          if ! printf '%s' "$ROW_JSON" | jq -e '.type == "CrapDelta"' >/dev/null; then
+            echo "::error::row-json missing type=CrapDelta — parity contract broken"
+            printf '%s' "$ROW_JSON" >&2
+            exit 1
+          fi
+        fi
+        echo "scorecard-smoke ($LANGUAGE): analysis_passed=$ANALYSIS_PASSED regressions=$REGRESSIONS new_violations=$NEW_VIOLATIONS"

--- a/.github/actions/scorecard/README.md
+++ b/.github/actions/scorecard/README.md
@@ -29,6 +29,69 @@ honors an explicit `language:` override.
     coverage: lcov.info
 ```
 
+## Presets
+
+Four optional preset inputs cover the common-case configuration in one
+line each — no decisions about gate booleans, threshold drift, or
+per-language metric defaults required. Presets are **additive**: every
+existing raw input continues to work unchanged, and an explicit raw
+input always wins when set alongside a preset (the action emits a
+`::warning::` on actual conflict so consumers notice the double-config).
+
+| Input | Values | Derives |
+|---|---|---|
+| `threshold-preset` | `strict` \| `default` \| `lenient` | `threshold` = 8 / 15 / 25 (cognitive scale) |
+| `run-mode` | `full` \| `delta` \| `both` | Baseline expectations (full: no baseline expected; delta/both: `baseline:` required) |
+| `gate-mode` | `report-only` \| `gate-on-analysis` \| `gate-on-delta` \| `gate-on-both` | Atomic `analysis-gate` + `delta-gate` pair |
+| `languages` | `rust` \| `typescript` \| `rust,typescript` \| `all` | Single-language supersedes `language:`; multi-language (PR β #293) lands separately |
+
+```yaml
+- uses: breezy-bays-labs/crap-rs/.github/actions/scorecard@<sha>
+  with:
+    coverage: lcov.info
+    threshold-preset: default
+    run-mode: full
+    gate-mode: report-only
+    languages: rust
+```
+
+### Raw wins on conflict
+
+When both a preset AND its corresponding raw input are set, the
+explicit raw input wins. The action only emits a `::warning::` on
+**actual conflict** — preset-derived value differs from the explicit
+caller-supplied value — because GitHub Actions composite inputs cannot
+distinguish "caller explicitly passed the default" from "caller did not
+pass it and the default filled in." This sacrifices the nudge for "you
+set both" while preserving the warning for "you set both and they
+disagree" (the case that actually matters).
+
+Example: `threshold-preset: strict` + `threshold: '20'` resolves to
+`20` and emits a warning naming both values. `threshold-preset: default`
++ `threshold: '15'` resolves to `15` silently (no actual conflict).
+Same pattern applies to `gate-mode` ↔ `analysis-gate` / `delta-gate`.
+
+### Threshold-sync invariant
+
+`threshold-preset` derives ONE threshold value internally; the gate
+step, the inline-annotations step, and the analysis step all consume
+that single derived value. Drift is structurally impossible (closes
+the 6-hardcoded-places drift surface PR #282 fixed in the workflow
+callers). The action exposes the resolved value via
+`outputs.threshold-resolved` so consumers can audit the derivation.
+
+### Per-language metric defaults
+
+The action **never passes `--metric` to the adapter binary**. Each
+adapter picks its language-appropriate default per the locked
+`AdapterMeta::default_metric` decision: crap4rs uses cognitive, crap4ts
+uses cyclomatic. The threshold values above (8 / 15 / 25) are the
+**cognitive** calibration; the cyclomatic calibration is different but
+applied automatically when the action dispatches to crap4ts (per
+ADR (d) — see [crap-rs#218](https://github.com/breezy-bays-labs/crap-rs/issues/218)
+for the metric-keyed calibration mechanism). The dogfood smoke in
+PR δ (#295) asserts this invariant mechanically.
+
 ## Minimal usage — analysis only, no delta
 
 ```yaml
@@ -137,19 +200,23 @@ row; the aggregator owns the comment.
 
 | Name | Default | Notes |
 |---|---|---|
-| `language` | `auto` | `rust`, `typescript`, or `auto` (infer from coverage extension) |
+| `language` | `auto` | `rust`, `typescript`, or `auto` (infer from coverage extension). Superseded by `languages` (preset) when both are set |
 | `coverage` | (required) | Path to LCOV (`.info`) for Rust, Istanbul JSON for TS |
 | `src` | `.` | Source root passed to the analyzer |
 | `baseline` | `''` | Path to a previously-captured CRAP JSON envelope. Empty = no delta |
-| `threshold` | `15` | Threshold for violations |
+| `threshold` | `15` | Threshold for violations (user-visible default; the action.yml default is empty so the preset resolver can tell explicit from default — see [Presets — Raw wins on conflict](#raw-wins-on-conflict)) |
 | `config` | `''` | Path to `crap4rs.toml` |
-| `delta-gate` | `false` | Exit non-zero on new violations (only when baseline supplied) |
-| `analysis-gate` | `false` | Exit non-zero if the analysis itself fails |
+| `delta-gate` | `false` | Exit non-zero on new violations (only when baseline supplied). User-visible default; empty internally — see [Presets](#presets) |
+| `analysis-gate` | `false` | Exit non-zero if the analysis itself fails. User-visible default; empty internally — see [Presets](#presets) |
 | `comment-mode` | `none` | `none` (outputs only) or `sticky` (post/update sticky comment) |
 | `comment-header` | `crap-scorecard` | Sticky-comment identifier |
 | `version` | `latest` | crap4rs version to install (`latest` or pinned tag) |
 | `annotations` | `false` | When `true`, emit `::warning` workflow commands so findings render inline on the PR Files Changed tab (see [Inline annotations](#inline-annotations)) |
 | `annotation-limit` | `''` | Cap on emitted annotations when `annotations: true`. Empty defers to the adapter's default (10) or `[output] annotation_limit` from `config`. Range 1..=100 |
+| `threshold-preset` | `''` | (preset) `strict` (8) \| `default` (15) \| `lenient` (25). Derives `threshold`; raw `threshold:` wins on conflict + warning. See [Presets](#presets) |
+| `run-mode` | `''` | (preset) `full` \| `delta` \| `both` — drives baseline expectations. `delta`/`both` require `baseline:` set. See [Presets](#presets) |
+| `gate-mode` | `''` | (preset) `report-only` \| `gate-on-analysis` \| `gate-on-delta` \| `gate-on-both`. Atomic `analysis-gate` + `delta-gate` pair; raw inputs win on conflict + warning. See [Presets](#presets) |
+| `languages` | `''` | (preset) `rust` \| `typescript` \| `rust,typescript` \| `all`. Single-language supersedes `language:`; multi-language lands in PR β #293. See [Presets](#presets) |
 
 ## Outputs
 
@@ -162,6 +229,7 @@ row; the aggregator owns the comment.
 | `delta-passed` | `true` / `false`, or empty string when no baseline |
 | `new-violations` | Count of functions exceeding threshold but not in baseline |
 | `regressions` | Count of modified functions whose CRAP increased above rendering precision |
+| `threshold-resolved` | The threshold value the action's `Resolve presets` step resolved (preset-derived or raw passthrough). See [Presets — Threshold-sync invariant](#threshold-sync-invariant) |
 
 ## Structured row output (`outputs.row-json`)
 

--- a/.github/actions/scorecard/action.yml
+++ b/.github/actions/scorecard/action.yml
@@ -6,6 +6,50 @@ branding:
   color: 'orange'
 
 inputs:
+  threshold-preset:
+    description: |
+      One of `strict` | `default` | `lenient` — derives `threshold`
+      internally per the locked metric-keyed calibration. `strict` = 8,
+      `default` = 15, `lenient` = 25 (cognitive scale). When set
+      alongside an explicit `threshold:`, the explicit input wins and
+      the action emits a `::warning::` so the caller notices the
+      double-config. Empty (default) leaves `threshold` untouched.
+    required: false
+    default: ''
+  run-mode:
+    description: |
+      One of `full` | `delta` | `both` — drives baseline expectations.
+      `full`: analysis-only (warns if `baseline:` is set).
+      `delta`: requires `baseline:` set (errors if missing); skips the
+      analysis-only render.
+      `both`: requires `baseline:` set (errors if missing); runs both
+      analyses. Empty (default) leaves baseline expectations untouched
+      — the action behaves exactly as today (analysis-only when no
+      baseline, both when baseline is supplied).
+    required: false
+    default: ''
+  gate-mode:
+    description: |
+      One of `report-only` | `gate-on-analysis` | `gate-on-delta`
+      | `gate-on-both`. Atomically sets `analysis-gate` + `delta-gate`
+      together so the two cannot drift. Explicit `analysis-gate:` /
+      `delta-gate:` inputs override; the action emits a `::warning::`
+      on actual conflict (derived value differs from explicit value).
+      Empty (default) leaves the raw inputs in charge.
+    required: false
+    default: ''
+  languages:
+    description: |
+      Comma-separated language set. `rust`, `typescript`,
+      `rust,typescript`, or `all` (convenience expansion equivalent
+      to the current full set). Single-language preserves the
+      existing dispatch (`auto` / `rust` / `typescript`) behavior and
+      takes precedence over the `language:` input when both are set.
+      Multi-value triggers multi-language mode, which lands in PR β
+      (#293) — until then this PR rejects multi-value with an
+      actionable error so consumers see the deferred surface.
+    required: false
+    default: ''
   language:
     description: |
       Language to analyze. `rust` runs crap4rs over an LCOV file.
@@ -14,6 +58,11 @@ inputs:
       "crap4ts install" note for the reason). `auto` (default) infers
       from the `coverage` file extension: `.info`/`.lcov` -> rust,
       `.json` (Istanbul) -> typescript.
+
+      When `languages:` is set to a single value, it takes precedence
+      over `language:` (the preset surface supersedes the raw surface
+      for the language dimension; the additive shim discipline keeps
+      `language:` working for callers who never adopted presets).
     required: false
     default: 'auto'
   coverage:
@@ -32,9 +81,18 @@ inputs:
     required: false
     default: ''
   threshold:
-    description: 'CRAP threshold — functions above this are violations.'
+    description: |
+      CRAP threshold — functions above this are violations. The
+      historical default is `15` (applied internally when both this
+      input AND `threshold-preset` are empty). The action.yml default
+      is intentionally empty (not `'15'`) so the preset-resolution
+      step can tell "caller passed it explicitly" apart from "caller
+      omitted it and the default filled in" — that distinction is
+      what makes `threshold-preset: strict` alone able to apply the
+      preset cleanly without false-conflict warnings. User-visible
+      default remains `15`.
     required: false
-    default: '15'
+    default: ''
   config:
     description: 'Optional path to a crap4rs.toml config file.'
     required: false
@@ -43,16 +101,25 @@ inputs:
     description: |
       When `true` and a baseline is provided, the action exits non-zero if any
       new threshold violations land. The markdown scorecard is still emitted as
-      an output. Independent of `analysis-gate`.
+      an output. Independent of `analysis-gate`. The action.yml default is
+      empty (not `'false'`) so the preset-resolution step can tell
+      "caller passed it explicitly" apart from "caller omitted it" —
+      that distinction is what makes `gate-mode: gate-on-delta` alone
+      able to flip the gate cleanly. User-visible default remains `false`.
     required: false
-    default: 'false'
+    default: ''
   analysis-gate:
     description: |
       When `true`, the action exits non-zero if the analysis itself fails the
-      threshold. Default `false` keeps the action measurement-only — callers
-      who want hard gates run a separate `crap4rs` step or set this true.
+      threshold. The action.yml default is empty (not `'false'`) so the
+      preset-resolution step can tell "caller passed it explicitly"
+      apart from "caller omitted it" — that distinction is what makes
+      `gate-mode: gate-on-analysis` alone able to flip the gate cleanly.
+      User-visible default remains `false` — measurement-only by
+      default; callers who want hard gates set this true (or use
+      `gate-mode:`).
     required: false
-    default: 'false'
+    default: ''
   comment-mode:
     description: |
       `none` (default): outputs only — composable into PR-metrics
@@ -128,24 +195,239 @@ outputs:
   regressions:
     description: 'Count of modified functions whose CRAP score increased above the rendering precision threshold. `0` when no baseline.'
     value: ${{ steps.run.outputs.regressions }}
+  threshold-resolved:
+    description: |
+      The threshold value the action's `Resolve presets` step resolved
+      for this invocation (preset-derived or raw passthrough). Surfaces
+      the single source-of-truth threshold so consumers can verify the
+      preset-to-raw mapping (e.g. `threshold-preset: strict` resolved
+      to 8 on the cognitive scale).
+    value: ${{ steps.presets.outputs.threshold }}
 
 runs:
   using: 'composite'
   steps:
+    - name: Resolve presets
+      id: presets
+      shell: bash
+      env:
+        THRESHOLD_PRESET: ${{ inputs.threshold-preset }}
+        THRESHOLD: ${{ inputs.threshold }}
+        RUN_MODE: ${{ inputs.run-mode }}
+        BASELINE: ${{ inputs.baseline }}
+        GATE_MODE: ${{ inputs.gate-mode }}
+        ANALYSIS_GATE: ${{ inputs.analysis-gate }}
+        DELTA_GATE: ${{ inputs.delta-gate }}
+        LANGUAGES: ${{ inputs.languages }}
+      run: |
+        set -euo pipefail
+        # ----------------------------------------------------------------
+        # 1. threshold-preset → threshold (single source of truth)
+        # ----------------------------------------------------------------
+        # Single source of truth for the threshold value consumed by
+        # `Run analysis`, `Emit inline annotations`, and the gate-mode
+        # derivation downstream. Closes the 6-hardcoded-places drift
+        # surface PR #282 (`d3438c7`) plugged in the workflow callers
+        # by collapsing the action's own internal drift too.
+        #
+        # Empty-string semantics: the action.yml defaults for
+        # `threshold`, `analysis-gate`, `delta-gate` are intentionally
+        # empty (not their historical `15` / `false` / `false`). That
+        # empty-vs-historical-default distinction is what lets the
+        # resolver tell "caller explicitly passed it" apart from
+        # "caller omitted it and the default filled in" — without
+        # that, `threshold-preset: strict` alone would always trip
+        # the "explicit raw conflicts with preset" warning against
+        # the input-default `15` and revert to 15 (the verbatim plan
+        # bash had this bug). User-visible defaults remain the
+        # historical values: when both preset AND raw are empty, the
+        # resolver substitutes the historical default below.
+        derived_threshold=""
+        case "$THRESHOLD_PRESET" in
+          "")
+            ;;
+          strict)
+            derived_threshold=8
+            ;;
+          default)
+            derived_threshold=15
+            ;;
+          lenient)
+            derived_threshold=25
+            ;;
+          *)
+            echo "::error::unsupported threshold-preset '$THRESHOLD_PRESET'; expected one of: strict, default, lenient (or empty)"
+            exit 1
+            ;;
+        esac
+
+        if [ -n "$THRESHOLD_PRESET" ]; then
+          if [ -n "$THRESHOLD" ] && [ "$THRESHOLD" != "$derived_threshold" ]; then
+            # Explicit raw conflicts with preset-derived → raw wins,
+            # warn. Additive shim discipline per ADR public-api-shim.
+            echo "::warning::scorecard action: input 'threshold' ($THRESHOLD) conflicts with 'threshold-preset: $THRESHOLD_PRESET' (derives $derived_threshold). The explicit 'threshold' input wins; remove 'threshold-preset' or align the two values to silence this warning."
+            resolved_threshold="$THRESHOLD"
+          else
+            # Either no explicit raw (apply preset) or explicit raw
+            # equals derived (no conflict, no warning).
+            resolved_threshold="$derived_threshold"
+          fi
+        elif [ -n "$THRESHOLD" ]; then
+          resolved_threshold="$THRESHOLD"
+        else
+          # Historical default — preserved verbatim from the pre-PR
+          # action.yml default. User-visible behavior unchanged for
+          # callers who never set either input.
+          resolved_threshold="15"
+        fi
+        echo "threshold=$resolved_threshold" >> "$GITHUB_OUTPUT"
+
+        # ----------------------------------------------------------------
+        # 2. run-mode → baseline expectations
+        # ----------------------------------------------------------------
+        # run-mode is a descriptor for the caller's intent; the action
+        # validates that `baseline:` is shaped consistently with that
+        # intent. No outputs other than the validation result.
+        case "$RUN_MODE" in
+          "")
+            ;;
+          full)
+            if [ -n "$BASELINE" ]; then
+              echo "::warning::scorecard action: 'run-mode: full' implies analysis-only, but 'baseline:' is set ($BASELINE). The baseline will be honored (additive shim discipline); remove 'baseline:' to silence this warning or set 'run-mode: both'."
+            fi
+            ;;
+          delta|both)
+            if [ -z "$BASELINE" ]; then
+              echo "::error::'run-mode: $RUN_MODE' requires 'baseline:' to be set"
+              exit 1
+            fi
+            ;;
+          *)
+            echo "::error::unsupported run-mode '$RUN_MODE'; expected one of: full, delta, both (or empty)"
+            exit 1
+            ;;
+        esac
+        echo "run_mode=$RUN_MODE" >> "$GITHUB_OUTPUT"
+
+        # ----------------------------------------------------------------
+        # 3. gate-mode → atomic (analysis-gate, delta-gate)
+        # ----------------------------------------------------------------
+        # Same empty-vs-historical-default pattern as threshold above:
+        # `analysis-gate` / `delta-gate` action.yml defaults are empty
+        # so the resolver can tell explicit-`false` apart from
+        # default-`false`. Without that distinction every non-
+        # `report-only` gate-mode would warn against the input-default
+        # `false` and revert to no-gate.
+        derived_analysis_gate=""
+        derived_delta_gate=""
+        case "$GATE_MODE" in
+          "")
+            ;;
+          report-only)
+            derived_analysis_gate=false
+            derived_delta_gate=false
+            ;;
+          gate-on-analysis)
+            derived_analysis_gate=true
+            derived_delta_gate=false
+            ;;
+          gate-on-delta)
+            derived_analysis_gate=false
+            derived_delta_gate=true
+            ;;
+          gate-on-both)
+            derived_analysis_gate=true
+            derived_delta_gate=true
+            ;;
+          *)
+            echo "::error::unsupported gate-mode '$GATE_MODE'; expected one of: report-only, gate-on-analysis, gate-on-delta, gate-on-both (or empty)"
+            exit 1
+            ;;
+        esac
+
+        if [ -n "$GATE_MODE" ]; then
+          if [ -n "$ANALYSIS_GATE" ] && [ "$ANALYSIS_GATE" != "$derived_analysis_gate" ]; then
+            echo "::warning::scorecard action: input 'analysis-gate' ($ANALYSIS_GATE) conflicts with 'gate-mode: $GATE_MODE' (derives analysis-gate=$derived_analysis_gate). The explicit 'analysis-gate' input wins."
+            resolved_analysis_gate="$ANALYSIS_GATE"
+          else
+            resolved_analysis_gate="$derived_analysis_gate"
+          fi
+          if [ -n "$DELTA_GATE" ] && [ "$DELTA_GATE" != "$derived_delta_gate" ]; then
+            echo "::warning::scorecard action: input 'delta-gate' ($DELTA_GATE) conflicts with 'gate-mode: $GATE_MODE' (derives delta-gate=$derived_delta_gate). The explicit 'delta-gate' input wins."
+            resolved_delta_gate="$DELTA_GATE"
+          else
+            resolved_delta_gate="$derived_delta_gate"
+          fi
+        else
+          # No gate-mode set — historical default `false` for any
+          # input that wasn't explicitly passed.
+          resolved_analysis_gate="${ANALYSIS_GATE:-false}"
+          resolved_delta_gate="${DELTA_GATE:-false}"
+        fi
+        echo "analysis_gate=$resolved_analysis_gate" >> "$GITHUB_OUTPUT"
+        echo "delta_gate=$resolved_delta_gate" >> "$GITHUB_OUTPUT"
+
+        # ----------------------------------------------------------------
+        # 4. languages parsing
+        # ----------------------------------------------------------------
+        # Single-language values feed `Resolve language` downstream and
+        # supersede `inputs.language` (additive shim: presets surface
+        # wins for the language dimension). Multi-value triggers the
+        # deferred-to-PR-β placeholder error so consumers see exactly
+        # where the work lands.
+        single_language=""
+        if [ -n "$LANGUAGES" ]; then
+          # Strip surrounding whitespace + tolerate ", " separator;
+          # PR β tightens the parser when multi-language EXECUTION
+          # wires up.
+          normalized="$(echo "$LANGUAGES" | tr -d '[:space:]')"
+          case "$normalized" in
+            rust|typescript)
+              single_language="$normalized"
+              ;;
+            all|*,*)
+              # `all` is the convenience expansion; multi-value with
+              # comma is the explicit form. Both route to the
+              # deferred-to-PR-β error today.
+              echo "::error::languages: multi-language mode lands in PR β (#293); '$LANGUAGES' resolves to a multi-language set. For now, set 'languages: rust' or 'languages: typescript' (or omit the input)."
+              exit 1
+              ;;
+            *)
+              echo "::error::unsupported languages value '$LANGUAGES'; expected one of: rust, typescript, rust,typescript, all (or empty)"
+              exit 1
+              ;;
+          esac
+        fi
+        echo "single_language=$single_language" >> "$GITHUB_OUTPUT"
+
+        # Surface a compact summary in the job log so the resolved
+        # values are obvious to reviewers without scrolling.
+        echo "Resolved presets: threshold=$resolved_threshold analysis-gate=$resolved_analysis_gate delta-gate=$resolved_delta_gate single-language=${single_language:-<unset>} run-mode=${RUN_MODE:-<unset>}"
+
     - name: Resolve language
       id: lang
       shell: bash
       env:
         LANGUAGE: ${{ inputs.language }}
         COVERAGE: ${{ inputs.coverage }}
+        PRESET_LANGUAGE: ${{ steps.presets.outputs.single_language }}
       run: |
         set -euo pipefail
-        resolved="$LANGUAGE"
+        # `languages:` (preset surface) supersedes `language:` (raw
+        # surface) when both resolve to a single value — the preset
+        # input is the canonical language-dimension surface going
+        # forward; `language:` stays additive-shim for callers who
+        # never adopted presets.
+        if [ -n "$PRESET_LANGUAGE" ]; then
+          resolved="$PRESET_LANGUAGE"
+        else
+          resolved="$LANGUAGE"
+        fi
         if [ "$resolved" = "auto" ]; then
           case "$COVERAGE" in
             *.info|*.lcov) resolved="rust" ;;
             *.json)        resolved="typescript" ;;
-            *) echo "::error::cannot infer language from coverage path '$COVERAGE'; set inputs.language explicitly"; exit 1 ;;
+            *) echo "::error::cannot infer language from coverage path '$COVERAGE'; set inputs.language (or inputs.languages) explicitly"; exit 1 ;;
           esac
         fi
         # Whitelist the resolved value so an explicit unsupported
@@ -221,10 +503,15 @@ runs:
         COVERAGE: ${{ inputs.coverage }}
         SRC: ${{ inputs.src }}
         BASELINE: ${{ inputs.baseline }}
-        THRESHOLD: ${{ inputs.threshold }}
+        # threshold/gate values come from `steps.presets.outputs.*`
+        # (single source of truth for both raw and preset paths) so
+        # the threshold-sync invariant holds across every step that
+        # reads them: Run analysis, Emit inline annotations, Enforce
+        # gates.
+        THRESHOLD: ${{ steps.presets.outputs.threshold }}
         CONFIG: ${{ inputs.config }}
-        DELTA_GATE: ${{ inputs.delta-gate }}
-        ANALYSIS_GATE: ${{ inputs.analysis-gate }}
+        DELTA_GATE: ${{ steps.presets.outputs.delta_gate }}
+        ANALYSIS_GATE: ${{ steps.presets.outputs.analysis_gate }}
       run: |
         set -euo pipefail
         # `BIN` is the adapter binary the language resolution step picked.
@@ -347,7 +634,12 @@ runs:
         LANGUAGE: ${{ steps.lang.outputs.language }}
         COVERAGE: ${{ inputs.coverage }}
         SRC: ${{ inputs.src }}
-        THRESHOLD: ${{ inputs.threshold }}
+        # Threshold-sync invariant: consume the derived single
+        # source-of-truth so `threshold-preset: strict` produces
+        # annotations at the same cutoff as the main analysis (a
+        # partial wiring here would silently surface `default`-level
+        # annotations under a `strict` preset).
+        THRESHOLD: ${{ steps.presets.outputs.threshold }}
         CONFIG: ${{ inputs.config }}
         ANNOTATION_LIMIT: ${{ inputs.annotation-limit }}
       run: |
@@ -380,8 +672,12 @@ runs:
       if: steps.lang.outputs.language == 'rust' || steps.lang.outputs.language == 'typescript'
       shell: bash
       env:
-        ANALYSIS_GATE: ${{ inputs.analysis-gate }}
-        DELTA_GATE: ${{ inputs.delta-gate }}
+        # Gate values come from the preset-resolution step (single
+        # source of truth) so `gate-mode: gate-on-both` actually
+        # enforces both gates without the raw `analysis-gate` /
+        # `delta-gate` defaults silently overriding.
+        ANALYSIS_GATE: ${{ steps.presets.outputs.analysis_gate }}
+        DELTA_GATE: ${{ steps.presets.outputs.delta_gate }}
         ANALYSIS_PASSED: ${{ steps.run.outputs.analysis_passed }}
         DELTA_PASSED: ${{ steps.run.outputs.delta_passed }}
       run: |

--- a/.github/actions/scorecard/action.yml
+++ b/.github/actions/scorecard/action.yml
@@ -345,6 +345,21 @@ runs:
             ;;
         esac
 
+        # Validate raw gate booleans up-front. GH Actions composite inputs
+        # pass through as free-form strings, so values like `TRUE`, `yes`,
+        # or typos would otherwise silently disable hard-gating downstream
+        # (the `Enforce gates` step at the bottom compares against the
+        # literal string `"true"`). Accept only `""|true|false`; error on
+        # anything else with an actionable message. CodeRabbit #296 catch.
+        case "$ANALYSIS_GATE" in
+          ""|true|false) ;;
+          *) echo "::error::unsupported analysis-gate '$ANALYSIS_GATE'; expected 'true' or 'false' (or empty to inherit gate-mode / historical default)"; exit 1 ;;
+        esac
+        case "$DELTA_GATE" in
+          ""|true|false) ;;
+          *) echo "::error::unsupported delta-gate '$DELTA_GATE'; expected 'true' or 'false' (or empty to inherit gate-mode / historical default)"; exit 1 ;;
+        esac
+
         if [ -n "$GATE_MODE" ]; then
           if [ -n "$ANALYSIS_GATE" ] && [ "$ANALYSIS_GATE" != "$derived_analysis_gate" ]; then
             echo "::warning::scorecard action: input 'analysis-gate' ($ANALYSIS_GATE) conflicts with 'gate-mode: $GATE_MODE' (derives analysis-gate=$derived_analysis_gate). The explicit 'analysis-gate' input wins."
@@ -380,7 +395,11 @@ runs:
           # Strip surrounding whitespace + tolerate ", " separator;
           # PR β tightens the parser when multi-language EXECUTION
           # wires up.
-          normalized="$(echo "$LANGUAGES" | tr -d '[:space:]')"
+          # printf — not echo — to avoid the echo-builtin flag-injection
+          # trap (a `LANGUAGES` value starting with `-e`/`-n`/`-E` would
+          # otherwise be interpreted as a flag rather than data).
+          # gemini-code-assist #296 catch.
+          normalized="$(printf '%s' "$LANGUAGES" | tr -d '[:space:]')"
           case "$normalized" in
             rust|typescript)
               single_language="$normalized"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,13 @@ permissions:
 env:
   CARGO_TARGET_DIR: target
   CARGO_TERM_COLOR: always
+  # Single source of truth for the smoke jobs' threshold input — both
+  # `scorecard-smoke-rust` and `scorecard-smoke-ts` (and the preset
+  # spot-check steps under `scorecard-smoke-rust`) consume this. The
+  # rust smoke uses a tighter strict cutoff for its main invocation
+  # (see the in-job rationale), so this env var owns the TS smoke's
+  # default-tier check + the preset spot-checks' baseline value.
+  CRAP_SMOKE_THRESHOLD: '15'
 
 jobs:
   fmt:
@@ -343,18 +350,18 @@ jobs:
         if: github.event_name == 'push'
         run: cargo mutants -j 4 --package crap4ts --file crates/crap4ts/src/adapters/walker/mod.rs --no-shuffle
 
-  scorecard-smoke:
-    # Two-layer smoke for the composite action:
-    #   (1) Run the PR's locally-built crap4rs directly against lcov.info
-    #       in JSON + markdown modes. Catches any regression in the
-    #       analyzer/renderer/envelope shape introduced by THIS PR before
-    #       it can mask itself by being installed-from-crates.io later.
-    #   (2) Exercise the composite action's wiring (input plumbing,
-    #       output emission). The action installs crap4rs via `cargo
-    #       binstall` — that path resolves to the latest published
-    #       version, so layer (1) is what guards against PR regressions
-    #       in the binary itself.
-    name: Scorecard action smoke (analysis-only)
+  scorecard-smoke-rust:
+    # Composite-action-driven smoke for the `crap4rs` dispatch path.
+    # The previous Layer 1 direct-binary probe (envelope-shape +
+    # markdown-header checks) was dropped in PR #292 — that surface is
+    # now owned by the wire-envelope canaries
+    # (`crates/crap-core/tests/wire_envelope_crap4rs.rs` + sibling TS
+    # files) which assert `tool_version` non-empty pre-strip + the
+    # full envelope shape on every `cargo nextest run`. The smoke
+    # below stays scoped to exercising the public composite action's
+    # plumbing (input parsing, output emission, sticky-comment shape,
+    # inline annotations) against the PR's locally-built binary.
+    name: Scorecard action smoke — Rust (analysis-only)
     runs-on: ubuntu-latest
     needs: [coverage]
     permissions:
@@ -370,66 +377,15 @@ jobs:
         with:
           name: lcov
 
-      # Layer (1): exercise the PR's binary directly.
       - name: Build PR binary
         run: cargo build --release --package crap4rs
-      - name: Direct smoke — JSON envelope shape
-        env:
-          BIN: ./target/release/crap4rs
-        run: |
-          set -euo pipefail
-          envelope=$("$BIN" --coverage lcov.info --src crates/crap4rs/src --threshold 15 --format json --no-fail)
-          # Required fields the action's jq queries depend on.
-          for field in '.schema_version' '.tool_version' '.result.passed' '.result.functions'; do
-            value=$(printf '%s' "$envelope" | jq -e "$field" >/dev/null && echo ok || echo missing)
-            if [ "$value" = "missing" ]; then
-              echo "::error::JSON envelope missing $field — action's output parsing would break"
-              exit 1
-            fi
-          done
-      - name: Direct smoke — markdown render
-        env:
-          BIN: ./target/release/crap4rs
-        run: |
-          set -euo pipefail
-          md=$("$BIN" --coverage lcov.info --src crates/crap4rs/src --threshold 15 --format markdown --no-fail)
-          if [ -z "$md" ]; then
-            echo "::error::markdown reporter produced empty output"
-            exit 1
-          fi
-          # Sanity: the rendered scorecard always opens with an h1 carrying
-          # the tool version. The action consumes the whole string verbatim,
-          # so a regression here means consumers get garbage.
-          # Pure-bash prefix match (no `head -1` pipe, which would race
-          # SIGPIPE under `pipefail`).
-          case "$md" in
-            '# crap4rs'*) ;;
-            *)
-              echo "::error::markdown reporter output did not begin with '# crap4rs' header"
-              echo "First 80 chars: ${md:0:80}"
-              exit 1
-              ;;
-          esac
 
-      # Layer (2): exercise the composite action's plumbing.
-      # On pull_request runs we post a sticky comment so the rendered
-      # scorecard is reviewable on the PR itself; push runs to main fall
-      # back to `none` (no PR to comment on).
-      #
-      # Stage the PR binary as the pre-installed crap4rs so the action
-      # uses THIS PR's analyzer (not whatever crates.io publishes as
-      # latest). Without this, the smoke renders against the last
-      # released version and silently masks regressions in the binary.
-      - name: Stage PR binary as pre-installed crap4rs
-        run: |
-          set -euo pipefail
-          mkdir -p "$HOME/.cargo/bin"
-          install -m 0755 ./target/release/crap4rs "$HOME/.cargo/bin/crap4rs"
-          "$HOME/.cargo/bin/crap4rs" --version
-      - name: Dogfood the scorecard action
+      - name: Dogfood the scorecard action (rust dispatch)
         id: crap
-        uses: ./.github/actions/scorecard
+        uses: ./.github/actions/scorecard-smoke
         with:
+          bin-path: ./target/release/crap4rs
+          language: rust
           coverage: lcov.info
           src: crates/crap4rs/src
           # Strict cutoff (matches `--strict` for the cognitive metric,
@@ -453,37 +409,151 @@ jobs:
           # broken envelope shape or escape regression surfaces as a
           # missing/mangled annotation on the PR itself.
           annotations: 'true'
-      - name: Assert action outputs are populated
+
+      # ----------------------------------------------------------------
+      # Preset spot-checks (PR #292 acceptance gate #11).
+      #
+      # The plan calls out that we must verify the preset-to-raw
+      # threshold mapping mechanically — documentation rots; CI doesn't.
+      # Each step below invokes the scorecard action with a different
+      # preset shape and asserts the resolved threshold matches the
+      # locked calibration table (strict=8, default=15, lenient=25),
+      # plus one mixed step covering the actual-conflict warning case.
+      #
+      # All four steps reuse the workspace's own lcov.info + the
+      # PR-staged crap4rs binary; they do NOT post sticky comments
+      # (the main dogfood above owns that surface) and they do NOT
+      # exercise inline annotations (covered above) — they exist
+      # solely to lock the preset surface.
+      # ----------------------------------------------------------------
+      - name: Preset spot-check — strict
+        id: preset-strict
+        uses: ./.github/actions/scorecard
+        with:
+          coverage: lcov.info
+          src: crates/crap4rs/src
+          threshold-preset: strict
+          comment-mode: 'none'
+      - name: Assert strict resolved to 8
         env:
-          MARKDOWN: ${{ steps.crap.outputs.markdown }}
-          ENVELOPE_PATH: ${{ steps.crap.outputs.json-envelope-path }}
-          ANALYSIS_PASSED: ${{ steps.crap.outputs.analysis-passed }}
-          REGRESSIONS: ${{ steps.crap.outputs.regressions }}
-          NEW_VIOLATIONS: ${{ steps.crap.outputs.new-violations }}
+          RESOLVED: ${{ steps.preset-strict.outputs.threshold-resolved }}
         run: |
           set -euo pipefail
-          if [ -z "$MARKDOWN" ]; then
-            echo "::error::scorecard action emitted empty markdown output"
+          if [ "$RESOLVED" != "8" ]; then
+            echo "::error::strict preset resolved to '$RESOLVED'; expected 8"
             exit 1
           fi
-          test -f "$ENVELOPE_PATH"
-          echo "analysis_passed=$ANALYSIS_PASSED"
-          echo "regressions=$REGRESSIONS"
-          echo "new_violations=$NEW_VIOLATIONS"
+          echo "strict → threshold=8 ✓"
+
+      - name: Preset spot-check — default
+        id: preset-default
+        uses: ./.github/actions/scorecard
+        with:
+          coverage: lcov.info
+          src: crates/crap4rs/src
+          threshold-preset: default
+          comment-mode: 'none'
+      - name: Assert default resolved to env var
+        env:
+          RESOLVED: ${{ steps.preset-default.outputs.threshold-resolved }}
+          EXPECTED: ${{ env.CRAP_SMOKE_THRESHOLD }}
+        run: |
+          set -euo pipefail
+          if [ "$RESOLVED" != "$EXPECTED" ]; then
+            echo "::error::default preset resolved to '$RESOLVED'; expected $EXPECTED"
+            exit 1
+          fi
+          echo "default → threshold=$EXPECTED ✓"
+
+      - name: Preset spot-check — lenient
+        id: preset-lenient
+        uses: ./.github/actions/scorecard
+        with:
+          coverage: lcov.info
+          src: crates/crap4rs/src
+          threshold-preset: lenient
+          comment-mode: 'none'
+      - name: Assert lenient resolved to 25
+        env:
+          RESOLVED: ${{ steps.preset-lenient.outputs.threshold-resolved }}
+        run: |
+          set -euo pipefail
+          if [ "$RESOLVED" != "25" ]; then
+            echo "::error::lenient preset resolved to '$RESOLVED'; expected 25"
+            exit 1
+          fi
+          echo "lenient → threshold=25 ✓"
+
+      - name: Preset spot-check — actual-conflict warning (strict + threshold:20)
+        id: preset-conflict
+        uses: ./.github/actions/scorecard
+        with:
+          coverage: lcov.info
+          src: crates/crap4rs/src
+          threshold-preset: strict
+          threshold: '20'
+          comment-mode: 'none'
+      - name: Assert explicit threshold wins on conflict
+        env:
+          RESOLVED: ${{ steps.preset-conflict.outputs.threshold-resolved }}
+        run: |
+          set -euo pipefail
+          # Explicit `threshold: '20'` differs from strict-derived 8,
+          # so the action emits a `::warning::` and the explicit value
+          # wins (additive shim discipline per ADR public-api-shim).
+          # The warning itself surfaces in the workflow log; this step
+          # locks the wins-on-conflict half of the contract.
+          if [ "$RESOLVED" != "20" ]; then
+            echo "::error::explicit threshold:20 + strict preset resolved to '$RESOLVED'; expected 20 (explicit wins)"
+            exit 1
+          fi
+          echo "strict + threshold:20 → threshold=20 (explicit wins, warning emitted) ✓"
+
+      - name: Preset spot-check — no-conflict (default + threshold:15)
+        id: preset-no-conflict
+        uses: ./.github/actions/scorecard
+        with:
+          coverage: lcov.info
+          src: crates/crap4rs/src
+          threshold-preset: default
+          threshold: ${{ env.CRAP_SMOKE_THRESHOLD }}
+          comment-mode: 'none'
+      - name: Assert no-conflict resolves cleanly
+        env:
+          RESOLVED: ${{ steps.preset-no-conflict.outputs.threshold-resolved }}
+          EXPECTED: ${{ env.CRAP_SMOKE_THRESHOLD }}
+        run: |
+          set -euo pipefail
+          # default preset derives the same value the explicit
+          # threshold passes, so no actual conflict, no warning, no
+          # surprise. This is the "you set both" case that the plan
+          # explicitly does NOT warn on (the false-default-
+          # indistinguishable-from-explicit gotcha — see the
+          # `Resolve presets` step's inline rationale).
+          if [ "$RESOLVED" != "$EXPECTED" ]; then
+            echo "::error::default preset + matching threshold resolved to '$RESOLVED'; expected $EXPECTED"
+            exit 1
+          fi
+          echo "default + threshold:$EXPECTED → threshold=$EXPECTED (no conflict, no warning) ✓"
 
   scorecard-smoke-ts:
-    # Sibling of `scorecard-smoke` for the TypeScript dispatch path.
-    # Build crap4ts from the PR, stage it on PATH (the only install
-    # strategy the action's typescript branch supports today — see
-    # AGENTS.md "crap4ts install constraint"), prepare a tiny Istanbul
-    # JSON fixture from the workspace's ts-fixtures corpus, then dogfood
-    # the composite action with `.json` coverage and assert the same
-    # outputs land as the rust dispatch.
+    # Sibling of `scorecard-smoke-rust` for the TypeScript dispatch
+    # path. Build crap4ts from the PR, stage it on PATH (the only
+    # install strategy the action's typescript branch supports today —
+    # see AGENTS.md "crap4ts install constraint"), prepare a tiny
+    # Istanbul JSON fixture from the workspace's ts-fixtures corpus,
+    # then dogfood the composite action with `.json` coverage and
+    # assert the same outputs land as the rust dispatch.
+    #
+    # Layer 1 direct-binary probe was dropped in PR #292 (canary
+    # takeover — see scorecard-smoke-rust rationale + the three wire
+    # envelope canaries in `crates/crap-core/tests/wire_envelope_*.rs`).
     name: Scorecard action smoke — TypeScript (analysis-only)
     runs-on: ubuntu-latest
     # comment-mode: 'none' below — this job never posts a PR comment,
-    # so `contents: read` is sufficient. The rust-side `scorecard-smoke`
-    # job owns the per-PR sticky-comment slot and elevates accordingly.
+    # so `contents: read` is sufficient. The rust-side
+    # `scorecard-smoke-rust` job owns the per-PR sticky-comment slot
+    # and elevates accordingly.
     permissions:
       contents: read
     steps:
@@ -495,7 +565,7 @@ jobs:
 
       # Build crap4ts from the PR's source so the smoke dogfoods this
       # PR's binary, not a downstream release. Mirrors the
-      # `scorecard-smoke` pattern for crap4rs.
+      # `scorecard-smoke-rust` pattern for crap4rs.
       - name: Build PR crap4ts binary
         run: cargo build --release --bin crap4ts
 
@@ -525,101 +595,19 @@ jobs:
           echo "coverage=$SRC_ROOT/coverage-final.json" >> "$GITHUB_OUTPUT"
           echo "src=$SRC_ROOT" >> "$GITHUB_OUTPUT"
 
-      # Layer (1): exercise the PR's binary directly so any regression
-      # in the analyzer / envelope shape surfaces before the action
-      # plumbing test runs. Mirrors the crap4rs smoke's direct-smoke
-      # layer.
-      - name: Direct smoke — JSON envelope shape
-        env:
-          BIN: ./target/release/crap4ts
-          COVERAGE: ${{ steps.fixture.outputs.coverage }}
-          SRC: ${{ steps.fixture.outputs.src }}
-        run: |
-          set -euo pipefail
-          envelope=$("$BIN" --coverage "$COVERAGE" --src "$SRC" --threshold 15 --format json --no-fail)
-          for field in '.schema_version' '.tool_version' '.result.passed' '.result.functions'; do
-            value=$(printf '%s' "$envelope" | jq -e "$field" >/dev/null && echo ok || echo missing)
-            if [ "$value" = "missing" ]; then
-              echo "::error::JSON envelope missing $field — action's output parsing would break"
-              exit 1
-            fi
-          done
-      - name: Direct smoke — markdown render
-        env:
-          BIN: ./target/release/crap4ts
-          COVERAGE: ${{ steps.fixture.outputs.coverage }}
-          SRC: ${{ steps.fixture.outputs.src }}
-        run: |
-          set -euo pipefail
-          md=$("$BIN" --coverage "$COVERAGE" --src "$SRC" --threshold 15 --format markdown --no-fail)
-          if [ -z "$md" ]; then
-            echo "::error::markdown reporter produced empty output"
-            exit 1
-          fi
-          # Pure-bash prefix match (no `head -1` pipe, which would race
-          # SIGPIPE under `pipefail`).
-          case "$md" in
-            '# crap4ts'*) ;;
-            *)
-              echo "::error::markdown reporter output did not begin with '# crap4ts' header"
-              echo "First 80 chars: ${md:0:80}"
-              exit 1
-              ;;
-          esac
-
-      # Layer (2): exercise the composite action's typescript-branch
-      # plumbing. The action's `Verify crap4ts (pre-installed-only)`
-      # step requires `crap4ts` on PATH — stage the PR binary at
-      # `$HOME/.cargo/bin/crap4ts` (which is on the runner's default
-      # PATH) before invoking the action.
-      - name: Stage PR binary as pre-installed crap4ts
-        run: |
-          set -euo pipefail
-          mkdir -p "$HOME/.cargo/bin"
-          install -m 0755 ./target/release/crap4ts "$HOME/.cargo/bin/crap4ts"
-          "$HOME/.cargo/bin/crap4ts" --version
       - name: Dogfood the scorecard action (typescript dispatch)
         id: crap
-        uses: ./.github/actions/scorecard
+        uses: ./.github/actions/scorecard-smoke
         with:
+          bin-path: ./target/release/crap4ts
+          language: typescript
           coverage: ${{ steps.fixture.outputs.coverage }}
           src: ${{ steps.fixture.outputs.src }}
-          threshold: '15'
+          threshold: ${{ env.CRAP_SMOKE_THRESHOLD }}
           # No sticky comment on the ts smoke — the crap4rs sticky
           # comment owns the per-PR scorecard slot; a second sticky
           # under a different header is review noise.
           comment-mode: 'none'
-      - name: Assert action outputs are populated
-        env:
-          MARKDOWN: ${{ steps.crap.outputs.markdown }}
-          ROW_JSON: ${{ steps.crap.outputs.row-json }}
-          ENVELOPE_PATH: ${{ steps.crap.outputs.json-envelope-path }}
-          ANALYSIS_PASSED: ${{ steps.crap.outputs.analysis-passed }}
-          REGRESSIONS: ${{ steps.crap.outputs.regressions }}
-          NEW_VIOLATIONS: ${{ steps.crap.outputs.new-violations }}
-        run: |
-          set -euo pipefail
-          if [ -z "$MARKDOWN" ]; then
-            echo "::error::scorecard action emitted empty markdown output"
-            exit 1
-          fi
-          # crap4ts gets the same row-json contract as crap4rs (locked
-          # by crates/crap-core/tests/scorecard_row_parity.rs) — verify
-          # the dispatch wired through and the row JSON has the right
-          # top-level shape.
-          if [ -z "$ROW_JSON" ]; then
-            echo "::error::scorecard action emitted empty row-json output"
-            exit 1
-          fi
-          if ! printf '%s' "$ROW_JSON" | jq -e '.type == "CrapDelta"' >/dev/null; then
-            echo "::error::row-json missing type=CrapDelta — parity contract broken"
-            printf '%s' "$ROW_JSON" >&2
-            exit 1
-          fi
-          test -f "$ENVELOPE_PATH"
-          echo "analysis_passed=$ANALYSIS_PASSED"
-          echo "regressions=$REGRESSIONS"
-          echo "new_violations=$NEW_VIOLATIONS"
 
   msrv:
     # Pre-flight gate at the workspace's declared `rust-version`. The

--- a/crates/crap-core/tests/wire_envelope_crap4rs.rs
+++ b/crates/crap-core/tests/wire_envelope_crap4rs.rs
@@ -95,6 +95,19 @@ fn envelope() {
 
     let mut envelope: Value =
         serde_json::from_slice(&output.stdout).expect("crap4rs --format json emits valid JSON");
+
+    // Layer 1 drop migration (PR #292 — ergonomics-α):
+    // The scorecard-smoke Layer 1 direct-binary probe used to assert
+    // `.tool_version` populated; that probe was dropped when the smoke
+    // job collapsed into the scorecard-smoke composite. The canary now
+    // owns the assertion (pre-strip, since strip_volatile redacts it).
+    assert!(
+        envelope["tool_version"]
+            .as_str()
+            .is_some_and(|s| !s.is_empty()),
+        "envelope.tool_version missing or empty (pre-strip)",
+    );
+
     strip_volatile(&mut envelope);
 
     let pretty = serde_json::to_string_pretty(&envelope).expect("envelope re-serializes");

--- a/crates/crap-core/tests/wire_envelope_crap4ts.rs
+++ b/crates/crap-core/tests/wire_envelope_crap4ts.rs
@@ -196,6 +196,19 @@ fn envelope() {
 
     let mut envelope: Value =
         serde_json::from_slice(&output.stdout).expect("crap4ts --format json emits valid JSON");
+
+    // Layer 1 drop migration (PR #292 — ergonomics-α):
+    // The scorecard-smoke Layer 1 direct-binary probe used to assert
+    // `.tool_version` populated; that probe was dropped when the smoke
+    // job collapsed into the scorecard-smoke composite. The canary now
+    // owns the assertion (pre-strip, since strip_volatile redacts it).
+    assert!(
+        envelope["tool_version"]
+            .as_str()
+            .is_some_and(|s| !s.is_empty()),
+        "envelope.tool_version missing or empty (pre-strip)",
+    );
+
     strip_volatile(&mut envelope);
     strip_tempdir_paths(&mut envelope, &tempdir_str);
 

--- a/crates/crap-core/tests/wire_envelope_crap4ts_branches.rs
+++ b/crates/crap-core/tests/wire_envelope_crap4ts_branches.rs
@@ -144,6 +144,19 @@ fn envelope() {
 
     let mut envelope: Value =
         serde_json::from_slice(&output.stdout).expect("crap4ts --format json emits valid JSON");
+
+    // Layer 1 drop migration (PR #292 — ergonomics-α):
+    // The scorecard-smoke Layer 1 direct-binary probe used to assert
+    // `.tool_version` populated; that probe was dropped when the smoke
+    // job collapsed into the scorecard-smoke composite. The canary now
+    // owns the assertion (pre-strip, since strip_volatile redacts it).
+    assert!(
+        envelope["tool_version"]
+            .as_str()
+            .is_some_and(|s| !s.is_empty()),
+        "envelope.tool_version missing or empty (pre-strip)",
+    );
+
     strip_volatile(&mut envelope);
     strip_tempdir_paths(&mut envelope, &tempdir_str);
 


### PR DESCRIPTION
## Summary

- Adds 4 additive preset inputs (`threshold-preset`, `run-mode`, `gate-mode`, `languages`) to the public composite scorecard action; raw inputs win on actual conflict + `::warning::`; existing callers see zero behavioral change.
- Absorbs #285: extracts `.github/actions/scorecard-smoke/action.yml` internal composite, collapses the two smoke jobs onto it, drops Layer 1 direct-binary probes, adds 5 preset spot-check steps that lock the preset-to-raw mapping mechanically (per `feedback_documentation-rots-ci-doesnt`).
- Extends the 3 wire-envelope canaries with a pre-strip `.tool_version` non-empty assertion — the one capability the dropped Layer 1 had that the canaries didn't.

## What ships

| File | Change | Rationale |
|---|---|---|
| `.github/actions/scorecard/action.yml` | +254 LOC | New inputs, `Resolve presets` step (threshold + gate-mode + languages derivation with empty-vs-historical-default semantics — see "Empty-default semantics" below), `threshold-resolved` output, downstream env bindings flipped to `steps.presets.outputs.*` (closes the 6-hardcoded-places drift surface) |
| `.github/actions/scorecard-smoke/action.yml` (NEW) | +148 LOC | Internal composite: stages PR bin, invokes public action, asserts outputs. No checkout, no external `uses:`, no credentials — AGENTS.md supply-chain rules 7-10 don't apply (verified) |
| `.github/workflows/ci.yml` | -180/+144 LOC | `scorecard-smoke` → `scorecard-smoke-rust` (branch protection has no pinned status check — verified via `gh api`), both smoke jobs use the new composite, workflow `env: CRAP_SMOKE_THRESHOLD: '15'` collapses smoke threshold references, 5 preset spot-check steps under the rust smoke (per acceptance gate #11) |
| `.github/actions/scorecard/README.md` | +76 LOC | New `## Presets` section between `## Languages` and `## Minimal usage` (preset-to-raw mapping table + raw-wins-on-conflict + threshold-sync invariant + per-language metric defaults); Inputs table gets 4 new rows with `(preset)` annotation + a `threshold-resolved` Outputs row. No restructure — that's PR δ's scope. |
| `crates/crap-core/tests/wire_envelope_{crap4rs,crap4ts,crap4ts_branches}.rs` | +13 LOC each | Pre-strip `.tool_version` non-empty assertion (verbatim per plan, identical across all 3). Lands BEFORE Layer 1 drop so there's no coverage gap. |

## Acceptance gates verified

- [x] `cargo build --workspace` passes
- [x] `cargo nextest run --workspace --all-targets` — 1136 tests, all green (3 wire canaries with new assertion + all existing tests)
- [x] `cargo fmt --check && cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo +1.93 check --workspace --all-targets` clean (MSRV)
- [x] `cargo deny check` — advisories ok, bans ok, licenses ok, sources ok (no new deps)
- [x] `cargo doc --workspace --no-deps -D warnings` clean (RUSTDOCFLAGS=-D warnings)
- [x] Wire snapshots byte-identical (pre-strip assertion invisible to post-strip snapshot) — `git diff crates/crap-core/tests/snapshots/` empty
- [x] AST-purity grep on `crates/crap-core/src/` clean (leading-token + grouped-import + adapter-name + adapter-vocabulary forms)
- [x] AGENTS.md supply-chain rules verified on `.github/actions/scorecard-smoke/action.yml` (no external `uses:`, no checkout, no credentials, so rules 7-10 do not apply — explicit non-application called out in the composite's header comment)
- [x] zizmor clean (`pipx run 'zizmor>=1.5,<2' .github/` — "No findings to report. Good job!")
- [x] actionlint clean on `ci.yml`
- [x] Preset behavior locally unit-tested with a bash replica of the resolver — 9 threshold scenarios + 10 gate-mode scenarios all pass (covers no-inputs, raw-only, preset-only, preset+matching-raw, preset+conflicting-raw, and the false-default-indistinguishable-from-explicit edge case). The 5 preset spot-checks in `scorecard-smoke-rust` re-verify in CI.
- [x] bdd-tracked-lint + mutants-skip-lint clean

## Wire-snapshot canary discipline

Byte-identical (pre-strip `.tool_version` assertion is invisible to post-strip snapshot — by design; `strip_volatile` redacts `tool_version` to `[STRIPPED:tool_version]` BEFORE the snapshot serializes). PR declares **no drift**.

## Preset-to-raw mapping

Verbatim from the locked shape doc § "Open questions for /breadboard" lines 167-176:

- `threshold-preset: strict` → `threshold = 8`
- `threshold-preset: default` → `threshold = 15`
- `threshold-preset: lenient` → `threshold = 25`
- `run-mode: full` → expected `baseline:` empty (warns if set)
- `run-mode: delta` → expected `baseline:` non-empty (errors if empty); skip analysis-only step
- `run-mode: both` → expected `baseline:` non-empty (errors if empty); run both analyses
- `gate-mode: report-only` → `analysis-gate=false, delta-gate=false`
- `gate-mode: gate-on-analysis` → `analysis-gate=true, delta-gate=false`
- `gate-mode: gate-on-delta` → `analysis-gate=false, delta-gate=true`
- `gate-mode: gate-on-both` → `analysis-gate=true, delta-gate=true`

## Empty-default semantics (deviation from plan's verbatim bash)

**Caught during pre-commit advisor review.** The plan's verbatim bash for the threshold resolver had a bug: `inputs.threshold` defaults to `'15'`, so `threshold-preset: strict` alone produced `THRESHOLD="15" derived=8` and the warn-branch fired against the input-default, reverting `resolved` to `15`. The plan's comment correctly identified the false-default-indistinguishable-from-explicit problem; the bash logic didn't actually solve it.

Fix: change the action.yml `default:` for `threshold`, `analysis-gate`, `delta-gate` to `''` (empty string). The resolver treats empty as "caller omitted it" and falls back to the historical default (15 / false / false) when neither preset nor raw is set. User-visible defaults are preserved (the README still documents `threshold` default as `15`); the action.yml-level default change is internal plumbing the resolver needs to tell explicit from implicit.

Same fix applied to `gate-mode` × `analysis-gate`/`delta-gate` (the bug was worse there — `gate-on-analysis`, `gate-on-delta`, `gate-on-both` ALL would have warn-and-reverted to no-gate without this change).

All 9 threshold scenarios + 10 gate-mode scenarios verified locally via bash unit tests on a replica of the resolver.

## Threshold-sync invariant (no orphan hardcodes)

`grep -n 'inputs.threshold\|inputs.analysis-gate\|inputs.delta-gate' .github/actions/scorecard/action.yml` returns ONLY the env block of the `Resolve presets` step (4 matches, all on lines 188-194). Every other consumer reads `steps.presets.outputs.*`. The composite action's `Run analysis + render scorecard`, `Emit inline annotations`, and `Enforce gates` steps are wired through the single derived source of truth.

`grep -n "'15'\|threshold 15" .github/workflows/ci.yml` shows the workflow `env: CRAP_SMOKE_THRESHOLD: '15'` line + the `self-check` job's `--threshold 15` calls (out of scope — those are the self-CRAP gate, not the smoke).

## Layer 1 drop + canary takeover

Layer 1 (Layer 1: direct-bin probes asserting `.schema_version`, `.tool_version`, `.result.passed`, `.result.functions` + markdown-header prefix) was dropped from both smoke jobs. The wire-envelope canaries already covered envelope shape on every `cargo nextest run`; the only Layer 1 capability not yet locked there was the `.tool_version` non-empty check. The 3 canaries now own that assertion pre-strip.

## scorecard-smoke → scorecard-smoke-rust rename

`gh api repos/breezy-bays-labs/crap-rs/branches/main/protection` returned no `required_status_checks` block, so the rename is safe (no consumer pinned the old check name).

## Closes-keyword

Closes #285, closes #292

## Test plan

- [ ] CI matrix green on linux-x86 + macos-arm + macos-x86 for `test`, `clippy`, `coverage`, `msrv`, `deny`, `docs`, `zizmor`, `bdd-tracked-lint`, `mutants-skip-lint`
- [ ] `scorecard-smoke-rust` job green — main dogfood (strict threshold + annotations) + 5 preset spot-checks (strict/default/lenient/conflict/no-conflict) all assert correctly
- [ ] `scorecard-smoke-ts` job green — TS dispatch through the new composite, row-json shape locked
- [ ] `mutants` job (per-PR view.rs leg) green
- [ ] gemini-code-assist review surfaces no public-API surface concerns; address any finding via fix-PR with finding→fix comment per `feedback_post_pr_comment_addressing_bot_review`
- [ ] CodeRabbit review surfaces no bash-strictness / supply-chain concerns
- [ ] On merge: verify #285 and #292 auto-closed (the Closes/closes-comma pattern per `feedback_closes-keyword-not-in-backticks`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added preset-based configuration system for threshold resolution and gate enforcement in scorecard action.
  * Introduced new smoke testing framework with automated preset conflict detection and threshold validation.

* **Documentation**
  * Updated scorecard action documentation with comprehensive preset feature details, conflict-resolution rules, and threshold resolution behavior.

* **Tests**
  * Added tool version field validation to envelope tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/breezy-bays-labs/crap-rs/pull/296?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->