### PR TITLE
ci(crap-rs): #298 #297 #300 — adopt org-wide release-plz GitHub App identity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1383,9 +1383,28 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: taiki-e/install-action@f48d2f8ba2b452934c948b7be1a768079c3632ff # v2
-        with:
-          tool: dasel
+      # `dasel` (TOML-aware parser used by the audit script) is not
+      # currently available via taiki-e/install-action OR
+      # cargo-binstall's prebuilt-binary index, so we curl the
+      # upstream binary directly and verify a SHA256 baked into this
+      # step. Bumping the version is a two-step manual edit (new
+      # DASEL_VERSION + recompute DASEL_SHA256), kept inline so the
+      # supply-chain provenance stays in one place — Dependabot
+      # doesn't have an ecosystem for curl-fetched binaries.
+      - name: Install dasel
+        env:
+          DASEL_VERSION: v2.8.1
+          DASEL_SHA256: 21fda0a4dc3c779c42737eca4b37e4f187d7ab91ba6301eed97b801af84a9ea2
+        run: |
+          set -euo pipefail
+          curl --fail --silent --show-error --location \
+            "https://github.com/TomWright/dasel/releases/download/${DASEL_VERSION}/dasel_linux_amd64" \
+            -o /tmp/dasel
+          echo "${DASEL_SHA256}  /tmp/dasel" | sha256sum -c -
+          chmod +x /tmp/dasel
+          mkdir -p "$HOME/.local/bin"
+          mv /tmp/dasel "$HOME/.local/bin/dasel"
+          dasel --version
       - name: Audit allowlist for this repo
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1358,6 +1358,39 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo doc --workspace --no-deps
 
+  release-plz-app-scope-audit:
+    # Leaf-scope drift check: assert this repo's name appears in the
+    # canonical release-plz App allowlist
+    # (breezy-bays-labs/.github/release-plz-allowlist.toml). Catches
+    # the case where a PR on the .github repo silently drops this
+    # repo from the allowlist — without this gate that drift would
+    # only surface at the next release-plz token-mint attempt,
+    # mid-release.
+    #
+    # NOT an org-global audit. A leaf-scope check runs on the default
+    # GITHUB_TOKEN (repo-scoped, sufficient to read public contents
+    # via the contents API). The complementary org-global audit
+    # — compare the canonical TOML against the App's actual
+    # per-repo installations — needs an Org Admin PAT, so it lives in
+    # a centralized cron in the breezy-bays-labs/.github repo rather
+    # than every consumer's CI.
+    name: release-plz App scope audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: taiki-e/install-action@f48d2f8ba2b452934c948b7be1a768079c3632ff # v2
+        with:
+          tool: dasel
+      - name: Audit allowlist for this repo
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: scripts/release-plz-app-scope-audit.sh
+
   zizmor:
     # Mechanical enforcement of the SHA-pin + workflow-security policy.
     # Runs `zizmor` (https://woodruffw.github.io/zizmor/) over every

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -12,11 +12,22 @@ name: release-plz
 #             → release-plz-release      (publishes + creates per-crate tags)
 #                  ├─ build-crap4ts-cdylib → publish-crap4ts-npm   (if crap4ts published)
 #                  └─ build-crap4rs-binaries → upload-crap4rs-assets (if crap4rs published)
+#   pull_request: → sync-crap4ts-package-json  (release-plz-opened PRs only)
 #
 # The cdylib build matrix and npm publish job port verbatim from the
 # retired publish.yml; the binary build matrix ports verbatim from
 # the retired release.yml. Gating on `needs.release-plz-release.outputs`
 # replaces the tag-trigger filtering those workflows used.
+#
+# release-plz-pr / release-plz-release / sync-crap4ts-package-json all
+# operate under an org-wide GitHub App identity (release-plz). The
+# App token is minted by the release-plz-app-token composite (hosted
+# in breezy-bays-labs/.github) and passed to release-plz/action via
+# env GITHUB_TOKEN; the workflow's own GITHUB_TOKEN stays scoped to
+# contents:read. Pushes signed by the App identity fire downstream
+# pull_request workflows (the default GITHUB_TOKEN's pushes don't,
+# which is why the sync job couldn't run from the release PR before
+# this identity adoption).
 #
 # Companion files:
 #   release-plz.toml — multi-crate release-plz config
@@ -27,6 +38,15 @@ name: release-plz
 on:
   push:
     branches: [main]
+  # The sync-crap4ts-package-json job (below) listens for release-plz's
+  # auto-opened release PRs. Both event types are needed: `opened`
+  # catches the initial PR, `synchronize` catches subsequent updates
+  # (release-plz force-pushes the release branch when push:main bumps
+  # the release set). Other jobs in this workflow ignore PR events via
+  # job-level `if: github.event_name == 'push'` gates so they stay
+  # push-only.
+  pull_request:
+    types: [opened, synchronize]
 
 # Least-privilege default; per-job permissions elevate as needed.
 permissions:
@@ -39,18 +59,26 @@ jobs:
   release-plz-pr:
     name: Open/update release PR
     runs-on: ubuntu-latest
+    # Push-only: pull_request events go to sync-crap4ts-package-json.
+    if: github.event_name == 'push'
+    # Scopes the org-level secrets (RELEASE_PLZ_APP_ID +
+    # RELEASE_PLZ_APP_PRIVATE_KEY) to this deployment environment so
+    # other workflows in this repo can't read them by accident.
+    environment: release-plz
     concurrency:
       # Serialize release-PR opens so two concurrent push events don't
       # race to create two competing release PRs against the same ref.
       group: release-plz-pr-${{ github.ref }}
       cancel-in-progress: false
     permissions:
-      contents: write
-      pull-requests: write
+      # The workflow's own GITHUB_TOKEN is intentionally read-only —
+      # all writes (release-PR branch push, PR open/update) happen via
+      # the App token minted below.
+      contents: read
     steps:
       # `persist-credentials: false` — release-plz authenticates with
-      # the GH App / GITHUB_TOKEN directly; the checkout token is not
-      # consumed by subsequent steps and must not linger in the runner.
+      # the App token directly; the checkout token is not consumed by
+      # subsequent steps and must not linger in the runner.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
@@ -65,26 +93,43 @@ jobs:
         with:
           enable-cache: "false"
 
+      - name: Mint release-plz App token
+        id: app-token
+        uses: breezy-bays-labs/.github/actions/release-plz-app-token@bdd828ba04ebe832c4a1da8efd1cc6853aae8302 # release-plz-app-token-v0.1.0
+        with:
+          app-id: ${{ secrets.RELEASE_PLZ_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLZ_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
       - uses: release-plz/action@064f4d1e36c843611ddf013be726beaa4ad804db # v0.5
         with:
           command: release-pr
         env:
-          # The action's git-config substep reads GITHUB_TOKEN to query
-          # the GraphQL viewer endpoint and configure the commit author
-          # identity for the auto-opened release PR. The workflow-level
-          # default `permissions: contents: read` plus this job's
-          # contents:write + pull-requests:write grant are what the
-          # short-lived token carries; the env passthrough is the
-          # plumbing release-plz's sub-action expects.
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # release-plz/action's git-config substep reads GITHUB_TOKEN
+          # to query the viewer endpoint and configure the commit
+          # author identity for the auto-opened release PR. The App
+          # token carries the write scopes; the workflow's own token
+          # remains read-only.
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
   release-plz-release:
     name: Publish + tag
     runs-on: ubuntu-latest
+    # Push-only: pull_request events go to sync-crap4ts-package-json.
+    if: github.event_name == 'push'
+    # Scopes the org-level App secrets to this deployment environment.
+    environment: release-plz
     permissions:
-      contents: write       # for git tag pushes + downstream gh release create
-      id-token: write       # for crates.io OIDC trusted publishing
-      pull-requests: read   # to read the merged release PR via release-plz outputs
+      # Workflow GITHUB_TOKEN stays read-only — App token (minted
+      # below) does the git tag pushes and gh release creates. The
+      # id-token mint must happen at the workflow-runner level for
+      # crates.io OIDC; pull-requests:read lets release-plz/action
+      # read the merged release PR via the workflow's GITHUB_TOKEN
+      # when that path isn't App-token-mediated.
+      contents: read
+      id-token: write
+      pull-requests: read
     outputs:
       releases: ${{ steps.release-plz.outputs.releases }}
       releases_created: ${{ steps.release-plz.outputs.releases_created }}
@@ -98,10 +143,19 @@ jobs:
         with:
           enable-cache: "false"
 
+      - name: Mint release-plz App token
+        id: app-token
+        uses: breezy-bays-labs/.github/actions/release-plz-app-token@bdd828ba04ebe832c4a1da8efd1cc6853aae8302 # release-plz-app-token-v0.1.0
+        with:
+          app-id: ${{ secrets.RELEASE_PLZ_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLZ_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: read
+
       - id: release-plz
         uses: release-plz/action@064f4d1e36c843611ddf013be726beaa4ad804db # v0.5
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           command: release
           # CARGO_REGISTRY_TOKEN is intentionally absent: with
@@ -279,15 +333,14 @@ jobs:
         run: npm install -g npm@^11.5.1
 
       - name: Verify package.json + Cargo.toml versions match
-        # Belt-and-braces check. Until the GitHub-App-driven automated
-        # sync ships, packages/crap4ts/package.json is bumped by a
-        # reviewer running scripts/sync-crap4ts-package-json.sh against
-        # the release PR before merge. This step catches the rare case
-        # where the package.json bump was skipped — release-plz would
-        # otherwise publish to crates.io with a fresh Cargo.toml version
-        # while npm receives the stale package.json. The verified
-        # version is exported so the publish step derives the dist-tag
-        # without re-parsing.
+        # Belt-and-braces check. package.json is normally bumped on
+        # the release PR by the sync-crap4ts-package-json job
+        # (release-plz.yml, pull_request-keyed). This step catches the
+        # rare case where that automation didn't run or didn't commit
+        # — release-plz would otherwise publish to crates.io with a
+        # fresh Cargo.toml version while npm receives the stale
+        # package.json. The verified version is exported so the
+        # publish step derives the dist-tag without re-parsing.
         id: verify
         run: |
           set -euo pipefail
@@ -296,7 +349,7 @@ jobs:
           echo "npm:    ${PKG_VERSION}"
           echo "cargo:  ${CARGO_VERSION}"
           if [ "${PKG_VERSION}" != "${CARGO_VERSION}" ]; then
-            echo "::error::version mismatch between package.json (${PKG_VERSION}) and Cargo.toml (${CARGO_VERSION}). Run scripts/sync-crap4ts-package-json.sh on the release PR before merging."
+            echo "::error::version mismatch between package.json (${PKG_VERSION}) and Cargo.toml (${CARGO_VERSION}). The sync-crap4ts-package-json job should have committed the package.json bump on the release PR — check its run log (Actions tab on the merged release PR). As an escape hatch, scripts/sync-crap4ts-package-json.sh can still be run locally against the PR head."
             exit 1
           fi
           echo "version=${CARGO_VERSION}" >> "$GITHUB_OUTPUT"
@@ -438,3 +491,58 @@ jobs:
           fi
           echo "uploading to $TAG"
           gh release upload "$TAG" --clobber artifacts/*.tar.gz
+
+  sync-crap4ts-package-json:
+    # Auto-sync packages/crap4ts/package.json from crates/crap4ts/Cargo.toml
+    # on every release-plz-opened PR. The publish-crap4ts-npm job's
+    # version-match check fails the publish if these drift, so the sync
+    # has to happen on the release PR itself — before merge — and the
+    # commit has to live on the PR head ref so the merge picks it up.
+    #
+    # The head-ref filter scopes this job to release-plz's auto-opened
+    # branches (release-plz convention: `release-plz-<timestamp>`). It
+    # does NOT fire on human-opened PRs.
+    #
+    # Loop termination: the sync script's version-compare early-exit
+    # plus a tree-state guard against HEAD ensure that the App-token
+    # push from the first useful run triggers exactly one no-op
+    # re-run on pull_request:synchronize.
+    name: Sync crap4ts package.json
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && startsWith(github.head_ref, 'release-plz-')
+    environment: release-plz
+    concurrency:
+      # Cancel an in-flight sync if a new push lands — the new run
+      # will pick up the latest tree and the script is idempotent.
+      group: sync-crap4ts-${{ github.head_ref }}
+      cancel-in-progress: true
+    permissions:
+      # Workflow GITHUB_TOKEN read-only; the App token does the
+      # commit + push.
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Check out the release PR's head ref so the commit lands on
+          # the same branch the PR is tracking.
+          ref: ${{ github.head_ref }}
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-rust
+        with:
+          # release-relevant workflow: a poisoned cache could
+          # propagate into the published package.json bump.
+          enable-cache: "false"
+
+      - name: Mint release-plz App token
+        id: app-token
+        uses: breezy-bays-labs/.github/actions/release-plz-app-token@bdd828ba04ebe832c4a1da8efd1cc6853aae8302 # release-plz-app-token-v0.1.0
+        with:
+          app-id: ${{ secrets.RELEASE_PLZ_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLZ_APP_PRIVATE_KEY }}
+          permission-contents: write
+
+      - name: Sync package.json
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: ./scripts/sync-crap4ts-package-json.sh

--- a/scripts/release-plz-app-scope-audit.sh
+++ b/scripts/release-plz-app-scope-audit.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Leaf-scope drift check: assert this repo's name is present in the
+# org-wide release-plz App allowlist (the canonical TOML in
+# breezy-bays-labs/.github). Run as a CI lint so a PR that drops this
+# repo's name from the allowlist (or a release-plz workflow change in
+# this repo that orphans it) fails loudly instead of silently breaking
+# the next release-plz token mint.
+#
+# Scope: this repo's name only. It does NOT compare the canonical
+# allowlist against the App's actual installations — that's an
+# org-global check, requires an Org Admin token, and lives in a
+# separate centralized cron in the .github repo (see follow-up).
+#
+# Dependencies (installed by the CI workflow): dasel, jq, gh.
+# Token: secrets.GITHUB_TOKEN (the repo-scoped default is sufficient
+# to read public contents from a sibling public repo via the
+# contents API).
+
+set -euo pipefail
+
+THIS_REPO="crap-rs"
+ALLOWLIST_REPO="breezy-bays-labs/.github"
+ALLOWLIST_PATH="release-plz-allowlist.toml"
+TMP_TOML="$(mktemp -t release-plz-allowlist.XXXXXX.toml)"
+trap 'rm -f "$TMP_TOML"' EXIT
+
+# Fetch the raw TOML in one round-trip. `Accept: application/vnd.github.raw`
+# returns the file body verbatim — no base64 decode step required, which
+# also avoids the GNU coreutils (`base64 -d`) vs BSD (`base64 -D`)
+# portability split that bites local debugging on macOS.
+gh api \
+  "repos/${ALLOWLIST_REPO}/contents/${ALLOWLIST_PATH}" \
+  -H "Accept: application/vnd.github.raw" \
+  > "$TMP_TOML"
+
+# Parse `repos = [...]` via dasel (TOML-aware) then jq for array
+# iteration. The `.[]?` form tolerates a missing-or-empty array
+# without throwing — that keeps the failure path informative (we
+# still hit the "${THIS_REPO} missing" branch with an empty list)
+# instead of bailing out with a parse error before the actionable
+# message can fire.
+mapfile -t CANONICAL < <(
+  dasel -f "$TMP_TOML" -r toml -w json '.repos' \
+    | jq -r '.[]?' \
+    | sort
+)
+
+# Search the array literally (avoid bash regex / glob interpretation
+# of `THIS_REPO`).
+for repo in "${CANONICAL[@]}"; do
+  if [ "$repo" = "$THIS_REPO" ]; then
+    echo "OK: ${THIS_REPO} present in canonical allowlist"
+    echo "(canonical list: ${CANONICAL[*]:-<empty>})"
+    exit 0
+  fi
+done
+
+# Format a stable, paste-friendly list for the error message, even
+# when CANONICAL is empty (which would otherwise render as a blank
+# placeholder that reads as a tooling bug rather than as drift).
+if [ "${#CANONICAL[@]}" -eq 0 ]; then
+  CANONICAL_REPR="<empty array — TOML may have repos = [] or be malformed>"
+else
+  CANONICAL_REPR="${CANONICAL[*]}"
+fi
+
+echo "::error::release-plz allowlist drift — '${THIS_REPO}' is missing from ${ALLOWLIST_REPO}/${ALLOWLIST_PATH}."
+echo "  canonical list: [${CANONICAL_REPR}]"
+echo "  fix: open a PR on ${ALLOWLIST_REPO} appending '${THIS_REPO}' to the repos array, land it, then re-run this check."
+exit 1

--- a/scripts/sync-crap4ts-package-json.sh
+++ b/scripts/sync-crap4ts-package-json.sh
@@ -3,16 +3,20 @@
 # crates/crap4ts/Cargo.toml so the npm publish step in
 # .github/workflows/release-plz.yml finds matching versions.
 #
-# Run this on every auto-opened release PR that includes a crap4ts
-# Cargo.toml bump, before merging:
+# Normally invoked by the `sync-crap4ts-package-json` job in
+# .github/workflows/release-plz.yml: when release-plz opens or
+# updates a release PR that bumps crap4ts's Cargo.toml, the job mints
+# a GitHub App token, checks out the release PR's head ref, runs this
+# script, and pushes the package.json bump back to the same branch so
+# the publish gate's version-match check passes.
+#
+# Reviewers may also run it locally as an escape hatch if the
+# automation is unavailable:
 #
 #   gh pr checkout <release-PR#>
 #   ./scripts/sync-crap4ts-package-json.sh
 #
 # No-ops cleanly when both files already report the same version.
-# Until a GitHub-App-driven release-plz identity ships (so that
-# release-plz-opened PRs can fire downstream workflows on push), this
-# manual step is the published v0 sync path.
 set -euo pipefail
 # Extract crap4ts's Cargo.toml version structurally via `cargo metadata`
 # (more robust than grep/sed against TOML).
@@ -24,6 +28,22 @@ if [ "$CARGO_VER" = "$PKG_VER" ]; then
   exit 0
 fi
 npm version --no-git-tag-version --prefix packages/crap4ts "$CARGO_VER"
+# Belt-and-braces guard against pushing an empty diff. The version
+# compare above is the primary idempotency hook, but it's tree-state
+# blind — a script edit that bypasses it (or a future ambiguity where
+# `npm version` reports a different version than what's on disk) would
+# fall through to the push without this. When the same workflow run
+# can be re-triggered by its own push (App-token pushes do fire
+# pull_request:synchronize), a no-op push wastes a CI cycle on every
+# re-trigger. Using `HEAD --` compares against the last commit, so the
+# guard catches the no-op case whether files are unstaged or already
+# staged by a prior step.
+if git diff --quiet HEAD -- \
+     packages/crap4ts/package.json \
+     packages/crap4ts/package-lock.json; then
+  echo "no tree-level change vs HEAD at $CARGO_VER; nothing to commit."
+  exit 0
+fi
 # Stage and commit only the files npm version touched, so a reviewer
 # with unrelated edits in the working tree doesn't accidentally ship
 # them. `npm version` updates package.json and (if present)


### PR DESCRIPTION
## Summary

Adopts an org-wide GitHub App identity (\`release-plz\`, owned by \`breezy-bays-labs\`) for \`release-plz.yml\` so release-plz-opened PRs trigger downstream \`pull_request\` workflows. Replaces the manual \`scripts/sync-crap4ts-package-json.sh\` ceremony with an automated A3 sync job that fires on the release PR itself. Bundles Y1 release deployment-environment scoping and ships the F11 App-installation-allowlist audit lint.

The composite action this PR consumes is published in [breezy-bays-labs/.github#6](https://github.com/breezy-bays-labs/.github/pull/6) (merged) and tagged as \`release-plz-app-token-v0.1.0\` (commit SHA \`bdd828ba04ebe832c4a1da8efd1cc6853aae8302\`).

Closes #298
Closes #297
Closes #300

## What changes

### \`.github/workflows/release-plz.yml\`

- **\`release-plz-pr\` (A1)** — workflow GITHUB_TOKEN dropped to \`contents: read\`; the App token (minted by the new composite-action step) carries \`contents: write\` + \`pull-requests: write\` for the release-PR branch push + PR open/update. Added \`environment: release-plz\` so the org-level App secrets only read in this deployment environment. Push-only via \`if: github.event_name == 'push'\`.
- **\`release-plz-release\` (A2)** — same App-token swap. Workflow token keeps \`id-token: write\` (OIDC must mint at the runner level — not App-delegable) + \`pull-requests: read\` (release-plz/action's outputs fallback). Adds \`environment: release-plz\`. Push-only.
- **\`sync-crap4ts-package-json\` (A3, NEW)** — fires on \`pull_request: opened/synchronize\`, gated to \`release-plz-*\` head refs. Checks out the PR head, mints an App token (\`permission-contents: write\` only), and runs the sync script to commit + push \`packages/crap4ts/package.json\` back to the PR head. \`cancel-in-progress: true\` so a new push during an in-flight sync wins.
- **\`publish-crap4ts-npm\` verify step** — error message rewritten to point at A3's job log instead of the manual script.
- Workflow \`on:\` extended with \`pull_request: types: [opened, synchronize]\`; A1/A2/downstream jobs all gated to \`push\` events so they stay push-only despite the new trigger.

### \`.github/workflows/ci.yml\`

New \`release-plz-app-scope-audit\` job runs \`scripts/release-plz-app-scope-audit.sh\` against the canonical \`release-plz-allowlist.toml\` in \`breezy-bays-labs/.github\`. Installs \`dasel\` via \`taiki-e/install-action\`. Uses the default repo-scoped \`GITHUB_TOKEN\` (sufficient to read public contents from a sibling public repo via the contents API). **This is a leaf-scope audit** — it asserts only that this repo's name appears in the canonical allowlist. The complementary org-global audit (canonical TOML vs the App's actual installations) needs an Org Admin PAT and is filed as a separate follow-up in the \`.github\` repo's own queue.

### \`scripts/sync-crap4ts-package-json.sh\`

- Header reframed: the A3 job is the primary invocation path; local invocation is the escape hatch.
- **Belt-and-braces idempotency guard** added before \`git commit\`:
  \`\`\`bash
  if git diff --quiet HEAD -- \\
       packages/crap4ts/package.json \\
       packages/crap4ts/package-lock.json; then
    echo \"no tree-level change vs HEAD at \$CARGO_VER; nothing to commit.\"
    exit 0
  fi
  \`\`\`
  The \`HEAD --\` form compares against the last commit so the guard works whether the files are unstaged or staged. Combined with the existing version-compare early-exit at the top of the script, this is the two-layer protection against the A3 → push → \`synchronize\` → A3 loop. Termination trace: useful first run commits + pushes, second run reads matching versions and early-exits OR diffs clean and exits before commit. One useful run + one no-op run, loop terminates.

### \`scripts/release-plz-app-scope-audit.sh\` (new)

The F11 leaf-scope audit script. Fetches the canonical TOML via \`gh api ... -H \"Accept: application/vnd.github.raw\"\` (no base64 round-trip, portable across GNU coreutils on Ubuntu runners and BSD base64 on macOS local debugging). Parses \`repos = [...]\` via \`dasel\` + \`jq -r '.[]?'\` (the \`?\` operator tolerates a missing array gracefully — empty CANONICAL still triggers the leaf-missing exit 1 with a clearer error). Emits an actionable \`::error::\` and \`exit 1\` if this repo's name is absent. Shellcheck clean.

## Blocked-by (resolved)

- breezy-bays-labs/.github#6 — merged. Tag \`release-plz-app-token-v0.1.0\` pushed pointing at \`bdd828ba04ebe832c4a1da8efd1cc6853aae8302\`. All three \`uses:\` sites in this PR pin to that SHA with a \`# release-plz-app-token-v0.1.0\` trailer.

## Out-of-band user actions (do these in order BEFORE merging this PR)

The PR's three new App-token mints depend on org-level secrets and a deployment environment that need to be provisioned out-of-band:

- [ ] **A1** Create org-owned \`release-plz\` App via UI: https://github.com/organizations/breezy-bays-labs/settings/apps/new. Permissions: Contents r/w + Pull-requests r/w. Scope: \"Only on this account\". **Uncheck the \"Active\" checkbox under Webhook** (release-plz operates via Actions API only — does NOT need webhooks; GitHub's UI requires a valid Webhook URL UNLESS Active is unchecked). **Record the assigned slug** (App settings page URL has the form \`/apps/<slug>\` — if \`release-plz\` was taken globally, GitHub appended a disambiguator like \`release-plz-1234\`; the composite action derives the slug dynamically so this is informational, but worth noting for future debugging).
- [ ] **A2** Install App on \`breezy-bays-labs/crap-rs\` only.
- [ ] **A3** Generate \`.pem\` private key. Create org-level Actions secrets \`RELEASE_PLZ_APP_ID\` + \`RELEASE_PLZ_APP_PRIVATE_KEY\`. Allowlist: selected repos → crap-rs. Discard \`.pem\`.
- [ ] **A6** Create \`release-plz\` deployment environment in crap-rs: https://github.com/breezy-bays-labs/crap-rs/settings/environments/new. No protection rules. **Must exist before merge or the App-token mint jobs fail with \"environment not found\".**
- [ ] Merge this PR.
- [ ] **A4** Set Actions variable \`RELEASE_PLZ_DRY_RUN=true\` for first canary; once green, unset.

### Canary verification (after A4 set + first push:main)

Verify 4 signals on the first \`release-plz-pr\` run:

1. The \"Mint release-plz App token\" step logs \`Token generated\` (composite action succeeded).
2. The release-plz-opened PR's commit author is the App's bot (e.g. \`release-plz[bot]\`), NOT \`github-actions[bot]\`.
3. The \`sync-crap4ts-package-json\` job fires when the release PR opens (visible in the Actions tab on that PR).
4. The sync job's output is either \`already in sync at <version>; no-op.\` (versions match) or \`package.json synced from X to Y and pushed.\` (mismatch resolved).

After canary green, unset \`vars.RELEASE_PLZ_DRY_RUN\` and merge the first real release PR.

## Onboarding sketch (for the next consumer repo)

When a sibling Rust workspace adopts release-plz:

1. Install the existing org-wide \`release-plz\` App on the new repo.
2. Open a PR on \`breezy-bays-labs/.github\` to append the new repo's name to \`release-plz-allowlist.toml\`. Land that PR first — this repo's F11 lint catches drift in either direction.
3. Add the new repo to the \`RELEASE_PLZ_APP_*\` org-secrets allowlist.
4. Create the \`release-plz\` deployment environment on the new repo.
5. Wire the composite action at the three \`uses:\` sites in the new repo's \`release-plz.yml\`, pinned to \`release-plz-app-token-vX.Y.Z\`'s SHA.

## Secret rotation (recurring)

Quarterly + on-leak. Regenerate \`.pem\` via the App's settings, update \`RELEASE_PLZ_APP_PRIVATE_KEY\` org secret, discard local \`.pem\`. The App ID is stable.

## Validation

Local (this worktree):

- \`pipx run 'zizmor>=1.5,<2' .github/\` — clean (\"No findings to report\"; 1 ignored, 22 suppressed)
- \`actionlint -color\` — clean
- \`shellcheck scripts/release-plz-app-scope-audit.sh scripts/sync-crap4ts-package-json.sh\` — clean
- \`python3 scripts/mutants-skip-lint.py\` — ok
- \`python3 scripts/bdd-tracked-lint.py\` — ok (246 deferred / 384 scanned)
- \`cargo nextest run --workspace --all-targets\` — 1156/1156 passed in 10.131s

CI will run the same on this PR plus the rest of the matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)