### PR TITLE
fix(ci): wire GITHUB_TOKEN env into release-plz/action steps

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -68,6 +68,15 @@ jobs:
       - uses: release-plz/action@064f4d1e36c843611ddf013be726beaa4ad804db # v0.5
         with:
           command: release-pr
+        env:
+          # The action's git-config substep reads GITHUB_TOKEN to query
+          # the GraphQL viewer endpoint and configure the commit author
+          # identity for the auto-opened release PR. The workflow-level
+          # default `permissions: contents: read` plus this job's
+          # contents:write + pull-requests:write grant are what the
+          # short-lived token carries; the env passthrough is the
+          # plumbing release-plz's sub-action expects.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   release-plz-release:
     name: Publish + tag
@@ -91,6 +100,8 @@ jobs:
 
       - id: release-plz
         uses: release-plz/action@064f4d1e36c843611ddf013be726beaa4ad804db # v0.5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           command: release
           # CARGO_REGISTRY_TOKEN is intentionally absent: with


### PR DESCRIPTION
## Summary

First release-plz workflow run after #270 merged [exited at the `git-config` substep](https://github.com/breezy-bays-labs/crap-rs/actions/runs/26372050439) with:

```
Error: environment variable GITHUB_TOKEN is undefined
```

The `release-plz/action` sub-action calls the GraphQL viewer endpoint to derive the commit-author identity for the auto-opened release PR, and it reads `GITHUB_TOKEN` directly from the process env — it does NOT auto-pick it up from the job's `permissions:` grant. This is the standard release-plz quickstart shape that the original port from the plan missed.

## Fix

Add `env: GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` to both `release-plz/action` invocations:

- `release-plz-pr` job — opens/updates the release PR
- `release-plz-release` job — publishes + tags after the release PR merges

The workflow's existing per-job permissions remain the security boundary (`contents:write` + `pull-requests:write` on the PR job; `contents:write` + `id-token:write` + `pull-requests:read` on the release job). The env passthrough is just the plumbing release-plz's sub-action expects.

## Verification

- YAML re-parses (`yq eval`)
- No logic changes; no pin changes
- The next `push:main` (this PR's merge, or any subsequent merge) will trigger release-plz again with the token wired

## Notes

This blocks the first auto-opened release PR from appearing. Once this lands, the OOB trusted-publisher setup on crates.io can be completed and the first real release can be opened by release-plz on the next push to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)