### PR TITLE
feat(ci): #293 — multi-language single-CI mode + split outputs + parity

### DIFF
--- a/.github/actions/scorecard/README.md
+++ b/.github/actions/scorecard/README.md
@@ -43,7 +43,7 @@ input always wins when set alongside a preset (the action emits a
 | `threshold-preset` | `strict` \| `default` \| `lenient` | `threshold` = 8 / 15 / 25 (cognitive scale) |
 | `run-mode` | `full` \| `delta` \| `both` | Baseline expectations (full: no baseline expected; delta/both: `baseline:` required) |
 | `gate-mode` | `report-only` \| `gate-on-analysis` \| `gate-on-delta` \| `gate-on-both` | Atomic `analysis-gate` + `delta-gate` pair |
-| `languages` | `rust` \| `typescript` \| `rust,typescript` \| `all` | Single-language supersedes `language:`; multi-language (PR β #293) lands separately |
+| `languages` | `rust` \| `typescript` \| `rust,typescript` \| `all` | Single-language supersedes `language:`; multi-language pairs Rust + TypeScript inputs and emits split outputs. See [Multi-language](#multi-language) |
 
 ```yaml
 - uses: breezy-bays-labs/crap-rs/.github/actions/scorecard@<sha>
@@ -91,6 +91,97 @@ applied automatically when the action dispatches to crap4ts (per
 ADR (d) — see [crap-rs#218](https://github.com/breezy-bays-labs/crap-rs/issues/218)
 for the metric-keyed calibration mechanism). The dogfood smoke in
 PR δ (#295) asserts this invariant mechanically.
+
+## Multi-language
+
+For mixed Rust + TypeScript repos, set `languages: rust,typescript`
+(or `languages: all`) and pair the Rust + TS coverage / source / baseline
+inputs. Both adapters run in one action invocation; outputs split per
+language so aggregators can drop each row in independently.
+
+```yaml
+- uses: breezy-bays-labs/crap-rs/.github/actions/scorecard@<sha>
+  id: crap
+  with:
+    languages: rust,typescript           # or `all`
+    coverage:    lcov.info               # Rust LCOV
+    coverage-ts: coverage-final.json     # TS Istanbul JSON
+    src:    crates/                      # Rust source root
+    src-ts: packages/                    # TS source root
+    threshold-preset: default
+    comment-mode: sticky
+```
+
+### Paired inputs
+
+When multi-language mode is active, the historical input set carries
+the Rust side and the new `*-ts` inputs carry the TypeScript side:
+
+| Rust input | TypeScript input | Purpose |
+|---|---|---|
+| `coverage:` | `coverage-ts:` | Coverage file path (LCOV / Istanbul JSON) |
+| `src:` | `src-ts:` | Source root passed to the analyzer |
+| `baseline:` | `baseline-ts:` | Previously-captured CRAP JSON envelope (optional, per language) |
+
+`coverage-ts:` and `src-ts:` are **required** when `languages:`
+resolves to a multi-language set; the action errors actionably at
+preset-resolution time when they're missing. `baseline-ts:` is
+optional independently per language — a multi-language run can have
+a Rust baseline + analysis-only TypeScript (or vice-versa, or no
+baseline on either side).
+
+### Split outputs
+
+Two new outputs join the existing `row-json` for multi-language
+aggregators:
+
+- `outputs.row-json-rust` — populated when Rust is in the resolved
+  language set (BOTH single-language `rust` and multi-language).
+- `outputs.row-json-typescript` — populated when TypeScript is in the
+  resolved language set.
+
+Both conform to the same locked `Row::CrapDelta` schema as
+`outputs.row-json` — see [Structured row output](#structured-row-output-outputsrow-json).
+
+The legacy `outputs.row-json` stays populated for **single-language**
+callers (back-compat: every consumer reading it today keeps working
+unchanged). In **multi-language mode**, `outputs.row-json` is the
+empty string and the action emits a `::warning::` directing
+consumers to the split outputs. The warning surfaces the migration
+path in the action's own log so a downstream `jq` parse doesn't
+silently fail on empty input.
+
+### Aggregation semantics
+
+Per-language passed flags / counts collapse to single output values
+via these rules:
+
+| Output | Rule | Notes |
+|---|---|---|
+| `analysis-passed` | AND across languages | `true` only when every language passed |
+| `delta-passed` | AND across languages (baseline-bearing ones only) | Empty string when no language ran with a baseline (back-compat) |
+| `new-violations` | SUM across languages | Per-language counts add |
+| `regressions` | SUM across languages | Per-language counts add |
+| `markdown` | Combined string under `## CRAP scorecard` wrapper + per-language `### Rust (crap4rs)` / `### TypeScript (crap4ts)` H3 sections | Single-language: raw adapter markdown, no wrapper (back-compat) |
+| `json-envelope-path` | Path to the FIRST language's envelope (canonical: Rust) | TS envelope at `$RUNNER_TEMP/crap4ts-envelope.json` |
+
+Existing single-language consumers reading `analysis-passed` /
+`delta-passed` see unchanged semantics. Multi-language consumers
+need to know the AND/SUM contract (not "whichever ran last").
+
+### Parsing edge cases
+
+- `languages: "rust, typescript"` (whitespace) → tolerated; splits identically to the no-whitespace form
+- `languages: "rust,rust"` → dedup collapses to single-language `rust` + `::warning::` so the input typo surfaces
+- `languages: rust,typescript` without `coverage-ts:` set → preset-resolution error directing the caller to add the paired input
+- `languages: garbage` → preset-resolution error naming the unsupported token
+
+### One sticky comment, not two
+
+`comment-mode: sticky` posts ONE comment under one `comment-header`,
+containing the combined `markdown` output (both per-language sections
+stacked). Aggregator workflows reading the split outputs and
+re-rendering elsewhere should still set `comment-mode: 'none'`.
 
 ## Minimal usage — analysis only, no delta
 
@@ -201,9 +292,12 @@ row; the aggregator owns the comment.
 | Name | Default | Notes |
 |---|---|---|
 | `language` | `auto` | `rust`, `typescript`, or `auto` (infer from coverage extension). Superseded by `languages` (preset) when both are set |
-| `coverage` | (required) | Path to LCOV (`.info`) for Rust, Istanbul JSON for TS |
-| `src` | `.` | Source root passed to the analyzer |
-| `baseline` | `''` | Path to a previously-captured CRAP JSON envelope. Empty = no delta |
+| `coverage` | (required) | Path to LCOV (`.info`) for Rust, Istanbul JSON for TS. In multi-language mode, carries the Rust LCOV (paired with `coverage-ts:`) |
+| `coverage-ts` | `''` | (paired) TypeScript Istanbul JSON path. Required in multi-language mode; ignored in single-language mode. See [Multi-language](#multi-language) |
+| `src` | `.` | Source root passed to the analyzer. In multi-language mode, carries the Rust source root |
+| `src-ts` | `''` | (paired) TypeScript source root. Required in multi-language mode; ignored in single-language mode. See [Multi-language](#multi-language) |
+| `baseline` | `''` | Path to a previously-captured CRAP JSON envelope. Empty = no delta. In multi-language mode, carries the Rust baseline |
+| `baseline-ts` | `''` | (paired) TypeScript baseline JSON envelope. Optional even in multi-language mode (per-language); a language without a baseline contributes neutrally to AND/SUM aggregation. See [Multi-language](#multi-language) |
 | `threshold` | `15` | Threshold for violations (user-visible default; the action.yml default is empty so the preset resolver can tell explicit from default — see [Presets — Raw wins on conflict](#raw-wins-on-conflict)) |
 | `config` | `''` | Path to `crap4rs.toml` |
 | `delta-gate` | `false` | Exit non-zero on new violations (only when baseline supplied). User-visible default; empty internally — see [Presets](#presets) |
@@ -216,19 +310,21 @@ row; the aggregator owns the comment.
 | `threshold-preset` | `''` | (preset) `strict` (8) \| `default` (15) \| `lenient` (25). Derives `threshold`; raw `threshold:` wins on conflict + warning. See [Presets](#presets) |
 | `run-mode` | `''` | (preset) `full` \| `delta` \| `both` — drives baseline expectations. `delta`/`both` require `baseline:` set. See [Presets](#presets) |
 | `gate-mode` | `''` | (preset) `report-only` \| `gate-on-analysis` \| `gate-on-delta` \| `gate-on-both`. Atomic `analysis-gate` + `delta-gate` pair; raw inputs win on conflict + warning. See [Presets](#presets) |
-| `languages` | `''` | (preset) `rust` \| `typescript` \| `rust,typescript` \| `all`. Single-language supersedes `language:`; multi-language lands in PR β #293. See [Presets](#presets) |
+| `languages` | `''` | (preset) `rust` \| `typescript` \| `rust,typescript` \| `all`. Single-language supersedes `language:`; multi-language pairs Rust + TypeScript inputs and emits split outputs. See [Multi-language](#multi-language) |
 
 ## Outputs
 
 | Name | Notes |
 |---|---|
-| `markdown` | The rendered scorecard — drop into aggregator comments verbatim |
-| `row-json` | `Row::CrapDelta` JSON object — for aggregators that re-render with full layout control. See [Structured row output](#structured-row-output-outputsrow-json) |
-| `json-envelope-path` | Path to the full JSON envelope on the runner |
-| `analysis-passed` | `true` / `false` |
-| `delta-passed` | `true` / `false`, or empty string when no baseline |
-| `new-violations` | Count of functions exceeding threshold but not in baseline |
-| `regressions` | Count of modified functions whose CRAP increased above rendering precision |
+| `markdown` | The rendered scorecard — drop into aggregator comments verbatim. Multi-language: combined under `## CRAP scorecard` wrapper with per-language `### Rust (crap4rs)` / `### TypeScript (crap4ts)` H3 sections. Single-language: raw adapter markdown (back-compat) |
+| `row-json` | `Row::CrapDelta` JSON object — for aggregators that re-render with full layout control. See [Structured row output](#structured-row-output-outputsrow-json). **Empty in multi-language mode** + `::warning::` directing consumers to `row-json-rust` / `row-json-typescript` |
+| `row-json-rust` | (multi-language split) `Row::CrapDelta` JSON for the Rust dispatch when Rust is in the resolved language set. Populated in both single-language `rust` and multi-language modes; empty otherwise. See [Multi-language — Split outputs](#split-outputs) |
+| `row-json-typescript` | (multi-language split) `Row::CrapDelta` JSON for the TypeScript dispatch when TypeScript is in the resolved language set. Populated in both single-language `typescript` and multi-language modes; empty otherwise. See [Multi-language — Split outputs](#split-outputs) |
+| `json-envelope-path` | Path to the full JSON envelope on the runner. Multi-language: first language's envelope (canonical: Rust); TS envelope at `$RUNNER_TEMP/crap4ts-envelope.json` |
+| `analysis-passed` | `true` / `false`. Multi-language: AND across languages. See [Multi-language — Aggregation semantics](#aggregation-semantics) |
+| `delta-passed` | `true` / `false`, or empty string when no baseline. Multi-language: AND across languages that ran with a baseline; empty when none did |
+| `new-violations` | Count of functions exceeding threshold but not in baseline. Multi-language: SUM across languages |
+| `regressions` | Count of modified functions whose CRAP increased above rendering precision. Multi-language: SUM across languages |
 | `threshold-resolved` | The threshold value the action's `Resolve presets` step resolved (preset-derived or raw passthrough). See [Presets — Threshold-sync invariant](#threshold-sync-invariant) |
 
 ## Structured row output (`outputs.row-json`)

--- a/.github/actions/scorecard/action.yml
+++ b/.github/actions/scorecard/action.yml
@@ -1041,31 +1041,35 @@ runs:
           fi
         fi
 
-        {
-          echo "row_json<<__CRAP_SCORECARD_ROW_EOF__"
-          printf '%s' "$legacy_row_json"
-          echo ""
-          echo "__CRAP_SCORECARD_ROW_EOF__"
-        } >> "$GITHUB_OUTPUT"
-
-        # Per-language split outputs. Each is the raw scorecard-row
-        # stdout for the corresponding adapter (or empty when the
-        # language did not run in this invocation). Both adapters
-        # emit the same Row JSON shape (locked by
+        # Emit each row output as a heredoc only when it carries
+        # content. An empty heredoc-style block emits `KEY="\n"`
+        # (the single trailing newline before the EOF marker), NOT
+        # the empty string that the README + action docs promise —
+        # downstream `[ -z "$row_json" ]` consumers would
+        # incorrectly treat the absent row as present. The plain
+        # `KEY=` form below guarantees a truly empty output value.
+        # Per-language split outputs follow the same pattern: each
+        # is the raw scorecard-row stdout for the corresponding
+        # adapter (or genuinely empty when the language did not run
+        # in this invocation). Both adapters emit the same Row JSON
+        # shape (locked by
         # crates/crap-core/tests/scorecard_row_parity.rs ::
         # envelope_multi_language_parity).
-        {
-          echo "row_json_rust<<__CRAP_SCORECARD_ROW_EOF__"
-          printf '%s' "$row_json_rust"
-          echo ""
-          echo "__CRAP_SCORECARD_ROW_EOF__"
-        } >> "$GITHUB_OUTPUT"
-        {
-          echo "row_json_typescript<<__CRAP_SCORECARD_ROW_EOF__"
-          printf '%s' "$row_json_typescript"
-          echo ""
-          echo "__CRAP_SCORECARD_ROW_EOF__"
-        } >> "$GITHUB_OUTPUT"
+        emit_row_output() {
+          local key="$1" value="$2"
+          if [ -z "$value" ]; then
+            printf '%s=\n' "$key" >> "$GITHUB_OUTPUT"
+          else
+            {
+              printf '%s<<__CRAP_SCORECARD_ROW_EOF__\n' "$key"
+              printf '%s\n' "$value"
+              printf '%s\n' "__CRAP_SCORECARD_ROW_EOF__"
+            } >> "$GITHUB_OUTPUT"
+          fi
+        }
+        emit_row_output "row_json" "$legacy_row_json"
+        emit_row_output "row_json_rust" "$row_json_rust"
+        emit_row_output "row_json_typescript" "$row_json_typescript"
 
         # Surface a compact summary in the job log so failures are
         # obvious without scrolling. Multi-language streams each
@@ -1108,14 +1112,34 @@ runs:
         # below owns hard gating.
         #
         # Per-language loop: single-language iterates once over the
-        # active language; multi-language iterates over both. Each
-        # language's findings render under the runner's own
-        # annotation cap (10 warnings per step); multi-language gets
-        # 2x effective annotation budget because two steps run.
+        # active language; multi-language iterates over both. The
+        # entire loop runs inside ONE composite-action `run:` block,
+        # which GitHub Actions treats as a single step — and the
+        # `::warning` workflow command cap is enforced per step, not
+        # per `run:` iteration. Without explicit per-language division,
+        # the first adapter to emit could exhaust the 10-warning cap
+        # and silently starve the second language's annotations.
         if [ -n "$LANGUAGE_SET" ]; then
           IFS=',' read -ra LANGS <<<"$LANGUAGE_SET"
         else
           LANGS=("$LANGUAGE")
+        fi
+        # Compute a per-language annotation budget only in
+        # multi-language mode. Single-language preserves existing
+        # precedence (explicit input → config file → adapter default of
+        # 10) so a `crap4rs.toml`-declared `[output] annotation_limit`
+        # is not silently overridden. Multi-language divides the
+        # explicit cap (or GitHub's default 10) by the number of
+        # languages, floored at 1 so each language still emits at
+        # least one annotation when there are violations.
+        per_lang_budget=""
+        if [ "$IS_MULTI" = "true" ]; then
+          n_langs="${#LANGS[@]}"
+          total_budget="${ANNOTATION_LIMIT:-10}"
+          per_lang_budget=$(( total_budget / n_langs ))
+          if [ "$per_lang_budget" -lt 1 ]; then
+            per_lang_budget=1
+          fi
         fi
         for lang in "${LANGS[@]}"; do
           case "$lang" in
@@ -1141,7 +1165,15 @@ runs:
           esac
           args=(--coverage "$LANG_COVERAGE" --src "$LANG_SRC" --threshold "$THRESHOLD" --no-fail --format github-annotations)
           [ -n "$CONFIG" ] && args+=(--config "$CONFIG")
-          [ -n "$ANNOTATION_LIMIT" ] && args+=(--annotation-limit "$ANNOTATION_LIMIT")
+          if [ -n "$per_lang_budget" ]; then
+            # Multi-language: the shared GH per-step cap is the hard
+            # constraint, so the per-language division overrides both
+            # the action input and any config-file value (otherwise
+            # we'd silently drop annotations beyond the cap).
+            args+=(--annotation-limit "$per_lang_budget")
+          elif [ -n "$ANNOTATION_LIMIT" ]; then
+            args+=(--annotation-limit "$ANNOTATION_LIMIT")
+          fi
           "$BIN" "${args[@]}"
         done
 

--- a/.github/actions/scorecard/action.yml
+++ b/.github/actions/scorecard/action.yml
@@ -45,9 +45,22 @@ inputs:
       to the current full set). Single-language preserves the
       existing dispatch (`auto` / `rust` / `typescript`) behavior and
       takes precedence over the `language:` input when both are set.
-      Multi-value triggers multi-language mode, which lands in PR β
-      (#293) — until then this PR rejects multi-value with an
-      actionable error so consumers see the deferred surface.
+
+      Multi-value (`rust,typescript` or `all`) triggers
+      **multi-language mode** (PR β #293): both adapters run in one
+      action invocation, paired against `coverage`/`coverage-ts` +
+      `src`/`src-ts` + `baseline`/`baseline-ts`. The action emits
+      split per-language outputs (`row-json-rust` +
+      `row-json-typescript`); `analysis-passed` / `delta-passed` are
+      AND across languages; `new-violations` / `regressions` are SUM
+      across languages; `markdown` is a single combined string with
+      `### Rust (crap4rs)` + `### TypeScript (crap4ts)` section
+      headers under one `## CRAP scorecard` wrapper. The legacy
+      `row-json` output is empty in multi-language mode + the action
+      emits a `::warning::` directing consumers to the split outputs.
+      Whitespace is tolerated (`rust, typescript` works); duplicate
+      tokens collapse with a `::warning::` (`rust,rust` → `rust`);
+      unsupported tokens error with an actionable message.
     required: false
     default: ''
   language:
@@ -66,18 +79,63 @@ inputs:
     required: false
     default: 'auto'
   coverage:
-    description: 'Path to the coverage file. LCOV (.info) for Rust, Istanbul JSON for TypeScript.'
+    description: |
+      Path to the coverage file. LCOV (.info) for Rust, Istanbul JSON
+      for TypeScript. In multi-language mode (`languages:
+      rust,typescript` or `all`), this is the **Rust** LCOV path; the
+      TypeScript Istanbul JSON path lives on `coverage-ts:` so both
+      languages can be paired in one action invocation.
     required: true
+  coverage-ts:
+    description: |
+      Path to the TypeScript Istanbul JSON coverage file. Used ONLY
+      in multi-language mode (`languages: rust,typescript` or `all`)
+      alongside `coverage:` (which then carries the Rust LCOV). The
+      action.yml default is empty (not `'coverage-final.json'`) so
+      the multi-language pairing validator can tell "caller omitted
+      the TS coverage" apart from "caller explicitly passed a path",
+      and error actionably when multi-language mode is requested
+      without the paired input. Ignored in single-language mode.
+    required: false
+    default: ''
   src:
-    description: 'Source root directory passed to the analyzer.'
+    description: |
+      Source root directory passed to the analyzer. In multi-language
+      mode, this is the **Rust** source root; the TypeScript source
+      root lives on `src-ts:`.
     required: false
     default: '.'
+  src-ts:
+    description: |
+      TypeScript source root, paired with `coverage-ts:`. Used ONLY
+      in multi-language mode. Empty default mirrors `coverage-ts:`:
+      multi-language mode requires this paired input alongside
+      `src:` (Rust). Ignored in single-language mode.
+    required: false
+    default: ''
   baseline:
     description: |
       Path to a previously-captured CRAP JSON envelope to compare against.
       Leave empty to skip delta and emit an analysis-only scorecard. Producing
       the baseline (typically a coverage run on the PR base) is the caller's
       responsibility — this action does not auto-checkout, by design.
+
+      In multi-language mode, this is the **Rust** baseline; the
+      TypeScript baseline lives on `baseline-ts:` so each language
+      can have its own previously-captured envelope.
+    required: false
+    default: ''
+  baseline-ts:
+    description: |
+      Path to the TypeScript baseline JSON envelope. Used ONLY in
+      multi-language mode, paired with `baseline:` (Rust). Either
+      side may be empty independently — a multi-language run can
+      have a Rust baseline + analysis-only TypeScript run, or
+      vice-versa, or no baseline on either side. The action emits
+      `delta-passed`/`new-violations`/`regressions` for the
+      language(s) that supplied a baseline; languages without one
+      contribute neutrally to the AND/SUM aggregation (passed=true,
+      counts=0).
     required: false
     default: ''
   threshold:
@@ -179,7 +237,36 @@ outputs:
       Producer-side status policy lives in crap-core's shared
       `format_as_scorecard_row` routing — see
       `docs/scorecard-row-contract.md`.
+
+      Populated in **single-language mode** (back-compat for every
+      consumer already reading this output). In **multi-language
+      mode** (`languages: rust,typescript` or `all`), this output is
+      the empty string and the action emits a `::warning::` directing
+      consumers to the split outputs `row-json-rust` and
+      `row-json-typescript`. The warning surfaces the migration path
+      in the action's own log so a downstream `jq` parse doesn't
+      silently fail on empty input.
     value: ${{ steps.run.outputs.row_json }}
+  row-json-rust:
+    description: |
+      The `Row::CrapDelta` JSON object emitted by `crap4rs --format
+      scorecard-row` when Rust is in the resolved language set.
+      Populated in BOTH single-language mode (`languages: rust`) and
+      multi-language mode (`languages: rust,typescript` or `all`);
+      empty when Rust is not in the resolved set. Pair with
+      `row-json-typescript` in multi-language aggregator workflows.
+      Same schema as `row-json` (the legacy single-output above).
+    value: ${{ steps.run.outputs.row_json_rust }}
+  row-json-typescript:
+    description: |
+      The `Row::CrapDelta` JSON object emitted by `crap4ts --format
+      scorecard-row` when TypeScript is in the resolved language set.
+      Populated in BOTH single-language mode (`languages: typescript`)
+      and multi-language mode (`languages: rust,typescript` or
+      `all`); empty when TypeScript is not in the resolved set. Pair
+      with `row-json-rust` in multi-language aggregator workflows.
+      Same schema as `row-json` (the legacy single-output above).
+    value: ${{ steps.run.outputs.row_json_typescript }}
   json-envelope-path:
     description: 'Path to the full JSON envelope on the runner — pass to downstream tooling.'
     value: ${{ steps.run.outputs.envelope_path }}
@@ -219,6 +306,12 @@ runs:
         ANALYSIS_GATE: ${{ inputs.analysis-gate }}
         DELTA_GATE: ${{ inputs.delta-gate }}
         LANGUAGES: ${{ inputs.languages }}
+        # Multi-language paired inputs — consumed only by the
+        # paired-input validation block below (single-language flows
+        # ignore these). Empty defaults preserve back-compat: the
+        # validation skips when `is_multi=false`.
+        COVERAGE_TS: ${{ inputs.coverage-ts }}
+        SRC_TS: ${{ inputs.src-ts }}
       run: |
         set -euo pipefail
         # ----------------------------------------------------------------
@@ -385,43 +478,152 @@ runs:
         # ----------------------------------------------------------------
         # 4. languages parsing
         # ----------------------------------------------------------------
-        # Single-language values feed `Resolve language` downstream and
-        # supersede `inputs.language` (additive shim: presets surface
-        # wins for the language dimension). Multi-value triggers the
-        # deferred-to-PR-β placeholder error so consumers see exactly
-        # where the work lands.
+        # `languages:` resolves to one of three shapes:
+        #   * empty            → no preset language; raw `language:` rules
+        #   * single value     → `single_language` set, supersedes
+        #                        `inputs.language` (additive shim:
+        #                        presets surface wins for the language
+        #                        dimension)
+        #   * multi-value set  → `language_set` (canonical-ordered CSV)
+        #                        + `is_multi=true`; downstream `Run
+        #                        analysis` loop dispatches BOTH adapters
+        # `all` is the convenience expansion for the full multi-language
+        # set (`rust,typescript` today; alphabetical-ordered as the set
+        # grows beyond two languages).
+        #
+        # printf — not echo — when re-emitting `LANGUAGES` to avoid the
+        # echo-builtin flag-injection trap (a value starting with `-e` /
+        # `-n` / `-E` would otherwise be interpreted as a flag rather
+        # than data). gemini-code-assist #296 catch.
         single_language=""
+        language_set=""
+        is_multi="false"
         if [ -n "$LANGUAGES" ]; then
-          # Strip surrounding whitespace + tolerate ", " separator;
-          # PR β tightens the parser when multi-language EXECUTION
-          # wires up.
-          # printf — not echo — to avoid the echo-builtin flag-injection
-          # trap (a `LANGUAGES` value starting with `-e`/`-n`/`-E` would
-          # otherwise be interpreted as a flag rather than data).
-          # gemini-code-assist #296 catch.
+          # Strip ALL whitespace then split on comma; `rust, typescript`
+          # and `rust,typescript` resolve identically. The strip-then-
+          # split is one pass per token via parameter expansion so the
+          # loop body stays POSIX-portable across runner shells.
           normalized="$(printf '%s' "$LANGUAGES" | tr -d '[:space:]')"
-          case "$normalized" in
+          if [ "$normalized" = "all" ]; then
+            # Convenience expansion. Canonical-ordered (rust,typescript)
+            # so output ordering and downstream loop ordering are
+            # deterministic regardless of how the caller spelled it.
+            normalized="rust,typescript"
+          fi
+          # Split on comma into a Bash array. `IFS=','` is scoped to
+          # the `read` invocation so the surrounding script's IFS is
+          # not mutated.
+          IFS=',' read -ra raw_langs <<<"$normalized"
+          # Validate each token AND dedupe (preserving first-seen
+          # order, so canonical `rust,typescript` stays in that order
+          # if both come through `all` or an `all`-equivalent set).
+          # Dedupe emits a `::warning::` so the caller sees the
+          # collapse — silent dedupe would mask `rust,rust` typos.
+          declare -a seen=()
+          for tok in "${raw_langs[@]}"; do
+            case "$tok" in
+              rust|typescript) ;;
+              "")
+                echo "::error::languages: empty token in '$LANGUAGES' — check for leading/trailing/duplicate commas"
+                exit 1
+                ;;
+              *)
+                echo "::error::languages: unsupported token '$tok' in '$LANGUAGES'; expected one of: rust, typescript, all"
+                exit 1
+                ;;
+            esac
+            # Dedupe.
+            already_seen="false"
+            for s in "${seen[@]:-}"; do
+              [ "$s" = "$tok" ] && already_seen="true" && break
+            done
+            if [ "$already_seen" = "true" ]; then
+              echo "::warning::scorecard action: 'languages: $LANGUAGES' contains duplicate token '$tok'; deduplicating to a single entry."
+            else
+              seen+=("$tok")
+            fi
+          done
+
+          # Reorder seen[] to the canonical (rust,typescript) order so
+          # the downstream loop, the markdown section headers, and the
+          # split-output ordering are deterministic across input
+          # spellings (`typescript,rust` and `rust,typescript` produce
+          # identical artifacts).
+          canonical_set=""
+          for canonical_lang in rust typescript; do
+            for s in "${seen[@]:-}"; do
+              if [ "$s" = "$canonical_lang" ]; then
+                if [ -z "$canonical_set" ]; then
+                  canonical_set="$canonical_lang"
+                else
+                  canonical_set="$canonical_set,$canonical_lang"
+                fi
+                break
+              fi
+            done
+          done
+
+          # Decide single vs multi based on the deduped set size, not
+          # on the raw input shape — `rust,rust` collapses to single
+          # `rust`, which is the only sane interpretation given the
+          # warning above.
+          case "$canonical_set" in
             rust|typescript)
-              single_language="$normalized"
+              single_language="$canonical_set"
+              language_set="$canonical_set"
               ;;
-            all|*,*)
-              # `all` is the convenience expansion; multi-value with
-              # comma is the explicit form. Both route to the
-              # deferred-to-PR-β error today.
-              echo "::error::languages: multi-language mode lands in PR β (#293); '$LANGUAGES' resolves to a multi-language set. For now, set 'languages: rust' or 'languages: typescript' (or omit the input)."
-              exit 1
+            rust,typescript)
+              language_set="$canonical_set"
+              is_multi="true"
               ;;
             *)
-              echo "::error::unsupported languages value '$LANGUAGES'; expected one of: rust, typescript, rust,typescript, all (or empty)"
+              # Defensive — the validation + dedupe + canonicalization
+              # above should make this branch unreachable. Surface it
+              # loudly if hit so any future parser regression fails
+              # the action rather than silently falling through.
+              echo "::error::languages: internal canonicalization produced unexpected set '$canonical_set' from input '$LANGUAGES'"
               exit 1
               ;;
           esac
         fi
         echo "single_language=$single_language" >> "$GITHUB_OUTPUT"
+        echo "language_set=$language_set"       >> "$GITHUB_OUTPUT"
+        echo "is_multi=$is_multi"               >> "$GITHUB_OUTPUT"
+
+        # ----------------------------------------------------------------
+        # 5. Multi-language paired-input validation
+        # ----------------------------------------------------------------
+        # When multi-language mode is active, the action runs BOTH
+        # adapters in one invocation. Each adapter needs its own
+        # coverage + src input; the paired-input convention puts the
+        # Rust inputs on `coverage:` / `src:` / `baseline:` (the
+        # historical single-language input set) and the TS inputs on
+        # `coverage-ts:` / `src-ts:` / `baseline-ts:` (the new paired
+        # inputs added in this PR). Missing-pair = actionable error
+        # surfaced in the job log; baseline is optional on either
+        # side (the per-language analysis runs without it). The
+        # validation fires here (during Resolve presets, before any
+        # adapter dispatch) so the error appears in the same step
+        # that resolved the language set — easier for callers to
+        # connect cause and effect than a downstream `Run analysis`
+        # failure.
+        if [ "$is_multi" = "true" ]; then
+          missing=""
+          if [ -z "${COVERAGE_TS:-}" ]; then
+            missing="${missing}coverage-ts "
+          fi
+          if [ -z "${SRC_TS:-}" ]; then
+            missing="${missing}src-ts "
+          fi
+          if [ -n "$missing" ]; then
+            echo "::error::languages: '$LANGUAGES' resolves to a multi-language set; missing paired input(s): $missing. Multi-language mode requires 'coverage:' (Rust LCOV) AND 'coverage-ts:' (TS Istanbul JSON), plus 'src:' (Rust source root) AND 'src-ts:' (TS source root). 'baseline:' / 'baseline-ts:' are optional on either side. Set the missing input(s) or drop a language from 'languages:' for single-language dispatch."
+            exit 1
+          fi
+        fi
 
         # Surface a compact summary in the job log so the resolved
         # values are obvious to reviewers without scrolling.
-        echo "Resolved presets: threshold=$resolved_threshold analysis-gate=$resolved_analysis_gate delta-gate=$resolved_delta_gate single-language=${single_language:-<unset>} run-mode=${RUN_MODE:-<unset>}"
+        echo "Resolved presets: threshold=$resolved_threshold analysis-gate=$resolved_analysis_gate delta-gate=$resolved_delta_gate single-language=${single_language:-<unset>} language-set=${language_set:-<unset>} is-multi=$is_multi run-mode=${RUN_MODE:-<unset>}"
 
     - name: Resolve language
       id: lang
@@ -430,8 +632,24 @@ runs:
         LANGUAGE: ${{ inputs.language }}
         COVERAGE: ${{ inputs.coverage }}
         PRESET_LANGUAGE: ${{ steps.presets.outputs.single_language }}
+        IS_MULTI: ${{ steps.presets.outputs.is_multi }}
       run: |
         set -euo pipefail
+        # Multi-language short-circuit: when `languages:` resolved
+        # to a multi-value set, the per-language Run analysis loop
+        # downstream handles dispatch. This step emits a sentinel
+        # `language=multi` so the downstream `if:` conditionals on
+        # Run analysis / Emit inline annotations / Post sticky PR
+        # comment / Enforce gates can match `rust || typescript ||
+        # multi` and proceed. The single-language conditional
+        # branches below are skipped — no auto-detect, no
+        # `inputs.language` fallback, since the language set is
+        # already canonical.
+        if [ "$IS_MULTI" = "true" ]; then
+          echo "language=multi" >> "$GITHUB_OUTPUT"
+          echo "Resolved language: multi (per-language loop dispatches both adapters)"
+          exit 0
+        fi
         # `languages:` (preset surface) supersedes `language:` (raw
         # surface) when both resolve to a single value — the preset
         # input is the canonical language-dimension surface going
@@ -463,11 +681,14 @@ runs:
         echo "Resolved language: $resolved"
 
     - name: Install cargo-binstall
-      if: steps.lang.outputs.language == 'rust'
+      # Needed for the crap4rs install (binstall path). Fires in both
+      # single-language `rust` mode AND multi-language `multi` mode
+      # since the latter dispatches BOTH adapters.
+      if: steps.lang.outputs.language == 'rust' || steps.lang.outputs.language == 'multi'
       uses: cargo-bins/cargo-binstall@dc19f1e48450eefe5a29b8da6c6b00a87d730b37 # v1.18.1
 
     - name: Install crap4rs
-      if: steps.lang.outputs.language == 'rust'
+      if: steps.lang.outputs.language == 'rust' || steps.lang.outputs.language == 'multi'
       shell: bash
       env:
         VERSION: ${{ inputs.version }}
@@ -489,7 +710,7 @@ runs:
         crap4rs --version
 
     - name: Verify crap4ts (pre-installed-only)
-      if: steps.lang.outputs.language == 'typescript'
+      if: steps.lang.outputs.language == 'typescript' || steps.lang.outputs.language == 'multi'
       shell: bash
       run: |
         set -euo pipefail
@@ -515,13 +736,25 @@ runs:
 
     - name: Run analysis + render scorecard
       id: run
-      if: steps.lang.outputs.language == 'rust' || steps.lang.outputs.language == 'typescript'
+      if: steps.lang.outputs.language == 'rust' || steps.lang.outputs.language == 'typescript' || steps.lang.outputs.language == 'multi'
       shell: bash
       env:
         LANGUAGE: ${{ steps.lang.outputs.language }}
+        LANGUAGE_SET: ${{ steps.presets.outputs.language_set }}
+        IS_MULTI: ${{ steps.presets.outputs.is_multi }}
+        # Single-language inputs (back-compat — the historical input
+        # set drove the pre-PR action). In multi-language mode, these
+        # carry the Rust side of each pair; the TS side lives on the
+        # `*_TS` env vars below.
         COVERAGE: ${{ inputs.coverage }}
         SRC: ${{ inputs.src }}
         BASELINE: ${{ inputs.baseline }}
+        # Multi-language paired inputs. Empty in single-language mode
+        # (the loop below ignores them); validated as non-empty in
+        # `Resolve presets` when `is_multi=true`.
+        COVERAGE_TS: ${{ inputs.coverage-ts }}
+        SRC_TS: ${{ inputs.src-ts }}
+        BASELINE_TS: ${{ inputs.baseline-ts }}
         # threshold/gate values come from `steps.presets.outputs.*`
         # (single source of truth for both raw and preset paths) so
         # the threshold-sync invariant holds across every step that
@@ -533,126 +766,329 @@ runs:
         ANALYSIS_GATE: ${{ steps.presets.outputs.analysis_gate }}
       run: |
         set -euo pipefail
-        # `BIN` is the adapter binary the language resolution step picked.
-        # Both bins share the CLI surface (via crap-core's shared `cli::run`
-        # orchestration), so a single shell body drives either dispatch.
-        if [ "$LANGUAGE" = "rust" ]; then
-          BIN=crap4rs
+        # Per-language loop. Single-language mode iterates once over
+        # the resolved single language; multi-language mode iterates
+        # in canonical order (rust,typescript). Each iteration runs
+        # the adapter's three formats (json + markdown + scorecard-row)
+        # against the language-appropriate coverage/src/baseline triple
+        # and accumulates per-language passed/delta/violations counts
+        # for the post-loop aggregation. The aggregation policy
+        # (AND for passed, SUM for counts) is documented in the
+        # README's "Multi-language" section.
+
+        # Resolve the iteration set from LANGUAGE_SET (multi-mode) or
+        # the resolved single language (single-mode). In single-mode
+        # LANGUAGE_SET is also populated by `Resolve presets` when
+        # `languages:` was set; we fall back to the legacy
+        # `Resolve language` output for callers using `language:`
+        # without `languages:`.
+        if [ -n "$LANGUAGE_SET" ]; then
+          IFS=',' read -ra LANGS <<<"$LANGUAGE_SET"
         else
-          BIN=crap4ts
-        fi
-        envelope="$RUNNER_TEMP/${BIN}-envelope.json"
-        markdown_file="$RUNNER_TEMP/${BIN}-scorecard.md"
-        row_json_file="$RUNNER_TEMP/${BIN}-row.json"
-        common=(--coverage "$COVERAGE" --src "$SRC" --threshold "$THRESHOLD")
-        [ -n "$CONFIG" ] && common+=(--config "$CONFIG")
-        if [ -n "$BASELINE" ]; then
-          common+=(--baseline "$BASELINE")
+          LANGS=("$LANGUAGE")
         fi
 
-        # Always capture truth into the envelope; --no-fail keeps the step
-        # green so we can surface counts/passed status via outputs even when
-        # gates would have tripped. The hard gating happens in the dedicated
-        # gate step below, gated by the analysis-gate / delta-gate inputs.
-        #
-        # Three-pass note: we run the adapter three times — once each for
-        # JSON, markdown, and scorecard-row — because the analyzer doesn't
-        # yet support multi-format output in a single invocation. The cost
-        # is two extra coverage parses + CRAP recomputes (cheap relative to
-        # runner setup); the user-visible latency is dominated by adapter
-        # install upstream. Tracked in
-        # https://github.com/breezy-bays-labs/crap-rs/issues/100.
-        "$BIN" "${common[@]}" --format json --no-fail > "$envelope"
-        "$BIN" "${common[@]}" --format markdown --no-fail > "$markdown_file"
+        # Per-language accumulator arrays. `passed_all` / `delta_all`
+        # walk to "false"/"" on the first failing leg (AND); count
+        # totals walk by `+=` (SUM). `markdown_combined` collects each
+        # iteration's adapter markdown; the post-loop assembly wraps
+        # multi-language under a single `## CRAP scorecard` H2 with
+        # per-language `### Rust (crap4rs)` / `### TypeScript
+        # (crap4ts)` H3s. Single-language assembly emits the raw
+        # adapter markdown unchanged (back-compat — same bytes as
+        # pre-PR).
+        analysis_passed_combined="true"
+        delta_passed_combined=""        # empty when no language ran with a baseline
+        delta_any_seen="false"
+        new_violations_total=0
+        regressions_total=0
+        row_json_rust=""
+        row_json_typescript=""
+        envelope_path_first=""
 
-        if [ "$LANGUAGE" = "rust" ]; then
-          # Graceful probe for crap4rs: --format scorecard-row landed in
-          # crap4rs 0.4.0 (https://github.com/breezy-bays-labs/crap4rs/pull/119).
-          # Older releases don't recognize the value and clap exits non-zero,
-          # so we probe before invoking and degrade to an empty row-json with
-          # a workflow warning when unsupported.
+        # Per-language markdown bodies live in temp files keyed by
+        # adapter name so the post-loop assembly stays simple.
+        for lang in "${LANGS[@]}"; do
+          case "$lang" in
+            rust)
+              BIN="crap4rs"
+              LANG_COVERAGE="$COVERAGE"
+              LANG_SRC="$SRC"
+              LANG_BASELINE="$BASELINE"
+              ;;
+            typescript)
+              BIN="crap4ts"
+              # In multi-language mode, TS triple comes from the
+              # paired `*_TS` inputs. In single-language `typescript`
+              # mode, the historical single-input set carries TS — so
+              # fall back to those when `*_TS` are empty.
+              if [ "$IS_MULTI" = "true" ]; then
+                LANG_COVERAGE="$COVERAGE_TS"
+                LANG_SRC="$SRC_TS"
+                LANG_BASELINE="$BASELINE_TS"
+              else
+                LANG_COVERAGE="$COVERAGE"
+                LANG_SRC="$SRC"
+                LANG_BASELINE="$BASELINE"
+              fi
+              ;;
+            *)
+              echo "::error::Run analysis: internal iteration over unexpected language '$lang' (LANGS='${LANGS[*]}'); expected rust or typescript"
+              exit 1
+              ;;
+          esac
+          envelope="$RUNNER_TEMP/${BIN}-envelope.json"
+          markdown_file="$RUNNER_TEMP/${BIN}-scorecard.md"
+          row_json_file="$RUNNER_TEMP/${BIN}-row.json"
+          common=(--coverage "$LANG_COVERAGE" --src "$LANG_SRC" --threshold "$THRESHOLD")
+          [ -n "$CONFIG" ] && common+=(--config "$CONFIG")
+          if [ -n "$LANG_BASELINE" ]; then
+            common+=(--baseline "$LANG_BASELINE")
+          fi
+
+          # Always capture truth into the envelope; --no-fail keeps the step
+          # green so we can surface counts/passed status via outputs even when
+          # gates would have tripped. The hard gating happens in the dedicated
+          # gate step below, gated by the analysis-gate / delta-gate inputs.
           #
-          # Probe by version, not `--help` text. crap4rs 0.4.0 replaced
-          # clap's `--format` ValueEnum with a custom FormatSpec parser so
-          # `--format` could accept `<format>:<file>` syntax (#100), and
-          # clap can't introspect a custom parser — `--help` no longer
-          # enumerates format names. Grepping `--help` for `scorecard-row`
-          # therefore false-negatives against the very versions that
-          # support it. `sort -V` works on both GitHub-hosted Ubuntu and
-          # macOS runners.
-          installed_version_raw="$(crap4rs --version 2>/dev/null | awk '{print $2}')"
-          installed_version="${installed_version_raw#v}"
-          required_version="0.4.0"
-          # Validate against a strict semver shape before `sort -V`. `sort -V`
-          # treats non-numeric tokens (e.g. "unknown", "garbage") and `v`-prefixed
-          # tags as sorting after pure semver strings, so without this gate they
-          # would false-positive into the supported branch and skip the warning.
-          supports_scorecard_row=false
-          if [[ "$installed_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]] \
-            && [ "$(printf '%s\n%s\n' "$required_version" "$installed_version" | sort -V | head -n1)" = "$required_version" ]; then
-            supports_scorecard_row=true
+          # Three-pass note: we run the adapter three times — once each for
+          # JSON, markdown, and scorecard-row — because the analyzer doesn't
+          # yet support multi-format output in a single invocation. The cost
+          # is two extra coverage parses + CRAP recomputes per language
+          # (cheap relative to runner setup); the user-visible latency is
+          # dominated by adapter install upstream. Tracked in
+          # https://github.com/breezy-bays-labs/crap-rs/issues/100.
+          "$BIN" "${common[@]}" --format json --no-fail > "$envelope"
+          "$BIN" "${common[@]}" --format markdown --no-fail > "$markdown_file"
+
+          if [ "$lang" = "rust" ]; then
+            # Graceful probe for crap4rs: --format scorecard-row landed in
+            # crap4rs 0.4.0 (https://github.com/breezy-bays-labs/crap4rs/pull/119).
+            # Older releases don't recognize the value and clap exits non-zero,
+            # so we probe before invoking and degrade to an empty row-json with
+            # a workflow warning when unsupported.
+            #
+            # Probe by version, not `--help` text. crap4rs 0.4.0 replaced
+            # clap's `--format` ValueEnum with a custom FormatSpec parser so
+            # `--format` could accept `<format>:<file>` syntax (#100), and
+            # clap can't introspect a custom parser — `--help` no longer
+            # enumerates format names. Grepping `--help` for `scorecard-row`
+            # therefore false-negatives against the very versions that
+            # support it. `sort -V` works on both GitHub-hosted Ubuntu and
+            # macOS runners.
+            installed_version_raw="$(crap4rs --version 2>/dev/null | awk '{print $2}')"
+            installed_version="${installed_version_raw#v}"
+            required_version="0.4.0"
+            # Validate against a strict semver shape before `sort -V`. `sort -V`
+            # treats non-numeric tokens (e.g. "unknown", "garbage") and `v`-prefixed
+            # tags as sorting after pure semver strings, so without this gate they
+            # would false-positive into the supported branch and skip the warning.
+            supports_scorecard_row=false
+            if [[ "$installed_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]] \
+              && [ "$(printf '%s\n%s\n' "$required_version" "$installed_version" | sort -V | head -n1)" = "$required_version" ]; then
+              supports_scorecard_row=true
+            fi
+
+            if [ "$supports_scorecard_row" = true ]; then
+              crap4rs "${common[@]}" --format scorecard-row --no-fail > "$row_json_file"
+            else
+              echo "::warning::Installed crap4rs (${installed_version:-unknown}) is older than $required_version or reports a non-semver version; outputs.row-json (and outputs.row-json-rust) will be empty. Pin the action's 'version' input to '$required_version' or later for structured Row::CrapDelta output."
+              : > "$row_json_file"
+            fi
+          else
+            # crap4ts: monorepo-shipped, structurally guarantees
+            # `--format scorecard-row` support (both adapters route through
+            # crap-core's shared `cli::format_as_scorecard_row` pipeline,
+            # locked by `crates/crap-core/tests/scorecard_row_parity.rs`).
+            # No probe needed — pre-installed-only means the caller is on a
+            # current build.
+            crap4ts "${common[@]}" --format scorecard-row --no-fail > "$row_json_file"
           fi
 
-          if [ "$supports_scorecard_row" = true ]; then
-            crap4rs "${common[@]}" --format scorecard-row --no-fail > "$row_json_file"
-          else
-            echo "::warning::Installed crap4rs (${installed_version:-unknown}) is older than $required_version or reports a non-semver version; outputs.row-json will be empty. Pin the action's 'version' input to '$required_version' or later for structured Row::CrapDelta output."
-            : > "$row_json_file"
+          # Parse the envelope. jq is preinstalled on GitHub-hosted runners.
+          lang_analysis_passed=$(jq -r '.result.passed' "$envelope")
+          lang_delta_passed=$(jq -r '.delta.summary.passed // ""' "$envelope")
+          lang_new_violations=$(jq -r '.delta.summary.new_violations // 0' "$envelope")
+          lang_regressions=$(jq -r '.delta.summary.regressions // 0' "$envelope")
+
+          # AND-reduce passed flags. The `--no-fail` invariant means
+          # exit code cannot be used (the bin always returns 0); jq
+          # extraction of `.result.passed` IS the contract.
+          if [ "$lang_analysis_passed" != "true" ]; then
+            analysis_passed_combined="false"
           fi
-        else
-          # crap4ts: monorepo-shipped, structurally guarantees
-          # `--format scorecard-row` support (both adapters route through
-          # crap-core's shared `cli::format_as_scorecard_row` pipeline,
-          # locked by `crates/crap-core/tests/scorecard_row_parity.rs`).
-          # No probe needed — pre-installed-only means the caller is on a
-          # current build.
-          crap4ts "${common[@]}" --format scorecard-row --no-fail > "$row_json_file"
+          # `delta_passed_combined` stays empty when NO language ran
+          # with a baseline (back-compat: single-language with no
+          # baseline emits ""). When at least one language has a
+          # baseline, the combined value is AND across the ones that
+          # did. A baseline-less language contributes neutrally
+          # (its `lang_delta_passed` is "" → skipped in the AND).
+          if [ -n "$lang_delta_passed" ]; then
+            delta_any_seen="true"
+            if [ "$lang_delta_passed" != "true" ]; then
+              delta_passed_combined="false"
+            elif [ -z "$delta_passed_combined" ] || [ "$delta_passed_combined" = "true" ]; then
+              delta_passed_combined="true"
+            fi
+          fi
+          new_violations_total=$((new_violations_total + lang_new_violations))
+          regressions_total=$((regressions_total + lang_regressions))
+
+          # Track envelope path for the legacy `json-envelope-path`
+          # output. Single-language: this is the only language's
+          # envelope. Multi-language: this is the FIRST language's
+          # envelope (rust, by canonical ordering) — downstream
+          # tooling that wants the TS envelope reads
+          # `$RUNNER_TEMP/crap4ts-envelope.json` directly (documented
+          # in the README "Multi-language" section).
+          if [ -z "$envelope_path_first" ]; then
+            envelope_path_first="$envelope"
+          fi
+
+          # Capture per-language row JSON for the split outputs.
+          # `row_json_file` is the raw stdout of `--format
+          # scorecard-row`, the JSON object that conforms to the
+          # locked Row::CrapDelta schema.
+          if [ "$lang" = "rust" ]; then
+            row_json_rust="$(cat "$row_json_file")"
+          else
+            row_json_typescript="$(cat "$row_json_file")"
+          fi
+        done
+
+        # If the loop never executed a baseline-bearing language but
+        # the historical contract emits "" for `delta-passed`, keep
+        # it empty. The defensive elif above already covers the case
+        # where every language had a baseline AND all passed.
+        if [ "$delta_any_seen" = "false" ]; then
+          delta_passed_combined=""
         fi
 
-        # Parse the envelope. jq is preinstalled on GitHub-hosted runners.
-        analysis_passed=$(jq -r '.result.passed' "$envelope")
-        delta_passed=$(jq -r '.delta.summary.passed // ""' "$envelope")
-        new_violations=$(jq -r '.delta.summary.new_violations // 0' "$envelope")
-        regressions=$(jq -r '.delta.summary.regressions // 0' "$envelope")
+        echo "analysis_passed=$analysis_passed_combined" >> "$GITHUB_OUTPUT"
+        echo "delta_passed=$delta_passed_combined"       >> "$GITHUB_OUTPUT"
+        echo "new_violations=$new_violations_total"      >> "$GITHUB_OUTPUT"
+        echo "regressions=$regressions_total"            >> "$GITHUB_OUTPUT"
+        echo "envelope_path=$envelope_path_first"        >> "$GITHUB_OUTPUT"
 
-        echo "analysis_passed=$analysis_passed" >> "$GITHUB_OUTPUT"
-        echo "delta_passed=$delta_passed"       >> "$GITHUB_OUTPUT"
-        echo "new_violations=$new_violations"   >> "$GITHUB_OUTPUT"
-        echo "regressions=$regressions"         >> "$GITHUB_OUTPUT"
-        echo "envelope_path=$envelope"          >> "$GITHUB_OUTPUT"
+        # Markdown assembly — single-language vs multi-language.
+        if [ "$IS_MULTI" = "true" ]; then
+          combined_md="$RUNNER_TEMP/scorecard-combined.md"
+          : > "$combined_md"
+          {
+            echo "## CRAP scorecard"
+            echo ""
+            for lang in "${LANGS[@]}"; do
+              case "$lang" in
+                rust)       header="### Rust (crap4rs)"       ; BIN="crap4rs" ;;
+                typescript) header="### TypeScript (crap4ts)" ; BIN="crap4ts" ;;
+              esac
+              echo "$header"
+              echo ""
+              # Demote the adapter's own header hierarchy by 3 levels
+              # so the markdown stays consistent under the outer
+              # `## CRAP scorecard` (H2) + `### Rust (crap4rs)` /
+              # `### TypeScript (crap4ts)` (H3) wrappers:
+              #   `# <bin> v<v> — CRAP Score Analysis`  (H1) → `####` (H4)
+              #   `## Summary` / `## All functions` / `## CRAP Scorecard` (H2) → `#####` (H5)
+              #   `### Regressions` / `### New violations` (H3) → `######` (H6)
+              # The adapter's markdown body is otherwise concatenated
+              # verbatim. `sed` runs on a copy; the original
+              # `$RUNNER_TEMP/${BIN}-scorecard.md` stays unchanged
+              # for any consumer reading it directly.
+              sed -E 's/^### /###### /; s/^## /##### /; s/^# /#### /' "$RUNNER_TEMP/${BIN}-scorecard.md"
+              echo ""
+            done
+          } > "$combined_md"
 
-        # Multi-line output: file the markdown via the heredoc-delimited form.
-        {
-          echo "markdown<<__CRAP_SCORECARD_EOF__"
-          cat "$markdown_file"
-          echo "__CRAP_SCORECARD_EOF__"
-        } >> "$GITHUB_OUTPUT"
+          {
+            echo "markdown<<__CRAP_SCORECARD_EOF__"
+            cat "$combined_md"
+            echo "__CRAP_SCORECARD_EOF__"
+          } >> "$GITHUB_OUTPUT"
+        else
+          # Single-language: emit the raw adapter markdown unchanged
+          # (back-compat — every byte matches the pre-PR shape). `BIN`
+          # carries the loop's only iteration's bin name (`crap4rs` or
+          # `crap4ts`), so the markdown file path is well-defined.
+          {
+            echo "markdown<<__CRAP_SCORECARD_EOF__"
+            cat "$RUNNER_TEMP/${BIN}-scorecard.md"
+            echo "__CRAP_SCORECARD_EOF__"
+          } >> "$GITHUB_OUTPUT"
+        fi
 
-        # Multi-line output: file the row-json via a distinct heredoc sentinel.
-        # The file is the raw stdout of `<bin> --format scorecard-row` —
-        # one Row::CrapDelta JSON object, no envelope wrapping. The
-        # sentinel must not appear in the JSON; pretty-printed CrapDelta
-        # never contains it. Both adapters emit the same Row JSON shape
-        # (locked by crates/crap-core/tests/scorecard_row_parity.rs).
+        # Legacy `row-json` output:
+        # * single-language: populated with the active language's row
+        #   (back-compat — every consumer reading `row-json` keeps
+        #   working unchanged)
+        # * multi-language: empty + `::warning::` directing consumers
+        #   to the split outputs. Without the warning, a consumer
+        #   flipping `languages:` to multi-value would see their
+        #   downstream `jq` parse silently fail on empty input — the
+        #   warning surfaces the migration path in the action's own
+        #   log.
+        if [ "$IS_MULTI" = "true" ]; then
+          echo "::warning::scorecard action: outputs.row-json is EMPTY in multi-language mode (languages='${LANGUAGE_SET}'). Use outputs.row-json-rust and outputs.row-json-typescript instead. See the action README's 'Multi-language' section for the split-output contract."
+          legacy_row_json=""
+        else
+          # Single-language: the active language's row populates the
+          # legacy output. The split per-language output is ALSO
+          # populated, so consumers can migrate at their own cadence.
+          if [ "${LANGS[0]}" = "rust" ]; then
+            legacy_row_json="$row_json_rust"
+          else
+            legacy_row_json="$row_json_typescript"
+          fi
+        fi
+
         {
           echo "row_json<<__CRAP_SCORECARD_ROW_EOF__"
-          cat "$row_json_file"
+          printf '%s' "$legacy_row_json"
+          echo ""
           echo "__CRAP_SCORECARD_ROW_EOF__"
         } >> "$GITHUB_OUTPUT"
 
-        # Surface a compact summary in the job log so failures are obvious
-        # without scrolling.
+        # Per-language split outputs. Each is the raw scorecard-row
+        # stdout for the corresponding adapter (or empty when the
+        # language did not run in this invocation). Both adapters
+        # emit the same Row JSON shape (locked by
+        # crates/crap-core/tests/scorecard_row_parity.rs ::
+        # envelope_multi_language_parity).
+        {
+          echo "row_json_rust<<__CRAP_SCORECARD_ROW_EOF__"
+          printf '%s' "$row_json_rust"
+          echo ""
+          echo "__CRAP_SCORECARD_ROW_EOF__"
+        } >> "$GITHUB_OUTPUT"
+        {
+          echo "row_json_typescript<<__CRAP_SCORECARD_ROW_EOF__"
+          printf '%s' "$row_json_typescript"
+          echo ""
+          echo "__CRAP_SCORECARD_ROW_EOF__"
+        } >> "$GITHUB_OUTPUT"
+
+        # Surface a compact summary in the job log so failures are
+        # obvious without scrolling. Multi-language streams each
+        # adapter's markdown in turn.
         echo "::group::CRAP scorecard"
-        cat "$markdown_file"
+        if [ "$IS_MULTI" = "true" ]; then
+          cat "$combined_md"
+        else
+          cat "$RUNNER_TEMP/${BIN}-scorecard.md"
+        fi
         echo "::endgroup::"
 
     - name: Emit inline annotations
-      if: (steps.lang.outputs.language == 'rust' || steps.lang.outputs.language == 'typescript') && inputs.annotations == 'true'
+      if: (steps.lang.outputs.language == 'rust' || steps.lang.outputs.language == 'typescript' || steps.lang.outputs.language == 'multi') && inputs.annotations == 'true'
       shell: bash
       env:
         LANGUAGE: ${{ steps.lang.outputs.language }}
+        LANGUAGE_SET: ${{ steps.presets.outputs.language_set }}
+        IS_MULTI: ${{ steps.presets.outputs.is_multi }}
         COVERAGE: ${{ inputs.coverage }}
         SRC: ${{ inputs.src }}
+        COVERAGE_TS: ${{ inputs.coverage-ts }}
+        SRC_TS: ${{ inputs.src-ts }}
         # Threshold-sync invariant: consume the derived single
         # source-of-truth so `threshold-preset: strict` produces
         # annotations at the same cutoff as the main analysis (a
@@ -670,25 +1106,54 @@ runs:
         # `--no-fail` keeps the step green so a failing analysis still
         # surfaces findings inline; the dedicated "Enforce gates" step
         # below owns hard gating.
-        if [ "$LANGUAGE" = "rust" ]; then
-          BIN=crap4rs
+        #
+        # Per-language loop: single-language iterates once over the
+        # active language; multi-language iterates over both. Each
+        # language's findings render under the runner's own
+        # annotation cap (10 warnings per step); multi-language gets
+        # 2x effective annotation budget because two steps run.
+        if [ -n "$LANGUAGE_SET" ]; then
+          IFS=',' read -ra LANGS <<<"$LANGUAGE_SET"
         else
-          BIN=crap4ts
+          LANGS=("$LANGUAGE")
         fi
-        args=(--coverage "$COVERAGE" --src "$SRC" --threshold "$THRESHOLD" --no-fail --format github-annotations)
-        [ -n "$CONFIG" ] && args+=(--config "$CONFIG")
-        [ -n "$ANNOTATION_LIMIT" ] && args+=(--annotation-limit "$ANNOTATION_LIMIT")
-        "$BIN" "${args[@]}"
+        for lang in "${LANGS[@]}"; do
+          case "$lang" in
+            rust)
+              BIN="crap4rs"
+              LANG_COVERAGE="$COVERAGE"
+              LANG_SRC="$SRC"
+              ;;
+            typescript)
+              BIN="crap4ts"
+              if [ "$IS_MULTI" = "true" ]; then
+                LANG_COVERAGE="$COVERAGE_TS"
+                LANG_SRC="$SRC_TS"
+              else
+                LANG_COVERAGE="$COVERAGE"
+                LANG_SRC="$SRC"
+              fi
+              ;;
+            *)
+              echo "::error::Emit inline annotations: internal iteration over unexpected language '$lang'; expected rust or typescript"
+              exit 1
+              ;;
+          esac
+          args=(--coverage "$LANG_COVERAGE" --src "$LANG_SRC" --threshold "$THRESHOLD" --no-fail --format github-annotations)
+          [ -n "$CONFIG" ] && args+=(--config "$CONFIG")
+          [ -n "$ANNOTATION_LIMIT" ] && args+=(--annotation-limit "$ANNOTATION_LIMIT")
+          "$BIN" "${args[@]}"
+        done
 
     - name: Post sticky PR comment
-      if: (steps.lang.outputs.language == 'rust' || steps.lang.outputs.language == 'typescript') && inputs.comment-mode == 'sticky' && github.event_name == 'pull_request'
+      if: (steps.lang.outputs.language == 'rust' || steps.lang.outputs.language == 'typescript' || steps.lang.outputs.language == 'multi') && inputs.comment-mode == 'sticky' && github.event_name == 'pull_request'
       uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
       with:
         header: ${{ inputs.comment-header }}
         message: ${{ steps.run.outputs.markdown }}
 
     - name: Enforce gates
-      if: steps.lang.outputs.language == 'rust' || steps.lang.outputs.language == 'typescript'
+      if: steps.lang.outputs.language == 'rust' || steps.lang.outputs.language == 'typescript' || steps.lang.outputs.language == 'multi'
       shell: bash
       env:
         # Gate values come from the preset-resolution step (single

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -609,6 +609,362 @@ jobs:
           # under a different header is review noise.
           comment-mode: 'none'
 
+  scorecard-smoke-multi-lang:
+    # Multi-language single-CI smoke for PR #293 — exercises the
+    # `languages: rust,typescript` / `languages: all` dispatch path
+    # added by the multi-language extension. Stages BOTH PR-built
+    # binaries onto PATH (so the action's pre-installed-detection
+    # picks them up), prepares both Rust LCOV + TS Istanbul fixtures,
+    # then runs the 8 parsing-edge-case spot checks the PR β
+    # acceptance gates call out. Single CI job (not a matrix) since
+    # each spot check is one composite-action invocation, and the
+    # invocations share the same staged binaries + fixture prep.
+    #
+    # SECURITY NOTE: every `run:` block reads only step outputs and
+    # workflow env vars via the `env:` indirection pattern (per the
+    # GH-workflow-injection guidance). No `github.event.*` /
+    # `github.head_ref` interpolation appears in any shell body.
+    name: Scorecard action smoke — multi-language
+    runs-on: ubuntu-latest
+    needs: [coverage]
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # tracks @stable branch
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: lcov
+
+      # Build BOTH binaries from the PR's source so the multi-language
+      # smoke dogfoods this PR's adapters end-to-end. Mirrors the
+      # `scorecard-smoke-rust` (`cargo build --release --package crap4rs`)
+      # and `scorecard-smoke-ts` (`cargo build --release --bin crap4ts`)
+      # patterns combined. `--bin crap4ts` lives in the crap4ts package
+      # (not crap4rs), so the build invokes both packages explicitly.
+      - name: Build PR binaries (crap4rs + crap4ts)
+        run: cargo build --release --package crap4rs --package crap4ts
+
+      - name: Stage PR binaries as pre-installed adapters
+        run: |
+          set -euo pipefail
+          # Multi-language mode requires BOTH adapters discoverable on
+          # PATH. The public scorecard action's pre-installed-detection
+          # short-circuits its binstall steps when `crap4rs --version`
+          # and `crap4ts --version` resolve to executables under PATH,
+          # so staging both into `$HOME/.cargo/bin` (which the GitHub-
+          # hosted runner pre-pends to PATH) is the standard pattern.
+          # The `scorecard-smoke` internal composite uses the same shape.
+          mkdir -p "$HOME/.cargo/bin"
+          install -m 0755 ./target/release/crap4rs "$HOME/.cargo/bin/crap4rs"
+          install -m 0755 ./target/release/crap4ts "$HOME/.cargo/bin/crap4ts"
+          crap4rs --version
+          crap4ts --version
+
+      # Prepare a tiny Istanbul fixture under a stable workspace path
+      # so the action's `--src-ts` input resolves the coverage `path`
+      # entries cleanly. Same template substitution as `scorecard-smoke-ts`.
+      - name: Prepare Istanbul JSON fixture (TS side)
+        id: ts-fixture
+        env:
+          SRC_ROOT: ${{ runner.temp }}/ts-multi-smoke
+        run: |
+          set -euo pipefail
+          mkdir -p "$SRC_ROOT"
+          cp crates/crap4ts/tests/fixtures/ts-fixtures/simple.ts "$SRC_ROOT/"
+          cp crates/crap4ts/tests/fixtures/ts-fixtures/arrow.ts "$SRC_ROOT/"
+          cp crates/crap4ts/tests/fixtures/ts-fixtures/Button.tsx "$SRC_ROOT/"
+          cp crates/crap4ts/tests/fixtures/ts-fixtures/map.ts "$SRC_ROOT/"
+          cp crates/crap4ts/tests/fixtures/ts-fixtures/mixed.ts "$SRC_ROOT/"
+          sed "s|{SRC_ROOT}|$SRC_ROOT|g" \
+            crates/crap4ts/tests/fixtures/istanbul-jest/coverage-final.json \
+            > "$SRC_ROOT/coverage-final.json"
+          echo "coverage=$SRC_ROOT/coverage-final.json" >> "$GITHUB_OUTPUT"
+          echo "src=$SRC_ROOT" >> "$GITHUB_OUTPUT"
+
+      # ----------------------------------------------------------------
+      # Spot-check matrix (PR #293 acceptance gate #7).
+      #
+      # 8 single-step invocations covering the parsing edge cases the
+      # shape doc Open Q 2 enumerated. Each step pairs a `with:` block
+      # exercising one input shape with a matching assertion step
+      # reading the action's resolved outputs. The full list:
+      #   1. languages: rust              — single-language back-compat
+      #   2. languages: typescript        — single-language back-compat
+      #   3. languages: rust,typescript   — multi-language explicit
+      #   4. languages: all               — multi-language convenience
+      #   5. "languages: rust, typescript" (whitespace) — multi-language
+      #   6. languages: rust,rust         — dedup warning + single-lang
+      #   7. languages: rust,typescript w/o coverage-ts — actionable error
+      #   8. languages: garbage           — actionable error
+      #
+      # Cases 1-6 succeed and assert output shape; cases 7-8 are
+      # expected-failure invocations exercised via `continue-on-error:
+      # true` + a follow-up step that asserts the prior step's outcome
+      # was `failure` — that proves the error surfaced rather than
+      # silently passing.
+      # ----------------------------------------------------------------
+
+      - name: Spot-check 1 — languages=rust (single-language back-compat)
+        id: spot-rust
+        uses: ./.github/actions/scorecard
+        with:
+          coverage: lcov.info
+          src: crates/crap4rs/src
+          languages: rust
+          threshold: ${{ env.CRAP_SMOKE_THRESHOLD }}
+          comment-mode: 'none'
+      - name: Assert spot-check 1 single-language outputs
+        env:
+          ROW_JSON: ${{ steps.spot-rust.outputs.row-json }}
+          ROW_JSON_RUST: ${{ steps.spot-rust.outputs.row-json-rust }}
+          ROW_JSON_TS: ${{ steps.spot-rust.outputs.row-json-typescript }}
+          MARKDOWN: ${{ steps.spot-rust.outputs.markdown }}
+        run: |
+          set -euo pipefail
+          # Single-language back-compat invariants:
+          #   * legacy `row-json` populated (every existing consumer)
+          #   * split `row-json-rust` ALSO populated (forward-compat)
+          #   * split `row-json-typescript` empty (TS didn't run)
+          #   * markdown carries NO `## CRAP scorecard` outer wrapper
+          if [ -z "$ROW_JSON" ]; then
+            echo "::error::spot-check 1: legacy row-json empty in single-language rust mode"
+            exit 1
+          fi
+          if [ -z "$ROW_JSON_RUST" ]; then
+            echo "::error::spot-check 1: row-json-rust empty in languages=rust"
+            exit 1
+          fi
+          if [ -n "$ROW_JSON_TS" ]; then
+            echo "::error::spot-check 1: row-json-typescript non-empty in languages=rust (got: $ROW_JSON_TS)"
+            exit 1
+          fi
+          if printf '%s' "$MARKDOWN" | grep -qE '^## CRAP scorecard$'; then
+            echo "::error::spot-check 1: single-language markdown should NOT carry the multi-language outer wrapper"
+            exit 1
+          fi
+          echo "spot-check 1 (languages=rust) ✓"
+
+      - name: Spot-check 2 — languages=typescript (single-language back-compat)
+        id: spot-ts
+        uses: ./.github/actions/scorecard
+        with:
+          coverage: ${{ steps.ts-fixture.outputs.coverage }}
+          src: ${{ steps.ts-fixture.outputs.src }}
+          languages: typescript
+          threshold: ${{ env.CRAP_SMOKE_THRESHOLD }}
+          comment-mode: 'none'
+      - name: Assert spot-check 2 single-language outputs
+        env:
+          ROW_JSON: ${{ steps.spot-ts.outputs.row-json }}
+          ROW_JSON_RUST: ${{ steps.spot-ts.outputs.row-json-rust }}
+          ROW_JSON_TS: ${{ steps.spot-ts.outputs.row-json-typescript }}
+        run: |
+          set -euo pipefail
+          if [ -z "$ROW_JSON" ]; then
+            echo "::error::spot-check 2: legacy row-json empty in single-language typescript mode"
+            exit 1
+          fi
+          if [ -n "$ROW_JSON_RUST" ]; then
+            echo "::error::spot-check 2: row-json-rust non-empty in languages=typescript"
+            exit 1
+          fi
+          if [ -z "$ROW_JSON_TS" ]; then
+            echo "::error::spot-check 2: row-json-typescript empty in languages=typescript"
+            exit 1
+          fi
+          echo "spot-check 2 (languages=typescript) ✓"
+
+      - name: Spot-check 3 — languages=rust,typescript (multi-language explicit)
+        id: spot-multi
+        uses: ./.github/actions/scorecard
+        with:
+          coverage: lcov.info
+          src: crates/crap4rs/src
+          coverage-ts: ${{ steps.ts-fixture.outputs.coverage }}
+          src-ts: ${{ steps.ts-fixture.outputs.src }}
+          languages: rust,typescript
+          threshold: ${{ env.CRAP_SMOKE_THRESHOLD }}
+          comment-mode: 'none'
+      - name: Assert spot-check 3 multi-language outputs
+        env:
+          ROW_JSON: ${{ steps.spot-multi.outputs.row-json }}
+          ROW_JSON_RUST: ${{ steps.spot-multi.outputs.row-json-rust }}
+          ROW_JSON_TS: ${{ steps.spot-multi.outputs.row-json-typescript }}
+          MARKDOWN: ${{ steps.spot-multi.outputs.markdown }}
+        run: |
+          set -euo pipefail
+          # Multi-language invariants:
+          #   * legacy `row-json` EMPTY (with `::warning::` in job log
+          #     directing consumers to the split outputs)
+          #   * both split outputs populated
+          #   * markdown carries `## CRAP scorecard` wrapper + per-
+          #     language `### Rust (crap4rs)` AND `### TypeScript
+          #     (crap4ts)` section headers
+          if [ -n "$ROW_JSON" ]; then
+            echo "::error::spot-check 3: legacy row-json should be EMPTY in multi-language mode (got: $ROW_JSON)"
+            exit 1
+          fi
+          if [ -z "$ROW_JSON_RUST" ]; then
+            echo "::error::spot-check 3: row-json-rust empty in multi-language mode"
+            exit 1
+          fi
+          if [ -z "$ROW_JSON_TS" ]; then
+            echo "::error::spot-check 3: row-json-typescript empty in multi-language mode"
+            exit 1
+          fi
+          if ! printf '%s' "$MARKDOWN" | grep -qE '^## CRAP scorecard$'; then
+            echo "::error::spot-check 3: multi-language markdown missing '## CRAP scorecard' outer wrapper"
+            exit 1
+          fi
+          if ! printf '%s' "$MARKDOWN" | grep -qE '^### Rust \(crap4rs\)$'; then
+            echo "::error::spot-check 3: multi-language markdown missing '### Rust (crap4rs)' section header"
+            exit 1
+          fi
+          if ! printf '%s' "$MARKDOWN" | grep -qE '^### TypeScript \(crap4ts\)$'; then
+            echo "::error::spot-check 3: multi-language markdown missing '### TypeScript (crap4ts)' section header"
+            exit 1
+          fi
+          echo "spot-check 3 (languages=rust,typescript) ✓"
+
+      - name: Spot-check 4 — languages=all (multi-language convenience expansion)
+        id: spot-all
+        uses: ./.github/actions/scorecard
+        with:
+          coverage: lcov.info
+          src: crates/crap4rs/src
+          coverage-ts: ${{ steps.ts-fixture.outputs.coverage }}
+          src-ts: ${{ steps.ts-fixture.outputs.src }}
+          languages: all
+          threshold: ${{ env.CRAP_SMOKE_THRESHOLD }}
+          comment-mode: 'none'
+      - name: Assert spot-check 4 expansion matches explicit form
+        env:
+          ROW_JSON_RUST: ${{ steps.spot-all.outputs.row-json-rust }}
+          ROW_JSON_TS: ${{ steps.spot-all.outputs.row-json-typescript }}
+        run: |
+          set -euo pipefail
+          # `all` is the convenience expansion for the full multi-language
+          # set. Today that's rust,typescript; the dispatch should
+          # behave IDENTICALLY to the explicit form (spot-check 3).
+          if [ -z "$ROW_JSON_RUST" ] || [ -z "$ROW_JSON_TS" ]; then
+            echo "::error::spot-check 4: languages=all did not produce both split outputs"
+            exit 1
+          fi
+          echo "spot-check 4 (languages=all) ✓"
+
+      - name: Spot-check 5 — languages with whitespace (multi-language)
+        id: spot-ws
+        uses: ./.github/actions/scorecard
+        with:
+          coverage: lcov.info
+          src: crates/crap4rs/src
+          coverage-ts: ${{ steps.ts-fixture.outputs.coverage }}
+          src-ts: ${{ steps.ts-fixture.outputs.src }}
+          languages: 'rust, typescript'
+          threshold: ${{ env.CRAP_SMOKE_THRESHOLD }}
+          comment-mode: 'none'
+      - name: Assert spot-check 5 whitespace tolerated
+        env:
+          ROW_JSON_RUST: ${{ steps.spot-ws.outputs.row-json-rust }}
+          ROW_JSON_TS: ${{ steps.spot-ws.outputs.row-json-typescript }}
+        run: |
+          set -euo pipefail
+          if [ -z "$ROW_JSON_RUST" ] || [ -z "$ROW_JSON_TS" ]; then
+            echo "::error::spot-check 5: 'rust, typescript' (whitespace) did not produce both split outputs"
+            exit 1
+          fi
+          echo "spot-check 5 (languages='rust, typescript') ✓"
+
+      - name: Spot-check 6 — languages=rust,rust (dedup → single-language + warning)
+        id: spot-dedup
+        uses: ./.github/actions/scorecard
+        with:
+          coverage: lcov.info
+          src: crates/crap4rs/src
+          languages: 'rust,rust'
+          threshold: ${{ env.CRAP_SMOKE_THRESHOLD }}
+          comment-mode: 'none'
+      - name: Assert spot-check 6 dedup collapses to single-language
+        env:
+          ROW_JSON_RUST: ${{ steps.spot-dedup.outputs.row-json-rust }}
+          ROW_JSON_TS: ${{ steps.spot-dedup.outputs.row-json-typescript }}
+          ROW_JSON: ${{ steps.spot-dedup.outputs.row-json }}
+        run: |
+          set -euo pipefail
+          # The dedupe warning itself goes to the workflow log (the
+          # action emits `::warning::scorecard action: 'languages:
+          # rust,rust' contains duplicate token 'rust' ...`); this
+          # assertion locks the dedupe BEHAVIOR (single-language dispatch
+          # after collapse), not the warning text. After collapse,
+          # `rust,rust` should behave identically to `languages: rust`
+          # (spot-check 1).
+          if [ -z "$ROW_JSON_RUST" ]; then
+            echo "::error::spot-check 6: dedup'd 'rust,rust' did not produce row-json-rust"
+            exit 1
+          fi
+          if [ -n "$ROW_JSON_TS" ]; then
+            echo "::error::spot-check 6: dedup'd 'rust,rust' produced TS output (should collapse to single-language rust)"
+            exit 1
+          fi
+          if [ -z "$ROW_JSON" ]; then
+            echo "::error::spot-check 6: dedup'd 'rust,rust' should populate legacy row-json (single-language back-compat)"
+            exit 1
+          fi
+          echo "spot-check 6 (languages=rust,rust → dedup ✓)"
+
+      - name: Spot-check 7 — multi-language without coverage-ts (actionable error)
+        id: spot-missing-pair
+        uses: ./.github/actions/scorecard
+        continue-on-error: true
+        with:
+          coverage: lcov.info
+          src: crates/crap4rs/src
+          # Intentionally OMIT coverage-ts + src-ts; the pre-execution
+          # validator in `Resolve presets` should error actionably.
+          languages: rust,typescript
+          threshold: ${{ env.CRAP_SMOKE_THRESHOLD }}
+          comment-mode: 'none'
+      - name: Assert spot-check 7 surfaced the paired-input error
+        env:
+          OUTCOME: ${{ steps.spot-missing-pair.outcome }}
+        run: |
+          set -euo pipefail
+          # `continue-on-error: true` makes the action's failure
+          # non-fatal to the job; we then assert the OUTCOME was
+          # actually `failure` so the pre-execution validator didn't
+          # silently let multi-language mode run without the paired
+          # input set.
+          if [ "$OUTCOME" != "failure" ]; then
+            echo "::error::spot-check 7: action should have failed on missing coverage-ts but outcome=$OUTCOME"
+            exit 1
+          fi
+          echo "spot-check 7 (missing coverage-ts → actionable error ✓)"
+
+      - name: Spot-check 8 — languages=garbage (actionable error)
+        id: spot-garbage
+        uses: ./.github/actions/scorecard
+        continue-on-error: true
+        with:
+          coverage: lcov.info
+          src: crates/crap4rs/src
+          languages: garbage
+          threshold: ${{ env.CRAP_SMOKE_THRESHOLD }}
+          comment-mode: 'none'
+      - name: Assert spot-check 8 surfaced the unsupported-token error
+        env:
+          OUTCOME: ${{ steps.spot-garbage.outcome }}
+        run: |
+          set -euo pipefail
+          if [ "$OUTCOME" != "failure" ]; then
+            echo "::error::spot-check 8: action should have failed on languages=garbage but outcome=$OUTCOME"
+            exit 1
+          fi
+          echo "spot-check 8 (languages=garbage → actionable error ✓)"
+
   msrv:
     # Pre-flight gate at the workspace's declared `rust-version`. The
     # original CEng audit (B3) ran lib-only `cargo +1.85 check` and

--- a/crates/crap-core/tests/scorecard_row_parity.rs
+++ b/crates/crap-core/tests/scorecard_row_parity.rs
@@ -47,12 +47,13 @@
 //!
 //! ## Mutants gate interaction
 //!
-//! Test fn is named `envelope` so the `--skip envelope` substring
-//! token in `.cargo/mutants.toml` covers it under `--package
-//! crap-core`. That scoped mutants run does not build the crap4rs
-//! or crap4ts bins; without the `--skip` the unmutated baseline
-//! would panic on `CARGO_BIN_EXE_*` unset and the gate would go
-//! silently dead. See AGENTS.md "Mutation testing" → "Why
+//! Test fns are named `envelope` and `envelope_multi_language_parity`
+//! so the `--skip envelope` substring token in `.cargo/mutants.toml`
+//! covers BOTH under `--package crap-core` (substring match — both
+//! names contain `envelope`). That scoped mutants run does not build
+//! the crap4rs or crap4ts bins; without the `--skip` the unmutated
+//! baseline would panic on `CARGO_BIN_EXE_*` unset and the gate would
+//! go silently dead. See AGENTS.md "Mutation testing" → "Why
 //! `additional_cargo_test_args` …" for the full rationale.
 
 use std::collections::BTreeSet;
@@ -200,6 +201,25 @@ fn key_set(value: &Value) -> BTreeSet<String> {
         .collect()
 }
 
+/// Combined key-set + value-shape conformance check, factored so the
+/// single-language `envelope()` test and the multi-language
+/// `envelope_multi_language_parity()` test share one assertion body.
+///
+/// `expected_keys` is `GREEN_KEYS` or `RED_KEYS` per the row's
+/// expected branch (caller passes the slice based on the threshold it
+/// invoked the adapter with). `adapter` is the human-readable label
+/// embedded in panic messages so a failure tells reviewers which side
+/// drifted (`crap4rs (green)`, `crap4ts (multi-red)`, etc.).
+fn assert_row_shape_conforms(row: &Value, expected_keys: &[&str], adapter: &str) {
+    let expected: BTreeSet<String> = expected_keys.iter().map(|s| (*s).to_string()).collect();
+    let actual = key_set(row);
+    assert_eq!(
+        actual, expected,
+        "{adapter}: Row key set drifted from contract: {row}"
+    );
+    assert_value_shape(row, adapter);
+}
+
 /// Stable-string-or-integer shape assertions both adapters' Rows
 /// must satisfy. Anything that varies by analyzed source (delta
 /// counts, failure detail text) is intentionally not asserted —
@@ -273,17 +293,8 @@ fn envelope() {
     let rs_green = run_crap4rs_row(green_threshold);
     let ts_green = run_crap4ts_row(green_threshold);
 
-    let expected_green: BTreeSet<String> = GREEN_KEYS.iter().map(|s| (*s).to_string()).collect();
-    assert_eq!(
-        key_set(&rs_green),
-        expected_green,
-        "crap4rs Green Row key set drifted from contract: {rs_green}"
-    );
-    assert_eq!(
-        key_set(&ts_green),
-        expected_green,
-        "crap4ts Green Row key set drifted from contract: {ts_green}"
-    );
+    assert_row_shape_conforms(&rs_green, GREEN_KEYS, "crap4rs (green)");
+    assert_row_shape_conforms(&ts_green, GREEN_KEYS, "crap4ts (green)");
     assert_eq!(
         key_set(&rs_green),
         key_set(&ts_green),
@@ -301,8 +312,6 @@ fn envelope() {
         Some("Green"),
         "crap4ts at threshold {green_threshold} must report Green status"
     );
-    assert_value_shape(&rs_green, "crap4rs (green)");
-    assert_value_shape(&ts_green, "crap4ts (green)");
 
     // Red branch: low threshold forces violations on both adapters.
     // Asserts the key set expands with `failure_detail_md` for both
@@ -313,17 +322,8 @@ fn envelope() {
     let rs_red = run_crap4rs_row(red_threshold);
     let ts_red = run_crap4ts_row(red_threshold);
 
-    let expected_red: BTreeSet<String> = RED_KEYS.iter().map(|s| (*s).to_string()).collect();
-    assert_eq!(
-        key_set(&rs_red),
-        expected_red,
-        "crap4rs Red Row key set drifted from contract: {rs_red}"
-    );
-    assert_eq!(
-        key_set(&ts_red),
-        expected_red,
-        "crap4ts Red Row key set drifted from contract: {ts_red}"
-    );
+    assert_row_shape_conforms(&rs_red, RED_KEYS, "crap4rs (red)");
+    assert_row_shape_conforms(&ts_red, RED_KEYS, "crap4ts (red)");
     assert_eq!(
         key_set(&rs_red),
         key_set(&ts_red),
@@ -345,6 +345,45 @@ fn envelope() {
             .is_some_and(|s| s.contains("over CRAP threshold")),
         "crap4ts Red failure_detail_md must reference threshold overrun: {ts_red}"
     );
-    assert_value_shape(&rs_red, "crap4rs (red)");
-    assert_value_shape(&ts_red, "crap4ts (red)");
+}
+
+/// Multi-language scorecard-row parity canary (PR β #293).
+///
+/// The composite scorecard action's multi-language mode runs BOTH
+/// adapters in a single invocation (`languages: rust,typescript`) and
+/// emits the per-language rows on split outputs (`row-json-rust` +
+/// `row-json-typescript`). This test simulates that path at the test
+/// layer — run both bins back-to-back at the same threshold, assert
+/// each row INDEPENDENTLY conforms to the locked `Row::CrapDelta`
+/// schema. Same parity contract as `fn envelope()` but exercises the
+/// dual-emission code path the action's per-language loop drives.
+///
+/// Why this is more than a `fn envelope()` rerun: the action ships
+/// each adapter's row out a DIFFERENT named output. A downstream
+/// aggregator parses `row-json-rust` and `row-json-typescript` with
+/// the SAME jq predicate. If a future refactor introduces a
+/// per-language post-processing step (e.g. injects a `language` field
+/// only on the Rust row), the existing `fn envelope()` catches the
+/// key-set divergence between adapters — but `fn envelope_multi_language_parity()`
+/// is the test whose name names the shape that breaks, making
+/// regressions self-documenting in the failure output.
+#[test]
+fn envelope_multi_language_parity() {
+    // Green: above-threshold for both. Each row independently
+    // conforms; no cross-adapter assertion here (that's `fn envelope()`'s
+    // job) — the contract this test locks is per-output independence.
+    let green_threshold = "1000";
+    let rs_green = run_crap4rs_row(green_threshold);
+    let ts_green = run_crap4ts_row(green_threshold);
+    assert_row_shape_conforms(&rs_green, GREEN_KEYS, "crap4rs (multi-green)");
+    assert_row_shape_conforms(&ts_green, GREEN_KEYS, "crap4ts (multi-green)");
+
+    // Red: both adapters cross the threshold; both rows carry
+    // `failure_detail_md`. Same dual-emission invariant — each row
+    // shaped independently.
+    let red_threshold = "1";
+    let rs_red = run_crap4rs_row(red_threshold);
+    let ts_red = run_crap4ts_row(red_threshold);
+    assert_row_shape_conforms(&rs_red, RED_KEYS, "crap4rs (multi-red)");
+    assert_row_shape_conforms(&ts_red, RED_KEYS, "crap4ts (multi-red)");
 }


### PR DESCRIPTION
## Summary

- Wires the composite scorecard action's multi-language single-CI path. `languages: rust,typescript` (or `languages: all`) now triggers paired execution of both adapters in one action invocation, with split per-language outputs and an AND/SUM aggregation contract.
- Combined-markdown sticky comment: one sticky comment with both scorecards stacked under per-language H3 section headers (`### Rust (crap4rs)` + `### TypeScript (crap4ts)`) under an outer `## CRAP scorecard` H2 wrapper. Single-language back-compat: raw adapter markdown unchanged, no wrapper.
- Extends `crates/crap-core/tests/scorecard_row_parity.rs` with `fn envelope_multi_language_parity()` so the split-output contract is locked at the test layer; factored shared assertion body into `assert_row_shape_conforms` helper between `envelope()` and the new test.

## What ships

| File | Change | Rationale |
|---|---|---|
| `.github/actions/scorecard/action.yml` | +545/−155 LOC | 3 paired inputs (`coverage-ts` / `src-ts` / `baseline-ts`); 2 split outputs (`row-json-rust` / `row-json-typescript`); `Resolve presets` languages parser extended end-to-end (whitespace, dedup with warning, canonical ordering, paired-input validation); `Resolve language` short-circuits to `multi` sentinel; install steps widen for both adapters; `Run analysis` refactored into per-language loop with AND/SUM aggregation + multi-language markdown wrapper with deepest-first 3-level header demotion; `Emit inline annotations` extended into per-language loop |
| `crates/crap-core/tests/scorecard_row_parity.rs` | +56/−54 LOC | `fn envelope_multi_language_parity()` added; shared `assert_row_shape_conforms` helper factored from `envelope()`; `// Mutants gate interaction` doc updated noting both fn names match `--skip envelope` substring |
| `.github/workflows/ci.yml` | +331 LOC | New `scorecard-smoke-multi-lang` job exercises the 8-spot-check matrix (parsing edge cases + back-compat). Stages both PR-built binaries onto PATH; reuses the existing TS Istanbul fixture template from `scorecard-smoke-ts` |
| `.github/actions/scorecard/README.md` | +116/−4 LOC | New `## Multi-language` section between `## Presets` and `## Minimal usage` documenting paired inputs, split outputs, aggregation semantics (AND for passed flags / SUM for counts), parsing edge cases, single-sticky behavior. Inputs + Outputs tables expanded with the new entries |

## Acceptance gates verified

- [x] `cargo build --workspace` passes
- [x] `cargo nextest run --workspace --all-targets` — 1137/1137 tests green; new `envelope_multi_language_parity` test green; all existing tests including the wire-envelope canaries green
- [x] `cargo fmt --check && cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo +1.93 check --workspace --all-targets` clean (MSRV gate)
- [x] `cargo deny check` — advisories ok, bans ok, licenses ok, sources ok (no new deps)
- [x] `cargo doc --workspace --no-deps` (RUSTDOCFLAGS=-D warnings) clean
- [x] AST-purity grep on `crates/crap-core/src/` clean (no syn / oxc / lcov imports)
- [x] Wire snapshots byte-identical (no diff under `crates/crap-core/tests/snapshots/`; envelope shape unchanged — additive split outputs land alongside `row-json`)
- [ ] CI matrix green on linux-x86 + macos-arm + macos-x86 — pending CI run

Additional locally-run gates:

- [x] zizmor (`pipx run 'zizmor>=1.5,<2' .github/`) clean — "No findings to report. Good job!"
- [x] actionlint + shellcheck on every `run:` block in `ci.yml` clean
- [x] `scripts/mutants-skip-lint.py` ok (3 `--skip` token(s) cover all adapter-bin shelling tests including the new parity test)
- [x] `scripts/bdd-tracked-lint.py` ok (246 deferred scenarios, 384 scanned)
- [x] Presets-step bash logic verified against 10 scenarios via local replica: single-language rust/typescript, multi-language explicit + `all` + whitespace + reverse-order, dedup, missing-pair error, garbage error, empty

## Wire-snapshot canary discipline

Byte-identical (additive split outputs; envelope shape unchanged). PR declares **no drift** — the JSON envelope each adapter emits is unchanged, and the split per-language outputs land alongside `row-json` without modifying its serialization. `git diff crates/crap-core/tests/snapshots/` empty.

## Parsing edge cases

The 8 spot checks in the new `scorecard-smoke-multi-lang` job mechanically lock the parsing contract:

| # | Input | Expected behavior |
|---|---|---|
| 1 | `languages: rust` | Single-language back-compat; legacy `row-json` populated; `row-json-rust` populated; `row-json-typescript` empty; no outer `## CRAP scorecard` wrapper |
| 2 | `languages: typescript` | Single-language back-compat (mirror of #1) |
| 3 | `languages: rust,typescript` + both coverage inputs | Multi-language executes; `row-json` empty + `::warning::`; both split outputs populated; markdown carries outer wrapper + per-language section headers |
| 4 | `languages: all` | Convenience expansion; behaves identically to #3 |
| 5 | `languages: 'rust, typescript'` (whitespace) | Whitespace tolerated; behaves identically to #3 |
| 6 | `languages: rust,rust` | Dedup collapses to single-language `rust` + workflow warning surfaces the input typo |
| 7 | `languages: rust,typescript` WITHOUT `coverage-ts:` | Pre-execution validator errors with actionable message naming the missing input(s) |
| 8 | `languages: garbage` | Parser errors with actionable message naming the offending token |

## Plan deviations

Documented per the orchestrator's "surface plan deviations" protocol:

1. **3-level header demotion** (not 1-level). The shape doc § Open Q 4 locked the outer `## CRAP scorecard / ### Rust (crap4rs)` wrapper but the adapter markdown starts with `# <bin> v<v> — CRAP Score Analysis` (H1), not just H2. To keep the hierarchy consistent, the loop sed-demotes adapter headers by 3 levels (H1→H4, H2→H5, H3→H6) in **deepest-first order** (otherwise `s/^# /#### /` would mangle `## Summary` into `#### # Summary`). Single-language emits raw adapter markdown unchanged (back-compat).

2. **`language=multi` sentinel** (vs the plan's "no-op pass-through"). `Resolve language` emits the string `multi` in multi-language mode, and downstream `if:` conditionals on `Run analysis` / `Emit inline annotations` / `Post sticky PR comment` / `Enforce gates` widen to also match `multi`. Cleaner than an empty string (which would break the `if:` switches) and keeps the existing single-language path verbatim.

3. **`cargo build --release --package crap4rs --package crap4ts`** for the multi-language smoke (vs the plan's implied combined `--bin`). The `crap4ts` bin lives in the crap4ts package, not the crap4rs package — `--bin crap4ts --package crap4rs` errors. Discovered during local build; the smoke step's run-line invokes both packages.

4. **Per-language inline annotations loop** (plan was silent on the annotations step). Extended the loop pattern from `Run analysis`; each language gets its own annotation step. GH's 10-warning-per-step cap applies per-language so multi-language gets 2× effective annotation budget.

5. **`baseline-ts` independently optional** (plan implied a paired requirement). A multi-language run can have a Rust baseline + TS analysis-only (or vice-versa, or no baseline on either side). The pre-execution validator only requires `coverage-ts` + `src-ts` in multi-language mode; `baseline-ts` is empty-default like the rest of the empty-default-convention inputs. Documented in the input description + the README "Paired inputs" subsection.

6. **`comment-header` collision behavior**: pinned consumers flipping `languages:` from single-language to multi-language continue to post under the SAME existing sticky header (one comment, more content — both languages stacked). No second sticky is created. Aligns with shape doc intra_shape_lock #3 ("SINGLE comment, both scorecards stacked").

## What's untested locally (validated in CI)

The per-language loop body in `Run analysis + render scorecard` is exercised end-to-end first time by the 8 spot checks in `scorecard-smoke-multi-lang`. The presets parser was verified against 10 scenarios locally (bash replica); the loop's per-language envelope/markdown/row capture + AND/SUM aggregation runs in CI. This is acceptable — the spot checks ARE the validation surface — but called out so reviewers know the loop body lacks local proof.

## Extension point for PR γ (#294)

PR β's acceptance gate #9 asked to confirm the loop leaves a clean extension point for PR γ's HTML wiring. The natural insertion is inside the per-`lang` case in `Run analysis + render scorecard` right after `"$BIN" "${common[@]}" --format markdown --no-fail > "$markdown_file"`:

```bash
if [ "$HTML_REPORT" = "true" ]; then
  html_file="$RUNNER_TEMP/${BIN}-report.html"
  "$BIN" "${common[@]}" --format html --no-fail > "$html_file"
  echo "html_path_${lang}=$html_file" >> "$GITHUB_OUTPUT"
fi
```

The per-language `actions/upload-artifact` steps that PR γ adds plug in after the loop, keyed on `html_path_rust` / `html_path_typescript`. No structural changes to the loop are needed.

## Test plan

- [ ] CI matrix green on linux-x86 + macos-arm + macos-x86 for `test`, `clippy`, `coverage`, `msrv`, `deny`, `docs`, `zizmor`, `bdd-tracked-lint`, `mutants-skip-lint`
- [ ] `scorecard-smoke-rust` green — preset spot checks (strict/default/lenient/conflict/no-conflict) + main dogfood still pass under the action.yml refactor
- [ ] `scorecard-smoke-ts` green — TS dispatch through the refactored loop still produces populated outputs
- [ ] `scorecard-smoke-multi-lang` green — all 8 spot checks pass; multi-language sticky posts ONE comment with both stacked scorecards
- [ ] `mutants` job (per-PR `view.rs` leg) green; new `envelope_multi_language_parity` test name covered by the existing `--skip envelope` token
- [ ] gemini-code-assist review surfaces no public-API surface concerns; orchestrator addresses any finding via fix-PR with finding→fix comment mapping per `feedback_post_pr_comment_addressing_bot_review`
- [ ] CodeRabbit review surfaces no bash-strictness / supply-chain concerns
- [ ] On merge: verify #293 auto-closed via the `Closes #293` keyword

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-language workflow support to analyze Rust and TypeScript projects in a single run.
  * New TypeScript-specific inputs (`coverage-ts`, `src-ts`, `baseline-ts`) for multi-language configurations.
  * New language-specific JSON outputs (`row-json-rust`, `row-json-typescript`) for split results.

* **Documentation**
  * Updated action documentation with multi-language mode guidance, output contracts, and aggregation semantics.

* **Tests**
  * Added smoke tests for multi-language workflow dispatch and output validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/breezy-bays-labs/crap-rs/pull/302?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->