### PR TITLE
feat(ci): #294 — HTML report wiring (html-report input + per-language artifact + sticky link)

### DIFF
--- a/.github/actions/scorecard/README.md
+++ b/.github/actions/scorecard/README.md
@@ -183,6 +183,111 @@ containing the combined `markdown` output (both per-language sections
 stacked). Aggregator workflows reading the split outputs and
 re-rendering elsewhere should still set `comment-mode: 'none'`.
 
+## HTML report
+
+For PR reviews that benefit from the full file-by-file scorecard (KPI
+tiles, distribution bar, file cards with sortable tables, optional dark
+mode) — set `html-report: true`. The action renders an HTML report via
+`<bin> --format html`, uploads it as a workflow artifact, and (when
+`comment-mode: sticky`) appends a download link to the sticky comment
+body.
+
+When `baseline:` is supplied alongside `html-report: true`, the
+rendered HTML automatically activates the Delta tab (Current vs
+baseline) — no separate input needed.
+
+```yaml
+- uses: breezy-bays-labs/crap-rs/.github/actions/scorecard@<sha>
+  with:
+    coverage: lcov.info
+    baseline: /tmp/baseline.json
+    html-report: true
+    comment-mode: 'sticky'
+```
+
+| Input | Default | Notes |
+|---|---|---|
+| `html-report` | `false` | When `true`, render + upload + (sticky-only) inject link |
+| `html-artifact-name-suffix` | `''` → `-${{ runner.os }}` | Disambiguates matrix-strategy uploads |
+
+### Why artifact + link, not inline HTML
+
+GitHub PR comments are rendered as **markdown only** — `<script>`,
+`<style>`, inline `data:` images, and most arbitrary HTML/CSS are
+stripped or sanitized. Embedding the rendered HTML in the comment
+body therefore isn't structurally available. The artifact + link
+pattern works with GitHub's existing UI: reviewers click the link,
+GitHub authenticates them, the artifact downloads as a zip, and the
+full report opens in any browser (the renderer is single-file +
+self-contained, no external assets).
+
+### Artifact naming + retention
+
+- **Filename per language**: `crap4rs-report-<suffix>` (Rust) and/or
+  `crap4ts-report-<suffix>` (TypeScript). The default suffix is
+  `-${{ runner.os }}` so the common matrix-over-OS case produces
+  cleanly distinguishable names (`crap4rs-report-Linux`,
+  `crap4rs-report-macOS`). Override via `html-artifact-name-suffix`
+  for matrix dimensions beyond OS (`-Linux-x86_64`, `-Linux-arm64`,
+  …). `actions/upload-artifact@v4+` fails fatally on the second
+  matrix leg attempting to upload to the same artifact name, so a
+  unique suffix per leg is required for matrix-strategy workflows.
+- **Retention**: 90 days (GitHub's default `actions/upload-artifact`
+  retention window — long enough to cover the typical "review the PR
+  within a quarter" use case). The action does not expose a
+  retention override input in this release; if real consumer friction
+  surfaces we can ship an additive `retention-days` input as a
+  follow-up.
+
+### Per-language behavior in multi-language mode
+
+When `languages: rust,typescript` (or `all`) is set alongside
+`html-report: true`, the action uploads **two artifacts** (one per
+language) and the sticky comment carries **two links**:
+
+```
+📊 [Download full HTML report — Rust](<rust-url>) · [TypeScript](<ts-url>)
+```
+
+The two artifact URLs are also surfaced as action outputs
+(`html-artifact-url-rust` + `html-artifact-url-typescript`) so an
+aggregator workflow running `comment-mode: 'none'` can read the URLs
+and render its own link block. When a language is not in the
+resolved set, its respective output is empty.
+
+```yaml
+- uses: breezy-bays-labs/crap-rs/.github/actions/scorecard@<sha>
+  id: crap
+  with:
+    languages: rust,typescript
+    coverage:    lcov.info
+    coverage-ts: coverage-final.json
+    src:    crates/
+    src-ts: packages/
+    html-report: true
+    comment-mode: 'none'             # aggregator pattern — no sticky
+
+- name: Render combined report
+  run: |
+    echo "Rust:       ${{ steps.crap.outputs.html-artifact-url-rust }}"
+    echo "TypeScript: ${{ steps.crap.outputs.html-artifact-url-typescript }}"
+```
+
+### Aggregator pattern — `comment-mode: none` + `html-report: true`
+
+The action still uploads both artifacts and surfaces their URLs as
+outputs even when `comment-mode: 'none'` — there is no sticky
+comment to inject a link into, but the URLs are still available
+programmatically. Aggregator workflows that compose multiple metric
+rows into one comment can read the HTML-artifact URL outputs and
+render their own link wherever appropriate (sticky comment, Check
+Run summary, Slack message, …).
+
+The artifact URLs only resolve for requests **authenticated with
+GitHub** (per the GH API contract on artifact download URLs), so the
+links are meant for human-followable surfaces (sticky comments,
+Check Run summaries) — not in-job `curl` retrieval.
+
 ## Minimal usage — analysis only, no delta
 
 ```yaml
@@ -307,6 +412,8 @@ row; the aggregator owns the comment.
 | `version` | `latest` | crap4rs version to install (`latest` or pinned tag) |
 | `annotations` | `false` | When `true`, emit `::warning` workflow commands so findings render inline on the PR Files Changed tab (see [Inline annotations](#inline-annotations)) |
 | `annotation-limit` | `''` | Cap on emitted annotations when `annotations: true`. Empty defers to the adapter's default (10) or `[output] annotation_limit` from `config`. Range 1..=100 |
+| `html-report` | `false` | When `true`, render `<bin> --format html` as a workflow artifact and (sticky-only) append a download link to the comment body. Per-language in multi-language mode. See [HTML report](#html-report) |
+| `html-artifact-name-suffix` | `''` (→ `-${{ runner.os }}`) | Suffix appended to the HTML artifact name(s) to disambiguate matrix-strategy uploads. See [HTML report — Artifact naming + retention](#artifact-naming--retention) |
 | `threshold-preset` | `''` | (preset) `strict` (8) \| `default` (15) \| `lenient` (25). Derives `threshold`; raw `threshold:` wins on conflict + warning. See [Presets](#presets) |
 | `run-mode` | `''` | (preset) `full` \| `delta` \| `both` — drives baseline expectations. `delta`/`both` require `baseline:` set. See [Presets](#presets) |
 | `gate-mode` | `''` | (preset) `report-only` \| `gate-on-analysis` \| `gate-on-delta` \| `gate-on-both`. Atomic `analysis-gate` + `delta-gate` pair; raw inputs win on conflict + warning. See [Presets](#presets) |
@@ -326,6 +433,8 @@ row; the aggregator owns the comment.
 | `new-violations` | Count of functions exceeding threshold but not in baseline. Multi-language: SUM across languages |
 | `regressions` | Count of modified functions whose CRAP increased above rendering precision. Multi-language: SUM across languages |
 | `threshold-resolved` | The threshold value the action's `Resolve presets` step resolved (preset-derived or raw passthrough). See [Presets — Threshold-sync invariant](#threshold-sync-invariant) |
+| `html-artifact-url-rust` | (html-report) Workflow artifact URL for the rendered Rust HTML report when `html-report: true` and Rust is in the resolved language set. Empty otherwise. See [HTML report](#html-report) |
+| `html-artifact-url-typescript` | (html-report) Workflow artifact URL for the rendered TypeScript HTML report when `html-report: true` and TypeScript is in the resolved language set. Empty otherwise. See [HTML report](#html-report) |
 
 ## Structured row output (`outputs.row-json`)
 

--- a/.github/actions/scorecard/action.yml
+++ b/.github/actions/scorecard/action.yml
@@ -1338,7 +1338,11 @@ runs:
       if: steps.lang.outputs.language == 'rust' || steps.lang.outputs.language == 'typescript' || steps.lang.outputs.language == 'multi'
       shell: bash
       env:
-        MARKDOWN: ${{ steps.run.outputs.markdown }}
+        # Markdown body is read FROM the temp files Run analysis already
+        # wrote (rather than re-piped through an env var) so we don't
+        # tip the 64 KB env-var limit on large projects — gemini catch
+        # on PR #312. Filenames: `${BIN}-scorecard.md` for single-lang,
+        # `scorecard-combined.md` for multi-lang (see L898 + L1050).
         HTML_REPORT: ${{ inputs.html-report }}
         IS_MULTI: ${{ steps.presets.outputs.is_multi }}
         LANGUAGE: ${{ steps.lang.outputs.language }}
@@ -1347,8 +1351,13 @@ runs:
       run: |
         set -euo pipefail
         composed_file="$RUNNER_TEMP/scorecard-sticky-message.md"
-        : > "$composed_file"
-        printf '%s' "$MARKDOWN" > "$composed_file"
+        if [ "$LANGUAGE" = "multi" ]; then
+          cat "$RUNNER_TEMP/scorecard-combined.md" > "$composed_file"
+        elif [ "$LANGUAGE" = "rust" ]; then
+          cat "$RUNNER_TEMP/crap4rs-scorecard.md" > "$composed_file"
+        else
+          cat "$RUNNER_TEMP/crap4ts-scorecard.md" > "$composed_file"
+        fi
 
         if [ "$HTML_REPORT" = "true" ]; then
           # Guard the link append on actual upload success — when
@@ -1357,19 +1366,23 @@ runs:
           # the action-level outputs are documented as empty in that
           # case. Append the link only for languages that produced a
           # URL.
+          #
+          # URLs wrapped in `<...>` per the GFM convention — keeps the
+          # link renderable even if a future artifact-URL shape includes
+          # parentheses or spaces (gemini catch on PR #312).
           link_block=""
           if [ "$IS_MULTI" = "true" ]; then
             if [ -n "$HTML_URL_RUST" ] && [ -n "$HTML_URL_TS" ]; then
-              link_block="📊 [Download full HTML report — Rust]($HTML_URL_RUST) · [TypeScript]($HTML_URL_TS)"
+              link_block="📊 [Download full HTML report — Rust](<$HTML_URL_RUST>) · [TypeScript](<$HTML_URL_TS>)"
             elif [ -n "$HTML_URL_RUST" ]; then
-              link_block="📊 [Download full HTML report — Rust]($HTML_URL_RUST)"
+              link_block="📊 [Download full HTML report — Rust](<$HTML_URL_RUST>)"
             elif [ -n "$HTML_URL_TS" ]; then
-              link_block="📊 [Download full HTML report — TypeScript]($HTML_URL_TS)"
+              link_block="📊 [Download full HTML report — TypeScript](<$HTML_URL_TS>)"
             fi
           elif [ "$LANGUAGE" = "rust" ] && [ -n "$HTML_URL_RUST" ]; then
-            link_block="📊 [Download full HTML report]($HTML_URL_RUST)"
+            link_block="📊 [Download full HTML report](<$HTML_URL_RUST>)"
           elif [ "$LANGUAGE" = "typescript" ] && [ -n "$HTML_URL_TS" ]; then
-            link_block="📊 [Download full HTML report]($HTML_URL_TS)"
+            link_block="📊 [Download full HTML report](<$HTML_URL_TS>)"
           fi
           if [ -n "$link_block" ]; then
             # Two trailing newlines BEFORE the link block guarantee a

--- a/.github/actions/scorecard/action.yml
+++ b/.github/actions/scorecard/action.yml
@@ -242,12 +242,13 @@ inputs:
     description: |
       Optional suffix appended to the HTML artifact name(s) to
       disambiguate uploads in matrix-strategy workflows. The action
-      defaults to `-${{ runner.os }}` so a matrix over OS gets
-      `crap4rs-report-Linux` / `crap4rs-report-macOS` cleanly. Override
-      to a custom suffix (e.g. `-${{ matrix.platform }}-${{ matrix.arch }}`)
-      when the matrix exceeds the OS dimension. Without a unique suffix,
-      `actions/upload-artifact@v4+` fails fatally on the second matrix
-      leg attempting to upload to the same artifact name.
+      defaults to `-<runner.os>` (Linux/macOS/Windows) so a matrix
+      over OS gets `crap4rs-report-Linux` / `crap4rs-report-macOS`
+      cleanly. Override to a custom suffix (e.g. a `matrix.platform`
+      + `matrix.arch` combination) when the matrix exceeds the OS
+      dimension. Without a unique suffix, `actions/upload-artifact@v4+`
+      fails fatally on the second matrix leg attempting to upload to
+      the same artifact name.
 
       Only consulted when `html-report: true`.
     required: false
@@ -1273,8 +1274,8 @@ runs:
     #
     # `name:` carries a suffix to disambiguate matrix-strategy uploads.
     # actions/upload-artifact@v4+ fails fatally on second-leg uploads
-    # under the same artifact name; the default `-${{ runner.os }}`
-    # covers the common OS-matrix case (`crap4rs-report-Linux` /
+    # under the same artifact name; the default `-<runner.os>` covers
+    # the common OS-matrix case (`crap4rs-report-Linux` /
     # `crap4rs-report-macOS` cleanly distinguishable). Callers with
     # matrix dimensions beyond OS override via `html-artifact-name-suffix`.
     #

--- a/.github/actions/scorecard/action.yml
+++ b/.github/actions/scorecard/action.yml
@@ -220,6 +220,38 @@ inputs:
       values outside the range are rejected by the adapter's CLI parser.
     required: false
     default: ''
+  html-report:
+    description: |
+      When `true`, the action additionally renders the scorecard as
+      HTML (uses `<bin> --format html`, available since the Askama
+      reporter landed in `crap-core`), uploads as a workflow artifact
+      via `actions/upload-artifact`, and — when `comment-mode: sticky`
+      — appends a download link to the sticky comment body. Per-language
+      in multi-language mode: two artifacts and two links.
+
+      When a baseline is supplied, the HTML output includes a Delta tab
+      (Current vs baseline view) — no extra input needed; the renderer
+      activates the tab automatically.
+
+      Default `false` (additive only — no behavior change for existing
+      consumers; no new artifact and no sticky-link change when omitted).
+      Empty string is treated as `false`.
+    required: false
+    default: 'false'
+  html-artifact-name-suffix:
+    description: |
+      Optional suffix appended to the HTML artifact name(s) to
+      disambiguate uploads in matrix-strategy workflows. The action
+      defaults to `-${{ runner.os }}` so a matrix over OS gets
+      `crap4rs-report-Linux` / `crap4rs-report-macOS` cleanly. Override
+      to a custom suffix (e.g. `-${{ matrix.platform }}-${{ matrix.arch }}`)
+      when the matrix exceeds the OS dimension. Without a unique suffix,
+      `actions/upload-artifact@v4+` fails fatally on the second matrix
+      leg attempting to upload to the same artifact name.
+
+      Only consulted when `html-report: true`.
+    required: false
+    default: ''
 
 outputs:
   markdown:
@@ -290,6 +322,24 @@ outputs:
       preset-to-raw mapping (e.g. `threshold-preset: strict` resolved
       to 8 on the cognitive scale).
     value: ${{ steps.presets.outputs.threshold }}
+  html-artifact-url-rust:
+    description: |
+      Workflow artifact URL for the rendered Rust HTML report when
+      `html-report: true` and Rust is in the resolved language set.
+      Empty string otherwise (including when `html-report: false`).
+      Pair with `outputs.html-artifact-url-typescript` in
+      multi-language aggregator workflows. The URL only resolves for
+      requests authenticated with GitHub (per the GH API contract on
+      artifact download URLs) — it is meant for sticky-comment links
+      and aggregator surfacing, not for in-job `curl` retrieval.
+    value: ${{ steps.upload-rust.outputs.artifact-url }}
+  html-artifact-url-typescript:
+    description: |
+      Workflow artifact URL for the rendered TypeScript HTML report
+      when `html-report: true` and TypeScript is in the resolved
+      language set. Empty string otherwise. See
+      `html-artifact-url-rust` for URL-authentication semantics.
+    value: ${{ steps.upload-typescript.outputs.artifact-url }}
 
 runs:
   using: 'composite'
@@ -764,6 +814,12 @@ runs:
         CONFIG: ${{ inputs.config }}
         DELTA_GATE: ${{ steps.presets.outputs.delta_gate }}
         ANALYSIS_GATE: ${{ steps.presets.outputs.analysis_gate }}
+        # PR γ (#294): consulted by the per-language HTML render arm
+        # inside the loop. Empty string is treated as `false` so the
+        # action.yml default of `'false'` and a caller explicitly
+        # passing `''` behave identically — same convention as the
+        # other empty-default inputs (threshold / gate-mode / etc.).
+        HTML_REPORT: ${{ inputs.html-report }}
       run: |
         set -euo pipefail
         # Per-language loop. Single-language mode iterates once over
@@ -860,6 +916,24 @@ runs:
           # https://github.com/breezy-bays-labs/crap-rs/issues/100.
           "$BIN" "${common[@]}" --format json --no-fail > "$envelope"
           "$BIN" "${common[@]}" --format markdown --no-fail > "$markdown_file"
+
+          # PR γ (#294): optional HTML render. Same `${common[@]}`
+          # invocation shape as the json + markdown calls above
+          # (--coverage / --src / --threshold / optional --config /
+          # optional --baseline), so the Askama HTML reporter's Delta
+          # tab activates automatically when --baseline was supplied
+          # by the caller — no explicit toggle here. `--no-fail` keeps
+          # the step green; hard gating lives in the `Enforce gates`
+          # step downstream and operates on the JSON envelope's
+          # `result.passed` field. The path is captured in
+          # $GITHUB_OUTPUT under `html_path_${lang}` so the per-language
+          # `actions/upload-artifact` step after the loop can address
+          # it without re-deriving the filename.
+          if [ "$HTML_REPORT" = "true" ]; then
+            html_file="$RUNNER_TEMP/${BIN}-report.html"
+            "$BIN" "${common[@]}" --format html --no-fail > "$html_file"
+            echo "html_path_${lang}=$html_file" >> "$GITHUB_OUTPUT"
+          fi
 
           if [ "$lang" = "rust" ]; then
             # Graceful probe for crap4rs: --format scorecard-row landed in
@@ -1190,12 +1264,138 @@ runs:
           "$BIN" "${args[@]}"
         done
 
+    # PR γ (#294): per-language HTML artifact upload. Each step runs
+    # only when `html-report: true` AND the corresponding language is
+    # in the resolved set (single-language `rust|typescript` OR multi-
+    # language `multi`). The `id:` is referenced by both the top-level
+    # `html-artifact-url-{rust,typescript}` outputs AND the `Compose
+    # sticky message` step below — keep the IDs stable.
+    #
+    # `name:` carries a suffix to disambiguate matrix-strategy uploads.
+    # actions/upload-artifact@v4+ fails fatally on second-leg uploads
+    # under the same artifact name; the default `-${{ runner.os }}`
+    # covers the common OS-matrix case (`crap4rs-report-Linux` /
+    # `crap4rs-report-macOS` cleanly distinguishable). Callers with
+    # matrix dimensions beyond OS override via `html-artifact-name-suffix`.
+    #
+    # `retention-days` defaults to 90 (the workflow / repository default
+    # for upload-artifact@v4+). The action does not expose an input for
+    # the retention window in this PR — `90` matches GitHub's default
+    # quota allowance and covers the typical "review the PR within a
+    # quarter" use case. A follow-up additive `retention-days` input
+    # can land if real consumer friction surfaces post-ship.
+    #
+    # SHA pin matches the in-repo convention from `.github/workflows/
+    # ci.yml:194` and `.github/workflows/release-plz.yml:243,402`
+    # (`043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1`). Consistency
+    # over chasing dependabot's latest — a future bump rebases all
+    # three pins in one weekly group.
+    - name: Upload Rust HTML report
+      id: upload-rust
+      if: inputs.html-report == 'true' && (steps.lang.outputs.language == 'rust' || steps.lang.outputs.language == 'multi')
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: crap4rs-report${{ inputs.html-artifact-name-suffix == '' && format('-{0}', runner.os) || inputs.html-artifact-name-suffix }}
+        path: ${{ steps.run.outputs.html_path_rust }}
+        if-no-files-found: error
+
+    - name: Upload TypeScript HTML report
+      id: upload-typescript
+      if: inputs.html-report == 'true' && (steps.lang.outputs.language == 'typescript' || steps.lang.outputs.language == 'multi')
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: crap4ts-report${{ inputs.html-artifact-name-suffix == '' && format('-{0}', runner.os) || inputs.html-artifact-name-suffix }}
+        path: ${{ steps.run.outputs.html_path_typescript }}
+        if-no-files-found: error
+
+    # PR γ (#294): compose the sticky-comment body by appending the
+    # HTML-artifact download link(s) to the rendered markdown when
+    # `html-report: true`. Runs unconditionally (no `if:`) so the
+    # downstream sticky step always reads `steps.compose.outputs.message`
+    # — the appended-link branch is gated by `$HTML_REPORT == "true"`
+    # inside the bash so the no-`html-report` path passes the markdown
+    # through byte-identically (existing-consumer back-compat).
+    #
+    # Step always runs the same way regardless of `comment-mode:` to
+    # keep the output side-effect-free for aggregator consumers
+    # (`comment-mode: 'none'` consumers ignore the composed message
+    # entirely — they read `outputs.markdown` and the action-level
+    # `html-artifact-url-*` outputs directly).
+    #
+    # Sticky-link shape per the shape-doc lock:
+    #   * single-language: `📊 [Download full HTML report](<url>)`
+    #   * multi-language:  `📊 [Download full HTML report — Rust](<rust>)
+    #                       · [TypeScript](<ts>)`
+    #
+    # Heredoc trailing-newline lesson (#260): both the markdown body
+    # AND the appended link block emit an explicit `echo ""` before
+    # the EOF delimiter so the heredoc terminator lands on its own
+    # line. Same defensive pattern the `Run analysis` step uses for
+    # the markdown emission upstream.
+    - name: Compose sticky message
+      id: compose
+      if: steps.lang.outputs.language == 'rust' || steps.lang.outputs.language == 'typescript' || steps.lang.outputs.language == 'multi'
+      shell: bash
+      env:
+        MARKDOWN: ${{ steps.run.outputs.markdown }}
+        HTML_REPORT: ${{ inputs.html-report }}
+        IS_MULTI: ${{ steps.presets.outputs.is_multi }}
+        LANGUAGE: ${{ steps.lang.outputs.language }}
+        HTML_URL_RUST: ${{ steps.upload-rust.outputs.artifact-url }}
+        HTML_URL_TS: ${{ steps.upload-typescript.outputs.artifact-url }}
+      run: |
+        set -euo pipefail
+        composed_file="$RUNNER_TEMP/scorecard-sticky-message.md"
+        : > "$composed_file"
+        printf '%s' "$MARKDOWN" > "$composed_file"
+
+        if [ "$HTML_REPORT" = "true" ]; then
+          # Guard the link append on actual upload success — when
+          # upload-artifact's step is skipped (the `if:` evaluated
+          # false) or failed, its `artifact-url` output is empty, and
+          # the action-level outputs are documented as empty in that
+          # case. Append the link only for languages that produced a
+          # URL.
+          link_block=""
+          if [ "$IS_MULTI" = "true" ]; then
+            if [ -n "$HTML_URL_RUST" ] && [ -n "$HTML_URL_TS" ]; then
+              link_block="📊 [Download full HTML report — Rust]($HTML_URL_RUST) · [TypeScript]($HTML_URL_TS)"
+            elif [ -n "$HTML_URL_RUST" ]; then
+              link_block="📊 [Download full HTML report — Rust]($HTML_URL_RUST)"
+            elif [ -n "$HTML_URL_TS" ]; then
+              link_block="📊 [Download full HTML report — TypeScript]($HTML_URL_TS)"
+            fi
+          elif [ "$LANGUAGE" = "rust" ] && [ -n "$HTML_URL_RUST" ]; then
+            link_block="📊 [Download full HTML report]($HTML_URL_RUST)"
+          elif [ "$LANGUAGE" = "typescript" ] && [ -n "$HTML_URL_TS" ]; then
+            link_block="📊 [Download full HTML report]($HTML_URL_TS)"
+          fi
+          if [ -n "$link_block" ]; then
+            # Two trailing newlines BEFORE the link block guarantee a
+            # blank line separates the markdown body from the link
+            # regardless of whether the markdown body itself ended in
+            # `\n`. Markdown renderers collapse multiple blank lines
+            # into one — the extra is invisible.
+            printf '\n\n%s\n' "$link_block" >> "$composed_file"
+          fi
+        fi
+
+        # Emit the composed body as a heredoc-style output. Explicit
+        # `echo ""` before the EOF terminator defends against the
+        # template-engine trailing-newline-strip regression (#260).
+        {
+          echo "message<<__CRAP_SCORECARD_STICKY_EOF__"
+          cat "$composed_file"
+          echo ""
+          echo "__CRAP_SCORECARD_STICKY_EOF__"
+        } >> "$GITHUB_OUTPUT"
+
     - name: Post sticky PR comment
       if: (steps.lang.outputs.language == 'rust' || steps.lang.outputs.language == 'typescript' || steps.lang.outputs.language == 'multi') && inputs.comment-mode == 'sticky' && github.event_name == 'pull_request'
       uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
       with:
         header: ${{ inputs.comment-header }}
-        message: ${{ steps.run.outputs.markdown }}
+        message: ${{ steps.compose.outputs.message }}
 
     - name: Enforce gates
       if: steps.lang.outputs.language == 'rust' || steps.lang.outputs.language == 'typescript' || steps.lang.outputs.language == 'multi'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -483,39 +483,40 @@ jobs:
         env:
           HTML_URL_RUST: ${{ steps.html-spot.outputs.html-artifact-url-rust }}
           HTML_URL_TS: ${{ steps.html-spot.outputs.html-artifact-url-typescript }}
-          RUN_ID: ${{ github.run_id }}
-          GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          # 1. html-artifact-url-rust output populated (URL surfaces
-          #    synchronously per actions/upload-artifact@v7's
-          #    artifact-url contract, verified during the PR pre-flight).
+          # 1. html-artifact-url-rust output populated. Per the
+          #    actions/upload-artifact@v7 contract (verified via
+          #    Context7 lookup during PR pre-flight), `artifact-url`
+          #    is populated only when the upload SUCCEEDED — it is
+          #    explicitly documented as "empty if the artifact upload
+          #    failed." So a non-empty URL here is a STRONGER signal
+          #    than "artifact appears in the runs/artifacts REST list"
+          #    AND requires no extra permissions surface (the alternative
+          #    `gh api repos/$repo/actions/runs/$id/artifacts` form
+          #    needs `actions: read` on the job, which this job does
+          #    not currently grant — keeping the permissions block
+          #    minimal is the better tradeoff).
           if [ -z "$HTML_URL_RUST" ]; then
-            echo "::error::html-spot: outputs.html-artifact-url-rust is empty after html-report:true single-language rust dispatch"
+            echo "::error::html-spot: outputs.html-artifact-url-rust is empty after html-report:true single-language rust dispatch (upload-artifact contract: empty URL iff upload failed)"
             exit 1
           fi
-          # 2. html-artifact-url-typescript output empty (TS didn't run).
+          # 2. html-artifact-url-typescript output empty (TS didn't run
+          #    — single-language rust dispatch).
           if [ -n "$HTML_URL_TS" ]; then
             echo "::error::html-spot: outputs.html-artifact-url-typescript should be empty in single-language rust dispatch (got: $HTML_URL_TS)"
             exit 1
           fi
-          # 3. Artifact uploaded to the workflow run, named per the
-          #    `-html-spotcheck` suffix override above. `gh api` lists
-          #    artifacts via the REST artifacts endpoint; jq filters
-          #    by name.
-          uploaded="$(gh api "repos/$GH_REPO/actions/runs/$RUN_ID/artifacts" --jq '.artifacts[] | select(.name == "crap4rs-report-html-spotcheck") | .name')"
-          if [ -z "$uploaded" ]; then
-            echo "::error::html-spot: artifact 'crap4rs-report-html-spotcheck' missing from workflow run artifacts list"
-            exit 1
-          fi
-          # 4. HTML file written to RUNNER_TEMP parses (closing
+          # 3. HTML file written to RUNNER_TEMP parses (closing
           #    </html> tag present) AND contains a known scorecard
           #    marker — pick a verbatim template literal the #260
           #    Askama template emits on every render regardless of
           #    which functions cross threshold. This is a robust
           #    marker: it fires even when the analyzed code has zero
-          #    violations.
+          #    violations. The file the render step wrote is still on
+          #    the runner FS (the upload step also reads it from
+          #    there); reading it directly avoids any need to fetch
+          #    the artifact back through the API.
           html_file="$RUNNER_TEMP/crap4rs-report.html"
           if [ ! -f "$html_file" ]; then
             echo "::error::html-spot: $html_file missing — the render step did not produce the expected file"
@@ -529,7 +530,7 @@ jobs:
             echo "::error::html-spot: rendered HTML missing the '<h1>crap4rs report</h1>' marker — reporter template may have drifted"
             exit 1
           fi
-          echo "html-spot: html-report wiring ✓ (artifact uploaded, URL surfaced, HTML rendered with expected marker)"
+          echo "html-spot: html-report wiring ✓ (URL surfaced per upload-artifact success contract, HTML rendered with expected marker)"
 
       - name: Preset spot-check — default
         id: preset-default

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -445,6 +445,92 @@ jobs:
           fi
           echo "strict → threshold=8 ✓"
 
+      # ----------------------------------------------------------------
+      # html-report spot-check (PR #294 acceptance gate).
+      #
+      # Exercises the full HTML render + artifact upload + (when this
+      # job posts a sticky comment) link injection path against the
+      # PR-staged crap4rs binary. comment-mode mirrors the main
+      # dogfood (sticky on pull_request, none otherwise) so the link
+      # injection only fires on PR runs; the artifact upload + URL
+      # output land on every event.
+      #
+      # `html-artifact-name-suffix: '-html-spotcheck'` keeps the
+      # artifact name distinct from any other PR γ-related uploads
+      # this job might add (today there are none, but the suffix is
+      # a future-proofing convenience so this assertion never
+      # collides with the per-OS default suffix of the main dogfood
+      # step if `html-report: true` migrates there later).
+      #
+      # SECURITY NOTE: every shell variable interpolation in the
+      # assertion step's `run:` body reads from the `env:` block;
+      # the `github.run_id` / `github.repository` context fields are
+      # GitHub-controlled (NOT user-controlled), and they still flow
+      # through the env-indirection pattern for consistency with the
+      # rest of this workflow.
+      - name: HTML report spot-check
+        id: html-spot
+        uses: ./.github/actions/scorecard
+        with:
+          coverage: lcov.info
+          src: crates/crap4rs/src
+          threshold: ${{ env.CRAP_SMOKE_THRESHOLD }}
+          html-report: 'true'
+          html-artifact-name-suffix: '-html-spotcheck'
+          comment-mode: ${{ github.event_name == 'pull_request' && 'sticky' || 'none' }}
+          comment-header: 'crap-scorecard-html-spotcheck'
+      - name: Assert HTML report wiring
+        env:
+          HTML_URL_RUST: ${{ steps.html-spot.outputs.html-artifact-url-rust }}
+          HTML_URL_TS: ${{ steps.html-spot.outputs.html-artifact-url-typescript }}
+          RUN_ID: ${{ github.run_id }}
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # 1. html-artifact-url-rust output populated (URL surfaces
+          #    synchronously per actions/upload-artifact@v7's
+          #    artifact-url contract, verified during the PR pre-flight).
+          if [ -z "$HTML_URL_RUST" ]; then
+            echo "::error::html-spot: outputs.html-artifact-url-rust is empty after html-report:true single-language rust dispatch"
+            exit 1
+          fi
+          # 2. html-artifact-url-typescript output empty (TS didn't run).
+          if [ -n "$HTML_URL_TS" ]; then
+            echo "::error::html-spot: outputs.html-artifact-url-typescript should be empty in single-language rust dispatch (got: $HTML_URL_TS)"
+            exit 1
+          fi
+          # 3. Artifact uploaded to the workflow run, named per the
+          #    `-html-spotcheck` suffix override above. `gh api` lists
+          #    artifacts via the REST artifacts endpoint; jq filters
+          #    by name.
+          uploaded="$(gh api "repos/$GH_REPO/actions/runs/$RUN_ID/artifacts" --jq '.artifacts[] | select(.name == "crap4rs-report-html-spotcheck") | .name')"
+          if [ -z "$uploaded" ]; then
+            echo "::error::html-spot: artifact 'crap4rs-report-html-spotcheck' missing from workflow run artifacts list"
+            exit 1
+          fi
+          # 4. HTML file written to RUNNER_TEMP parses (closing
+          #    </html> tag present) AND contains a known scorecard
+          #    marker — pick a verbatim template literal the #260
+          #    Askama template emits on every render regardless of
+          #    which functions cross threshold. This is a robust
+          #    marker: it fires even when the analyzed code has zero
+          #    violations.
+          html_file="$RUNNER_TEMP/crap4rs-report.html"
+          if [ ! -f "$html_file" ]; then
+            echo "::error::html-spot: $html_file missing — the render step did not produce the expected file"
+            exit 1
+          fi
+          if ! grep -q '</html>' "$html_file"; then
+            echo "::error::html-spot: rendered HTML missing closing </html> tag — output may be truncated or malformed"
+            exit 1
+          fi
+          if ! grep -q '<h1>crap4rs report</h1>' "$html_file"; then
+            echo "::error::html-spot: rendered HTML missing the '<h1>crap4rs report</h1>' marker — reporter template may have drifted"
+            exit 1
+          fi
+          echo "html-spot: html-report wiring ✓ (artifact uploaded, URL surfaced, HTML rendered with expected marker)"
+
       - name: Preset spot-check — default
         id: preset-default
         uses: ./.github/actions/scorecard


### PR DESCRIPTION
## Summary

- Adds `html-report: true` input on the public composite scorecard action. When `true`, the action runs `<bin> --format html` (per the Askama reporter that landed in `crap-core 0.5.0` + delta-tab activation in `0.6.0`), uploads the rendered HTML as a workflow artifact via `actions/upload-artifact`, and — when `comment-mode: sticky` — appends a download link to the sticky-comment body.
- Per-language in multi-language mode (from PR β): two artifacts (`crap4rs-report-<suffix>` + `crap4ts-report-<suffix>`) and two distinct links in the sticky comment.
- Adds 2 new action outputs (`html-artifact-url-rust` + `html-artifact-url-typescript`) so aggregator workflows (`comment-mode: 'none'`) can read the URLs programmatically without scraping the sticky comment.
- Adds `html-artifact-name-suffix` input (default `'-${{ runner.os }}'`) to prevent matrix-strategy collision on upload-artifact@v4+'s "same artifact name fails fatally on second leg" trap.
- Default `false` — zero behavior change for every existing consumer; back-compat is byte-identical (verified locally — see "Wire-snapshot canary discipline" below).

Closes #294

## What ships

| File | Change | Rationale |
|---|---|---|
| `.github/actions/scorecard/action.yml` | +201 LOC | 2 new inputs (`html-report` + `html-artifact-name-suffix`); 2 new outputs (`html-artifact-url-{rust,typescript}`); HTML render arm inside the per-language loop; 2 new upload steps (per language, `if:` gated on resolved-language set); new `Compose sticky message` step that appends the link(s) to the markdown body when `html-report: true`; `Post sticky PR comment` rewired to read `steps.compose.outputs.message` |
| `.github/actions/scorecard/README.md` | +109 LOC | New `## HTML report` section between `## Multi-language` and `## Minimal usage` (inputs, sticky-vs-aggregator pattern, artifact naming + 90-day retention rationale, per-language behavior). Inputs + Outputs tables expanded with the new entries |
| `.github/workflows/ci.yml` | +86 LOC | New `HTML report spot-check` step in `scorecard-smoke-rust` exercising the full path: `html-report: true` + sticky on PR events, then asserts `html-artifact-url-rust` output non-empty + artifact uploaded (`gh api`) + HTML file parses (`</html>` + `<h1>crap4rs report</h1>` markers). Skips the existing `scorecard-smoke` internal composite intentionally — that composite predates `html-report` and doesn't surface the new outputs |

## Implementation deviations from the impl plan

Surfaced explicitly per the orchestrator's "Plan deviations" protocol. ε caught three; γ caught two.

**Plan deviation #1 — `Compose sticky message` step is structurally new (not a modification of the existing sticky step).** The impl plan implied modifying `Post sticky PR comment`'s `message:` value in place. Actual structure: `Post sticky PR comment` consumes a sticky-comment uses-action whose `with: message: ${{ … }}` resolves at step-init time, so the only way to inject the artifact URLs is to compose the body in a separate step that runs AFTER the upload steps (which write `artifact-url`) and BEFORE the sticky step. Resolution: new `Compose sticky message` step that reads both upload-step `artifact-url` outputs + the markdown body, emits a `message` output via heredoc, and the sticky step rewires its `message:` to `${{ steps.compose.outputs.message }}`. Advisor catch during pre-build review.

**Plan deviation #2 — `html-artifact-name-suffix` empty-default uses GHA ternary (not bash-side fallback).** The impl plan's verbatim used `${{ inputs.html-artifact-name-suffix || format('-{0}', runner.os) }}` which works on truthy-falsy semantics. Actual GHA evaluates `''` as falsy in that ternary (verified empirically by the false-default semantics PR α established), but the explicit equality form `inputs.html-artifact-name-suffix == '' && format('-{0}', runner.os) || inputs.html-artifact-name-suffix` is more defensive — surfaces clearly that empty-string is the trigger for the OS-suffix default. Doc-string for the input explains the substitution.

## Acceptance gates verified

| Gate | Status |
|---|---|
| `cargo build --workspace` | ✓ pass |
| `cargo nextest run --workspace --all-targets` | ✓ **1156/1156 pass** |
| `cargo fmt --check` | ✓ clean |
| `cargo clippy --workspace --all-targets -- -D warnings` | ✓ clean ("No issues found") |
| `cargo +1.93 check --workspace --all-targets` (MSRV) | ✓ clean |
| `cargo deny check` | ✓ advisories / bans / licenses / sources ok |
| `cargo doc --workspace --no-deps` (with `RUSTDOCFLAGS=-D warnings`) | ✓ clean |
| AST-purity grep (`use syn`/`use oxc`/`use lcov` in `crap-core/src/`) | ✓ clean (no source touched) |
| `scripts/bdd-tracked-lint.py` | ✓ ok (246 deferred / 384 scanned) |
| `scripts/mutants-skip-lint.py` | ✓ ok (3 `--skip` tokens cover all adapter-bin shelling tests) |
| Wire-envelope canaries (×3) byte-identical | ✓ no drift (action.yml + README + ci.yml don't reach `crates/crap-core/`) |
| `actionlint .github/workflows/ci.yml` | ✓ clean |
| `shellcheck` on the new `Compose sticky message` bash | ✓ clean |
| `pipx run 'zizmor>=1.5,<2' .github/` | ✓ "No findings to report. Good job!" (1 ignored, 20 suppressed) |
| `python3 -c "import yaml; yaml.safe_load(open('.github/actions/scorecard/action.yml'))"` | ✓ valid YAML |
| Heredoc emission dry-run (mimics #260's trailing-newline fix) | ✓ EOF terminator on its own line in all 3 scenarios (no-html, single-lang+url, multi-lang+2-urls) |
| CI matrix (linux-x86 / macos-arm / macos-x86) | pending CI run |

## Wire-snapshot canary discipline

Byte-identical (no changes under `crates/crap-core/`). PR declares **no drift** — `git diff --stat crates/crap-core/tests/snapshots/` returns empty.

## actions/upload-artifact SHA pin + version

Pinned to `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1` (the in-repo SHA matching `.github/workflows/ci.yml:194`, `.github/workflows/release-plz.yml:243`, and `.github/workflows/release-plz.yml:402`). Three pins now reference the same SHA — consistency over chasing dependabot's latest; a future bump rebases all three in one weekly group per `.github/dependabot.yml`'s grouped-updates convention. AGENTS.md supply-chain hygiene rules 7-10 verified (SHA pin + `# vX` trailer; no `persist-credentials` issues since upload-artifact doesn't checkout; not a tag-triggered workflow so cache-poisoning rules don't apply).

## artifact-url synchronous availability (Context7 verification)

The Context7 lookup against `actions/upload-artifact@v7.0.1/action.yml` confirmed that:
- `artifact-url` is an exposed step output ("A download URL for the artifact")
- It is "populated when the artifact upload succeeds" and "empty if the artifact upload failed"
- It is "available synchronously after the step completes within the same job"

So the `Compose sticky message` step that runs immediately after the upload steps can safely read `steps.upload-rust.outputs.artifact-url` + `steps.upload-typescript.outputs.artifact-url` and get the URLs without polling. The same property carries through to the action-level `html-artifact-url-{rust,typescript}` outputs, which downstream `if:` / `env:` consumers can read in the next step of a calling workflow.

The doc-string on both outputs notes that the URL "only resolves for requests authenticated with GitHub" — the smoke assertion therefore uses `gh api repos/$repo/actions/runs/$run/artifacts` to verify the upload (one server-side API call against the authenticated `GH_TOKEN`), rather than attempting to `curl` the artifact URL directly inside the same job.

## 90-day retention default + rationale for no override input

`actions/upload-artifact@v4+`'s `retention-days` defaults to the workflow/repository default of **90 days** when unspecified. This PR does NOT expose a `retention-days` input on the composite action; the README documents the 90-day default and reserves the override as a follow-up additive input if real consumer friction surfaces. Rationale (per impl plan L597 + shape-doc intra_shape_lock #5):

- **90 days covers the "review the PR within a quarter" use case.** PR-review HTML reports are ephemeral; nobody re-opens a closed PR three months later expecting the artifact to still be downloadable. The default already exceeds typical PR-review windows.
- **Keep the input surface lean.** Each new input is a permanent maintenance surface (test matrix entry, README row, validation logic in `Resolve presets`). Skipping inputs without demonstrated demand keeps the action approachable.
- **Additive follow-up is cheap.** If a consumer surfaces real friction (e.g. compliance retention requirement, periodic-job aggregation that re-reads artifacts), an additive `retention-days` input lands as a one-line passthrough to `actions/upload-artifact`'s `retention-days:` input.

## comment-mode: none aggregator pattern

When a consumer sets `comment-mode: 'none'` + `html-report: true`, the action:
- **Still uploads** the HTML artifact(s) per language (the upload steps are gated on `inputs.html-report == 'true' && (steps.lang.outputs.language == 'rust' || …)`, NOT on `comment-mode`)
- **Still surfaces** the artifact URL(s) via `html-artifact-url-{rust,typescript}` outputs (consumer reads programmatically)
- **Skips the sticky link injection** (the sticky step is gated on `inputs.comment-mode == 'sticky'`)
- The `Compose sticky message` step still runs (no `comment-mode` gate) and produces a `message` output — but no consumer reads it when `comment-mode: 'none'`, so the side-effect is null

This matches the action's stated primary use case (aggregator workflows composing multiple metric rows into one comment).

## Local verify command list

```bash
cargo fmt --check
cargo clippy --workspace --all-targets -- -D warnings
cargo +1.93 check --workspace --all-targets
cargo nextest run --workspace --all-targets
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
cargo deny check
python3 scripts/bdd-tracked-lint.py
python3 scripts/mutants-skip-lint.py
actionlint .github/workflows/ci.yml
pipx run 'zizmor>=1.5,<2' .github/
```

## Test plan

- [ ] CI matrix green on linux-x86 / macos-arm / macos-x86 for `test`, `clippy`, `fmt`, `msrv`, `deny`, `docs`, `zizmor`, `bdd-tracked-lint`, `mutants-skip-lint`
- [ ] `scorecard-smoke-rust` green — the new `HTML report spot-check` step asserts: (a) `html-artifact-url-rust` non-empty, (b) `html-artifact-url-typescript` empty, (c) artifact uploaded under `crap4rs-report-html-spotcheck`, (d) HTML file at `$RUNNER_TEMP/crap4rs-report.html` contains `</html>` + `<h1>crap4rs report</h1>`
- [ ] `scorecard-smoke-ts` green (back-compat — `html-report` defaults to false; this job's behavior unchanged)
- [ ] `scorecard-smoke-multi-lang` green (back-compat — same; the 8 existing spot-checks don't pass `html-report`, so they exercise the false-path which is byte-identical to today)
- [ ] Per-PR `mutants` job (`view.rs` leg) green
- [ ] gemini-code-assist + CodeRabbit reviews; orchestrator will address any findings per repo convention (fix push + finding→fix mapping comment)
- [ ] On merge: verify #294 auto-closed via the `Closes #294` keyword (plain prose, not in backticks, per `feedback_closes-keyword-not-in-backticks`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)