### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -97,7 +97,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -167,9 +167,9 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd"
+checksum = "2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6"
 dependencies = [
  "anstyle",
  "bstr",
@@ -182,9 +182,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base64"
@@ -218,9 +218,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "borrow-or-share"
@@ -241,9 +241,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytecount"
@@ -268,9 +268,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -291,9 +291,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.2"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff7a1dccbdd8b078c2bdebff47e404615151534d5043da397ec50286816f9cb"
+checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
 dependencies = [
  "clap",
 ]
@@ -310,9 +310,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -338,7 +338,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -348,7 +348,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
 dependencies = [
  "ansi-str",
- "console 0.16.3",
+ "console",
  "crossterm",
  "unicode-segmentation",
  "unicode-width",
@@ -370,18 +370,6 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
-dependencies = [
- "encode_unicode",
- "libc",
- "once_cell",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "console"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
@@ -389,7 +377,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "unicode-width",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -443,7 +431,7 @@ dependencies = [
 
 [[package]]
 name = "crap4rs"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -472,7 +460,7 @@ dependencies = [
 
 [[package]]
 name = "crap4ts"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 dependencies = [
  "assert_cmd",
  "crap-core",
@@ -538,9 +526,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.11.1"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "400a21f1014a968ec518c7ccdf9b4a4ed0cac8c56ccb6d604f8b91f00110501e"
+checksum = "6d765eb1c0bda10d31e0ea185f5ee15da532d60b0912d2bd1441783439e749c5"
 
 [[package]]
 name = "cucumber"
@@ -550,7 +538,7 @@ checksum = "16cbb27bc2064274afa3a3d8bc9a0e71333589850573aa632ec4520e4af14d94"
 dependencies = [
  "anyhow",
  "clap",
- "console 0.16.3",
+ "console",
  "cucumber-codegen",
  "cucumber-expressions",
  "derive_more",
@@ -664,9 +652,9 @@ checksum = "fd8e701084c37e7ef62d3f9e453b618130cbc0ef3573847785952a3ac3f746bf"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "email_address"
@@ -696,7 +684,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -712,9 +700,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fluent-uri"
@@ -920,12 +908,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-
-[[package]]
-name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
@@ -1072,12 +1054,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -1090,11 +1072,11 @@ checksum = "a257582fdcde896fd96463bf2d40eefea0580021c0712a0e2b028b60b47a837a"
 
 [[package]]
 name = "insta"
-version = "1.46.3"
+version = "1.47.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82db8c87c7f1ccecb34ce0c24399b8a73081427f3c7c50a5d597925356115e4"
+checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
 dependencies = [
- "console 0.15.11",
+ "console",
  "once_cell",
  "serde",
  "similar",
@@ -1133,9 +1115,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1183,9 +1165,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -1250,9 +1232,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "napi"
-version = "3.8.6"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e55037284865448ecf329baa86a4d05401f647ebde99f5747b640d32c2c5226"
+checksum = "f1d395473824516f38dd1071a1a37bc57daa7be65b293ebba4ead5f7abb017a2"
 dependencies = [
  "bitflags",
  "ctor",
@@ -1265,15 +1247,15 @@ dependencies = [
 
 [[package]]
 name = "napi-build"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d376940fd5b723c6893cd1ee3f33abbfd86acb1cd1ec079f3ab04a2a3bc4d3b1"
+checksum = "c9c366d2c8c60b86fa632df75f745509b52f9128f91a6bad4c796e44abb505e1"
 
 [[package]]
 name = "napi-derive"
-version = "3.5.5"
+version = "3.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ba740fe4c9524d86fd90798fd8ccdb23402b3eef7e7c30897a8a369b529fcf"
+checksum = "89b3f766e04667e6da0e181e2da4f85475d5a6513b7cf6a80bea184e224a5b42"
 dependencies = [
  "convert_case 0.11.0",
  "ctor",
@@ -1770,18 +1752,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1916,9 +1898,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -2049,7 +2031,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2104,9 +2086,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "seq-macro"
@@ -2146,9 +2128,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -2290,7 +2272,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2300,7 +2282,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2352,9 +2334,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "pin-project-lite",
  "tokio-macros",
@@ -2550,11 +2532,11 @@ dependencies = [
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -2563,14 +2545,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2581,9 +2563,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2591,9 +2573,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2604,9 +2586,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -2667,7 +2649,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2684,85 +2666,12 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -2790,6 +2699,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -2907,18 +2822,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2927,9 +2842,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/crates/crap4rs/CHANGELOG.md
+++ b/crates/crap4rs/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/breezy-bays-labs/crap-rs/compare/crap4rs-v0.5.0...crap4rs-v0.6.0) - 2026-05-24
+
+### Added
+
+- *(crap-core)* #260 — askama-templated HTML + markdown reporters + Sakura HTML redesign ([#307](https://github.com/breezy-bays-labs/crap-rs/pull/307))
+- *(ci)* #270 — adopt release-plz + crates.io OIDC trusted publishing ([#301](https://github.com/breezy-bays-labs/crap-rs/pull/301))
+- #276 — github-annotations reporter + composite action input ([#288](https://github.com/breezy-bays-labs/crap-rs/pull/288))
+- #139 #114 — composite scorecard action dispatches crap4ts + cross-adapter row parity ([#282](https://github.com/breezy-bays-labs/crap-rs/pull/282))
+- *(crap-core)* [**breaking**] align CRAP thresholds + risk tiers (8/15/25) ([#281](https://github.com/breezy-bays-labs/crap-rs/pull/281))
+- #180 #196 #202 — BDD tracked-comment lint + delta.feature spec + colored set_override poison fix ([#279](https://github.com/breezy-bays-labs/crap-rs/pull/279))
+- *(crap-core)* #188 — CrapError::MetricNotSupported + AdapterMeta::default_metric + crap4ts walker check + ADR (d) + crap-core 0.2.0 ([#203](https://github.com/breezy-bays-labs/crap-rs/pull/203))
+- #73 — `crap4rs init` subcommand (with crap4ts inheritance via AdapterMeta) ([#171](https://github.com/breezy-bays-labs/crap-rs/pull/171))
+- *(cli)* #131 — --summary one-line analysis verdict flag ([#167](https://github.com/breezy-bays-labs/crap-rs/pull/167))
+- *(crap-core)* [**breaking**] #147 — restore #[non_exhaustive] on 15 result structs (v1.0 prep) ([#166](https://github.com/breezy-bays-labs/crap-rs/pull/166))
+- *(crap-core)* #148+#152+#160 — AdapterMeta + decouple from Rust/crap4rs ([#162](https://github.com/breezy-bays-labs/crap-rs/pull/162))
+
+### Fixed
+
+- *(crap4ts)* #253 — skip `.d.ts` declaration files via AdapterMeta::forced_excludes ([#258](https://github.com/breezy-bays-labs/crap-rs/pull/258))
+- #163 — adapter-aware coverage preflight + walker reconciliation + config-path hint ([#164](https://github.com/breezy-bays-labs/crap-rs/pull/164))
+- *(crap-core)* #150 — late-bind coverage adapter via factory closure ([#158](https://github.com/breezy-bays-labs/crap-rs/pull/158))
+
+### Other
+
+- add per-crate READMEs for crates.io display ([#305](https://github.com/breezy-bays-labs/crap-rs/pull/305))
+- *(ci)* #261 — ast-purity layer-4 adapter-vocabulary string-literal ban ([#286](https://github.com/breezy-bays-labs/crap-rs/pull/286))
+- *(crap-core)* #178 #179 — port-surface cleanup (CrapError rename + CoveragePort::parse to &Path) ([#262](https://github.com/breezy-bays-labs/crap-rs/pull/262))
+- pre-flight scaffold for TS-adapter pipeline (gitignore + delta.feature relocation + #173 BDD scenarios) ([#195](https://github.com/breezy-bays-labs/crap-rs/pull/195))
+- *(bdd)* #168 — tag lexicon + retag scenarios + clean up Background ([#170](https://github.com/breezy-bays-labs/crap-rs/pull/170))
+- *(crap-core)* #161 — AdapterMeta polish + ci(ast-purity) adapter-name gate ([#165](https://github.com/breezy-bays-labs/crap-rs/pull/165))
+
 ### Added
 
 - `--format github-annotations` emits GitHub Actions `::warning`

--- a/crates/crap4rs/CHANGELOG.md
+++ b/crates/crap4rs/CHANGELOG.md
@@ -11,35 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- *(crap-core)* #260 — askama-templated HTML + markdown reporters + Sakura HTML redesign ([#307](https://github.com/breezy-bays-labs/crap-rs/pull/307))
-- *(ci)* #270 — adopt release-plz + crates.io OIDC trusted publishing ([#301](https://github.com/breezy-bays-labs/crap-rs/pull/301))
-- #276 — github-annotations reporter + composite action input ([#288](https://github.com/breezy-bays-labs/crap-rs/pull/288))
-- #139 #114 — composite scorecard action dispatches crap4ts + cross-adapter row parity ([#282](https://github.com/breezy-bays-labs/crap-rs/pull/282))
-- *(crap-core)* [**breaking**] align CRAP thresholds + risk tiers (8/15/25) ([#281](https://github.com/breezy-bays-labs/crap-rs/pull/281))
-- #180 #196 #202 — BDD tracked-comment lint + delta.feature spec + colored set_override poison fix ([#279](https://github.com/breezy-bays-labs/crap-rs/pull/279))
-- *(crap-core)* #188 — CrapError::MetricNotSupported + AdapterMeta::default_metric + crap4ts walker check + ADR (d) + crap-core 0.2.0 ([#203](https://github.com/breezy-bays-labs/crap-rs/pull/203))
-- #73 — `crap4rs init` subcommand (with crap4ts inheritance via AdapterMeta) ([#171](https://github.com/breezy-bays-labs/crap-rs/pull/171))
-- *(cli)* #131 — --summary one-line analysis verdict flag ([#167](https://github.com/breezy-bays-labs/crap-rs/pull/167))
-- *(crap-core)* [**breaking**] #147 — restore #[non_exhaustive] on 15 result structs (v1.0 prep) ([#166](https://github.com/breezy-bays-labs/crap-rs/pull/166))
-- *(crap-core)* #148+#152+#160 — AdapterMeta + decouple from Rust/crap4rs ([#162](https://github.com/breezy-bays-labs/crap-rs/pull/162))
-
-### Fixed
-
-- *(crap4ts)* #253 — skip `.d.ts` declaration files via AdapterMeta::forced_excludes ([#258](https://github.com/breezy-bays-labs/crap-rs/pull/258))
-- #163 — adapter-aware coverage preflight + walker reconciliation + config-path hint ([#164](https://github.com/breezy-bays-labs/crap-rs/pull/164))
-- *(crap-core)* #150 — late-bind coverage adapter via factory closure ([#158](https://github.com/breezy-bays-labs/crap-rs/pull/158))
-
-### Other
-
-- add per-crate READMEs for crates.io display ([#305](https://github.com/breezy-bays-labs/crap-rs/pull/305))
-- *(ci)* #261 — ast-purity layer-4 adapter-vocabulary string-literal ban ([#286](https://github.com/breezy-bays-labs/crap-rs/pull/286))
-- *(crap-core)* #178 #179 — port-surface cleanup (CrapError rename + CoveragePort::parse to &Path) ([#262](https://github.com/breezy-bays-labs/crap-rs/pull/262))
-- pre-flight scaffold for TS-adapter pipeline (gitignore + delta.feature relocation + #173 BDD scenarios) ([#195](https://github.com/breezy-bays-labs/crap-rs/pull/195))
-- *(bdd)* #168 — tag lexicon + retag scenarios + clean up Background ([#170](https://github.com/breezy-bays-labs/crap-rs/pull/170))
-- *(crap-core)* #161 — AdapterMeta polish + ci(ast-purity) adapter-name gate ([#165](https://github.com/breezy-bays-labs/crap-rs/pull/165))
-
-### Added
-
 - `--format github-annotations` emits GitHub Actions `::warning`
   workflow commands so threshold-exceeding functions render inline on
   the PR Files Changed tab — universal, free, no GHAS / Code Scanning
@@ -50,56 +21,90 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   per-step UI cap; over-cap eligible findings surface as a trailing
   `::notice::N more functions exceed threshold; see scorecard for the
   full list` line. Also configurable via `[output] annotation_limit`
-  in `crap4rs.toml`. The composite scorecard action
-  gained matching `annotations` (bool) and `annotation-limit` inputs
-  for opt-in inline rendering. (#276)
-- `crap4rs init` subcommand generates a starter `crap4rs.toml`
-  in the current directory. Auto-detects `src/`
-  → `crates/` → falls back to `src` with a hint comment. Interactive
-  by default (one prompt mapping `s|d|l` to strict/default/lenient
-  preset); `--non-interactive` for CI; `--force` to overwrite an
-  existing config. Emits Rust-ecosystem exclude defaults
-  (`tests/**`, `benches/**`, `examples/**`). (#73)
-- `--summary` flag emits a single-line analysis verdict to stdout (e.g.
-  `PASS: 1082 functions | 0 above threshold (25) | worst: 13.0 | avg: 1.6`),
-  matching crap4ts's `formatSummaryLine` byte-for-byte. Short-circuits
-  `--format`, composes with `--no-fail` (exit 0 always, summary
-  emitted) and `--quiet` (quiet wins — no output). Closes the
-  2026-05-08 crap4rs ↔ crap4ts parity audit's final gap. (#131)
+  in `crap4rs.toml`. The composite scorecard action gained matching
+  `annotations` (bool) and `annotation-limit` inputs for opt-in
+  inline rendering. ([#288](https://github.com/breezy-bays-labs/crap-rs/pull/288))
+- `crap4rs init` subcommand generates a starter `crap4rs.toml` in the
+  current directory. Auto-detects `src/` → `crates/` → falls back to
+  `src` with a hint comment. Interactive by default (one prompt
+  mapping `s|d|l` to strict/default/lenient preset);
+  `--non-interactive` for CI; `--force` to overwrite an existing
+  config. Emits Rust-ecosystem exclude defaults (`tests/**`,
+  `benches/**`, `examples/**`). Inherited by `crap4ts` via
+  `AdapterMeta`. ([#171](https://github.com/breezy-bays-labs/crap-rs/pull/171))
+- `--summary` flag emits a single-line analysis verdict to stdout
+  (e.g. `PASS: 1082 functions | 0 above threshold (25) | worst: 13.0
+  | avg: 1.6`), matching crap4ts's `formatSummaryLine` byte-for-byte.
+  Short-circuits `--format`, composes with `--no-fail` (exit 0
+  always, summary emitted) and `--quiet` (quiet wins — no output).
+  Closes the 2026-05-08 crap4rs ↔ crap4ts parity audit's final gap.
+  ([#167](https://github.com/breezy-bays-labs/crap-rs/pull/167))
+- *(crap-core)* askama-templated HTML + markdown reporters + Sakura
+  HTML redesign. ([#307](https://github.com/breezy-bays-labs/crap-rs/pull/307))
+- *(ci)* adopt release-plz + crates.io OIDC trusted publishing. ([#301](https://github.com/breezy-bays-labs/crap-rs/pull/301))
+- Composite scorecard action dispatches crap4ts + cross-adapter
+  scorecard-row parity. ([#282](https://github.com/breezy-bays-labs/crap-rs/pull/282))
+- *(crap-core)* [**breaking**] align CRAP thresholds + risk tiers
+  (8/15/25). ([#281](https://github.com/breezy-bays-labs/crap-rs/pull/281))
+- BDD tracked-comment lint + `delta.feature` spec + `colored
+  set_override` poison fix. ([#279](https://github.com/breezy-bays-labs/crap-rs/pull/279))
+- *(crap-core)* `CrapError::MetricNotSupported` +
+  `AdapterMeta::default_metric` + crap4ts walker check + supporting
+  ADR + crap-core 0.2.0. ([#203](https://github.com/breezy-bays-labs/crap-rs/pull/203))
+- *(crap-core)* [**breaking**] restore `#[non_exhaustive]` on 15
+  result structs (v1.0 prep). ([#166](https://github.com/breezy-bays-labs/crap-rs/pull/166))
+- *(crap-core)* `AdapterMeta` + decouple from Rust/crap4rs. ([#162](https://github.com/breezy-bays-labs/crap-rs/pull/162))
 
 ### Fixed
 
 - Threshold cutoffs are now calibrated per complexity metric instead
   of a single shared scalar. A cyclomatic count and a cognitive count
   have different magnitudes for the same function, so one cutoff
-  cannot fit both — applying the cognitive cutoff to cyclomatic scores
-  silently mis-gated. The strict/default/lenient presets now resolve
-  to cyclomatic `8/16/30` or cognitive `15/25/40` based on the
-  effective metric. User-visible behavior change: `crap4rs --metric
-  cyclomatic` with no flag now gates at `16` (was `25`) and `--strict`
-  at `8` (was `15`). `crap4rs`'s cognitive defaults (the common path)
-  are unchanged. The generated `crap4rs.toml` threshold comment now
-  states which metric the printed cutoffs apply to. (#218)
+  cannot fit both — applying the cognitive cutoff to cyclomatic
+  scores silently mis-gated. The strict/default/lenient presets now
+  resolve to cyclomatic `8/16/30` or cognitive `15/25/40` based on
+  the effective metric. User-visible behavior change: `crap4rs
+  --metric cyclomatic` with no flag now gates at `16` (was `25`) and
+  `--strict` at `8` (was `15`). `crap4rs`'s cognitive defaults (the
+  common path) are unchanged. The generated `crap4rs.toml` threshold
+  comment now states which metric the printed cutoffs apply to.
+  ([#281](https://github.com/breezy-bays-labs/crap-rs/pull/281))
+- *(crap4ts)* skip `.d.ts` declaration files via
+  `AdapterMeta::forced_excludes`. ([#258](https://github.com/breezy-bays-labs/crap-rs/pull/258))
+- Adapter-aware coverage preflight + walker reconciliation +
+  config-path hint. ([#164](https://github.com/breezy-bays-labs/crap-rs/pull/164))
+- *(crap-core)* late-bind coverage adapter via factory closure. ([#158](https://github.com/breezy-bays-labs/crap-rs/pull/158))
 
 ### Changed
 
-- Multi-format `--format` invocations now permit a single stdout entry
-  alongside file-targeted entries (previously every entry had to
-  specify a file). Two or more stdout entries are still rejected — the
-  underlying "cannot multiplex stdout" rule stands. Unblocks the
-  intended composite-CI shape
-  `--format markdown:scorecard.md,github-annotations`, where the
-  markdown is captured as a workflow artefact and the
-  `github-annotations` workflow commands flow through to the GH
-  Actions runner. (#276)
-- Config-file `threshold = N` now takes precedence over
-  `preset = "..."` when both are set in the same `crap4rs.toml`.
-  This makes config-file resolution consistent with
-  CLI semantics, where an explicit `--threshold N` already overrides
-  `--strict` / `--lenient`. Users who had both fields set will now get
-  the literal value; previously the preset silently won. The
-  `init`-generated config never writes both, so the blast radius is
-  limited to hand-edited configs. (#218)
+- Multi-format `--format` invocations now permit a single stdout
+  entry alongside file-targeted entries (previously every entry had
+  to specify a file). Two or more stdout entries are still rejected —
+  the underlying "cannot multiplex stdout" rule stands. Unblocks the
+  intended composite-CI shape `--format
+  markdown:scorecard.md,github-annotations`, where the markdown is
+  captured as a workflow artefact and the `github-annotations`
+  workflow commands flow through to the GH Actions runner. ([#288](https://github.com/breezy-bays-labs/crap-rs/pull/288))
+- Config-file `threshold = N` now takes precedence over `preset =
+  "..."` when both are set in the same `crap4rs.toml`. This makes
+  config-file resolution consistent with CLI semantics, where an
+  explicit `--threshold N` already overrides `--strict` /
+  `--lenient`. Users who had both fields set will now get the literal
+  value; previously the preset silently won. The `init`-generated
+  config never writes both, so the blast radius is limited to
+  hand-edited configs. ([#281](https://github.com/breezy-bays-labs/crap-rs/pull/281))
+
+### Other
+
+- Per-crate READMEs for crates.io display. ([#305](https://github.com/breezy-bays-labs/crap-rs/pull/305))
+- *(ci)* AST-purity layer-4 adapter-vocabulary string-literal ban. ([#286](https://github.com/breezy-bays-labs/crap-rs/pull/286))
+- *(crap-core)* port-surface cleanup (CrapError rename +
+  `CoveragePort::parse` to `&Path`). ([#262](https://github.com/breezy-bays-labs/crap-rs/pull/262))
+- Pre-flight scaffold for TS-adapter pipeline (gitignore +
+  `delta.feature` relocation + BDD scenarios). ([#195](https://github.com/breezy-bays-labs/crap-rs/pull/195))
+- *(bdd)* tag lexicon + retag scenarios + clean up Background. ([#170](https://github.com/breezy-bays-labs/crap-rs/pull/170))
+- *(crap-core)* `AdapterMeta` polish + ci(ast-purity) adapter-name
+  gate. ([#165](https://github.com/breezy-bays-labs/crap-rs/pull/165))
 
 ## [0.5.0] - 2026-05-10
 

--- a/crates/crap4rs/Cargo.toml
+++ b/crates/crap4rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crap4rs"
-version = "0.5.0"
+version = "0.6.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/crap4ts/Cargo.toml
+++ b/crates/crap4ts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crap4ts"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/packages/crap4ts/CHANGELOG.md
+++ b/packages/crap4ts/CHANGELOG.md
@@ -17,10 +17,8 @@ shared-core development.
 
 ### Added
 
-- *(crap-core)* #260 — askama-templated HTML + markdown reporters + Sakura HTML redesign ([#307](https://github.com/breezy-bays-labs/crap-rs/pull/307))
-
-### Added
-
+- *(crap-core)* askama-templated HTML + markdown reporters + Sakura
+  HTML redesign. ([#307](https://github.com/breezy-bays-labs/crap-rs/pull/307))
 - `crap4ts init` subcommand generates a starter `crap4ts.toml`
   in the current directory. Auto-detects `src/`
   → `crates/` → falls back to `src` with a hint comment. Interactive
@@ -154,7 +152,8 @@ Initial extraction from the `crap4rs` workspace.
   [`breezy-bays-labs/crap4ts`](https://github.com/breezy-bays-labs/crap4ts)
   enters maintenance-only mode.
 
-[Unreleased]: https://github.com/breezy-bays-labs/crap-rs/compare/crap4ts-v2.0.0-rc.2...HEAD
+[Unreleased]: https://github.com/breezy-bays-labs/crap-rs/compare/crap4ts-v2.0.0-rc.3...HEAD
+[2.0.0-rc.3]: https://github.com/breezy-bays-labs/crap-rs/releases/tag/crap4ts-v2.0.0-rc.3
 [2.0.0-rc.2]: https://github.com/breezy-bays-labs/crap-rs/releases/tag/crap4ts-v2.0.0-rc.2
 [2.0.0-rc.1]: https://github.com/breezy-bays-labs/crap-rs/releases/tag/crap4ts-v2.0.0-rc.1
 [2.0.0-alpha.1]: https://github.com/breezy-bays-labs/crap-rs/releases/tag/crap4ts-v2.0.0-alpha.1

--- a/packages/crap4ts/CHANGELOG.md
+++ b/packages/crap4ts/CHANGELOG.md
@@ -13,6 +13,12 @@ shared-core development.
 
 ## [Unreleased]
 
+## [2.0.0-rc.3](https://github.com/breezy-bays-labs/crap-rs/compare/crap4ts-v2.0.0-rc.2...crap4ts-v2.0.0-rc.3) - 2026-05-24
+
+### Added
+
+- *(crap-core)* #260 — askama-templated HTML + markdown reporters + Sakura HTML redesign ([#307](https://github.com/breezy-bays-labs/crap-rs/pull/307))
+
 ### Added
 
 - `crap4ts init` subcommand generates a starter `crap4ts.toml`

--- a/packages/crap4ts/package.json
+++ b/packages/crap4ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crap4ts",
-  "version": "2.0.0-rc.2",
+  "version": "2.0.0-rc.3",
   "description": "TypeScript adapter for crap-rs — Rust-powered CRAP score analyzer combining oxc AST complexity with Istanbul JSON coverage. Identifies functions that are both complex and under-tested.",
   "main": "index.js",
   "files": [


### PR DESCRIPTION



## 🤖 New release

* `crap-core`: 0.4.0 -> 0.5.0
* `crap4rs`: 0.5.0 -> 0.6.0 (✓ API compatible changes)
* `crap4ts`: 2.0.0-rc.2 -> 2.0.0-rc.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `crap-core`

<blockquote>

## [0.5.0]

### Changed

- HTML and Markdown reporters now render through askama compile-time
  templates. Templates live at `crates/crap-core/templates/` and are
  checked at compile time by `#[derive(Template)]`. Refactor under
  the hood; no behavioral change to the markdown output (snapshots
  byte-identical), HTML redesigned per the Sakura Reports design
  system. (#260)
- HTML reporter redesigned around the **Sakura Reports** design
  system: a verdict-stamped header, 4 KPI tiles (down from 6), a
  risk distribution bar, up to 4 worst offenders (down from 6), a
  `<details>` card per file with a real `<table>` for function-level
  data, light + optional dark mode, and a per-adapter footer that
  carries metric / coverage / threshold provenance. Inline `<script>`
  now permitted (theme toggle, file-list filter, `/` keyboard
  shortcut); external assets still rejected. (#260)
- `reporters::format_html` signature widened from
  `(view, threshold, tool_name: &str, tool_version: &str)` to
  `(view, threshold, meta: &AdapterMeta, effective_metric: ComplexityMetric)`.
  The new arguments thread adapter identity + runtime-resolved
  complexity metric into the per-adapter footer without leaking
  domain state into the template. (#260)
- `reporters::format_markdown` signature shifted its last two
  `(&str, &str)` arguments to `(&AdapterMeta, ComplexityMetric)` for
  signature symmetry with `format_html` — markdown does not yet
  surface the metric label but the bundle is threaded uniformly.
  (#260)
- `AdapterMeta` gains a `display_name: &'static str` field carrying
  the human-readable language label (`"Rust"` / `"TypeScript"`)
  used by the HTML reporter's per-adapter footer row. Adapter
  binaries must initialize this field. (#260)
</blockquote>

## `crap4rs`

<blockquote>

## [0.6.0](https://github.com/breezy-bays-labs/crap-rs/compare/crap4rs-v0.5.0...crap4rs-v0.6.0) - 2026-05-24

### Added

- *(crap-core)* #260 — askama-templated HTML + markdown reporters + Sakura HTML redesign ([#307](https://github.com/breezy-bays-labs/crap-rs/pull/307))
- *(ci)* #270 — adopt release-plz + crates.io OIDC trusted publishing ([#301](https://github.com/breezy-bays-labs/crap-rs/pull/301))
- #276 — github-annotations reporter + composite action input ([#288](https://github.com/breezy-bays-labs/crap-rs/pull/288))
- #139 #114 — composite scorecard action dispatches crap4ts + cross-adapter row parity ([#282](https://github.com/breezy-bays-labs/crap-rs/pull/282))
- *(crap-core)* [**breaking**] align CRAP thresholds + risk tiers (8/15/25) ([#281](https://github.com/breezy-bays-labs/crap-rs/pull/281))
- #180 #196 #202 — BDD tracked-comment lint + delta.feature spec + colored set_override poison fix ([#279](https://github.com/breezy-bays-labs/crap-rs/pull/279))
- *(crap-core)* #188 — CrapError::MetricNotSupported + AdapterMeta::default_metric + crap4ts walker check + ADR (d) + crap-core 0.2.0 ([#203](https://github.com/breezy-bays-labs/crap-rs/pull/203))
- #73 — `crap4rs init` subcommand (with crap4ts inheritance via AdapterMeta) ([#171](https://github.com/breezy-bays-labs/crap-rs/pull/171))
- *(cli)* #131 — --summary one-line analysis verdict flag ([#167](https://github.com/breezy-bays-labs/crap-rs/pull/167))
- *(crap-core)* [**breaking**] #147 — restore #[non_exhaustive] on 15 result structs (v1.0 prep) ([#166](https://github.com/breezy-bays-labs/crap-rs/pull/166))
- *(crap-core)* #148+#152+#160 — AdapterMeta + decouple from Rust/crap4rs ([#162](https://github.com/breezy-bays-labs/crap-rs/pull/162))

### Fixed

- *(crap4ts)* #253 — skip `.d.ts` declaration files via AdapterMeta::forced_excludes ([#258](https://github.com/breezy-bays-labs/crap-rs/pull/258))
- #163 — adapter-aware coverage preflight + walker reconciliation + config-path hint ([#164](https://github.com/breezy-bays-labs/crap-rs/pull/164))
- *(crap-core)* #150 — late-bind coverage adapter via factory closure ([#158](https://github.com/breezy-bays-labs/crap-rs/pull/158))

### Other

- add per-crate READMEs for crates.io display ([#305](https://github.com/breezy-bays-labs/crap-rs/pull/305))
- *(ci)* #261 — ast-purity layer-4 adapter-vocabulary string-literal ban ([#286](https://github.com/breezy-bays-labs/crap-rs/pull/286))
- *(crap-core)* #178 #179 — port-surface cleanup (CrapError rename + CoveragePort::parse to &Path) ([#262](https://github.com/breezy-bays-labs/crap-rs/pull/262))
- pre-flight scaffold for TS-adapter pipeline (gitignore + delta.feature relocation + #173 BDD scenarios) ([#195](https://github.com/breezy-bays-labs/crap-rs/pull/195))
- *(bdd)* #168 — tag lexicon + retag scenarios + clean up Background ([#170](https://github.com/breezy-bays-labs/crap-rs/pull/170))
- *(crap-core)* #161 — AdapterMeta polish + ci(ast-purity) adapter-name gate ([#165](https://github.com/breezy-bays-labs/crap-rs/pull/165))

### Added

- `--format github-annotations` emits GitHub Actions `::warning`
  workflow commands so threshold-exceeding functions render inline on
  the PR Files Changed tab — universal, free, no GHAS / Code Scanning
  dependency. Like SARIF, this is a gate translation: the reporter
  iterates the unshaped `view.full.functions` regardless of `--top` /
  `--sort-by` / `--only-failing`. New `--annotation-limit N` (u32,
  range 1..=100, default 10) caps emission to match the GH Actions
  per-step UI cap; over-cap eligible findings surface as a trailing
  `::notice::N more functions exceed threshold; see scorecard for the
  full list` line. Also configurable via `[output] annotation_limit`
  in `crap4rs.toml`. The composite scorecard action
  gained matching `annotations` (bool) and `annotation-limit` inputs
  for opt-in inline rendering. (#276)
- `crap4rs init` subcommand generates a starter `crap4rs.toml`
  in the current directory. Auto-detects `src/`
  → `crates/` → falls back to `src` with a hint comment. Interactive
  by default (one prompt mapping `s|d|l` to strict/default/lenient
  preset); `--non-interactive` for CI; `--force` to overwrite an
  existing config. Emits Rust-ecosystem exclude defaults
  (`tests/**`, `benches/**`, `examples/**`). (#73)
- `--summary` flag emits a single-line analysis verdict to stdout (e.g.
  `PASS: 1082 functions | 0 above threshold (25) | worst: 13.0 | avg: 1.6`),
  matching crap4ts's `formatSummaryLine` byte-for-byte. Short-circuits
  `--format`, composes with `--no-fail` (exit 0 always, summary
  emitted) and `--quiet` (quiet wins — no output). Closes the
  2026-05-08 crap4rs ↔ crap4ts parity audit's final gap. (#131)

### Fixed

- Threshold cutoffs are now calibrated per complexity metric instead
  of a single shared scalar. A cyclomatic count and a cognitive count
  have different magnitudes for the same function, so one cutoff
  cannot fit both — applying the cognitive cutoff to cyclomatic scores
  silently mis-gated. The strict/default/lenient presets now resolve
  to cyclomatic `8/16/30` or cognitive `15/25/40` based on the
  effective metric. User-visible behavior change: `crap4rs --metric
  cyclomatic` with no flag now gates at `16` (was `25`) and `--strict`
  at `8` (was `15`). `crap4rs`'s cognitive defaults (the common path)
  are unchanged. The generated `crap4rs.toml` threshold comment now
  states which metric the printed cutoffs apply to. (#218)

### Changed

- Multi-format `--format` invocations now permit a single stdout entry
  alongside file-targeted entries (previously every entry had to
  specify a file). Two or more stdout entries are still rejected — the
  underlying "cannot multiplex stdout" rule stands. Unblocks the
  intended composite-CI shape
  `--format markdown:scorecard.md,github-annotations`, where the
  markdown is captured as a workflow artefact and the
  `github-annotations` workflow commands flow through to the GH
  Actions runner. (#276)
- Config-file `threshold = N` now takes precedence over
  `preset = "..."` when both are set in the same `crap4rs.toml`.
  This makes config-file resolution consistent with
  CLI semantics, where an explicit `--threshold N` already overrides
  `--strict` / `--lenient`. Users who had both fields set will now get
  the literal value; previously the preset silently won. The
  `init`-generated config never writes both, so the blast radius is
  limited to hand-edited configs. (#218)
</blockquote>

## `crap4ts`

<blockquote>

## [2.0.0-rc.3](https://github.com/breezy-bays-labs/crap-rs/compare/crap4ts-v2.0.0-rc.2...crap4ts-v2.0.0-rc.3) - 2026-05-24

### Added

- *(crap-core)* #260 — askama-templated HTML + markdown reporters + Sakura HTML redesign ([#307](https://github.com/breezy-bays-labs/crap-rs/pull/307))

### Added

- `crap4ts init` subcommand generates a starter `crap4ts.toml`
  in the current directory. Auto-detects `src/`
  → `crates/` → falls back to `src` with a hint comment. Interactive
  by default (one prompt mapping `s|d|l` to strict/default/lenient
  preset); `--non-interactive` for CI; `--force` to overwrite an
  existing config. Emits TS-ecosystem exclude defaults
  (`node_modules/**`, `dist/**`, `coverage/**`). (#73)

### Fixed

- Threshold cutoffs are now calibrated per complexity metric instead
  of a single shared scalar. A cyclomatic count and a cognitive count
  have different magnitudes for the same function, so one cutoff
  cannot fit both — applying the cognitive cutoff to cyclomatic scores
  silently mis-gated. The strict/default/lenient presets now resolve
  to cyclomatic `8/16/30` or cognitive `15/25/40` based on the
  effective metric. User-visible behavior change: `crap4ts` with no
  threshold flag now gates at `16` (was `25`), `--strict` at `8`
  (was `15`), `--lenient` at `30` (was `40`). The generated
  `crap4ts.toml` threshold comment now states which metric the
  printed cutoffs apply to. (#218)

### Changed

- Config-file `threshold = N` now takes precedence over
  `preset = "..."` when both are set in the same `crap4ts.toml`.
  This makes config-file resolution consistent with
  CLI semantics, where an explicit `--threshold N` already overrides
  `--strict` / `--lenient`. Users who had both fields set will now get
  the literal value; previously the preset silently won. The
  `init`-generated config never writes both, so the blast radius is
  limited to hand-edited configs. (#218)
- Istanbul `coverage-final.json` parser now models only the
  fields it actually consumes (`path`, `s`, `statementMap.start.line`,
  `b`, `branchMap`). Unconsumed fields (`f`/`fnMap`, statement/branch
  `end` positions, `column`, branch `type`) are no longer deserialized,
  so emitter-side `null` or shape drift in those fields can no longer
  abort the whole-file parse. Forward-looking: every captured jest 29 /
  vitest-istanbul 4 / nyc 17 / c8 10 fixture already parsed cleanly, so
  no current producer triggered this; the change removes a latent
  whole-file-bail vector and locks the four producers as regression
  fixtures. (#214)
- Functions declared inside a TypeScript `namespace` now report with
  a namespace-qualified name — `Foo.bar`, `A.B.f` (dotted and
  block-nested forms both qualify), `Svc.Repo.find` for a class method
  inside a namespace — instead of the bare local name. This mirrors
  the existing class-method qualification (`C.m`) and changes the
  `function` field in the JSON envelope and the table/markdown
  reporters for any namespaced function. Qualification is shallow:
  only direct namespace members carry the prefix; functions nested
  inside them stay bare (`inner`, not `A.inner`), matching how
  class-nested functions already behave. Forward-looking: no
  first-party fixture corpus emits namespaced output today (the
  wire-snapshot corpus has no `namespace`), so no captured snapshot
  drifts; the change disambiguates namespace output and makes it
  consistent with class output ahead of crap4ts@2.0.0. (#221)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub annotations reporter with annotation limit control
  * Configuration generator utility
  * Summary output flag
  * Improved threshold calibration for complexity metrics
  * Enhanced HTML and markdown reporters with updated visual design

* **Documentation**
  * Updated changelogs for versions 0.6.0 and 2.0.0-rc.3

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/breezy-bays-labs/crap-rs/pull/308?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->