### PR TITLE
docs: replace dangling release.yml/publish.yml references with release-plz.yml

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -22,11 +22,12 @@ inputs:
     default: "true"
   enable-cache:
     description: >-
-      When "false", skip the Swatinem/rust-cache step entirely. Tag-triggered
-      workflows (publish.yml, release.yml) set this to "false" to close the
-      cache-poisoning audit — they should neither READ caches that may have
-      been poisoned by a malicious tag push nor SAVE caches keyed to a tag.
-      Defaults to "true" so PR + main-branch CI keeps using the cache.
+      When "false", skip the Swatinem/rust-cache step entirely. Release-relevant
+      workflows (release-plz.yml — both the release-plz jobs and the downstream
+      build/publish matrices) set this to "false" to close the cache-poisoning
+      audit: a release run must neither READ caches that may have been poisoned
+      nor SAVE caches that subsequent release runs could restore. Defaults to
+      "true" so PR + main-branch CI keeps using the cache.
       See https://docs.zizmor.sh/audits/#cache-poisoning.
     required: false
     default: "true"
@@ -77,10 +78,11 @@ runs:
         targets: ${{ inputs.targets }}
 
     - name: Cache cargo registry + target
-      # `enable-cache: false` skips this step entirely. Tag-triggered
-      # workflows (publish.yml, release.yml) pass that to close the
+      # `enable-cache: false` skips this step entirely. Release-relevant
+      # workflows (release-plz.yml) pass that to close the
       # `cache-poisoning` zizmor audit — a release run must neither
-      # restore a poisoned cache nor save a tag-keyed cache. See
+      # restore a poisoned cache nor save a cache that subsequent
+      # release runs could restore. See
       # https://docs.zizmor.sh/audits/#cache-poisoning.
       if: inputs.enable-cache != 'false'
       uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,7 +198,7 @@ commit SHA isn't).
 
 7. **`persist-credentials: false` on every `actions/checkout`.**
    Workflows that never push (every job in this repo's `ci.yml` +
-   `publish.yml/build` + `release.yml/build`) keep the GH App
+   the build/publish jobs in `release-plz.yml`) keep the GH App
    checkout token out of the runner's `.git/config`. Already wired
    on every checkout repo-wide; the `artipacked` audit fails any
    new checkout that omits it.
@@ -206,24 +206,25 @@ commit SHA isn't).
 8. **Scoped per-job `permissions:` blocks (least privilege).** Each
    workflow declares a top-level `permissions: contents: read`
    default; jobs that need more elevate explicitly (e.g.
-   `release.yml/release` needs `contents: write` for
-   `gh release create`; `ci.yml/scorecard-smoke` needs
-   `pull-requests: write` for the sticky-comment dogfood). Never let
-   a job inherit the runner's default workflow permissions silently;
+   `release-plz.yml/release-plz-release` needs `contents: write` +
+   `id-token: write` for the OIDC publish path; `ci.yml/scorecard-smoke`
+   needs `pull-requests: write` for the sticky-comment dogfood). Never
+   let a job inherit the runner's default workflow permissions silently;
    the `excessive-permissions` audit fails any job missing a
    `permissions:` block.
 
-9. **Cache-poisoning fix shape for tag-triggered workflows.**
-   Workflows that trigger only on `push: tags` (`release.yml`,
-   `publish.yml`) must neither restore nor save caches: a poisoned
-   cache from a malicious tag push would otherwise become part of
-   the published artifact. The pattern: the `setup-rust` composite
-   action accepts `enable-cache: "false"` which skips its embedded
-   `Swatinem/rust-cache` step via `if:`. Tag-triggered callers pass
-   that input. `actions/setup-node` is opted-out by simply omitting
-   the `cache:` input (which would otherwise enable caching), and
-   carries an inline `# zizmor: ignore[cache-poisoning]` because
-   zizmor's heuristic flags setup-node defensively. See
+9. **Cache-poisoning fix shape for release-relevant workflows.**
+   Workflows whose downstream jobs publish to crates.io / npm or
+   upload signed binaries (every job in `release-plz.yml`) must
+   neither restore nor save caches: a poisoned cache from a malicious
+   push would otherwise become part of the published artifact.
+   The pattern: the `setup-rust` composite action accepts
+   `enable-cache: "false"` which skips its embedded `Swatinem/rust-cache`
+   step via `if:`. Release-relevant callers pass that input.
+   `actions/setup-node` is opted-out by simply omitting the `cache:`
+   input (which would otherwise enable caching), and carries an inline
+   `# zizmor: ignore[cache-poisoning]` because zizmor's heuristic
+   flags setup-node defensively. See
    https://docs.zizmor.sh/audits/#cache-poisoning.
 
 10. **Prefer the `gh` CLI to a third-party release action.** GitHub

--- a/release-checklist.md
+++ b/release-checklist.md
@@ -1,5 +1,21 @@
 # Release Checklist
 
+> **Status (post-#270): this document is the pre-release-plz manual
+> ceremony, preserved as historical reference for the v0.5.0 cut and
+> earlier. The canonical forward-looking flow is `release-plz.yml`,
+> which automates conventional-commit-driven version bumps, per-crate
+> CHANGELOG updates, crates.io publish via OIDC, tag creation on the
+> merge commit, and downstream binary/npm publish. The new release-PR
+> review checklist (including the `scripts/sync-crap4ts-package-json.sh`
+> step) lives in the PR body of the auto-opened release PR. The
+> canonical ops-wide rewrite is tracked at
+> [ops#340](https://github.com/breezy-bays-labs/ops/issues/340).**
+>
+> The historical sections below remain accurate for the manual flow
+> they describe; references to `release.yml` and `publish.yml` reflect
+> that flow's workflow names, both of which were removed in the
+> release-plz adoption PR.
+
 Operational steps for cutting a `crap4rs` / `crap-core` release from this
 workspace. The checklist encodes two load-bearing rules that surfaced
 during prior cuts:


### PR DESCRIPTION
## Summary

Fast-follow on #270 (release-plz adoption). #270 deletes `release.yml` and `publish.yml` and unifies both into `release-plz.yml`; that PR's "Files touched" table is intentionally scope-tight, leaving surviving references in non-touched files. This chore updates them so docs and inline comments stay accurate.

## What changed

- **`AGENTS.md`** §Supply-chain hygiene rules 7, 8, 9 — rewrite the job examples to the post-#270 workflow names; rule 9 reframed from "tag-triggered" to "release-relevant" since release-plz creates tags itself rather than reacting to manual `git push <tag>`.
- **`.github/actions/setup-rust/action.yml`** — rewrite the `enable-cache:` guidance (both the input description and the inline step comment) so the cache-poisoning posture references `release-plz.yml` rather than the deleted tag-triggered workflows.
- **`crates/crap4rs/Cargo.toml`** — fix the `[package.metadata.binstall]` comment that referenced `release.yml`'s tar invocation.
- **`release-checklist.md`** — add a deprecation banner at the top pointing at `release-plz.yml` as the canonical flow. The historical manual ceremony is preserved verbatim because it documents how v0.5.0 actually shipped; the forward-looking ops-wide rewrite is tracked at [ops#340](https://github.com/breezy-bays-labs/ops/issues/340).

## Out of scope

- No workflow logic changes; `release-plz.yml` itself is untouched.
- No `CHANGELOG.md` revision — historical entries describe what existed at the time of each release.
- No release-checklist.md rewrite — the canonical post-release-plz checklist lives in ops#340 (org-wide standard) and in the PR body of each auto-opened release PR.

## Test plan

- [ ] CI green (fmt / clippy / nextest / zizmor)
- [ ] `rg 'release\.yml|publish\.yml' --type-add 'docs:*.{md,yml,yaml,toml}' -t docs` returns only intentional historical references (in `CHANGELOG.md` and inside `release-checklist.md`'s preserved historical sections)

🤖 Generated with [Claude Code](https://claude.com/claude-code)