### PR TITLE
chore(ci): #321 — swap release-plz.yml composite consumers from app-id → client-id + bump to v0.2.0

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -95,9 +95,9 @@ jobs:
 
       - name: Mint release-plz App token
         id: app-token
-        uses: breezy-bays-labs/.github/actions/release-plz-app-token@bdd828ba04ebe832c4a1da8efd1cc6853aae8302 # release-plz-app-token-v0.1.0
+        uses: breezy-bays-labs/.github/actions/release-plz-app-token@97eb083e81d600e08e0754adc2cb6debedebf020 # release-plz-app-token-v0.2.0
         with:
-          app-id: ${{ secrets.RELEASE_PLZ_APP_ID }}
+          client-id: ${{ secrets.RELEASE_PLZ_APP_ID }}
           private-key: ${{ secrets.RELEASE_PLZ_APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write
@@ -145,9 +145,9 @@ jobs:
 
       - name: Mint release-plz App token
         id: app-token
-        uses: breezy-bays-labs/.github/actions/release-plz-app-token@bdd828ba04ebe832c4a1da8efd1cc6853aae8302 # release-plz-app-token-v0.1.0
+        uses: breezy-bays-labs/.github/actions/release-plz-app-token@97eb083e81d600e08e0754adc2cb6debedebf020 # release-plz-app-token-v0.2.0
         with:
-          app-id: ${{ secrets.RELEASE_PLZ_APP_ID }}
+          client-id: ${{ secrets.RELEASE_PLZ_APP_ID }}
           private-key: ${{ secrets.RELEASE_PLZ_APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: read
@@ -536,9 +536,9 @@ jobs:
 
       - name: Mint release-plz App token
         id: app-token
-        uses: breezy-bays-labs/.github/actions/release-plz-app-token@bdd828ba04ebe832c4a1da8efd1cc6853aae8302 # release-plz-app-token-v0.1.0
+        uses: breezy-bays-labs/.github/actions/release-plz-app-token@97eb083e81d600e08e0754adc2cb6debedebf020 # release-plz-app-token-v0.2.0
         with:
-          app-id: ${{ secrets.RELEASE_PLZ_APP_ID }}
+          client-id: ${{ secrets.RELEASE_PLZ_APP_ID }}
           private-key: ${{ secrets.RELEASE_PLZ_APP_PRIVATE_KEY }}
           permission-contents: write
 


### PR DESCRIPTION
## Summary

Coordinated follow-up to breezy-bays-labs/.github#12 (merged 2026-05-26, tagged `release-plz-app-token-v0.2.0`). Swaps the 3 composite-action call sites in `.github/workflows/release-plz.yml` to:

- Use the new `client-id` input name (the `app-id` input was renamed in the composite to silence the `actions/create-github-app-token@v3.1.1` deprecation warning surfaced by F8's first canary)
- Pin to v0.2.0's commit SHA (`97eb083e81d600e08e0754adc2cb6debedebf020`)

## What changes

Three identical-shape edits across `release-plz.yml`, one per composite-consumer job:

| Job | Line | Change |
|---|---|---|
| `release-plz-pr` (A1) | 98 → SHA pin, 100 → input | `uses:` → v0.2.0 SHA + `# release-plz-app-token-v0.2.0` trailer; `app-id:` → `client-id:` |
| `release-plz-release` (A2) | 148 → SHA pin, 150 → input | same shape |
| `sync-crap4ts-package-json` (A3) | 539 → SHA pin, 541 → input | same shape |

Total diff: **6 lines changed across 3 sites in 1 file.**

## Why the secret value doesn't change

`secrets.RELEASE_PLZ_APP_ID` continues to hold the App's integer ID. `actions/create-github-app-token`'s `client-id` input is forwarded directly to `@octokit/auth-app`'s `appId` parameter, which is **polymorphic** — it accepts either the integer App ID or the Client ID string form. The composite v0.2.0 README documents this in a new *Secret name vs. input name* subsection. Renaming the secret (`RELEASE_PLZ_APP_ID` → `RELEASE_PLZ_APP_CLIENT_ID`) would be operationally costly (delete/recreate + re-allowlist) for zero functional benefit, so we kept it.

## Validation

Local (this worktree):
- `pipx run 'zizmor>=1.5,<2' .github/workflows/release-plz.yml` — clean (7 suppressed)
- `actionlint -color .github/workflows/release-plz.yml` — clean

CI will run the full matrix.

## Post-merge expectation

Next post-merge `release-plz` workflow run on `main` should NOT emit the `Input 'app-id' has been deprecated` warning. That's the canary signal this PR is meant to close.

## Closes

Closes #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)