### PR TITLE
docs: add per-crate READMEs for crates.io display

### DIFF
--- a/crates/crap-core/Cargo.toml
+++ b/crates/crap-core/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 description = "Language-agnostic foundation for the CRAP analyzer family — domain types, port traits, and shared invariants for crap4rs / future crap4ts."
 keywords = ["crap", "complexity", "coverage", "testing", "quality"]
 categories = ["development-tools::testing"]
+readme = "README.md"
 
 [lib]
 name = "crap_core"

--- a/crates/crap-core/README.md
+++ b/crates/crap-core/README.md
@@ -4,24 +4,30 @@
 [![docs.rs](https://img.shields.io/docsrs/crap-core)](https://docs.rs/crap-core)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](https://github.com/breezy-bays-labs/crap-rs#license)
 
-Language-agnostic foundation for the CRAP (Change Risk Anti-Patterns) analyzer family. Domain types, port traits, threshold/risk logic, reporters, and the shared scorecard envelope used by every CRAP adapter.
+**Language-agnostic foundation for the CRAP (Change Risk Anti-Patterns) analyzer family.** Domain types, port traits, threshold and risk logic, reporters, and the shared scorecard envelope used by every CRAP adapter.
 
 ## What this is
 
-`crap-core` is the shared backbone for analyzers that compute CRAP scores — `complexity² × (1 − coverage)³ + complexity` — across different source languages. It owns:
+`crap-core` is the shared backbone for analyzers that compute CRAP scores —
 
-- The CRAP formula and risk-tier classification (Low / Acceptable / Moderate / High)
-- The `ComplexityPort` and `CoveragePort` traits that language adapters implement
-- The wire envelope (`scorecard`, `delta`, `crap-delta` shapes) consumed by reporters and downstream tooling
-- All reporters (`json`, `markdown`, `table`, `csv`, `sarif`, `scorecard`, `scorecard-row`, `github-annotations`)
-- Threshold presets, configuration parsing, and delta-gate semantics
+```
+CRAP(complexity, coverage) = complexity² × (1 − coverage)³ + complexity
+```
 
-If you're using `crap-core` directly, you're probably building a new language adapter. Most users want one of the adapter crates instead:
+— across different source languages. It owns:
 
-- **[`crap4rs`](https://crates.io/crates/crap4rs)** — Rust analyzer (syn-based complexity + LCOV coverage)
-- **[`crap4ts`](https://crates.io/crates/crap4ts)** — TypeScript / JavaScript analyzer (oxc-based complexity + Istanbul JSON coverage)
+- The **CRAP formula** and four-tier **risk classification** (Low / Acceptable / Moderate / High)
+- The **`ComplexityPort` and `CoveragePort`** traits that language adapters implement
+- The locked **wire envelope** (`scorecard`, `delta`, `crap-delta` shapes) consumed by reporters and downstream tooling
+- **All reporters** — `table`, `markdown`, `json`, `csv`, `sarif`, `scorecard`, `scorecard-row`, `github-annotations`. HTML is on the roadmap
+- **Threshold presets** (`strict` / default / `lenient`), configuration parsing, and delta-gate semantics
 
-Both link `crap-core` and produce byte-identical scorecard envelopes for the same `(complexity, coverage)` inputs — so cross-language CI gates and reports stay consistent.
+If you're using `crap-core` directly, you're probably building a new language adapter. End users want one of the adapter crates instead:
+
+- **[`crap4rs`](https://crates.io/crates/crap4rs)** — Rust analyzer (`syn` complexity + LCOV coverage; cognitive complexity default)
+- **[`crap4ts`](https://crates.io/crates/crap4ts)** — TypeScript / JavaScript analyzer (`oxc` complexity + Istanbul JSON coverage; cyclomatic complexity)
+
+Both link `crap-core` and produce byte-identical scorecard envelopes for the same `(complexity, coverage)` inputs — Rust and TypeScript CI gates stay consistent.
 
 ## Install
 
@@ -41,14 +47,117 @@ assert_eq!(format!("{:.2}", score), "15.23");
 
 For the port traits and how adapters wire complexity + coverage data into a `Scorecard`, see the [API docs on docs.rs](https://docs.rs/crap-core).
 
+## Threshold presets and risk tiers
+
+`crap-core` defines four risk tiers and three preset gates calibrated against them. Every adapter inherits this taxonomy automatically.
+
+| CRAP score | Risk tier |
+|---|---|
+| ≤ 8 | Low |
+| ≤ 15 | Acceptable |
+| ≤ 25 | Moderate |
+| > 25 | High |
+
+| Preset | Threshold | Gates at | Use for |
+|---|---|---|---|
+| `--strict` | CRAP ≤ 8 | Low → Acceptable | safety-critical, high-quality libraries |
+| *(default)* | CRAP ≤ 15 | Acceptable → Moderate | typical app / library code |
+| `--lenient` | CRAP ≤ 25 | Moderate → High | legacy / transitional codebases |
+
+The same preset values apply for both cognitive and cyclomatic complexity inputs (adapters choose which metric they pass into the formula).
+
+## What the output looks like
+
+Every reporter consumes the same `AnalysisView` projection over the scored functions. Adapters never re-render shapes themselves — they hand `crap-core` the data and pick a `--format`.
+
+### Table — TTY default
+
+```
+crap4rs v0.5.0 — CRAP Score Analysis
+
++------------------------------------+----------------------------------+----+-------+-------+----------+
+| File                               | Function                         | CC | Cov%  | CRAP  | Risk     |
++========================================================================================================+
+| adapters/reporters/table.rs        | inject_breakdown_subrows         | 13 | 100.0 | 13.00 | moderate |
+| domain/summary.rs                  | compute_summary                  | 13 | 100.0 | 13.00 | moderate |
+| adapters/reporters/markdown.rs     | format_markdown_delta            | 12 |  97.1 | 12.00 | moderate |
++------------------------------------+----------------------------------+----+-------+-------+----------+
+```
+
+### JSON — programmatic / cross-tool
+
+```json
+{
+  "schema_version": 2,
+  "run_meta": { "tool": "crap4rs", "version": "0.5.0", "metric": "cognitive" },
+  "result": {
+    "summary": {
+      "total_functions": 988,
+      "exceeding_threshold": 0,
+      "distribution": { "low": 951, "acceptable": 22, "moderate": 15, "high": 0 },
+      "max_crap": { "value": 13.0, "risk_level": "moderate" }
+    },
+    "functions": [
+      {
+        "scored": {
+          "identity": { "file_path": "src/lib.rs", "qualified_name": "process_request", "span": { "start_line": 42, "end_line": 87 } },
+          "complexity": 11,
+          "complexity_metric": "cognitive",
+          "coverage_percent": 42.3,
+          "crap": { "value": 28.42, "risk_level": "high" }
+        },
+        "threshold": 15.0,
+        "exceeds": true
+      }
+    ]
+  }
+}
+```
+
+The envelope shape is locked across patch releases of the adapter that emits it — downstream consumers can pin against a `schema_version`.
+
+### GitHub Actions inline annotations
+
+```
+::warning file=src/lib.rs,line=42,title=CRAP 28.4::Function `process_request` has CRAP 28.42 (complexity=11, coverage=42.3%) which exceeds threshold 15.0
+```
+
+Renders as an inline annotation on the PR Files Changed tab — no GitHub Advanced Security / Code Scanning license required.
+
+### Markdown — PR-comment ready
+
+```markdown
+# crap4rs v0.5.0 — CRAP Score Analysis
+
+**Result:** PASS · **Functions:** 988 · **Above threshold (15):** 0
+
+| Metric     | Worst | Average | Median |
+|------------|------:|--------:|-------:|
+| CRAP       | 13.00 |    1.62 |   1.00 |
+| Complexity |    13 |     1.6 |    1.0 |
+| Coverage   |  0.0% |   98.3% | 100.0% |
+
+**Risk distribution:** low 951 · acceptable 22 · moderate 15 · high 0
+```
+
+### HTML report
+
+Interactive, sortable HTML report with per-function contributor drill-down. **Coming in a future release** — open an issue if you want early-access interest tracked.
+
+### Other formats
+
+`csv`, `sarif` (Code Scanning surface), `scorecard` (single-row CI gate), `scorecard-row` (cross-adapter parity-locked CI row).
+
+Multiple formats compose in one pass: `--format json:envelope.json,markdown:report.md` writes both from a single analysis.
+
 ## Stability
 
-`crap-core` is at `0.x` and follows pre-1.0 semver: breaking changes can land on minor bumps. Adapter crates pin against a specific minor version. The wire envelope schema is locked once published — patch releases never change envelope shape; minor releases may add fields under `#[serde(default)]`.
+`crap-core` is at `0.x` and follows pre-1.0 semver — breaking changes can land on minor bumps; adapter crates pin against a specific minor. The wire envelope schema is locked once published — patch releases never change envelope shape; minor releases may add fields under `#[serde(default)]`.
 
 ## See also
 
 - **Repository**: [github.com/breezy-bays-labs/crap-rs](https://github.com/breezy-bays-labs/crap-rs)
-- **Project README**: [workspace overview](https://github.com/breezy-bays-labs/crap-rs#readme) — explains CRAP scoring, risk tiers, and threshold presets
+- **Project README**: [workspace overview](https://github.com/breezy-bays-labs/crap-rs#readme)
 - **Issues**: [github.com/breezy-bays-labs/crap-rs/issues](https://github.com/breezy-bays-labs/crap-rs/issues)
 
 ## License

--- a/crates/crap-core/README.md
+++ b/crates/crap-core/README.md
@@ -1,0 +1,56 @@
+# crap-core
+
+[![crates.io](https://img.shields.io/crates/v/crap-core.svg)](https://crates.io/crates/crap-core)
+[![docs.rs](https://img.shields.io/docsrs/crap-core)](https://docs.rs/crap-core)
+[![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](https://github.com/breezy-bays-labs/crap-rs#license)
+
+Language-agnostic foundation for the CRAP (Change Risk Anti-Patterns) analyzer family. Domain types, port traits, threshold/risk logic, reporters, and the shared scorecard envelope used by every CRAP adapter.
+
+## What this is
+
+`crap-core` is the shared backbone for analyzers that compute CRAP scores — `complexity² × (1 − coverage)³ + complexity` — across different source languages. It owns:
+
+- The CRAP formula and risk-tier classification (Low / Acceptable / Moderate / High)
+- The `ComplexityPort` and `CoveragePort` traits that language adapters implement
+- The wire envelope (`scorecard`, `delta`, `crap-delta` shapes) consumed by reporters and downstream tooling
+- All reporters (`json`, `markdown`, `table`, `csv`, `sarif`, `scorecard`, `scorecard-row`, `github-annotations`)
+- Threshold presets, configuration parsing, and delta-gate semantics
+
+If you're using `crap-core` directly, you're probably building a new language adapter. Most users want one of the adapter crates instead:
+
+- **[`crap4rs`](https://crates.io/crates/crap4rs)** — Rust analyzer (syn-based complexity + LCOV coverage)
+- **[`crap4ts`](https://crates.io/crates/crap4ts)** — TypeScript / JavaScript analyzer (oxc-based complexity + Istanbul JSON coverage)
+
+Both link `crap-core` and produce byte-identical scorecard envelopes for the same `(complexity, coverage)` inputs — so cross-language CI gates and reports stay consistent.
+
+## Install
+
+```toml
+[dependencies]
+crap-core = "0.4"
+```
+
+## Quick example
+
+```rust
+use crap_core::domain::crap::compute_crap;
+
+let score = compute_crap(15, 0.90);
+assert_eq!(format!("{:.2}", score), "15.23");
+```
+
+For the port traits and how adapters wire complexity + coverage data into a `Scorecard`, see the [API docs on docs.rs](https://docs.rs/crap-core).
+
+## Stability
+
+`crap-core` is at `0.x` and follows pre-1.0 semver: breaking changes can land on minor bumps. Adapter crates pin against a specific minor version. The wire envelope schema is locked once published — patch releases never change envelope shape; minor releases may add fields under `#[serde(default)]`.
+
+## See also
+
+- **Repository**: [github.com/breezy-bays-labs/crap-rs](https://github.com/breezy-bays-labs/crap-rs)
+- **Project README**: [workspace overview](https://github.com/breezy-bays-labs/crap-rs#readme) — explains CRAP scoring, risk tiers, and threshold presets
+- **Issues**: [github.com/breezy-bays-labs/crap-rs/issues](https://github.com/breezy-bays-labs/crap-rs/issues)
+
+## License
+
+Dual-licensed under MIT OR Apache-2.0 at your option.

--- a/crates/crap4rs/Cargo.toml
+++ b/crates/crap4rs/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 description = "CRAP score analyzer for Rust — find complex, under-tested functions"
 keywords = ["crap", "complexity", "coverage", "testing", "quality"]
 categories = ["development-tools::testing", "command-line-utilities"]
+readme = "README.md"
 
 [package.metadata.binstall]
 # The `crap4rs-v{version}` tag prefix is the per-crate tag pattern created

--- a/crates/crap4rs/README.md
+++ b/crates/crap4rs/README.md
@@ -4,17 +4,15 @@
 [![docs.rs](https://img.shields.io/docsrs/crap4rs)](https://docs.rs/crap4rs)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](https://github.com/breezy-bays-labs/crap-rs#license)
 
-CRAP (Change Risk Anti-Patterns) score analyzer for Rust. Joins [`syn`](https://crates.io/crates/syn)-driven AST complexity (cognitive by default, cyclomatic available) with [`cargo-llvm-cov`](https://github.com/taiki-e/cargo-llvm-cov) LCOV output to identify functions that are both complex and under-tested — the ones most likely to break when changed.
+**CRAP (Change Risk Anti-Patterns) score analyzer for Rust.** Find the functions in your codebase that are both complex *and* under-tested — the ones most likely to break when changed.
 
-## What you get
-
-For each function in your crate (or workspace), `crap4rs` reports complexity, coverage, and a CRAP score:
+`crap4rs` combines [`syn`](https://crates.io/crates/syn)-driven AST complexity with [`cargo-llvm-cov`](https://github.com/taiki-e/cargo-llvm-cov) LCOV output. One pass, one CI gate, one number per function.
 
 ```
 CRAP(complexity, coverage) = complexity² × (1 − coverage)³ + complexity
 ```
 
-Functions above the configured threshold fail the CI gate. Several output formats are supported — `table` (TTY default), `markdown` (PR comments), `scorecard` (CI delta gating), `github-annotations` (inline PR review annotations), `json`, `csv`, `sarif`.
+High complexity + low coverage = high CRAP = high change risk.
 
 ## Install
 
@@ -26,20 +24,139 @@ cargo binstall crap4rs
 cargo install crap4rs
 ```
 
-## Usage
+## 30-second tour
 
 ```bash
-# 1. Generate coverage with cargo-llvm-cov
-cargo llvm-cov --lcov --output-path lcov.info
-
-# 2. Analyze
-crap4rs --coverage lcov.info
-
-# 3. Or gate CI on a threshold
-crap4rs --coverage lcov.info --threshold strict
+cargo llvm-cov --lcov --output-path lcov.info     # generate coverage
+crap4rs --coverage lcov.info                       # analyze
+crap4rs --coverage lcov.info --strict              # gate CI strictly
+crap4rs --coverage lcov.info --format markdown     # PR-comment friendly
 ```
 
-Full documentation — including the threshold presets (`strict` / default / `lenient`), delta-gate behavior, baseline-comparison mode, configuration file (`crap-rs.toml`), and the GitHub Actions composite scorecard action — lives in the [workspace README](https://github.com/breezy-bays-labs/crap-rs#readme).
+## Why cognitive complexity (default)
+
+`crap4rs` defaults to **cognitive complexity**, not cyclomatic. Rust code leans heavily on `match`, nested control flow, and combinator chains — and cyclomatic complexity counts every `match` arm as +1, which inflates the score on perfectly readable Rust idioms.
+
+Cognitive complexity scores how *hard a function is to follow*, weighting by nesting depth and structural break-up rather than raw branch count. A 12-arm `match` over an enum scores 1 (one decision); a deeply nested `if let Some(_) = ... { if let Ok(_) = ... { ... } }` scores higher because the nesting hurts readers.
+
+Cyclomatic is still available — `--metric cyclomatic` — for parity with classic CRAP tooling or comparing against other complexity reporters.
+
+## Threshold presets
+
+`crap4rs` ships three preset gates calibrated against four risk tiers:
+
+| Preset | Threshold | Gates at | Use for |
+|---|---|---|---|
+| `--strict` | CRAP ≤ 8 | Low → Acceptable | safety-critical, high-quality libraries |
+| *(default)* | CRAP ≤ 15 | Acceptable → Moderate | typical app / library code |
+| `--lenient` | CRAP ≤ 25 | Moderate → High | legacy / transitional codebases |
+
+The risk tiers themselves:
+
+| CRAP score | Risk |
+|---|---|
+| ≤ 8 | Low |
+| ≤ 15 | Acceptable |
+| ≤ 25 | Moderate |
+| > 25 | High |
+
+The presets correspond to "gate at the next risk tier up." Override with `--threshold <N>` for a custom value, or define presets per-codebase in `crap4rs.toml`.
+
+## What it looks like
+
+### Table (TTY default)
+
+```
+crap4rs v0.5.0 — CRAP Score Analysis
+
++------------------------------------+----------------------------------+----+-------+-------+----------+
+| File                               | Function                         | CC | Cov%  | CRAP  | Risk     |
++========================================================================================================+
+| adapters/reporters/table.rs        | inject_breakdown_subrows         | 13 | 100.0 | 13.00 | moderate |
+| domain/summary.rs                  | compute_summary                  | 13 | 100.0 | 13.00 | moderate |
+| adapters/reporters/markdown.rs     | format_markdown_delta            | 12 |  97.1 | 12.00 | moderate |
+| core/mod.rs                        | ensure_source_files_found        |  7 |  60.9 |  9.94 | moderate |
+| domain/matching.rs                 | compute_branch_coverage          | 10 | 100.0 | 10.00 | moderate |
++------------------------------------+----------------------------------+----+-------+-------+----------+
+
+Functions: 988 · Above threshold: 0 · Worst CRAP: 13.00 · Distribution: 951 low · 22 acceptable · 15 moderate · 0 high
+```
+
+### Markdown (`--format markdown`) — PR-comment ready
+
+```markdown
+# crap4rs v0.5.0 — CRAP Score Analysis
+
+**Result:** PASS · **Functions:** 988 · **Above threshold (15):** 0
+
+| Metric     | Worst | Average | Median |
+|------------|------:|--------:|-------:|
+| CRAP       | 13.00 |    1.62 |   1.00 |
+| Complexity |    13 |     1.6 |    1.0 |
+| Coverage   |  0.0% |   98.3% | 100.0% |
+
+**Risk distribution:** low 951 · acceptable 22 · moderate 15 · high 0
+```
+
+### GitHub annotations (`--format github-annotations`) — inline PR review
+
+Drops findings as inline warnings on the PR Files Changed tab, no GHAS / Code Scanning license needed:
+
+```
+::warning file=src/lib.rs,line=42,title=CRAP 28.4::Function `process_request` has CRAP 28.42 (complexity=11, coverage=42.3%) which exceeds threshold 15.0
+```
+
+### JSON (`--format json`) — programmatic consumption
+
+```json
+{
+  "schema_version": 2,
+  "run_meta": { "tool": "crap4rs", "version": "0.5.0", "metric": "cognitive" },
+  "result": {
+    "summary": {
+      "total_functions": 988,
+      "exceeding_threshold": 0,
+      "distribution": { "low": 951, "acceptable": 22, "moderate": 15, "high": 0 },
+      "max_crap": { "value": 13.0, "risk_level": "moderate" }
+    },
+    "functions": [
+      {
+        "scored": {
+          "identity": { "file_path": "src/lib.rs", "qualified_name": "process_request", "span": { "start_line": 42, "end_line": 87 } },
+          "complexity": 11,
+          "complexity_metric": "cognitive",
+          "coverage_percent": 42.3,
+          "crap": { "value": 28.42, "risk_level": "high" },
+          "contributors": [ /* per-decision-point breakdown */ ]
+        },
+        "threshold": 15.0,
+        "exceeds": true
+      }
+    ]
+  }
+}
+```
+
+### Other formats
+
+- `--format csv` — spreadsheet ingestion
+- `--format sarif` — Code Scanning upload (requires GHAS) for surface-as-security-finding flows
+- `--format scorecard` — single-row CI gate output for cross-PR delta tracking
+- **HTML report** — interactive, sortable, with per-function contributor drill-down. *Coming in a future release; file an issue for early-access interest.*
+
+Multiple formats compose in one pass: `--format json:envelope.json,markdown:report.md` writes both files from a single analysis.
+
+## Delta gates — fail PRs that introduce new high-CRAP functions
+
+```bash
+# Generate baseline on main
+crap4rs --coverage main-lcov.info --format json > baseline.json
+
+# On PR — fail only on NEW threshold violations
+crap4rs --coverage pr-lcov.info --baseline baseline.json --delta-gate
+```
+
+A function above-threshold on main doesn't fail the PR; only functions newly introduced or newly elevated do. Lets teams ratchet quality forward without blocking every PR on pre-existing debt.
 
 ## Library use
 
@@ -52,7 +169,7 @@ crap4rs = "0.5"
 
 ## Stability
 
-`crap4rs` is at `0.x` and follows pre-1.0 semver. The scorecard wire envelope is locked once published.
+`crap4rs` is at `0.x` and follows pre-1.0 semver. The scorecard wire envelope is locked once published — patch releases never change envelope shape; minor releases may add fields under `#[serde(default)]`.
 
 ## See also
 

--- a/crates/crap4rs/README.md
+++ b/crates/crap4rs/README.md
@@ -1,0 +1,66 @@
+# crap4rs
+
+[![crates.io](https://img.shields.io/crates/v/crap4rs.svg)](https://crates.io/crates/crap4rs)
+[![docs.rs](https://img.shields.io/docsrs/crap4rs)](https://docs.rs/crap4rs)
+[![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](https://github.com/breezy-bays-labs/crap-rs#license)
+
+CRAP (Change Risk Anti-Patterns) score analyzer for Rust. Joins [`syn`](https://crates.io/crates/syn)-driven AST complexity (cognitive by default, cyclomatic available) with [`cargo-llvm-cov`](https://github.com/taiki-e/cargo-llvm-cov) LCOV output to identify functions that are both complex and under-tested — the ones most likely to break when changed.
+
+## What you get
+
+For each function in your crate (or workspace), `crap4rs` reports complexity, coverage, and a CRAP score:
+
+```
+CRAP(complexity, coverage) = complexity² × (1 − coverage)³ + complexity
+```
+
+Functions above the configured threshold fail the CI gate. Several output formats are supported — `table` (TTY default), `markdown` (PR comments), `scorecard` (CI delta gating), `github-annotations` (inline PR review annotations), `json`, `csv`, `sarif`.
+
+## Install
+
+```bash
+# Pre-built binaries (recommended)
+cargo binstall crap4rs
+
+# From source
+cargo install crap4rs
+```
+
+## Usage
+
+```bash
+# 1. Generate coverage with cargo-llvm-cov
+cargo llvm-cov --lcov --output-path lcov.info
+
+# 2. Analyze
+crap4rs --coverage lcov.info
+
+# 3. Or gate CI on a threshold
+crap4rs --coverage lcov.info --threshold strict
+```
+
+Full documentation — including the threshold presets (`strict` / default / `lenient`), delta-gate behavior, baseline-comparison mode, configuration file (`crap-rs.toml`), and the GitHub Actions composite scorecard action — lives in the [workspace README](https://github.com/breezy-bays-labs/crap-rs#readme).
+
+## Library use
+
+```toml
+[dependencies]
+crap4rs = "0.5"
+```
+
+`crap4rs` re-exports `crap-core`'s public API and adds the Rust-specific adapters (syn walker, LCOV parser). If you only need the scoring/envelope/reporter logic without Rust-specific I/O, depend on [`crap-core`](https://crates.io/crates/crap-core) directly.
+
+## Stability
+
+`crap4rs` is at `0.x` and follows pre-1.0 semver. The scorecard wire envelope is locked once published.
+
+## See also
+
+- **Repository**: [github.com/breezy-bays-labs/crap-rs](https://github.com/breezy-bays-labs/crap-rs)
+- **TypeScript / JavaScript analyzer**: [`crap4ts`](https://crates.io/crates/crap4ts) (crates.io) · [npm package](https://www.npmjs.com/package/crap4ts)
+- **Shared core library**: [`crap-core`](https://crates.io/crates/crap-core)
+- **Issues**: [github.com/breezy-bays-labs/crap-rs/issues](https://github.com/breezy-bays-labs/crap-rs/issues)
+
+## License
+
+Dual-licensed under MIT OR Apache-2.0 at your option.

--- a/crates/crap4ts/Cargo.toml
+++ b/crates/crap4ts/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 description = "TypeScript adapter for crap-rs — Rust-powered CRAP score analyzer combining oxc AST complexity with Istanbul JSON coverage"
 keywords = ["crap", "complexity", "coverage", "typescript", "quality"]
 categories = ["development-tools::testing", "command-line-utilities"]
+readme = "README.md"
 
 # Single-crate cdylib + bin (CAO A3). The cdylib artifact powers the
 # napi-rs Node.js binding; the bin artifact is the standalone CLI that

--- a/crates/crap4ts/README.md
+++ b/crates/crap4ts/README.md
@@ -1,0 +1,69 @@
+# crap4ts
+
+[![crates.io](https://img.shields.io/crates/v/crap4ts.svg)](https://crates.io/crates/crap4ts)
+[![npm](https://img.shields.io/npm/v/crap4ts.svg)](https://www.npmjs.com/package/crap4ts)
+[![docs.rs](https://img.shields.io/docsrs/crap4ts)](https://docs.rs/crap4ts)
+[![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](https://github.com/breezy-bays-labs/crap-rs#license)
+
+Rust-powered CRAP (Change Risk Anti-Patterns) score analyzer for TypeScript and JavaScript. Joins [oxc](https://oxc.rs/)-driven AST complexity with [Istanbul](https://istanbul.js.org/) JSON coverage to identify functions that are both complex and under-tested.
+
+> **JavaScript / Node consumers**: install [`crap4ts` from npm](https://www.npmjs.com/package/crap4ts) — that package ships pre-built Node addons for every supported platform. Its [npm README](https://github.com/breezy-bays-labs/crap-rs/blob/main/packages/crap4ts/README.md) covers Node-side usage.
+>
+> **This crates.io page** documents the Rust crate: the standalone CLI binary and the `cdylib` artifact that backs the npm package.
+
+## Install (CLI)
+
+```bash
+cargo binstall crap4ts
+# or from source
+cargo install crap4ts
+```
+
+## Usage
+
+```bash
+# 1. Generate Istanbul JSON coverage (e.g. via Vitest + istanbul provider)
+vitest run --coverage --coverage.reporter=json
+
+# 2. Analyze
+crap4ts --coverage coverage/coverage-final.json --src src
+
+# 3. Gate CI on the default threshold
+crap4ts --coverage coverage/coverage-final.json --src src --threshold default
+```
+
+`crap4ts` emits the same scorecard envelope as `crap4rs` — same fields, same risk tiers, same delta-gate semantics — so a multi-language monorepo can drive a single CI gate across both ecosystems.
+
+## What this is
+
+`crap4ts` is the TypeScript / JavaScript adapter in the [`crap-rs`](https://github.com/breezy-bays-labs/crap-rs) workspace. It compiles to two artifacts from one crate:
+
+- A standalone Rust CLI binary, distributed via crates.io (this page) and `cargo binstall`
+- A [napi-rs](https://napi.rs/) `cdylib` Node addon, distributed via [npm](https://www.npmjs.com/package/crap4ts)
+
+Both share the same walker (`oxc` for complexity), the same Istanbul JSON coverage parser, and the same [`crap-core`](https://crates.io/crates/crap-core) scoring/reporter pipeline as the Rust adapter [`crap4rs`](https://crates.io/crates/crap4rs).
+
+## Library use (Rust)
+
+```toml
+[dependencies]
+crap4ts = "2"
+```
+
+Most users want the CLI or the npm package; the library crate is intended for downstream tooling that needs programmatic access to TypeScript walking + scoring without spawning a subprocess.
+
+## Stability
+
+`crap4ts` is in the `2.0.0-rc.x` release-candidate series ahead of the GA `2.0.0` cut. The CLI surface, configuration shape, and scorecard envelope are locked across the rc series; rc bumps fix bugs and tighten the walker. See the [changelog](https://github.com/breezy-bays-labs/crap-rs/blob/main/packages/crap4ts/CHANGELOG.md) for the per-version history.
+
+## See also
+
+- **Repository**: [github.com/breezy-bays-labs/crap-rs](https://github.com/breezy-bays-labs/crap-rs)
+- **npm package**: [`crap4ts` on npm](https://www.npmjs.com/package/crap4ts) — for JS/Node consumers
+- **Rust analyzer**: [`crap4rs`](https://crates.io/crates/crap4rs)
+- **Shared core library**: [`crap-core`](https://crates.io/crates/crap-core)
+- **Issues**: [github.com/breezy-bays-labs/crap-rs/issues](https://github.com/breezy-bays-labs/crap-rs/issues)
+
+## License
+
+Dual-licensed under MIT OR Apache-2.0 at your option.

--- a/crates/crap4ts/README.md
+++ b/crates/crap4ts/README.md
@@ -5,7 +5,15 @@
 [![docs.rs](https://img.shields.io/docsrs/crap4ts)](https://docs.rs/crap4ts)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](https://github.com/breezy-bays-labs/crap-rs#license)
 
-Rust-powered CRAP (Change Risk Anti-Patterns) score analyzer for TypeScript and JavaScript. Joins [oxc](https://oxc.rs/)-driven AST complexity with [Istanbul](https://istanbul.js.org/) JSON coverage to identify functions that are both complex and under-tested.
+**Rust-powered CRAP (Change Risk Anti-Patterns) score analyzer for TypeScript and JavaScript.** Find the functions in your codebase that are both complex *and* under-tested.
+
+`crap4ts` combines [oxc](https://oxc.rs/)-driven AST complexity with [Istanbul](https://istanbul.js.org/) JSON coverage. One pass, one CI gate, one number per function.
+
+```
+CRAP(complexity, coverage) = complexity² × (1 − coverage)³ + complexity
+```
+
+High complexity + low coverage = high CRAP = high change risk.
 
 > **JavaScript / Node consumers**: install [`crap4ts` from npm](https://www.npmjs.com/package/crap4ts) — that package ships pre-built Node addons for every supported platform. Its [npm README](https://github.com/breezy-bays-labs/crap-rs/blob/main/packages/crap4ts/README.md) covers Node-side usage.
 >
@@ -14,27 +22,153 @@ Rust-powered CRAP (Change Risk Anti-Patterns) score analyzer for TypeScript and 
 ## Install (CLI)
 
 ```bash
-cargo binstall crap4ts
-# or from source
 cargo install crap4ts
 ```
 
-## Usage
+Pre-built CLI binaries for `crap4ts` are tracked for a future release (the napi `cdylib` for the npm package ships pre-built today; the standalone CLI artifact does not yet). Use `cargo install` for now, or install the [npm package](https://www.npmjs.com/package/crap4ts) if you're consuming from Node.
+
+## 30-second tour
 
 ```bash
-# 1. Generate Istanbul JSON coverage (e.g. via Vitest + istanbul provider)
+# Generate Istanbul JSON coverage (e.g. via Vitest + istanbul provider)
 vitest run --coverage --coverage.reporter=json
 
-# 2. Analyze
+# Analyze
 crap4ts --coverage coverage/coverage-final.json --src src
 
-# 3. Gate CI on the default threshold
-crap4ts --coverage coverage/coverage-final.json --src src --threshold default
+# Gate CI strictly
+crap4ts --coverage coverage/coverage-final.json --src src --strict
 ```
 
-`crap4ts` emits the same scorecard envelope as `crap4rs` — same fields, same risk tiers, same delta-gate semantics — so a multi-language monorepo can drive a single CI gate across both ecosystems.
+## Why cyclomatic complexity (only)
 
-## What this is
+`crap4ts` 2.x ships **cyclomatic complexity** as the only supported metric. Two reasons:
+
+1. **Classic CRAP semantics.** Cyclomatic decision-point count is the original CRAP metric and aligns with how virtually every TypeScript / JavaScript quality tool (ESLint's `complexity` rule, SonarJS, Code Climate, etc.) reports complexity. CI gates and reviewer expectations transfer cleanly.
+2. **AST signal density differs from Rust.** TypeScript code doesn't lean as heavily on `match`-style branching as idiomatic Rust does, so the cognitive-vs-cyclomatic divergence is much smaller. Cyclomatic ships first; cognitive may follow in a later release if the ecosystem demand justifies the additional walker logic.
+
+Passing `--metric cognitive` errors out cleanly with `MetricNotSupported`.
+
+The companion Rust analyzer [`crap4rs`](https://crates.io/crates/crap4rs) defaults to cognitive complexity for the inverse reason — Rust idioms benefit from it. The shared CRAP formula, risk tiers, and envelope shape are identical across both adapters; only the complexity number entering the formula differs.
+
+## Threshold presets
+
+`crap4ts` ships three preset gates calibrated against four risk tiers:
+
+| Preset | Threshold | Gates at | Use for |
+|---|---|---|---|
+| `--strict` | CRAP ≤ 8 | Low → Acceptable | safety-critical, high-quality libraries |
+| *(default)* | CRAP ≤ 15 | Acceptable → Moderate | typical app / library code |
+| `--lenient` | CRAP ≤ 25 | Moderate → High | legacy / transitional codebases |
+
+The risk tiers themselves:
+
+| CRAP score | Risk |
+|---|---|
+| ≤ 8 | Low |
+| ≤ 15 | Acceptable |
+| ≤ 25 | Moderate |
+| > 25 | High |
+
+The presets correspond to "gate at the next risk tier up." Override with `--threshold <N>` for a custom value, or define presets per-codebase in `crap4ts.toml`.
+
+## What it looks like
+
+### Table (TTY default)
+
+```
+crap4ts v2.0.0-rc.2 — CRAP Score Analysis
+
++-----------------------------+-------------------------+----+-------+-------+----------+
+| File                        | Function                | CC | Cov%  | CRAP  | Risk     |
++=========================================================================================+
+| src/walker.ts               | walkExpression          | 14 |  72.0 | 17.06 | moderate |
+| src/cli.ts                  | resolveConfig           | 11 |  88.5 | 11.16 | acceptable |
+| src/reporters/markdown.ts   | renderTopOffenders      |  9 | 100.0 |  9.00 | acceptable |
+| src/coverage/istanbul.ts    | parseStatementMap       |  8 |  91.2 |  8.05 | acceptable |
++-----------------------------+-------------------------+----+-------+-------+----------+
+
+Functions: 142 · Above threshold: 1 · Worst CRAP: 17.06 · Distribution: 98 low · 32 acceptable · 11 moderate · 1 high
+```
+
+### Markdown (`--format markdown`) — PR-comment ready
+
+```markdown
+# crap4ts v2.0.0-rc.2 — CRAP Score Analysis
+
+**Result:** FAIL · **Functions:** 142 · **Above threshold (15):** 1
+
+| Metric     | Worst | Average | Median |
+|------------|------:|--------:|-------:|
+| CRAP       | 17.06 |    2.41 |   1.00 |
+| Complexity |    14 |     2.3 |    1.0 |
+| Coverage   |  0.0% |   89.4% |  98.5% |
+
+**Risk distribution:** low 98 · acceptable 32 · moderate 11 · high 1
+```
+
+### GitHub annotations (`--format github-annotations`) — inline PR review
+
+Drops findings as inline warnings on the PR Files Changed tab, no GHAS / Code Scanning license needed:
+
+```
+::warning file=src/walker.ts,line=128,title=CRAP 17.1::Function `walkExpression` has CRAP 17.06 (complexity=14, coverage=72.0%) which exceeds threshold 15.0
+```
+
+### JSON (`--format json`) — programmatic consumption
+
+```json
+{
+  "schema_version": 2,
+  "run_meta": { "tool": "crap4ts", "version": "2.0.0-rc.2", "metric": "cyclomatic" },
+  "result": {
+    "summary": {
+      "total_functions": 142,
+      "exceeding_threshold": 1,
+      "distribution": { "low": 98, "acceptable": 32, "moderate": 11, "high": 1 },
+      "max_crap": { "value": 17.06, "risk_level": "moderate" }
+    },
+    "functions": [
+      {
+        "scored": {
+          "identity": { "file_path": "src/walker.ts", "qualified_name": "walkExpression", "span": { "start_line": 128, "end_line": 184 } },
+          "complexity": 14,
+          "complexity_metric": "cyclomatic",
+          "coverage_percent": 72.0,
+          "crap": { "value": 17.06, "risk_level": "moderate" }
+        },
+        "threshold": 15.0,
+        "exceeds": true
+      }
+    ]
+  }
+}
+```
+
+The wire envelope is byte-identical to `crap4rs`'s output — same fields, same risk-tier strings, same delta-gate semantics. A multi-language monorepo can drive a single CI gate across both ecosystems.
+
+### Other formats
+
+- `--format csv` — spreadsheet ingestion
+- `--format sarif` — Code Scanning upload (requires GHAS) for surface-as-security-finding flows
+- `--format scorecard` — single-row CI gate output for cross-PR delta tracking
+- **HTML report** — interactive, sortable, with per-function contributor drill-down. *Coming in a future release; file an issue for early-access interest.*
+
+Multiple formats compose in one pass: `--format json:envelope.json,markdown:report.md` writes both files from a single analysis.
+
+## Delta gates — fail PRs that introduce new high-CRAP functions
+
+```bash
+# Generate baseline on main
+crap4ts --coverage main-coverage/coverage-final.json --src src --format json > baseline.json
+
+# On PR — fail only on NEW threshold violations
+crap4ts --coverage pr-coverage/coverage-final.json --src src --baseline baseline.json --delta-gate
+```
+
+A function above-threshold on main doesn't fail the PR; only functions newly introduced or newly elevated do. Lets teams ratchet quality forward without blocking every PR on pre-existing debt.
+
+## What this is (architecture)
 
 `crap4ts` is the TypeScript / JavaScript adapter in the [`crap-rs`](https://github.com/breezy-bays-labs/crap-rs) workspace. It compiles to two artifacts from one crate:
 


### PR DESCRIPTION
## Summary

Each published crate (`crap-core`, `crap4rs`, `crap4ts`) now ships its own crate-specific README. crates.io renders these on the per-crate page; docs.rs picks them up for the front-page About panel. Without this, each crate's crates.io page rendered nothing useful for a user landing there.

This lands ahead of the first release-plz auto-PR so the next published version of every crate ships with its README.

## What's in

- `crates/crap-core/README.md` — describes the shared backbone; flags it as primarily for adapter authors; links to `crap4rs` / `crap4ts` for end users
- `crates/crap4rs/README.md` — Rust CLI install / usage / library-use snippets; points at workspace README for full docs
- `crates/crap4ts/README.md` — covers the Rust CLI + the `cdylib`-backed npm distribution; explicitly directs JS / Node consumers at the [npm package README](https://github.com/breezy-bays-labs/crap-rs/blob/main/packages/crap4ts/README.md)
- `crates/{crap-core,crap4rs,crap4ts}/Cargo.toml` — adds `readme = "README.md"` so cargo-package + crates.io pick the file up

## Verification

- `cargo metadata --format-version 1 --no-deps` parses cleanly with the new `readme` fields
- `cargo package --list -p <crate>` confirms each crate's README is in its publish bundle
- All three READMEs have balanced markdown code fences
- No source / logic changes; metadata + docs only

## Out of scope

- Workspace root README revision — keeping it untouched; future opportunistic touch can pare it down once per-crate READMEs absorb the crate-specific install / usage sections
- `description` field copy edits on `crap-core` (the "future crap4ts" wording is stale) — separate small chore

🤖 Generated with [Claude Code](https://claude.com/claude-code)