### PR TITLE
chore(ci): #324 — uncomment dry_run wiring in release-plz.yml so RELEASE_PLZ_DRY_RUN engages canary discipline

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -163,11 +163,14 @@ jobs:
           # short-lived OIDC token that crates.io verifies against
           # the trusted-publisher binding configured out-of-band on
           # crates.io's "Trusted Publishers" settings for each crate.
-          # The first auto-opened release PR can be inspected and
-          # `dry_run: true` toggled via a `RELEASE_PLZ_DRY_RUN` repo
-          # variable if a canary run is needed before the first
-          # real publish:
-          # dry_run: ${{ vars.RELEASE_PLZ_DRY_RUN }}
+          # `dry_run` is gated by an Actions variable so a canary
+          # run can be staged without editing this workflow: set
+          # repo var `RELEASE_PLZ_DRY_RUN=true` to have release-plz
+          # validate the publish path without actually pushing to
+          # crates.io. Unset the variable after the canary is green.
+          # An empty/unset value passes through as an empty string,
+          # which release-plz's `dry_run` input treats as falsy.
+          dry_run: ${{ vars.RELEASE_PLZ_DRY_RUN }}
 
   build-crap4ts-cdylib:
     name: Build crap4ts cdylib (${{ matrix.platform }})


### PR DESCRIPTION
## Summary

Uncomments the `dry_run: ${{ vars.RELEASE_PLZ_DRY_RUN }}` wiring in `release-plz.yml`'s `release-plz-release` job so the canary discipline OOB-A4 documented in #316's body actually engages when `vars.RELEASE_PLZ_DRY_RUN=true` is set.

Discovered by the first canary run (2026-05-25, recorded in the F8 build-phase observations): the variable was set per OOB-A4 but had no consumer, so the workflow ran in REAL publishing mode. The cycle succeeded only because release-plz independently determined there were no version changes to publish. If a release-worthy commit had been on `main` at canary time, the first canary would have published to crates.io for real instead of dry-running — defeating the whole point of canary gating.

## What changes

Single tightly-scoped edit in `release-plz-release` (A2):

```diff
           command: release
-          # The first auto-opened release PR can be inspected and
-          # `dry_run: true` toggled via a `RELEASE_PLZ_DRY_RUN` repo
-          # variable if a canary run is needed before the first
-          # real publish:
-          # dry_run: ${{ vars.RELEASE_PLZ_DRY_RUN }}
+          # `dry_run` is gated by an Actions variable so a canary
+          # run can be staged without editing this workflow: set
+          # repo var `RELEASE_PLZ_DRY_RUN=true` to have release-plz
+          # validate the publish path without actually pushing to
+          # crates.io. Unset the variable after the canary is green.
+          # An empty/unset value passes through as an empty string,
+          # which release-plz's `dry_run` input treats as falsy.
+          dry_run: ${{ vars.RELEASE_PLZ_DRY_RUN }}
```

The surrounding comment block is reworded — the old comment framed the variable as a "if a canary run is needed" hint that lived alongside a commented-out example; with the example now live, the comment is rewritten to explain what the active line does and the safe-when-empty semantics.

## Why uncommenting is safe (no behavior change at rest)

When `vars.RELEASE_PLZ_DRY_RUN` is unset, GitHub's `vars.*` context evaluates to an empty string. `release-plz/action@v0.5`'s `dry_run` input has `default: "false"` per the action's `action.yml` definition; empty string passed as input is treated as the falsy form. Net effect today (no canary in flight, variable unset): identical to pre-PR behavior. Once the variable is set to `true`, A2 dry-runs.

## Validation

Local:
- `pipx run 'zizmor>=1.5,<2' .github/workflows/release-plz.yml` — clean (7 suppressed)
- `actionlint -color .github/workflows/release-plz.yml` — clean

Functional canary path: not exercising here. The next time someone sets `RELEASE_PLZ_DRY_RUN=true` and pushes a release-worthy commit, A2 will dry-run instead of publishing — which is what OOB-A4 always claimed it would.

## Companion follow-ups

- Already merged: #316 (F8 PR2, the original release-plz-app-token adoption) + #322 (client-id rename / v0.2.0 bump).
- This PR closes the second of the two findings the canary surfaced.
- After this, the F8 work is fully canary-clean and ready for `/review` + `/closeout`.

## Closes

Closes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)
