### PR TITLE
feat(crap-core+ci): #326 — Current/Delta View axis on multi-language unified HTML report

### DIFF
--- a/.github/actions/scorecard/README.md
+++ b/.github/actions/scorecard/README.md
@@ -276,10 +276,28 @@ self-contained, no external assets).
 
 When `languages: rust,typescript` (or `all`) is set alongside
 `html-report: true`, the action renders **one unified HTML
-document** carrying both adapters' analyses with a Language /
-Combined toggle at the top of the page. The sticky comment carries
-**one canonical link** plus two deep-link anchors so reviewers can
-land directly on a per-language panel:
+document** carrying both adapters' analyses with two
+navigation axes:
+
+- A **Language axis** (Sakura `.segmented` group at the top of the
+  page) — switch between Rust, TypeScript, and the cross-adapter
+  Combined view.
+- A **View axis** (Sakura `.tabs` group inside each panel) —
+  switch between **Current run** and **Delta vs baseline** within
+  the active language panel. The View axis only renders when at
+  least one adapter supplied a baseline. Languages without a
+  baseline render their Delta tab disabled with a tooltip
+  pointing at how to provide one.
+
+URL hash routing supports both axes via the
+`#<lang>:<view>` format — e.g. `#rust:delta` deep-links to the
+Rust panel's Delta tab, `#combined:current` is the default first-
+load target, and a deep-link to a disabled tab silently falls
+back to `current`.
+
+The sticky comment carries **one canonical link** plus two
+deep-link anchors so reviewers can land directly on a per-language
+panel:
 
 ```text
 📊 [Open report](<unified-url>) · [Rust panel](<unified-url>#rust) · [TypeScript panel](<unified-url>#typescript)

--- a/.github/actions/scorecard/action.yml
+++ b/.github/actions/scorecard/action.yml
@@ -372,6 +372,19 @@ outputs:
       TypeScript-only artifact, and no deprecation warning is
       emitted.
     value: ${{ steps.upload-unified.outputs.artifact-url != '' && format('{0}#typescript', steps.upload-unified.outputs.artifact-url) || steps.upload-typescript.outputs.artifact-url }}
+  unified-html-path:
+    description: |
+      Filesystem path on the runner to the rendered unified HTML
+      report when `html-report: true` AND `languages` resolves to
+      multi-language mode. Empty string otherwise.
+
+      Surfaced so callers can grep-assert the rendered consumer-
+      facing artifact in CI (Combined / per-language View nav, tab
+      counts, etc.) without re-downloading the uploaded artifact via
+      an authenticated `gh api artifacts` call. The path lives under
+      the runner's `$RUNNER_TEMP` and is preserved for the rest of
+      the job's steps.
+    value: ${{ steps.render-unified.outputs.unified_path }}
 
 runs:
   using: 'composite'

--- a/.github/actions/scorecard/action.yml
+++ b/.github/actions/scorecard/action.yml
@@ -1396,17 +1396,32 @@ runs:
         # `Run analysis` loop above (saved to
         # `$RUNNER_TEMP/${BIN}-envelope.json`). The unified renderer
         # composes both into one HTML document with a Language /
-        # Combined toggle.
+        # Combined toggle plus a Current/Delta View axis inside each
+        # panel when a baseline is supplied.
         RUST_ENV: ${{ runner.temp }}/crap4rs-envelope.json
         TS_ENV: ${{ runner.temp }}/crap4ts-envelope.json
+        # Baseline envelopes — already validated as paths to the
+        # per-language baseline JSONs by the caller's input. Either
+        # may be empty (analysis-only on that side); the render step
+        # gates each `--baseline` argument independently so a
+        # mismatched-baseline run still produces a unified report
+        # (with the missing side's Delta tab disabled).
+        RUST_BASELINE: ${{ inputs.baseline }}
+        TS_BASELINE: ${{ inputs.baseline-ts }}
         UNIFIED: ${{ runner.temp }}/crap-scorecard-unified.html
       run: |
         set -euo pipefail
-        crap-render \
-          --input "rust=${RUST_ENV}" \
-          --input "typescript=${TS_ENV}" \
-          --format html \
-          --output "${UNIFIED}"
+        args=(
+          --input "rust=${RUST_ENV}"
+          --input "typescript=${TS_ENV}"
+        )
+        if [[ -n "${RUST_BASELINE}" ]]; then
+          args+=(--baseline "rust=${RUST_BASELINE}")
+        fi
+        if [[ -n "${TS_BASELINE}" ]]; then
+          args+=(--baseline "typescript=${TS_BASELINE}")
+        fi
+        crap-render "${args[@]}" --format html --output "${UNIFIED}"
         echo "unified_path=${UNIFIED}" >> "$GITHUB_OUTPUT"
 
     - name: Upload unified HTML report

--- a/.github/workflows/quick-start-smoke.yml
+++ b/.github/workflows/quick-start-smoke.yml
@@ -369,3 +369,50 @@ jobs:
             done
             echo "$bin --format scorecard-row = valid JSON with all required keys ok"
           done
+
+      # Gate (i) — View axis nav rendered in unified HTML artifact.
+      #
+      # The unified HTML report is the consumer-facing surface for the
+      # Current/Delta View axis. The smoke runs `run-mode: full` (no
+      # baseline produced), which exercises the no-baseline path
+      # consumers hit on first-touch. That path MUST still render the
+      # View nav with the Delta tab disabled — otherwise the feature
+      # is invisible to consumers in the dominant workflow.
+      #
+      # The action surfaces the on-disk path via the
+      # `unified-html-path` output so this assertion runs against the
+      # rendered HTML directly, without re-downloading the uploaded
+      # artifact via an authenticated `gh api .../artifacts` call
+      # (which would require an `actions: read` perm elevation + a
+      # zip round-trip). `unified-html-path` is sourced from the
+      # action's own `render-unified` step output — same trust
+      # boundary as every other `steps.crap.outputs.*` env binding in
+      # this file (per the workflow-injection guidance, untrusted
+      # event payloads stay behind env-var indirection — step outputs
+      # from a sibling step in the same repo don't qualify as
+      # untrusted).
+      - name: Gate (i) — View axis nav rendered in unified HTML
+        env:
+          HTML_PATH: ${{ steps.crap.outputs.unified-html-path }}
+        run: |
+          set -euo pipefail
+          if [ -z "$HTML_PATH" ]; then
+            echo "::error::unified-html-path output is empty — the action did not surface the rendered HTML path"
+            exit 1
+          fi
+          if [ ! -s "$HTML_PATH" ]; then
+            echo "::error::unified-html-path points at a missing or empty file: $HTML_PATH"
+            exit 1
+          fi
+          NAVS=$(grep -c '<nav class="tabs"' "$HTML_PATH" || true)
+          if [ "${NAVS:-0}" -lt 3 ]; then
+            echo "::error::expected at least 3 '<nav class=\"tabs\"' elements in unified HTML (Combined + 2 per-language panels); got ${NAVS:-0}"
+            echo "rendered file: $HTML_PATH ($(wc -c <"$HTML_PATH") bytes)"
+            exit 1
+          fi
+          DISABLED=$(grep -c 'data-tab="delta" type="button" disabled' "$HTML_PATH" || true)
+          if [ "${DISABLED:-0}" -lt 3 ]; then
+            echo "::error::expected at least 3 disabled Delta tabs in unified HTML (no-baseline smoke); got ${DISABLED:-0}"
+            exit 1
+          fi
+          echo "unified HTML carries ${NAVS} View navs and ${DISABLED} disabled Delta tabs ok"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,7 +406,7 @@ checksum = "417bef24afe1460300965a25ff4a24b8b45ad011948302ec221e8a0a81eb2c79"
 
 [[package]]
 name = "crap-core"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "askama",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ authors = ["Christopher Bays <cmbays@breezybayslabs.com>"]
 # Rust adapter. Future siblings (`crap4ts`) inherit the same pins.
 [workspace.dependencies]
 # ── In-workspace crates ──
-crap-core = { path = "crates/crap-core", version = "0.7.0" }
+crap-core = { path = "crates/crap-core", version = "0.8.0" }
 
 # ── CLI (crap4rs only today) ──
 clap = { version = "4", features = ["derive", "string"] }

--- a/crates/crap-core/CHANGELOG.md
+++ b/crates/crap-core/CHANGELOG.md
@@ -8,6 +8,67 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `crap-core` is the language-agnostic foundation shared by the
 `crap4rs` (Rust) and `crap4ts` (TypeScript) adapters.
 
+## [0.8.0]
+
+### Added
+
+- View axis (Current / Delta tabs) on the multi-language unified HTML
+    report. Each per-language panel renders a Current/Delta tab pair
+    when its block carries a baseline; languages without a baseline
+    render the Delta tab disabled with a no-baseline tooltip so the
+    asymmetric state is visible without suppressing other languages'
+    deltas. The Combined panel exposes its own Current/Delta tabs;
+    Combined → Delta surfaces a cross-adapter ranked table of
+    regressions and new functions sorted by risk band desc then
+    CRAP/threshold ratio desc within band (matches the dimensional-
+    consistency rule that governs the Current-view Combined
+    ranking). (crap-rs#326)
+- New domain types in `crap_core::domain::multi_lang` to support the
+    Combined Delta aggregate: `CombinedDelta`,
+    `CombinedDeltaSummary`, `RankedDeltaRow`, `RankedDeltaKind`,
+    `DeltaRowSnapshot`. The types are N-adapter-agnostic — adding a
+    new adapter that supplies a baseline contributes to the
+    Combined Delta without code changes outside the calling site.
+    (crap-rs#326)
+- New library entry point
+    `crap_core::core::compose::compose_combined_delta(blocks) ->
+    Option<CombinedDelta>`. Returns `None` precisely when no
+    language supplied a baseline — the renderer reads this signal
+    to suppress the View axis nav entirely so the no-baseline
+    multi-language render path stays equivalent to the v0.7.0
+    output. (crap-rs#326)
+- `crap-render --baseline <LANG>=<FILE>` CLI flag (additive, fully
+    optional). Each baseline pairs by language key with one of the
+    `--input` envelopes; a baseline whose language key has no
+    matching input is an error. The flag is repeatable; same
+    duplicate-language guard as `--input`. (crap-rs#326)
+- Two-axis URL hash routing in the multi-language report's inline
+    `<script>`. URL hash format is `#<lang>:<view>` where `<lang>` is
+    one of the Language nav buttons and `<view>` is `current` or
+    `delta`. Default on first load with no hash: `#combined:current`.
+    Switching Language preserves View where possible (e.g. on
+    `#rust:delta`, clicking TypeScript navigates to
+    `#typescript:delta`, not `#typescript:current`). Navigating to a
+    disabled tab silently falls back to `current` and logs to the
+    browser console — no error toast. (crap-rs#326)
+
+### Changed
+
+- `format_html_multi` template context (`HtmlMultiReport`) gained
+    `has_view_axis: bool` and `combined_delta_panel:
+    Option<Box<CombinedDeltaPanel>>` fields; `LangPanel` gained
+    `has_delta: bool`, `current_tab_count`, `delta_tab_count`,
+    `delta_has_news`, and `delta_panel: Option<Box<DeltaPanel>>`.
+    These are internal template-context types — the public
+    `format_html_multi` signature is unchanged.
+- Single-language passthrough (`multi.languages.len() == 1`)
+    continues to delegate to `format_html` for byte-identical
+    output. The View axis plumbing in the multi-lang glue does not
+    leak into the n=1 short-circuit even when a baseline is supplied
+    — a new test (`multi_lang_single_language_passthrough_byte_identical_with_baseline`)
+    locks this invariant in addition to the existing
+    no-baseline passthrough test.
+
 ## [0.7.0]
 
 ### Added

--- a/crates/crap-core/Cargo.toml
+++ b/crates/crap-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crap-core"
-version = "0.7.0"
+version = "0.8.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/crap-core/src/adapters/reporters/html.rs
+++ b/crates/crap-core/src/adapters/reporters/html.rs
@@ -739,6 +739,9 @@ fn render_multi_lang(
     let combined = build_combined_view(multi, threshold);
     let language_panels = build_language_panels(multi, threshold);
     let adapters_footer = build_adapters_footer(multi);
+    let combined_delta = crate::core::compose::compose_combined_delta(&multi.languages);
+    let has_view_axis = combined_delta.is_some();
+    let combined_delta_panel = combined_delta.map(|cd| Box::new(build_combined_delta_panel(cd)));
 
     let title = if language_count == 0 {
         "CRAP scorecard — multi-language".to_string()
@@ -762,6 +765,8 @@ fn render_multi_lang(
         combined,
         language_panels,
         adapters_footer,
+        has_view_axis,
+        combined_delta_panel,
     };
     tmpl.render()
         .expect("html_multi template render is total — all fields owned")
@@ -783,6 +788,18 @@ struct HtmlMultiReport {
     combined: CombinedPanel,
     language_panels: Vec<LangPanel>,
     adapters_footer: Vec<AdapterFooterRow>,
+    /// True when at least one language supplied a baseline, so the
+    /// View axis nav (Current / Delta tabs) should be rendered
+    /// inside each `.lang-panel`. The whole no-baseline path stays
+    /// byte-for-byte equivalent to the v0.7.0 multi-language render
+    /// when this is `false`, mirroring `format_html`'s
+    /// `has_delta`-gated tabs pattern.
+    has_view_axis: bool,
+    /// Combined Delta panel: cross-adapter aggregate + ranked
+    /// regressions/new violations. Boxed to keep the dominant
+    /// no-baseline arm cheap; same `large_enum_variant` rationale
+    /// as the single-language `delta_panel`.
+    combined_delta_panel: Option<Box<CombinedDeltaPanel>>,
 }
 
 struct LangButton {
@@ -858,12 +875,116 @@ struct LangPanel {
     dist_moderate: usize,
     dist_high: usize,
     files: Vec<FileCard>,
+    /// True when this language supplied a baseline. The template
+    /// renders the Delta tab as enabled when `true`, disabled +
+    /// titled with a no-baseline tooltip when `false`. The Current
+    /// tab is always enabled.
+    has_delta: bool,
+    /// Tab-count badge for the Current tab — total analyzed
+    /// functions, mirroring the single-language template's
+    /// `current_tab_count`.
+    current_tab_count: usize,
+    /// Tab-count badge for the Delta tab — sum of all change kinds.
+    /// Zero when this language has no baseline.
+    delta_tab_count: u32,
+    /// Drives the inline news-dot indicator on the Delta tab when
+    /// regressions or new violations are present.
+    delta_has_news: bool,
+    /// Per-language delta panel. Boxed for the same
+    /// `large_enum_variant` reason as the single-language reporter
+    /// — the dominant no-baseline arm stays cheap.
+    delta_panel: Option<Box<DeltaPanel>>,
 }
 
 struct AdapterFooterRow {
     display_name: String,
     metric_label: &'static str,
     threshold_display: String,
+}
+
+/// Combined Delta panel — cross-adapter aggregate plus a ranked list
+/// of regressions + new violations across every language with a
+/// baseline.
+///
+/// Boxed at the `HtmlMultiReport` level to keep the dominant
+/// no-baseline arm cheap; same `large_enum_variant` rationale as the
+/// per-language reporter's `DeltaPanel`. Built by
+/// `build_combined_delta_panel` from a `CombinedDelta` aggregate
+/// produced by `compose_combined_delta`.
+struct CombinedDeltaPanel {
+    /// Aggregate change counts across contributing languages.
+    /// Drives the scope-banner copy + delta tab badge counts.
+    summary: CombinedDeltaPanelSummary,
+    /// Verdict pill class for the Combined Delta hero. "pass" when
+    /// every contributing language passed; "fail" when any reported
+    /// a new violation (AND-aggregated across blocks). Mirrors the
+    /// per-language reporter's verdict polarity exactly.
+    verdict_class: &'static str,
+    verdict_label: &'static str,
+    verdict_glyph: &'static str,
+    /// Display labels of languages that contributed a baseline.
+    /// Surfaced in the scope-banner copy so reviewers see which
+    /// languages this aggregate represents.
+    contributing_languages: Vec<String>,
+    /// Display labels of languages with no baseline. Rendered as a
+    /// scope-banner note ("TypeScript has no baseline yet — provide
+    /// one via …") so the asymmetry between Current and Delta views
+    /// is visible in-document, not just at the disabled-tab level.
+    missing_baseline_languages: Vec<String>,
+    /// Workspace-wide ranked rows. Sort: risk band desc, then
+    /// CRAP/threshold ratio desc within band; per-row `kind`
+    /// distinguishes regressions from new functions.
+    ranked_rows: Vec<CombinedDeltaRow>,
+}
+
+#[derive(Clone, Copy)]
+struct CombinedDeltaPanelSummary {
+    added: u32,
+    removed: u32,
+    modified: u32,
+    regressions: u32,
+    improvements: u32,
+    new_violations: u32,
+}
+
+/// One row of the Combined Delta ranked table — same shape as
+/// `RankedRow` plus baseline + delta cells so reviewers see the
+/// before/after CRAP transition without leaving the row.
+struct CombinedDeltaRow {
+    language: String,
+    adapter_display: String,
+    badge_glyph: String,
+    qualified_name: String,
+    file_path: String,
+    start_line: usize,
+    end_line: usize,
+    /// Render label for the per-row kind: `"regression"` or `"new"`.
+    /// Drives the per-row badge so reviewers can distinguish a
+    /// modified-with-regression row from a brand-new function at a
+    /// glance.
+    kind_label: &'static str,
+    /// Baseline CRAP value, `"5.20"` formatted, or empty for new
+    /// functions.
+    baseline_crap: String,
+    /// Current CRAP value, `"45.20"` formatted.
+    current_crap: String,
+    /// CRAP / threshold for the current row, formatted as `"5.65"`
+    /// or `"∞"` for the zero-threshold safe-divide guard.
+    ratio_display: String,
+    /// Signed delta string `"+40.00"`; empty for new functions.
+    delta_value: String,
+    /// `"▲"` / `"▼"` / `""` mirror of the per-language delta panel
+    /// row glyphs. Empty when delta_value is empty.
+    delta_glyph: &'static str,
+    /// `"up"` / `"down"` / `"flat"` for chip color.
+    delta_direction: &'static str,
+    /// Current risk-pill data-risk value (1..=4).
+    current_risk: u8,
+    /// Current risk-pill text label.
+    current_risk_label: &'static str,
+    /// True when the current row's CRAP exceeds its adapter's
+    /// threshold. Drives the `data-exceeds="1"` row-tint.
+    exceeds: bool,
 }
 
 fn build_language_buttons(
@@ -968,6 +1089,17 @@ fn build_language_panels(
             } else {
                 file_cards(&block.view, panel_threshold)
             };
+            let delta_panel = block.delta.as_ref().map(|d| Box::new(build_delta_panel(d)));
+            let has_delta = delta_panel.is_some();
+            let current_tab_count = if is_empty { 0 } else { summary.total_functions };
+            let delta_tab_count = delta_panel
+                .as_ref()
+                .map(|p| p.summary.added + p.summary.removed + p.summary.modified)
+                .unwrap_or(0);
+            let delta_has_news = delta_panel
+                .as_ref()
+                .map(|p| p.summary.regressions > 0 || p.summary.new_violations > 0)
+                .unwrap_or(false);
             LangPanel {
                 language: block.language.clone(),
                 display_name: block.display_name.clone(),
@@ -991,6 +1123,11 @@ fn build_language_panels(
                 dist_moderate: summary_view.dist_moderate,
                 dist_high: summary_view.dist_high,
                 files,
+                has_delta,
+                current_tab_count,
+                delta_tab_count,
+                delta_has_news,
+                delta_panel,
             }
         })
         .collect()
@@ -1033,6 +1170,87 @@ fn format_ratio_value(ratio: f64) -> String {
         "∞".to_string()
     } else {
         format!("{:.2}", ratio)
+    }
+}
+
+/// Build the Combined Delta panel template projection from the
+/// composed cross-adapter aggregate.
+///
+/// Verdict polarity mirrors the per-language reporter: any
+/// `new_violations` count above zero flips the verdict to
+/// REGRESSED; otherwise PASS. Caller has already guaranteed at least
+/// one language contributed (the aggregate is wrapped in `Option<>`
+/// so the no-baseline arm of the renderer never reaches this code).
+fn build_combined_delta_panel(cd: crate::domain::multi_lang::CombinedDelta) -> CombinedDeltaPanel {
+    let summary = CombinedDeltaPanelSummary {
+        added: cd.summary.added,
+        removed: cd.summary.removed,
+        modified: cd.summary.modified,
+        regressions: cd.summary.regressions,
+        improvements: cd.summary.improvements,
+        new_violations: cd.summary.new_violations,
+    };
+
+    let (verdict_class, verdict_label, verdict_glyph) = if cd.summary.passed {
+        ("pass", "PASS", "✓")
+    } else {
+        ("fail", "REGRESSED", "▲")
+    };
+
+    let ranked_rows: Vec<CombinedDeltaRow> = cd
+        .ordered_rows
+        .into_iter()
+        .map(|r| {
+            let (kind_label, baseline_crap, delta_value, delta_glyph, delta_direction) =
+                match r.kind {
+                    crate::domain::multi_lang::RankedDeltaKind::Regression => {
+                        let baseline = r
+                            .baseline
+                            .as_ref()
+                            .expect("regressions always carry a baseline snapshot");
+                        let delta = r.current.crap - baseline.crap;
+                        (
+                            "regression",
+                            format!("{:.2}", baseline.crap),
+                            format!("{:+.2}", delta),
+                            signed_glyph_f64(delta),
+                            direction_f64(delta),
+                        )
+                    }
+                    crate::domain::multi_lang::RankedDeltaKind::NewFunction => {
+                        ("new", String::new(), String::new(), "", "flat")
+                    }
+                };
+            CombinedDeltaRow {
+                badge_glyph: adapter_glyph(&r.language, &r.adapter_display),
+                language: r.language,
+                adapter_display: r.adapter_display,
+                qualified_name: r.current.identity.qualified_name.clone(),
+                file_path: r.current.identity.file_path.clone(),
+                start_line: r.current.identity.span.start_line,
+                end_line: r.current.identity.span.end_line,
+                kind_label,
+                baseline_crap,
+                current_crap: format!("{:.2}", r.current.crap),
+                ratio_display: format_ratio_value(r.ratio),
+                delta_value,
+                delta_glyph,
+                delta_direction,
+                current_risk: risk_data(r.current.risk_level),
+                current_risk_label: risk_label(r.current.risk_level),
+                exceeds: r.current.exceeds,
+            }
+        })
+        .collect();
+
+    CombinedDeltaPanel {
+        summary,
+        verdict_class,
+        verdict_label,
+        verdict_glyph,
+        contributing_languages: cd.contributing_languages,
+        missing_baseline_languages: cd.missing_baseline_languages,
+        ranked_rows,
     }
 }
 
@@ -1362,6 +1580,7 @@ mod tests {
         make_empty_result, make_multi_function_result, make_single_function_result,
         make_view_default,
     };
+    use crate::domain::multi_lang::LanguageBlock;
     use crate::domain::types::RiskLevel;
 
     fn test_meta() -> AdapterMeta {
@@ -2174,5 +2393,620 @@ mod tests {
         let multi = crate::core::compose::compose_multi_lang(blocks);
         let out = format_html_multi(&multi, 8.0, HtmlMultiOptions::default());
         insta::assert_snapshot!(out);
+    }
+
+    // ── View axis tests (per-language Current/Delta + Combined Delta) ──
+
+    /// Helper: produce a Rust + TypeScript pair of baselines + current
+    /// fixtures that exercises every Delta affordance:
+    ///   - Rust regression (CRAP 10 → 22, Acceptable → Moderate)
+    ///   - Rust improvement (CRAP 14 → 6, Moderate → Acceptable)
+    ///   - Rust new function (Added, exceeds threshold → new violation)
+    ///   - TypeScript regression with smaller-band crossing
+    ///
+    /// Returns four owned `AnalysisResult`s (rs_baseline, rs_current,
+    /// ts_baseline, ts_current) so callers can build `AnalysisDelta`s
+    /// in place and borrow into `LanguageBlock`s.
+    #[allow(clippy::type_complexity)]
+    fn two_lang_baseline_current_fixtures() -> (
+        crate::domain::types::AnalysisResult,
+        crate::domain::types::AnalysisResult,
+        crate::domain::types::AnalysisResult,
+        crate::domain::types::AnalysisResult,
+    ) {
+        use crate::adapters::reporters::test_fixtures::make_verdict;
+        use crate::domain::types::{AnalysisResult, AnalysisSummary, CrapScore, RiskDistribution};
+
+        // Rust baseline: regressing (10.0, Acceptable), improving (14.0, Moderate)
+        let rs_baseline = AnalysisResult {
+            functions: vec![
+                make_verdict(
+                    "rs::regressing",
+                    "src/lib.rs",
+                    5,
+                    70.0,
+                    10.0,
+                    RiskLevel::Acceptable,
+                    8.0,
+                ),
+                make_verdict(
+                    "rs::improving",
+                    "src/lib.rs",
+                    8,
+                    50.0,
+                    14.0,
+                    RiskLevel::Moderate,
+                    8.0,
+                ),
+            ],
+            summary: AnalysisSummary {
+                total_functions: 2,
+                total_files: 1,
+                exceeding_threshold: 1,
+                average_crap: 12.0,
+                median_crap: 12.0,
+                max_crap: Some(CrapScore {
+                    value: 14.0,
+                    risk_level: RiskLevel::Moderate,
+                }),
+                distribution: RiskDistribution {
+                    low: 0,
+                    acceptable: 1,
+                    moderate: 1,
+                    high: 0,
+                },
+                ..Default::default()
+            },
+            passed: false,
+        };
+
+        // Rust current: regressing → Moderate, improving → Acceptable,
+        // plus a brand-new function that exceeds threshold.
+        let rs_current = AnalysisResult {
+            functions: vec![
+                make_verdict(
+                    "rs::regressing",
+                    "src/lib.rs",
+                    8,
+                    55.0,
+                    22.0,
+                    RiskLevel::Moderate,
+                    8.0,
+                ),
+                make_verdict(
+                    "rs::improving",
+                    "src/lib.rs",
+                    4,
+                    85.0,
+                    6.0,
+                    RiskLevel::Acceptable,
+                    8.0,
+                ),
+                make_verdict(
+                    "rs::brand_new",
+                    "src/new.rs",
+                    10,
+                    40.0,
+                    15.0,
+                    RiskLevel::Moderate,
+                    8.0,
+                ),
+            ],
+            summary: AnalysisSummary {
+                total_functions: 3,
+                total_files: 2,
+                exceeding_threshold: 2,
+                average_crap: 14.33,
+                median_crap: 15.0,
+                max_crap: Some(CrapScore {
+                    value: 22.0,
+                    risk_level: RiskLevel::Moderate,
+                }),
+                distribution: RiskDistribution {
+                    low: 0,
+                    acceptable: 1,
+                    moderate: 2,
+                    high: 0,
+                },
+                ..Default::default()
+            },
+            passed: false,
+        };
+
+        // TypeScript baseline: one Acceptable function.
+        let ts_baseline = AnalysisResult {
+            functions: vec![make_verdict(
+                "ts::parser",
+                "apps/web/src/parser.ts",
+                5,
+                75.0,
+                7.0,
+                RiskLevel::Acceptable,
+                8.0,
+            )],
+            summary: AnalysisSummary {
+                total_functions: 1,
+                total_files: 1,
+                exceeding_threshold: 0,
+                average_crap: 7.0,
+                median_crap: 7.0,
+                max_crap: Some(CrapScore {
+                    value: 7.0,
+                    risk_level: RiskLevel::Acceptable,
+                }),
+                distribution: RiskDistribution {
+                    low: 0,
+                    acceptable: 1,
+                    moderate: 0,
+                    high: 0,
+                },
+                ..Default::default()
+            },
+            passed: true,
+        };
+
+        // TypeScript current: regression on parser (7.0 → 13.0).
+        let ts_current = AnalysisResult {
+            functions: vec![make_verdict(
+                "ts::parser",
+                "apps/web/src/parser.ts",
+                7,
+                60.0,
+                13.0,
+                RiskLevel::Moderate,
+                8.0,
+            )],
+            summary: AnalysisSummary {
+                total_functions: 1,
+                total_files: 1,
+                exceeding_threshold: 1,
+                average_crap: 13.0,
+                median_crap: 13.0,
+                max_crap: Some(CrapScore {
+                    value: 13.0,
+                    risk_level: RiskLevel::Moderate,
+                }),
+                distribution: RiskDistribution {
+                    low: 0,
+                    acceptable: 0,
+                    moderate: 1,
+                    high: 0,
+                },
+                ..Default::default()
+            },
+            passed: false,
+        };
+
+        (rs_baseline, rs_current, ts_baseline, ts_current)
+    }
+
+    /// View axis renders per-language Current/Delta tabs and the
+    /// Combined panel exposes its own Delta tab when at least one
+    /// language has a baseline.
+    #[test]
+    fn multi_lang_view_axis_renders_when_any_language_has_baseline() {
+        let (rs_b, rs_c, ts_b, ts_c) = two_lang_baseline_current_fixtures();
+        let rs_delta = crate::domain::delta::compute(rs_b, rs_c.clone());
+        let ts_delta = crate::domain::delta::compute(ts_b, ts_c.clone());
+
+        let rs_block = LanguageBlock {
+            tool_name: "crap4rs".to_string(),
+            display_name: "Rust".to_string(),
+            language: "rust".to_string(),
+            tool_version: TEST_TOOL_VERSION.to_string(),
+            metric: ComplexityMetric::Cognitive,
+            threshold: 8.0,
+            view: make_view_default(&rs_c),
+            delta: Some(crate::domain::delta::apply(
+                &rs_delta,
+                crate::domain::delta::DeltaViewSpec::default(),
+            )),
+        };
+        let ts_block = LanguageBlock {
+            tool_name: "crap4ts".to_string(),
+            display_name: "TypeScript".to_string(),
+            language: "typescript".to_string(),
+            tool_version: TEST_TOOL_VERSION.to_string(),
+            metric: ComplexityMetric::Cyclomatic,
+            threshold: 8.0,
+            view: make_view_default(&ts_c),
+            delta: Some(crate::domain::delta::apply(
+                &ts_delta,
+                crate::domain::delta::DeltaViewSpec::default(),
+            )),
+        };
+        let multi = crate::core::compose::compose_multi_lang(vec![rs_block, ts_block]);
+        let out = format_html_multi(&multi, 8.0, HtmlMultiOptions::default());
+
+        // Tab nav present on the Combined panel.
+        assert!(
+            out.contains(r#"<nav class="tabs" role="tablist" aria-label="Combined views">"#),
+            "Combined panel must carry View axis tabs when any language has a baseline"
+        );
+        // Per-language Delta tabs present and enabled for both languages.
+        assert!(
+            out.contains(r#"<nav class="tabs" role="tablist" aria-label="Rust views">"#),
+            "Rust panel must carry View axis tabs"
+        );
+        assert!(
+            out.contains(r#"<nav class="tabs" role="tablist" aria-label="TypeScript views">"#),
+            "TypeScript panel must carry View axis tabs"
+        );
+        // No disabled Delta tab when both languages have baselines.
+        assert!(
+            !out.contains(r#"title="no baseline available"#),
+            "no language should render the disabled Delta tooltip when both have baselines"
+        );
+        // Combined Delta hero references both contributing languages.
+        assert!(out.contains("Comparing</strong> current run vs baseline across"));
+        // Per-language Delta panels carry the per-row regression rows.
+        assert!(
+            out.contains("rs::regressing"),
+            "Rust regression row must surface in the Rust Delta panel"
+        );
+    }
+
+    /// Mismatched-baseline scenario: only Rust has a baseline. The
+    /// TypeScript panel must render the Delta tab DISABLED with the
+    /// no-baseline tooltip; the Combined Delta scope-banner must note
+    /// TypeScript's missing baseline.
+    #[test]
+    fn multi_lang_mismatched_baselines_disables_typescript_delta_tab() {
+        let (rs_b, rs_c, _ts_b, ts_c) = two_lang_baseline_current_fixtures();
+        let rs_delta = crate::domain::delta::compute(rs_b, rs_c.clone());
+
+        let rs_block = LanguageBlock {
+            tool_name: "crap4rs".to_string(),
+            display_name: "Rust".to_string(),
+            language: "rust".to_string(),
+            tool_version: TEST_TOOL_VERSION.to_string(),
+            metric: ComplexityMetric::Cognitive,
+            threshold: 8.0,
+            view: make_view_default(&rs_c),
+            delta: Some(crate::domain::delta::apply(
+                &rs_delta,
+                crate::domain::delta::DeltaViewSpec::default(),
+            )),
+        };
+        let ts_block = LanguageBlock {
+            tool_name: "crap4ts".to_string(),
+            display_name: "TypeScript".to_string(),
+            language: "typescript".to_string(),
+            tool_version: TEST_TOOL_VERSION.to_string(),
+            metric: ComplexityMetric::Cyclomatic,
+            threshold: 8.0,
+            view: make_view_default(&ts_c),
+            delta: None,
+        };
+        let multi = crate::core::compose::compose_multi_lang(vec![rs_block, ts_block]);
+        let out = format_html_multi(&multi, 8.0, HtmlMultiOptions::default());
+
+        // Rust Delta tab is enabled (no disabled marker).
+        let rs_nav_start = out
+            .find(r#"aria-label="Rust views""#)
+            .expect("Rust tabs nav present");
+        let next_close = out[rs_nav_start..].find("</nav>").unwrap();
+        let rs_nav = &out[rs_nav_start..rs_nav_start + next_close];
+        assert!(
+            !rs_nav.contains("disabled"),
+            "Rust Delta tab must be enabled when Rust has a baseline; got: {rs_nav}"
+        );
+
+        // TypeScript Delta tab IS disabled with the no-baseline title.
+        let ts_nav_start = out
+            .find(r#"aria-label="TypeScript views""#)
+            .expect("TypeScript tabs nav present");
+        let next_close = out[ts_nav_start..].find("</nav>").unwrap();
+        let ts_nav = &out[ts_nav_start..ts_nav_start + next_close];
+        assert!(
+            ts_nav.contains("disabled"),
+            "TypeScript Delta tab must be disabled when TypeScript has no baseline; got: {ts_nav}"
+        );
+        assert!(
+            ts_nav.contains(r#"title="no baseline available for TypeScript""#),
+            "Disabled Delta tab must carry the no-baseline tooltip; got: {ts_nav}"
+        );
+
+        // Combined Delta scope-banner surfaces the missing-baseline note.
+        assert!(
+            out.contains(r#"class="missing-baseline-note""#),
+            "Combined Delta hero must render the missing-baseline note"
+        );
+        assert!(
+            out.contains("<strong>TypeScript</strong>") && out.contains("has no baseline yet"),
+            "missing-baseline-note must name TypeScript"
+        );
+    }
+
+    /// Combined → Delta ranks regressions and new functions by risk
+    /// band desc then ratio desc, mixing rows from both adapters.
+    #[test]
+    fn multi_lang_combined_delta_ranks_cross_adapter_by_risk_band_then_ratio() {
+        use crate::adapters::reporters::test_fixtures::make_verdict;
+        use crate::domain::types::{AnalysisResult, AnalysisSummary, CrapScore, RiskDistribution};
+
+        // Rust baseline: low-risk Acceptable function.
+        let rs_baseline = AnalysisResult {
+            functions: vec![make_verdict(
+                "rs::regressing_hard",
+                "src/lib.rs",
+                4,
+                75.0,
+                6.0,
+                RiskLevel::Acceptable,
+                8.0,
+            )],
+            summary: AnalysisSummary {
+                total_functions: 1,
+                total_files: 1,
+                exceeding_threshold: 0,
+                average_crap: 6.0,
+                median_crap: 6.0,
+                max_crap: Some(CrapScore {
+                    value: 6.0,
+                    risk_level: RiskLevel::Acceptable,
+                }),
+                distribution: RiskDistribution {
+                    low: 0,
+                    acceptable: 1,
+                    moderate: 0,
+                    high: 0,
+                },
+                ..Default::default()
+            },
+            passed: true,
+        };
+        // Rust current: a brutal regression to High risk; ratio ~5.7
+        let rs_current = AnalysisResult {
+            functions: vec![make_verdict(
+                "rs::regressing_hard",
+                "src/lib.rs",
+                20,
+                30.0,
+                45.6,
+                RiskLevel::High,
+                8.0,
+            )],
+            summary: AnalysisSummary {
+                total_functions: 1,
+                total_files: 1,
+                exceeding_threshold: 1,
+                distribution: RiskDistribution {
+                    low: 0,
+                    acceptable: 0,
+                    moderate: 0,
+                    high: 1,
+                },
+                ..Default::default()
+            },
+            passed: false,
+        };
+
+        // TypeScript baseline: another low-risk function.
+        let ts_baseline = AnalysisResult {
+            functions: vec![make_verdict(
+                "ts::moderate_change",
+                "src/parser.ts",
+                4,
+                75.0,
+                6.0,
+                RiskLevel::Acceptable,
+                8.0,
+            )],
+            summary: AnalysisSummary {
+                total_functions: 1,
+                total_files: 1,
+                exceeding_threshold: 0,
+                average_crap: 6.0,
+                median_crap: 6.0,
+                max_crap: Some(CrapScore {
+                    value: 6.0,
+                    risk_level: RiskLevel::Acceptable,
+                }),
+                distribution: RiskDistribution {
+                    low: 0,
+                    acceptable: 1,
+                    moderate: 0,
+                    high: 0,
+                },
+                ..Default::default()
+            },
+            passed: true,
+        };
+        // TypeScript current: regression to Moderate; ratio 2.5
+        let ts_current = AnalysisResult {
+            functions: vec![make_verdict(
+                "ts::moderate_change",
+                "src/parser.ts",
+                10,
+                60.0,
+                20.0,
+                RiskLevel::Moderate,
+                8.0,
+            )],
+            summary: AnalysisSummary {
+                total_functions: 1,
+                total_files: 1,
+                exceeding_threshold: 1,
+                distribution: RiskDistribution {
+                    low: 0,
+                    acceptable: 0,
+                    moderate: 1,
+                    high: 0,
+                },
+                ..Default::default()
+            },
+            passed: false,
+        };
+
+        let rs_delta_full = crate::domain::delta::compute(rs_baseline, rs_current.clone());
+        let ts_delta_full = crate::domain::delta::compute(ts_baseline, ts_current.clone());
+
+        let blocks = vec![
+            LanguageBlock {
+                tool_name: "crap4rs".to_string(),
+                display_name: "Rust".to_string(),
+                language: "rust".to_string(),
+                tool_version: TEST_TOOL_VERSION.to_string(),
+                metric: ComplexityMetric::Cognitive,
+                threshold: 8.0,
+                view: make_view_default(&rs_current),
+                delta: Some(crate::domain::delta::apply(
+                    &rs_delta_full,
+                    crate::domain::delta::DeltaViewSpec::default(),
+                )),
+            },
+            LanguageBlock {
+                tool_name: "crap4ts".to_string(),
+                display_name: "TypeScript".to_string(),
+                language: "typescript".to_string(),
+                tool_version: TEST_TOOL_VERSION.to_string(),
+                metric: ComplexityMetric::Cyclomatic,
+                threshold: 8.0,
+                view: make_view_default(&ts_current),
+                delta: Some(crate::domain::delta::apply(
+                    &ts_delta_full,
+                    crate::domain::delta::DeltaViewSpec::default(),
+                )),
+            },
+        ];
+        let multi = crate::core::compose::compose_multi_lang(blocks);
+        let out = format_html_multi(&multi, 8.0, HtmlMultiOptions::default());
+
+        // Locate the Combined Delta tab panel and confirm the Rust
+        // High-risk row appears before the TypeScript Moderate-risk
+        // row inside it.
+        let combined_delta_start = out
+            .find(r#"data-tab="delta" role="tabpanel""#)
+            .expect("Combined Delta tab-panel must render");
+        let combined_delta_section = &out[combined_delta_start..];
+        let rs_pos = combined_delta_section
+            .find("rs::regressing_hard")
+            .expect("Rust High-risk regression must surface in Combined Delta");
+        let ts_pos = combined_delta_section
+            .find("ts::moderate_change")
+            .expect("TypeScript Moderate-risk regression must surface in Combined Delta");
+        assert!(
+            rs_pos < ts_pos,
+            "Rust High-risk regression must rank ahead of TypeScript Moderate-risk regression in Combined Delta (D2d sort: risk band desc, ratio desc)"
+        );
+    }
+
+    /// Insta snapshot lock for the both-baselines View axis render.
+    #[test]
+    fn full_html_multi_two_language_with_baselines_snapshot() {
+        let (rs_b, rs_c, ts_b, ts_c) = two_lang_baseline_current_fixtures();
+        let rs_delta = crate::domain::delta::compute(rs_b, rs_c.clone());
+        let ts_delta = crate::domain::delta::compute(ts_b, ts_c.clone());
+
+        let rs_block = LanguageBlock {
+            tool_name: "crap4rs".to_string(),
+            display_name: "Rust".to_string(),
+            language: "rust".to_string(),
+            tool_version: TEST_TOOL_VERSION.to_string(),
+            metric: ComplexityMetric::Cognitive,
+            threshold: 8.0,
+            view: make_view_default(&rs_c),
+            delta: Some(crate::domain::delta::apply(
+                &rs_delta,
+                crate::domain::delta::DeltaViewSpec::default(),
+            )),
+        };
+        let ts_block = LanguageBlock {
+            tool_name: "crap4ts".to_string(),
+            display_name: "TypeScript".to_string(),
+            language: "typescript".to_string(),
+            tool_version: TEST_TOOL_VERSION.to_string(),
+            metric: ComplexityMetric::Cyclomatic,
+            threshold: 8.0,
+            view: make_view_default(&ts_c),
+            delta: Some(crate::domain::delta::apply(
+                &ts_delta,
+                crate::domain::delta::DeltaViewSpec::default(),
+            )),
+        };
+        let multi = crate::core::compose::compose_multi_lang(vec![rs_block, ts_block]);
+        let out = format_html_multi(&multi, 8.0, HtmlMultiOptions::default());
+        insta::assert_snapshot!(out);
+    }
+
+    /// Insta snapshot lock for the mismatched-baseline scenario
+    /// (Rust has a baseline; TypeScript doesn't).
+    #[test]
+    fn full_html_multi_mismatched_baseline_snapshot() {
+        let (rs_b, rs_c, _ts_b, ts_c) = two_lang_baseline_current_fixtures();
+        let rs_delta = crate::domain::delta::compute(rs_b, rs_c.clone());
+
+        let rs_block = LanguageBlock {
+            tool_name: "crap4rs".to_string(),
+            display_name: "Rust".to_string(),
+            language: "rust".to_string(),
+            tool_version: TEST_TOOL_VERSION.to_string(),
+            metric: ComplexityMetric::Cognitive,
+            threshold: 8.0,
+            view: make_view_default(&rs_c),
+            delta: Some(crate::domain::delta::apply(
+                &rs_delta,
+                crate::domain::delta::DeltaViewSpec::default(),
+            )),
+        };
+        let ts_block = LanguageBlock {
+            tool_name: "crap4ts".to_string(),
+            display_name: "TypeScript".to_string(),
+            language: "typescript".to_string(),
+            tool_version: TEST_TOOL_VERSION.to_string(),
+            metric: ComplexityMetric::Cyclomatic,
+            threshold: 8.0,
+            view: make_view_default(&ts_c),
+            delta: None,
+        };
+        let multi = crate::core::compose::compose_multi_lang(vec![rs_block, ts_block]);
+        let out = format_html_multi(&multi, 8.0, HtmlMultiOptions::default());
+        insta::assert_snapshot!(out);
+    }
+
+    /// Single-language passthrough must remain byte-identical to the
+    /// single-binary path even when the language carries a baseline.
+    /// Confirms the new View axis plumbing in the multi-lang glue
+    /// doesn't leak into the n=1 short-circuit.
+    #[test]
+    fn multi_lang_single_language_passthrough_byte_identical_with_baseline() {
+        use crate::adapters::reporters::test_fixtures::{
+            make_delta_view_default, make_sample_delta,
+        };
+
+        let delta = make_sample_delta();
+        let view = make_view_default(&delta.current);
+        let dview = make_delta_view_default(&delta);
+
+        let direct = format_html(
+            &view,
+            Some(&dview),
+            8.0,
+            &test_meta(),
+            ComplexityMetric::Cognitive,
+        );
+
+        let block = LanguageBlock {
+            tool_name: TEST_TOOL_NAME.to_string(),
+            display_name: "Test".to_string(),
+            language: "rust".to_string(),
+            tool_version: TEST_TOOL_VERSION.to_string(),
+            metric: ComplexityMetric::Cognitive,
+            threshold: 8.0,
+            view: make_view_default(&delta.current),
+            delta: Some(make_delta_view_default(&delta)),
+        };
+        let multi = crate::core::compose::compose_multi_lang(vec![block]);
+        let unified = format_html_multi(&multi, 8.0, HtmlMultiOptions::default());
+
+        assert_eq!(
+            direct, unified,
+            "single-language passthrough must be byte-identical to format_html WITH a baseline too — the n=1 short-circuit must not gain multi-lang chrome when delta is present"
+        );
+        assert!(
+            !unified.contains("data-multi-lang"),
+            "single-language passthrough must not render the multi-lang body marker"
+        );
     }
 }

--- a/crates/crap-core/src/adapters/reporters/html.rs
+++ b/crates/crap-core/src/adapters/reporters/html.rs
@@ -739,9 +739,8 @@ fn render_multi_lang(
     let combined = build_combined_view(multi, threshold);
     let language_panels = build_language_panels(multi, threshold);
     let adapters_footer = build_adapters_footer(multi);
-    let combined_delta = crate::core::compose::compose_combined_delta(&multi.languages);
-    let has_view_axis = combined_delta.is_some();
-    let combined_delta_panel = combined_delta.map(|cd| Box::new(build_combined_delta_panel(cd)));
+    let combined_delta_panel = crate::core::compose::compose_combined_delta(&multi.languages)
+        .map(|cd| Box::new(build_combined_delta_panel(cd)));
 
     let title = if language_count == 0 {
         "CRAP scorecard — multi-language".to_string()
@@ -765,7 +764,6 @@ fn render_multi_lang(
         combined,
         language_panels,
         adapters_footer,
-        has_view_axis,
         combined_delta_panel,
     };
     tmpl.render()
@@ -788,17 +786,13 @@ struct HtmlMultiReport {
     combined: CombinedPanel,
     language_panels: Vec<LangPanel>,
     adapters_footer: Vec<AdapterFooterRow>,
-    /// True when at least one language supplied a baseline, so the
-    /// View axis nav (Current / Delta tabs) should be rendered
-    /// inside each `.lang-panel`. The whole no-baseline path stays
-    /// byte-for-byte equivalent to the v0.7.0 multi-language render
-    /// when this is `false`, mirroring `format_html`'s
-    /// `has_delta`-gated tabs pattern.
-    has_view_axis: bool,
     /// Combined Delta panel: cross-adapter aggregate + ranked
-    /// regressions/new violations. Boxed to keep the dominant
-    /// no-baseline arm cheap; same `large_enum_variant` rationale
-    /// as the single-language `delta_panel`.
+    /// regressions/new violations. `None` when no language supplied a
+    /// baseline; the template still renders the View nav, but the
+    /// Delta tab is rendered disabled with a no-baseline tooltip so
+    /// the affordance stays visible to consumers. Boxed to keep the
+    /// dominant no-baseline arm cheap; same `large_enum_variant`
+    /// rationale as the single-language `delta_panel`.
     combined_delta_panel: Option<Box<CombinedDeltaPanel>>,
 }
 
@@ -2715,6 +2709,124 @@ mod tests {
         assert!(
             out.contains("<strong>TypeScript</strong>") && out.contains("has no baseline yet"),
             "missing-baseline-note must name TypeScript"
+        );
+    }
+
+    /// No-baseline path: when neither language supplies a baseline,
+    /// the View axis nav must still render in every panel (Combined +
+    /// per-language) with the Delta tab in the disabled state. The
+    /// affordance must stay visible so consumers downloading the
+    /// rendered HTML in the dominant no-baseline case learn the
+    /// feature exists rather than being silently denied a tab nav
+    /// they can't see is gated.
+    #[test]
+    fn multi_lang_no_baselines_renders_view_nav_with_disabled_delta_in_every_panel() {
+        let rs_result = make_multi_function_result();
+        let ts_result = make_single_function_result(
+            "parseInvoiceDraft",
+            "apps/web/src/composer.ts",
+            6,
+            55.0,
+            12.0,
+            RiskLevel::Moderate,
+            8.0,
+        );
+        let blocks = vec![
+            build_block(
+                &rs_result,
+                "crap4rs",
+                "Rust",
+                "rust",
+                ComplexityMetric::Cognitive,
+                8.0,
+            ),
+            build_block(
+                &ts_result,
+                "crap4ts",
+                "TypeScript",
+                "typescript",
+                ComplexityMetric::Cyclomatic,
+                8.0,
+            ),
+        ];
+        let multi = crate::core::compose::compose_multi_lang(blocks);
+        let out = format_html_multi(&multi, 8.0, HtmlMultiOptions::default());
+
+        // All three View navs render even though no language supplied
+        // a baseline.
+        assert!(
+            out.contains(r#"<nav class="tabs" role="tablist" aria-label="Combined views">"#),
+            "Combined panel must carry View axis tabs even without baselines"
+        );
+        assert!(
+            out.contains(r#"<nav class="tabs" role="tablist" aria-label="Rust views">"#),
+            "Rust panel must carry View axis tabs even without a baseline"
+        );
+        assert!(
+            out.contains(r#"<nav class="tabs" role="tablist" aria-label="TypeScript views">"#),
+            "TypeScript panel must carry View axis tabs even without a baseline"
+        );
+
+        // Three navs total — one per panel.
+        let nav_count = out.matches(r#"<nav class="tabs""#).count();
+        assert_eq!(
+            nav_count, 3,
+            "expected exactly three View navs (Combined + Rust + TypeScript); got {nav_count}"
+        );
+
+        // The Combined Delta tab is disabled with the cross-adapter
+        // no-baseline tooltip.
+        let combined_nav_start = out
+            .find(r#"aria-label="Combined views""#)
+            .expect("Combined tabs nav present");
+        let next_close = out[combined_nav_start..]
+            .find("</nav>")
+            .expect("Combined nav has closing tag");
+        let combined_nav = &out[combined_nav_start..combined_nav_start + next_close];
+        assert!(
+            combined_nav.contains("disabled") && combined_nav.contains("aria-disabled=\"true\""),
+            "Combined Delta tab must be disabled when no language supplied a baseline; got: {combined_nav}"
+        );
+        assert!(
+            combined_nav.contains(
+                r#"title="no baselines provided — pass --baseline to enable cross-adapter delta""#
+            ),
+            "Combined Delta disabled tooltip must name the no-baselines cause; got: {combined_nav}"
+        );
+
+        // Both per-language Delta tabs are disabled with the per-language tooltip.
+        for lang_label in ["Rust", "TypeScript"] {
+            let nav_start = out
+                .find(&format!(r#"aria-label="{lang_label} views""#))
+                .unwrap_or_else(|| panic!("{lang_label} tabs nav present"));
+            let close_off = out[nav_start..]
+                .find("</nav>")
+                .expect("per-language nav has closing tag");
+            let nav = &out[nav_start..nav_start + close_off];
+            assert!(
+                nav.contains("disabled") && nav.contains("aria-disabled=\"true\""),
+                "{lang_label} Delta tab must be disabled when {lang_label} has no baseline; got: {nav}"
+            );
+            assert!(
+                nav.contains(&format!(
+                    r#"title="no baseline available for {lang_label}""#
+                )),
+                "{lang_label} Delta disabled tooltip must name the language; got: {nav}"
+            );
+        }
+
+        // No Delta tab-panel renders for any language; the Current
+        // panel is always the only `.tab-panel` per `.lang-panel`.
+        // The JS skips clicks on disabled buttons (early return at the
+        // tab handler), so the missing Delta panel never gets
+        // activated. Lock the absence so a regression that emits an
+        // orphan Delta panel without populating it surfaces here.
+        // `<div class="tab-panel" data-tab="delta"` is the panel
+        // marker; the disabled button uses `<button` so the panel
+        // assertion stays orthogonal to the button assertions above.
+        assert!(
+            !out.contains(r#"<div class="tab-panel" data-tab="delta""#),
+            "no-baseline render must not emit a Delta tab-panel for any language"
         );
     }
 

--- a/crates/crap-core/src/adapters/reporters/snapshots/crap_core__adapters__reporters__html__tests__full_html_multi_mismatched_baseline_snapshot.snap
+++ b/crates/crap-core/src/adapters/reporters/snapshots/crap_core__adapters__reporters__html__tests__full_html_multi_mismatched_baseline_snapshot.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/crap-core/src/adapters/reporters/html.rs
-assertion_line: 2397
+assertion_line: 2971
 expression: out
 ---
 <!doctype html>
@@ -1420,14 +1420,24 @@ pre code { background: transparent; padding: 0; }
 
 <!-- ── Combined panel ──────────────────────────────────────────────── -->
 <div class="lang-panel" data-lang="combined" data-active>
+  <nav class="tabs" role="tablist" aria-label="Combined views">
+    <button class="tab" role="tab" aria-selected="true" data-tab="current" type="button">
+      Current run <span class="tab-count">4</span>
+    </button>
+    <button class="tab" role="tab" aria-selected="false" data-tab="delta" type="button">
+      Delta vs baseline <span class="tab-dot" aria-hidden="true"></span>
+      <span class="tab-count">2 changed</span>
+    </button>
+  </nav>
+  <div class="tab-panel" data-tab="current" data-active role="tabpanel">
   <section class="scope-banner" aria-label="Combined scope">
     <p>
       <strong>3 of 4</strong>
       functions exceed their adapter thresholds across the workspace.
       
-      Worst offender at <code>5.65×</code> over threshold (complex_fn, Rust).
+      Worst offender at <code>2.75×</code> over threshold (rs::regressing, Rust).
       
-      <span class="meta">4 files · 2 adapters</span>
+      <span class="meta">3 files · 2 adapters</span>
     </p>
   </section>
 
@@ -1444,12 +1454,12 @@ pre code { background: transparent; padding: 0; }
     </div>
     <div class="kpi">
       <span class="kpi-label">Files analyzed</span>
-      <span class="kpi-value">4</span>
+      <span class="kpi-value">3</span>
       <span class="kpi-foot">disjoint source trees</span>
     </div>
     <div class="kpi">
       <span class="kpi-label">Worst CRAP/threshold ratio</span>
-      <span class="kpi-value">5.65×</span>
+      <span class="kpi-value">2.75×</span>
       <span class="kpi-foot">Rust adapter</span>
     </div>
   </section>
@@ -1457,17 +1467,17 @@ pre code { background: transparent; padding: 0; }
   <section class="panel" aria-label="Combined risk distribution">
     <div class="panel-header"><h2>Risk distribution</h2></div>
     <div class="dist-bar">
-      <span class="dist-seg" data-risk="1" style="flex:1" title="low: 1 functions">
-        <span class="dist-count">1</span><span class="dist-label">low</span>
+      <span class="dist-seg" data-risk="1" style="flex:0" title="low: 0 functions">
+        <span class="dist-count">0</span><span class="dist-label">low</span>
       </span>
-      <span class="dist-seg" data-risk="2" style="flex:0" title="acceptable: 0 functions">
-        <span class="dist-count">0</span><span class="dist-label">acceptable</span>
+      <span class="dist-seg" data-risk="2" style="flex:1" title="acceptable: 1 functions">
+        <span class="dist-count">1</span><span class="dist-label">acceptable</span>
       </span>
-      <span class="dist-seg" data-risk="3" style="flex:2" title="moderate: 2 functions">
-        <span class="dist-count">2</span><span class="dist-label">moderate</span>
+      <span class="dist-seg" data-risk="3" style="flex:3" title="moderate: 3 functions">
+        <span class="dist-count">3</span><span class="dist-label">moderate</span>
       </span>
-      <span class="dist-seg" data-risk="4" style="flex:1" title="high: 1 functions">
-        <span class="dist-count">1</span><span class="dist-label">high</span>
+      <span class="dist-seg" data-risk="4" style="flex:0" title="high: 0 functions">
+        <span class="dist-count">0</span><span class="dist-label">high</span>
       </span>
     </div>
     <div class="dist-legend">
@@ -1505,13 +1515,13 @@ pre code { background: transparent; padding: 0; }
             <span class="adapter-badge" title="Rust adapter" aria-label="Rust adapter">R</span>
             <span class="sr-only">Rust</span>
           </td>
-          <td><span class="fn-name">complex_fn</span></td>
-          <td><span class="fn-path">src/domain/crap.rs L1–10</span></td>
-          <td class="num">20</td>
-          <td class="num">30.0%</td>
-          <td class="num">45.20</td>
-          <td class="num">5.65</td>
-          <td><span class="risk-pill" data-risk="4">high</span></td>
+          <td><span class="fn-name">rs::regressing</span></td>
+          <td><span class="fn-path">src/lib.rs L1–10</span></td>
+          <td class="num">8</td>
+          <td class="num">55.0%</td>
+          <td class="num">22.00</td>
+          <td class="num">2.75</td>
+          <td><span class="risk-pill" data-risk="3">moderate</span></td>
         </tr>
         
         <tr data-lang="rust" data-exceeds="1">
@@ -1519,10 +1529,10 @@ pre code { background: transparent; padding: 0; }
             <span class="adapter-badge" title="Rust adapter" aria-label="Rust adapter">R</span>
             <span class="sr-only">Rust</span>
           </td>
-          <td><span class="fn-name">parse_record</span></td>
-          <td><span class="fn-path">src/adapters/coverage/mod.rs L1–10</span></td>
-          <td class="num">6</td>
-          <td class="num">72.5%</td>
+          <td><span class="fn-name">rs::brand_new</span></td>
+          <td><span class="fn-path">src/new.rs L1–10</span></td>
+          <td class="num">10</td>
+          <td class="num">40.0%</td>
           <td class="num">15.00</td>
           <td class="num">1.88</td>
           <td><span class="risk-pill" data-risk="3">moderate</span></td>
@@ -1533,12 +1543,12 @@ pre code { background: transparent; padding: 0; }
             <span class="adapter-badge" title="TypeScript adapter" aria-label="TypeScript adapter">T</span>
             <span class="sr-only">TypeScript</span>
           </td>
-          <td><span class="fn-name">parseInvoiceDraft</span></td>
-          <td><span class="fn-path">apps/web/src/composer.ts L1–10</span></td>
-          <td class="num">6</td>
-          <td class="num">55.0%</td>
-          <td class="num">12.00</td>
-          <td class="num">1.50</td>
+          <td><span class="fn-name">ts::parser</span></td>
+          <td><span class="fn-path">apps/web/src/parser.ts L1–10</span></td>
+          <td class="num">7</td>
+          <td class="num">60.0%</td>
+          <td class="num">13.00</td>
+          <td class="num">1.62</td>
           <td><span class="risk-pill" data-risk="3">moderate</span></td>
         </tr>
         
@@ -1547,32 +1557,123 @@ pre code { background: transparent; padding: 0; }
             <span class="adapter-badge" title="Rust adapter" aria-label="Rust adapter">R</span>
             <span class="sr-only">Rust</span>
           </td>
-          <td><span class="fn-name">simple_fn</span></td>
+          <td><span class="fn-name">rs::improving</span></td>
           <td><span class="fn-path">src/lib.rs L1–10</span></td>
-          <td class="num">2</td>
-          <td class="num">95.0%</td>
-          <td class="num">3.00</td>
-          <td class="num">0.38</td>
-          <td><span class="risk-pill" data-risk="1">low</span></td>
+          <td class="num">4</td>
+          <td class="num">85.0%</td>
+          <td class="num">6.00</td>
+          <td class="num">0.75</td>
+          <td><span class="risk-pill" data-risk="2">acceptable</span></td>
         </tr>
         
       </tbody>
     </table>
   </section>
   
+  </div>
+  <div class="tab-panel" data-tab="delta" role="tabpanel">
+    <section class="scope-banner delta-hero" aria-label="Combined Delta scope">
+      <p>
+        <strong>Comparing</strong> current run vs baseline across
+        the Rust adapter.
+        <span class="verdict is-fail" aria-label="Combined Delta verdict: REGRESSED">
+          <span class="verdict-glyph">▲</span>
+          REGRESSED
+        </span>
+        <span class="meta">
+          1 added · 0 removed · 2 modified ·
+          1 regression ·
+          1 improvement ·
+          1 new violation
+        </span>
+      </p>
+      <p class="missing-baseline-note">
+        <strong>TypeScript</strong>
+        has no baseline yet — its Delta tab is disabled until one is supplied.
+      </p>
+    </section>
+    <section aria-label="Combined Delta ranking">
+      <h2>Workspace regressions &amp; new functions <span class="muted">· by risk band, then CRAP/threshold ratio</span></h2>
+      <p class="ranked-note">
+        Cross-adapter delta ordering uses risk level (per-adapter calibrated) then
+        CRAP/threshold ratio. Raw CRAP scores are not dimensionally equivalent
+        across adapters with different complexity metrics; the per-language Delta
+        tabs below show within-adapter rankings.
+      </p>
+      <table class="ranked-table">
+        <thead><tr>
+          <th>Adapter</th>
+          <th>Function</th>
+          <th>File</th>
+          <th>Kind</th>
+          <th class="num">Baseline</th>
+          <th class="num">Current</th>
+          <th class="num">Δ</th>
+          <th class="num">Ratio</th>
+          <th>Risk</th>
+        </tr></thead>
+        <tbody>
+          
+          <tr data-lang="rust" data-kind="regression" data-exceeds="1">
+            <td>
+              <span class="adapter-badge" title="Rust adapter" aria-label="Rust adapter">R</span>
+              <span class="sr-only">Rust</span>
+            </td>
+            <td><span class="fn-name">rs::regressing</span></td>
+            <td><span class="fn-path">src/lib.rs L1–10</span></td>
+            <td><span class="kind-pill" data-kind="regression">regression</span></td>
+            <td class="num">10.00</td>
+            <td class="num">22.00</td>
+            <td class="num"><span class="delta-chip" data-direction="up" data-regression="1"><span class="chip-glyph" aria-hidden="true">▲</span>
+                <span class="chip-value">+12.00</span>
+              </span>
+            </td>
+            <td class="num">2.75</td>
+            <td><span class="risk-pill" data-risk="3">moderate</span></td>
+          </tr>
+          
+          <tr data-lang="rust" data-kind="new" data-exceeds="1">
+            <td>
+              <span class="adapter-badge" title="Rust adapter" aria-label="Rust adapter">R</span>
+              <span class="sr-only">Rust</span>
+            </td>
+            <td><span class="fn-name">rs::brand_new</span></td>
+            <td><span class="fn-path">src/new.rs L1–10</span></td>
+            <td><span class="kind-pill" data-kind="new">new</span></td>
+            <td class="num">—</td>
+            <td class="num">15.00</td>
+            <td class="num">—
+            </td>
+            <td class="num">1.88</td>
+            <td><span class="risk-pill" data-risk="3">moderate</span></td>
+          </tr>
+          
+        </tbody>
+      </table>
+    </section>
+  </div>
 </div>
 
 <!-- ── Per-language panels ─────────────────────────────────────────── -->
 
 <div class="lang-panel" data-lang="rust">
+  <nav class="tabs" role="tablist" aria-label="Rust views">
+    <button class="tab" role="tab" aria-selected="true" data-tab="current" type="button">
+      Current run <span class="tab-count">3</span>
+    </button>
+    <button class="tab" role="tab" aria-selected="false" data-tab="delta" type="button">Delta vs baseline <span class="tab-dot" aria-hidden="true"></span>
+      <span class="tab-count">3 changed</span>
+    </button>
+  </nav>
+  <div class="tab-panel" data-tab="current" data-active role="tabpanel">
   <section class="scope-banner" aria-label="Rust scope">
     <p>
       <strong>2 of 3</strong>
       functions exceed threshold.
       
-      Worst offender scores <code>45.20</code>.
+      Worst offender scores <code>22.00</code>.
       
-      <span class="meta">3 files · Rust adapter</span>
+      <span class="meta">2 files · Rust adapter</span>
     </p>
   </section>
 
@@ -1584,35 +1685,35 @@ pre code { background: transparent; padding: 0; }
     </div>
     <div class="kpi">
       <span class="kpi-label">Average CRAP</span>
-      <span class="kpi-value">21.07</span>
-      <span class="kpi-foot">median <code>15.00</code> · max <code>45.20</code></span>
+      <span class="kpi-value">14.33</span>
+      <span class="kpi-foot">median <code>15.00</code> · max <code>22.00</code></span>
     </div>
     <div class="kpi">
       <span class="kpi-label">Avg line coverage</span>
-      <span class="kpi-value">65.8<span class="kpi-unit">%</span></span>
-      <div class="bar is-thick" aria-hidden="true"><span class="is-2" style="width:65.8%"></span></div>
+      <span class="kpi-value">0.0<span class="kpi-unit">%</span></span>
+      <div class="bar is-thick" aria-hidden="true"><span class="is-4" style="width:0.0%"></span></div>
     </div>
     <div class="kpi">
       <span class="kpi-label">Avg complexity</span>
-      <span class="kpi-value">9.3</span>
-      <span class="kpi-foot">median <code>6.0</code> · max <code>20</code> cognitive</span>
+      <span class="kpi-value">0.0</span>
+      <span class="kpi-foot">median <code>0.0</code> · max <code>0</code> cognitive</span>
     </div>
   </section>
 
   <section class="panel" aria-label="Rust risk distribution">
     <div class="panel-header"><h2>Risk distribution</h2></div>
     <div class="dist-bar">
-      <span class="dist-seg" data-risk="1" style="flex:1" title="low: 1 functions">
-        <span class="dist-count">1</span><span class="dist-label">low</span>
+      <span class="dist-seg" data-risk="1" style="flex:0" title="low: 0 functions">
+        <span class="dist-count">0</span><span class="dist-label">low</span>
       </span>
-      <span class="dist-seg" data-risk="2" style="flex:0" title="acceptable: 0 functions">
-        <span class="dist-count">0</span><span class="dist-label">acceptable</span>
+      <span class="dist-seg" data-risk="2" style="flex:1" title="acceptable: 1 functions">
+        <span class="dist-count">1</span><span class="dist-label">acceptable</span>
       </span>
-      <span class="dist-seg" data-risk="3" style="flex:1" title="moderate: 1 functions">
-        <span class="dist-count">1</span><span class="dist-label">moderate</span>
+      <span class="dist-seg" data-risk="3" style="flex:2" title="moderate: 2 functions">
+        <span class="dist-count">2</span><span class="dist-label">moderate</span>
       </span>
-      <span class="dist-seg" data-risk="4" style="flex:1" title="high: 1 functions">
-        <span class="dist-count">1</span><span class="dist-label">high</span>
+      <span class="dist-seg" data-risk="4" style="flex:0" title="high: 0 functions">
+        <span class="dist-count">0</span><span class="dist-label">high</span>
       </span>
     </div>
   </section>
@@ -1622,14 +1723,14 @@ pre code { background: transparent; padding: 0; }
     <h2>Functions by file <span class="muted">· Rust</span></h2>
     <div class="file-list">
       
-      <details class="severity-card file-card" data-risk="4" data-exceeds="1" open>
+      <details class="severity-card file-card" data-risk="3" data-exceeds="1" open>
         <summary>
           <span class="stripe"></span>
           <span class="caret">›</span>
-          <span class="sev-path">src/domain/crap.rs</span>
+          <span class="sev-path">src/lib.rs</span>
           <span class="sev-meta">
-            <span><b>1</b> fn</span>
-            <span>max CRAP <b>45.20</b></span>
+            <span><b>2</b> fn</span>
+            <span>max CRAP <b>22.00</b></span>
             
             <span class="over"><b>1 over</b></span>
             
@@ -1643,11 +1744,19 @@ pre code { background: transparent; padding: 0; }
             <tbody>
               
               <tr class="is-exceeds">
-                <td><span class="fn-name">complex_fn</span><span class="fn-loc">10 LOC</span></td>
+                <td><span class="fn-name">rs::regressing</span><span class="fn-loc">10 LOC</span></td>
                 <td>1–10</td>
-                <td><div class="metric-cell"><div class="num-line"><span>20</span><span class="note">cognitive</span></div><div class="bar"><span class="is-4" style="width:100%"></span></div></div></td>
-                <td><div class="metric-cell"><div class="num-line"><span>30.0%</span><span class="note">lines</span></div><div class="bar"><span class="is-4" style="width:30.0%"></span></div></div></td>
-                <td class="num"><span class="crap-cell">45.20 <span class="risk-pill" data-risk="4">high</span><span class="over-by">+37.20</span></span></td>
+                <td><div class="metric-cell"><div class="num-line"><span>8</span><span class="note">cognitive</span></div><div class="bar"><span class="is-3" style="width:40%"></span></div></div></td>
+                <td><div class="metric-cell"><div class="num-line"><span>55.0%</span><span class="note">lines</span></div><div class="bar"><span class="is-3" style="width:55.0%"></span></div></div></td>
+                <td class="num"><span class="crap-cell">22.00 <span class="risk-pill" data-risk="3">moderate</span><span class="over-by">+14.00</span></span></td>
+              </tr>
+              
+              <tr>
+                <td><span class="fn-name">rs::improving</span><span class="fn-loc">10 LOC</span></td>
+                <td>1–10</td>
+                <td><div class="metric-cell"><div class="num-line"><span>4</span><span class="note">cognitive</span></div><div class="bar"><span class="is-2" style="width:20%"></span></div></div></td>
+                <td><div class="metric-cell"><div class="num-line"><span>85.0%</span><span class="note">lines</span></div><div class="bar"><span class="is-1" style="width:85.0%"></span></div></div></td>
+                <td class="num"><span class="crap-cell">6.00 <span class="risk-pill" data-risk="2">acceptable</span></span></td>
               </tr>
               
             </tbody>
@@ -1659,7 +1768,7 @@ pre code { background: transparent; padding: 0; }
         <summary>
           <span class="stripe"></span>
           <span class="caret">›</span>
-          <span class="sev-path">src/adapters/coverage/mod.rs</span>
+          <span class="sev-path">src/new.rs</span>
           <span class="sev-meta">
             <span><b>1</b> fn</span>
             <span>max CRAP <b>15.00</b></span>
@@ -1676,44 +1785,11 @@ pre code { background: transparent; padding: 0; }
             <tbody>
               
               <tr class="is-exceeds">
-                <td><span class="fn-name">parse_record</span><span class="fn-loc">10 LOC</span></td>
+                <td><span class="fn-name">rs::brand_new</span><span class="fn-loc">10 LOC</span></td>
                 <td>1–10</td>
-                <td><div class="metric-cell"><div class="num-line"><span>6</span><span class="note">cognitive</span></div><div class="bar"><span class="is-2" style="width:30%"></span></div></div></td>
-                <td><div class="metric-cell"><div class="num-line"><span>72.5%</span><span class="note">lines</span></div><div class="bar"><span class="is-2" style="width:72.5%"></span></div></div></td>
+                <td><div class="metric-cell"><div class="num-line"><span>10</span><span class="note">cognitive</span></div><div class="bar"><span class="is-3" style="width:50%"></span></div></div></td>
+                <td><div class="metric-cell"><div class="num-line"><span>40.0%</span><span class="note">lines</span></div><div class="bar"><span class="is-3" style="width:40.0%"></span></div></div></td>
                 <td class="num"><span class="crap-cell">15.00 <span class="risk-pill" data-risk="3">moderate</span><span class="over-by">+7.00</span></span></td>
-              </tr>
-              
-            </tbody>
-          </table>
-        </div>
-      </details>
-      
-      <details class="severity-card file-card" data-risk="1" data-exceeds="0">
-        <summary>
-          <span class="stripe"></span>
-          <span class="caret">›</span>
-          <span class="sev-path">src/lib.rs</span>
-          <span class="sev-meta">
-            <span><b>1</b> fn</span>
-            <span>max CRAP <b>3.00</b></span>
-            
-            <span>0 over</span>
-            
-          </span>
-        </summary>
-        <div class="severity-card-body">
-          <table class="file-fns">
-            <thead><tr>
-              <th>Function</th><th>Lines</th><th>Complexity</th><th>Coverage</th><th class="num">CRAP</th>
-            </tr></thead>
-            <tbody>
-              
-              <tr>
-                <td><span class="fn-name">simple_fn</span><span class="fn-loc">10 LOC</span></td>
-                <td>1–10</td>
-                <td><div class="metric-cell"><div class="num-line"><span>2</span><span class="note">cognitive</span></div><div class="bar"><span class="is-1" style="width:10%"></span></div></div></td>
-                <td><div class="metric-cell"><div class="num-line"><span>95.0%</span><span class="note">lines</span></div><div class="bar"><span class="is-1" style="width:95.0%"></span></div></div></td>
-                <td class="num"><span class="crap-cell">3.00 <span class="risk-pill" data-risk="1">low</span></span></td>
               </tr>
               
             </tbody>
@@ -1724,15 +1800,201 @@ pre code { background: transparent; padding: 0; }
     </div>
   </section>
   
+  </div>
+  <div class="tab-panel" data-tab="delta" role="tabpanel">
+    <section class="scope-banner delta-hero" aria-label="Rust Delta scope">
+      <p>
+        <strong>Comparing</strong> current run vs <code>baseline</code>.
+        <span class="verdict is-fail" aria-label="Delta verdict: REGRESSED">
+          <span class="verdict-glyph">▲</span>
+          REGRESSED
+        </span>
+        <span class="meta">
+          1 added · 0 removed · 2 modified ·
+          1 regression ·
+          1 improvement ·
+          1 new violation
+        </span>
+      </p>
+    </section>
+
+    <section class="delta-kpi-grid" aria-label="Rust Delta summary">
+      
+      <div class="delta-kpi" data-direction="up" data-regression="1">
+        <span class="delta-kpi-label">Exceeding threshold</span>
+        <div class="delta-kpi-ba">
+          <span class="before">1</span>
+          <span class="arrow" aria-hidden="true">→</span>
+          <span class="after">2</span>
+        </div>
+        
+        <span class="delta-chip" data-direction="up" data-regression="1">
+          <span class="chip-glyph" aria-hidden="true">▲</span>
+          <span class="chip-value">+1</span>
+        </span>
+        
+        
+        <span class="delta-kpi-foot">1 new function broke the threshold.</span>
+        
+      </div>
+      
+      <div class="delta-kpi" data-direction="up" data-regression="1">
+        <span class="delta-kpi-label">Max CRAP</span>
+        <div class="delta-kpi-ba">
+          <span class="before">14.00</span>
+          <span class="arrow" aria-hidden="true">→</span>
+          <span class="after">22.00</span>
+        </div>
+        
+        <span class="delta-chip" data-direction="up" data-regression="1">
+          <span class="chip-glyph" aria-hidden="true">▲</span>
+          <span class="chip-value">+8.00</span>
+        </span>
+        
+        
+      </div>
+      
+      <div class="delta-kpi" data-direction="up" data-regression="1">
+        <span class="delta-kpi-label">Average CRAP</span>
+        <div class="delta-kpi-ba">
+          <span class="before">12.00</span>
+          <span class="arrow" aria-hidden="true">→</span>
+          <span class="after">14.33</span>
+        </div>
+        
+        <span class="delta-chip" data-direction="up" data-regression="1">
+          <span class="chip-glyph" aria-hidden="true">▲</span>
+          <span class="chip-value">+2.33</span>
+        </span>
+        
+        
+        <span class="delta-kpi-foot">1 added · 0 removed · 2 modified</span>
+        
+      </div>
+      
+      <div class="delta-kpi" data-direction="flat">
+        <span class="delta-kpi-label">Avg coverage</span>
+        <div class="delta-kpi-ba">
+          <span class="before">0.0%</span>
+          <span class="arrow" aria-hidden="true">→</span>
+          <span class="after">0.0%</span>
+        </div>
+        
+        
+        <span class="delta-kpi-foot">Coverage unchanged.</span>
+        
+      </div>
+      
+    </section>
+
+    
+    <section aria-label="Rust regressions">
+      <h2>Regressions <span class="delta-section-count">1</span></h2>
+      <table class="delta-table regressions">
+        <thead><tr>
+          <th>Function</th><th class="num">Baseline CRAP</th><th class="num">Current CRAP</th><th>Coverage</th><th>Risk transition</th><th class="num">Δ</th>
+        </tr></thead>
+        <tbody>
+          
+          <tr data-exceeds="1">
+            <td>
+              <span class="fn-name">rs::regressing</span>
+              <span class="fn-loc">src/lib.rs L1–10</span>
+            </td>
+            <td class="num">10.00</td>
+            <td class="num">22.00</td>
+            <td><span class="ba-cell"><span class="b">70.0%</span> <span class="arrow" aria-hidden="true">→</span> <span class="a">55.0%</span></span></td>
+            <td>
+              <span class="transition-pill">
+                <span class="risk-pill" data-risk="2">acceptable</span>
+                <span class="arrow" aria-hidden="true">→</span>
+                <span class="risk-pill" data-risk="3">moderate</span>
+              </span>
+            </td>
+            <td class="num"><span class="delta-chip" data-direction="up" data-regression="1"><span class="chip-glyph" aria-hidden="true">▲</span> <span class="chip-value">+12.00</span></span></td>
+          </tr>
+          
+        </tbody>
+      </table>
+    </section>
+    
+
+    
+    <section aria-label="Rust improvements">
+      <h2>Improvements <span class="delta-section-count">1</span></h2>
+      <table class="delta-table improvements">
+        <thead><tr>
+          <th>Function</th><th class="num">Baseline CRAP</th><th class="num">Current CRAP</th><th>Coverage</th><th>Risk transition</th><th class="num">Δ</th>
+        </tr></thead>
+        <tbody>
+          
+          <tr>
+            <td>
+              <span class="fn-name">rs::improving</span>
+              <span class="fn-loc">src/lib.rs L1–10</span>
+            </td>
+            <td class="num">14.00</td>
+            <td class="num">6.00</td>
+            <td><span class="ba-cell"><span class="b">50.0%</span> <span class="arrow" aria-hidden="true">→</span> <span class="a">85.0%</span></span></td>
+            <td>
+              <span class="transition-pill">
+                <span class="risk-pill" data-risk="3">moderate</span>
+                <span class="arrow" aria-hidden="true">→</span>
+                <span class="risk-pill" data-risk="2">acceptable</span>
+              </span>
+            </td>
+            <td class="num"><span class="delta-chip" data-direction="down"><span class="chip-glyph" aria-hidden="true">▼</span> <span class="chip-value">-8.00</span></span></td>
+          </tr>
+          
+        </tbody>
+      </table>
+    </section>
+    
+
+    
+    <section aria-label="Rust new functions">
+      <h2>New functions <span class="delta-section-count">1</span></h2>
+      <table class="delta-table new-functions">
+        <thead><tr>
+          <th>Function</th><th class="num">Current CRAP</th><th>Coverage</th><th>Risk</th>
+        </tr></thead>
+        <tbody>
+          
+          <tr data-exceeds="1">
+            <td>
+              <span class="fn-name">rs::brand_new</span>
+              <span class="fn-loc">src/new.rs L1–10</span>
+            </td>
+            <td class="num">15.00</td>
+            <td class="num">40.0%</td>
+            <td><span class="risk-pill" data-risk="3">moderate</span></td>
+          </tr>
+          
+        </tbody>
+      </table>
+    </section>
+    
+
+    
+  </div>
 </div>
 
 <div class="lang-panel" data-lang="typescript">
+  <nav class="tabs" role="tablist" aria-label="TypeScript views">
+    <button class="tab" role="tab" aria-selected="true" data-tab="current" type="button">
+      Current run <span class="tab-count">1</span>
+    </button>
+    <button class="tab" role="tab" aria-selected="false" data-tab="delta" type="button" disabled aria-disabled="true" title="no baseline available for TypeScript">
+      Delta vs baseline <span class="tab-count">—</span>
+    </button>
+  </nav>
+  <div class="tab-panel" data-tab="current" data-active role="tabpanel">
   <section class="scope-banner" aria-label="TypeScript scope">
     <p>
       <strong>1 of 1</strong>
       function exceeds threshold.
       
-      Worst offender scores <code>12.00</code>.
+      Worst offender scores <code>13.00</code>.
       
       <span class="meta">1 file · TypeScript adapter</span>
     </p>
@@ -1746,8 +2008,8 @@ pre code { background: transparent; padding: 0; }
     </div>
     <div class="kpi">
       <span class="kpi-label">Average CRAP</span>
-      <span class="kpi-value">12.00</span>
-      <span class="kpi-foot">median <code>12.00</code> · max <code>12.00</code></span>
+      <span class="kpi-value">13.00</span>
+      <span class="kpi-foot">median <code>13.00</code> · max <code>13.00</code></span>
     </div>
     <div class="kpi">
       <span class="kpi-label">Avg line coverage</span>
@@ -1788,10 +2050,10 @@ pre code { background: transparent; padding: 0; }
         <summary>
           <span class="stripe"></span>
           <span class="caret">›</span>
-          <span class="sev-path">apps/web/src/composer.ts</span>
+          <span class="sev-path">apps/web/src/parser.ts</span>
           <span class="sev-meta">
             <span><b>1</b> fn</span>
-            <span>max CRAP <b>12.00</b></span>
+            <span>max CRAP <b>13.00</b></span>
             
             <span class="over"><b>1 over</b></span>
             
@@ -1805,11 +2067,11 @@ pre code { background: transparent; padding: 0; }
             <tbody>
               
               <tr class="is-exceeds">
-                <td><span class="fn-name">parseInvoiceDraft</span><span class="fn-loc">10 LOC</span></td>
+                <td><span class="fn-name">ts::parser</span><span class="fn-loc">10 LOC</span></td>
                 <td>1–10</td>
-                <td><div class="metric-cell"><div class="num-line"><span>6</span><span class="note">cyclomatic</span></div><div class="bar"><span class="is-2" style="width:30%"></span></div></div></td>
-                <td><div class="metric-cell"><div class="num-line"><span>55.0%</span><span class="note">lines</span></div><div class="bar"><span class="is-3" style="width:55.0%"></span></div></div></td>
-                <td class="num"><span class="crap-cell">12.00 <span class="risk-pill" data-risk="3">moderate</span><span class="over-by">+4.00</span></span></td>
+                <td><div class="metric-cell"><div class="num-line"><span>7</span><span class="note">cyclomatic</span></div><div class="bar"><span class="is-3" style="width:35%"></span></div></div></td>
+                <td><div class="metric-cell"><div class="num-line"><span>60.0%</span><span class="note">lines</span></div><div class="bar"><span class="is-2" style="width:60.0%"></span></div></div></td>
+                <td class="num"><span class="crap-cell">13.00 <span class="risk-pill" data-risk="3">moderate</span><span class="over-by">+5.00</span></span></td>
               </tr>
               
             </tbody>
@@ -1820,6 +2082,7 @@ pre code { background: transparent; padding: 0; }
     </div>
   </section>
   
+  </div>
 </div>
 
 

--- a/crates/crap-core/src/adapters/reporters/snapshots/crap_core__adapters__reporters__html__tests__full_html_multi_two_language_snapshot.snap
+++ b/crates/crap-core/src/adapters/reporters/snapshots/crap_core__adapters__reporters__html__tests__full_html_multi_two_language_snapshot.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/crap-core/src/adapters/reporters/html.rs
-assertion_line: 2397
+assertion_line: 2389
 expression: out
 ---
 <!doctype html>
@@ -1420,6 +1420,15 @@ pre code { background: transparent; padding: 0; }
 
 <!-- ── Combined panel ──────────────────────────────────────────────── -->
 <div class="lang-panel" data-lang="combined" data-active>
+  <nav class="tabs" role="tablist" aria-label="Combined views">
+    <button class="tab" role="tab" aria-selected="true" data-tab="current" type="button">
+      Current run <span class="tab-count">4</span>
+    </button>
+    <button class="tab" role="tab" aria-selected="false" data-tab="delta" type="button" disabled aria-disabled="true" title="no baselines provided — pass --baseline to enable cross-adapter delta">
+      Delta vs baseline <span class="tab-count">—</span>
+    </button>
+  </nav>
+  <div class="tab-panel" data-tab="current" data-active role="tabpanel">
   <section class="scope-banner" aria-label="Combined scope">
     <p>
       <strong>3 of 4</strong>
@@ -1560,11 +1569,21 @@ pre code { background: transparent; padding: 0; }
     </table>
   </section>
   
+  </div>
 </div>
 
 <!-- ── Per-language panels ─────────────────────────────────────────── -->
 
 <div class="lang-panel" data-lang="rust">
+  <nav class="tabs" role="tablist" aria-label="Rust views">
+    <button class="tab" role="tab" aria-selected="true" data-tab="current" type="button">
+      Current run <span class="tab-count">3</span>
+    </button>
+    <button class="tab" role="tab" aria-selected="false" data-tab="delta" type="button" disabled aria-disabled="true" title="no baseline available for Rust">
+      Delta vs baseline <span class="tab-count">—</span>
+    </button>
+  </nav>
+  <div class="tab-panel" data-tab="current" data-active role="tabpanel">
   <section class="scope-banner" aria-label="Rust scope">
     <p>
       <strong>2 of 3</strong>
@@ -1724,9 +1743,19 @@ pre code { background: transparent; padding: 0; }
     </div>
   </section>
   
+  </div>
 </div>
 
 <div class="lang-panel" data-lang="typescript">
+  <nav class="tabs" role="tablist" aria-label="TypeScript views">
+    <button class="tab" role="tab" aria-selected="true" data-tab="current" type="button">
+      Current run <span class="tab-count">1</span>
+    </button>
+    <button class="tab" role="tab" aria-selected="false" data-tab="delta" type="button" disabled aria-disabled="true" title="no baseline available for TypeScript">
+      Delta vs baseline <span class="tab-count">—</span>
+    </button>
+  </nav>
+  <div class="tab-panel" data-tab="current" data-active role="tabpanel">
   <section class="scope-banner" aria-label="TypeScript scope">
     <p>
       <strong>1 of 1</strong>
@@ -1820,6 +1849,7 @@ pre code { background: transparent; padding: 0; }
     </div>
   </section>
   
+  </div>
 </div>
 
 

--- a/crates/crap-core/src/adapters/reporters/snapshots/crap_core__adapters__reporters__html__tests__full_html_multi_two_language_with_baselines_snapshot.snap
+++ b/crates/crap-core/src/adapters/reporters/snapshots/crap_core__adapters__reporters__html__tests__full_html_multi_two_language_with_baselines_snapshot.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/crap-core/src/adapters/reporters/html.rs
-assertion_line: 2397
+assertion_line: 2936
 expression: out
 ---
 <!doctype html>
@@ -1420,14 +1420,24 @@ pre code { background: transparent; padding: 0; }
 
 <!-- ── Combined panel ──────────────────────────────────────────────── -->
 <div class="lang-panel" data-lang="combined" data-active>
+  <nav class="tabs" role="tablist" aria-label="Combined views">
+    <button class="tab" role="tab" aria-selected="true" data-tab="current" type="button">
+      Current run <span class="tab-count">4</span>
+    </button>
+    <button class="tab" role="tab" aria-selected="false" data-tab="delta" type="button">
+      Delta vs baseline <span class="tab-dot" aria-hidden="true"></span>
+      <span class="tab-count">4 changed</span>
+    </button>
+  </nav>
+  <div class="tab-panel" data-tab="current" data-active role="tabpanel">
   <section class="scope-banner" aria-label="Combined scope">
     <p>
       <strong>3 of 4</strong>
       functions exceed their adapter thresholds across the workspace.
       
-      Worst offender at <code>5.65×</code> over threshold (complex_fn, Rust).
+      Worst offender at <code>2.75×</code> over threshold (rs::regressing, Rust).
       
-      <span class="meta">4 files · 2 adapters</span>
+      <span class="meta">3 files · 2 adapters</span>
     </p>
   </section>
 
@@ -1444,12 +1454,12 @@ pre code { background: transparent; padding: 0; }
     </div>
     <div class="kpi">
       <span class="kpi-label">Files analyzed</span>
-      <span class="kpi-value">4</span>
+      <span class="kpi-value">3</span>
       <span class="kpi-foot">disjoint source trees</span>
     </div>
     <div class="kpi">
       <span class="kpi-label">Worst CRAP/threshold ratio</span>
-      <span class="kpi-value">5.65×</span>
+      <span class="kpi-value">2.75×</span>
       <span class="kpi-foot">Rust adapter</span>
     </div>
   </section>
@@ -1457,17 +1467,17 @@ pre code { background: transparent; padding: 0; }
   <section class="panel" aria-label="Combined risk distribution">
     <div class="panel-header"><h2>Risk distribution</h2></div>
     <div class="dist-bar">
-      <span class="dist-seg" data-risk="1" style="flex:1" title="low: 1 functions">
-        <span class="dist-count">1</span><span class="dist-label">low</span>
+      <span class="dist-seg" data-risk="1" style="flex:0" title="low: 0 functions">
+        <span class="dist-count">0</span><span class="dist-label">low</span>
       </span>
-      <span class="dist-seg" data-risk="2" style="flex:0" title="acceptable: 0 functions">
-        <span class="dist-count">0</span><span class="dist-label">acceptable</span>
+      <span class="dist-seg" data-risk="2" style="flex:1" title="acceptable: 1 functions">
+        <span class="dist-count">1</span><span class="dist-label">acceptable</span>
       </span>
-      <span class="dist-seg" data-risk="3" style="flex:2" title="moderate: 2 functions">
-        <span class="dist-count">2</span><span class="dist-label">moderate</span>
+      <span class="dist-seg" data-risk="3" style="flex:3" title="moderate: 3 functions">
+        <span class="dist-count">3</span><span class="dist-label">moderate</span>
       </span>
-      <span class="dist-seg" data-risk="4" style="flex:1" title="high: 1 functions">
-        <span class="dist-count">1</span><span class="dist-label">high</span>
+      <span class="dist-seg" data-risk="4" style="flex:0" title="high: 0 functions">
+        <span class="dist-count">0</span><span class="dist-label">high</span>
       </span>
     </div>
     <div class="dist-legend">
@@ -1505,13 +1515,13 @@ pre code { background: transparent; padding: 0; }
             <span class="adapter-badge" title="Rust adapter" aria-label="Rust adapter">R</span>
             <span class="sr-only">Rust</span>
           </td>
-          <td><span class="fn-name">complex_fn</span></td>
-          <td><span class="fn-path">src/domain/crap.rs L1–10</span></td>
-          <td class="num">20</td>
-          <td class="num">30.0%</td>
-          <td class="num">45.20</td>
-          <td class="num">5.65</td>
-          <td><span class="risk-pill" data-risk="4">high</span></td>
+          <td><span class="fn-name">rs::regressing</span></td>
+          <td><span class="fn-path">src/lib.rs L1–10</span></td>
+          <td class="num">8</td>
+          <td class="num">55.0%</td>
+          <td class="num">22.00</td>
+          <td class="num">2.75</td>
+          <td><span class="risk-pill" data-risk="3">moderate</span></td>
         </tr>
         
         <tr data-lang="rust" data-exceeds="1">
@@ -1519,10 +1529,10 @@ pre code { background: transparent; padding: 0; }
             <span class="adapter-badge" title="Rust adapter" aria-label="Rust adapter">R</span>
             <span class="sr-only">Rust</span>
           </td>
-          <td><span class="fn-name">parse_record</span></td>
-          <td><span class="fn-path">src/adapters/coverage/mod.rs L1–10</span></td>
-          <td class="num">6</td>
-          <td class="num">72.5%</td>
+          <td><span class="fn-name">rs::brand_new</span></td>
+          <td><span class="fn-path">src/new.rs L1–10</span></td>
+          <td class="num">10</td>
+          <td class="num">40.0%</td>
           <td class="num">15.00</td>
           <td class="num">1.88</td>
           <td><span class="risk-pill" data-risk="3">moderate</span></td>
@@ -1533,12 +1543,12 @@ pre code { background: transparent; padding: 0; }
             <span class="adapter-badge" title="TypeScript adapter" aria-label="TypeScript adapter">T</span>
             <span class="sr-only">TypeScript</span>
           </td>
-          <td><span class="fn-name">parseInvoiceDraft</span></td>
-          <td><span class="fn-path">apps/web/src/composer.ts L1–10</span></td>
-          <td class="num">6</td>
-          <td class="num">55.0%</td>
-          <td class="num">12.00</td>
-          <td class="num">1.50</td>
+          <td><span class="fn-name">ts::parser</span></td>
+          <td><span class="fn-path">apps/web/src/parser.ts L1–10</span></td>
+          <td class="num">7</td>
+          <td class="num">60.0%</td>
+          <td class="num">13.00</td>
+          <td class="num">1.62</td>
           <td><span class="risk-pill" data-risk="3">moderate</span></td>
         </tr>
         
@@ -1547,32 +1557,138 @@ pre code { background: transparent; padding: 0; }
             <span class="adapter-badge" title="Rust adapter" aria-label="Rust adapter">R</span>
             <span class="sr-only">Rust</span>
           </td>
-          <td><span class="fn-name">simple_fn</span></td>
+          <td><span class="fn-name">rs::improving</span></td>
           <td><span class="fn-path">src/lib.rs L1–10</span></td>
-          <td class="num">2</td>
-          <td class="num">95.0%</td>
-          <td class="num">3.00</td>
-          <td class="num">0.38</td>
-          <td><span class="risk-pill" data-risk="1">low</span></td>
+          <td class="num">4</td>
+          <td class="num">85.0%</td>
+          <td class="num">6.00</td>
+          <td class="num">0.75</td>
+          <td><span class="risk-pill" data-risk="2">acceptable</span></td>
         </tr>
         
       </tbody>
     </table>
   </section>
   
+  </div>
+  <div class="tab-panel" data-tab="delta" role="tabpanel">
+    <section class="scope-banner delta-hero" aria-label="Combined Delta scope">
+      <p>
+        <strong>Comparing</strong> current run vs baseline across
+        2 adapters
+        (Rust, TypeScript).
+        <span class="verdict is-fail" aria-label="Combined Delta verdict: REGRESSED">
+          <span class="verdict-glyph">▲</span>
+          REGRESSED
+        </span>
+        <span class="meta">
+          1 added · 0 removed · 3 modified ·
+          2 regressions ·
+          1 improvement ·
+          2 new violations
+        </span>
+      </p>
+    </section>
+    <section aria-label="Combined Delta ranking">
+      <h2>Workspace regressions &amp; new functions <span class="muted">· by risk band, then CRAP/threshold ratio</span></h2>
+      <p class="ranked-note">
+        Cross-adapter delta ordering uses risk level (per-adapter calibrated) then
+        CRAP/threshold ratio. Raw CRAP scores are not dimensionally equivalent
+        across adapters with different complexity metrics; the per-language Delta
+        tabs below show within-adapter rankings.
+      </p>
+      <table class="ranked-table">
+        <thead><tr>
+          <th>Adapter</th>
+          <th>Function</th>
+          <th>File</th>
+          <th>Kind</th>
+          <th class="num">Baseline</th>
+          <th class="num">Current</th>
+          <th class="num">Δ</th>
+          <th class="num">Ratio</th>
+          <th>Risk</th>
+        </tr></thead>
+        <tbody>
+          
+          <tr data-lang="rust" data-kind="regression" data-exceeds="1">
+            <td>
+              <span class="adapter-badge" title="Rust adapter" aria-label="Rust adapter">R</span>
+              <span class="sr-only">Rust</span>
+            </td>
+            <td><span class="fn-name">rs::regressing</span></td>
+            <td><span class="fn-path">src/lib.rs L1–10</span></td>
+            <td><span class="kind-pill" data-kind="regression">regression</span></td>
+            <td class="num">10.00</td>
+            <td class="num">22.00</td>
+            <td class="num"><span class="delta-chip" data-direction="up" data-regression="1"><span class="chip-glyph" aria-hidden="true">▲</span>
+                <span class="chip-value">+12.00</span>
+              </span>
+            </td>
+            <td class="num">2.75</td>
+            <td><span class="risk-pill" data-risk="3">moderate</span></td>
+          </tr>
+          
+          <tr data-lang="rust" data-kind="new" data-exceeds="1">
+            <td>
+              <span class="adapter-badge" title="Rust adapter" aria-label="Rust adapter">R</span>
+              <span class="sr-only">Rust</span>
+            </td>
+            <td><span class="fn-name">rs::brand_new</span></td>
+            <td><span class="fn-path">src/new.rs L1–10</span></td>
+            <td><span class="kind-pill" data-kind="new">new</span></td>
+            <td class="num">—</td>
+            <td class="num">15.00</td>
+            <td class="num">—
+            </td>
+            <td class="num">1.88</td>
+            <td><span class="risk-pill" data-risk="3">moderate</span></td>
+          </tr>
+          
+          <tr data-lang="typescript" data-kind="regression" data-exceeds="1">
+            <td>
+              <span class="adapter-badge" title="TypeScript adapter" aria-label="TypeScript adapter">T</span>
+              <span class="sr-only">TypeScript</span>
+            </td>
+            <td><span class="fn-name">ts::parser</span></td>
+            <td><span class="fn-path">apps/web/src/parser.ts L1–10</span></td>
+            <td><span class="kind-pill" data-kind="regression">regression</span></td>
+            <td class="num">7.00</td>
+            <td class="num">13.00</td>
+            <td class="num"><span class="delta-chip" data-direction="up" data-regression="1"><span class="chip-glyph" aria-hidden="true">▲</span>
+                <span class="chip-value">+6.00</span>
+              </span>
+            </td>
+            <td class="num">1.62</td>
+            <td><span class="risk-pill" data-risk="3">moderate</span></td>
+          </tr>
+          
+        </tbody>
+      </table>
+    </section>
+  </div>
 </div>
 
 <!-- ── Per-language panels ─────────────────────────────────────────── -->
 
 <div class="lang-panel" data-lang="rust">
+  <nav class="tabs" role="tablist" aria-label="Rust views">
+    <button class="tab" role="tab" aria-selected="true" data-tab="current" type="button">
+      Current run <span class="tab-count">3</span>
+    </button>
+    <button class="tab" role="tab" aria-selected="false" data-tab="delta" type="button">Delta vs baseline <span class="tab-dot" aria-hidden="true"></span>
+      <span class="tab-count">3 changed</span>
+    </button>
+  </nav>
+  <div class="tab-panel" data-tab="current" data-active role="tabpanel">
   <section class="scope-banner" aria-label="Rust scope">
     <p>
       <strong>2 of 3</strong>
       functions exceed threshold.
       
-      Worst offender scores <code>45.20</code>.
+      Worst offender scores <code>22.00</code>.
       
-      <span class="meta">3 files · Rust adapter</span>
+      <span class="meta">2 files · Rust adapter</span>
     </p>
   </section>
 
@@ -1584,35 +1700,35 @@ pre code { background: transparent; padding: 0; }
     </div>
     <div class="kpi">
       <span class="kpi-label">Average CRAP</span>
-      <span class="kpi-value">21.07</span>
-      <span class="kpi-foot">median <code>15.00</code> · max <code>45.20</code></span>
+      <span class="kpi-value">14.33</span>
+      <span class="kpi-foot">median <code>15.00</code> · max <code>22.00</code></span>
     </div>
     <div class="kpi">
       <span class="kpi-label">Avg line coverage</span>
-      <span class="kpi-value">65.8<span class="kpi-unit">%</span></span>
-      <div class="bar is-thick" aria-hidden="true"><span class="is-2" style="width:65.8%"></span></div>
+      <span class="kpi-value">0.0<span class="kpi-unit">%</span></span>
+      <div class="bar is-thick" aria-hidden="true"><span class="is-4" style="width:0.0%"></span></div>
     </div>
     <div class="kpi">
       <span class="kpi-label">Avg complexity</span>
-      <span class="kpi-value">9.3</span>
-      <span class="kpi-foot">median <code>6.0</code> · max <code>20</code> cognitive</span>
+      <span class="kpi-value">0.0</span>
+      <span class="kpi-foot">median <code>0.0</code> · max <code>0</code> cognitive</span>
     </div>
   </section>
 
   <section class="panel" aria-label="Rust risk distribution">
     <div class="panel-header"><h2>Risk distribution</h2></div>
     <div class="dist-bar">
-      <span class="dist-seg" data-risk="1" style="flex:1" title="low: 1 functions">
-        <span class="dist-count">1</span><span class="dist-label">low</span>
+      <span class="dist-seg" data-risk="1" style="flex:0" title="low: 0 functions">
+        <span class="dist-count">0</span><span class="dist-label">low</span>
       </span>
-      <span class="dist-seg" data-risk="2" style="flex:0" title="acceptable: 0 functions">
-        <span class="dist-count">0</span><span class="dist-label">acceptable</span>
+      <span class="dist-seg" data-risk="2" style="flex:1" title="acceptable: 1 functions">
+        <span class="dist-count">1</span><span class="dist-label">acceptable</span>
       </span>
-      <span class="dist-seg" data-risk="3" style="flex:1" title="moderate: 1 functions">
-        <span class="dist-count">1</span><span class="dist-label">moderate</span>
+      <span class="dist-seg" data-risk="3" style="flex:2" title="moderate: 2 functions">
+        <span class="dist-count">2</span><span class="dist-label">moderate</span>
       </span>
-      <span class="dist-seg" data-risk="4" style="flex:1" title="high: 1 functions">
-        <span class="dist-count">1</span><span class="dist-label">high</span>
+      <span class="dist-seg" data-risk="4" style="flex:0" title="high: 0 functions">
+        <span class="dist-count">0</span><span class="dist-label">high</span>
       </span>
     </div>
   </section>
@@ -1622,14 +1738,14 @@ pre code { background: transparent; padding: 0; }
     <h2>Functions by file <span class="muted">· Rust</span></h2>
     <div class="file-list">
       
-      <details class="severity-card file-card" data-risk="4" data-exceeds="1" open>
+      <details class="severity-card file-card" data-risk="3" data-exceeds="1" open>
         <summary>
           <span class="stripe"></span>
           <span class="caret">›</span>
-          <span class="sev-path">src/domain/crap.rs</span>
+          <span class="sev-path">src/lib.rs</span>
           <span class="sev-meta">
-            <span><b>1</b> fn</span>
-            <span>max CRAP <b>45.20</b></span>
+            <span><b>2</b> fn</span>
+            <span>max CRAP <b>22.00</b></span>
             
             <span class="over"><b>1 over</b></span>
             
@@ -1643,11 +1759,19 @@ pre code { background: transparent; padding: 0; }
             <tbody>
               
               <tr class="is-exceeds">
-                <td><span class="fn-name">complex_fn</span><span class="fn-loc">10 LOC</span></td>
+                <td><span class="fn-name">rs::regressing</span><span class="fn-loc">10 LOC</span></td>
                 <td>1–10</td>
-                <td><div class="metric-cell"><div class="num-line"><span>20</span><span class="note">cognitive</span></div><div class="bar"><span class="is-4" style="width:100%"></span></div></div></td>
-                <td><div class="metric-cell"><div class="num-line"><span>30.0%</span><span class="note">lines</span></div><div class="bar"><span class="is-4" style="width:30.0%"></span></div></div></td>
-                <td class="num"><span class="crap-cell">45.20 <span class="risk-pill" data-risk="4">high</span><span class="over-by">+37.20</span></span></td>
+                <td><div class="metric-cell"><div class="num-line"><span>8</span><span class="note">cognitive</span></div><div class="bar"><span class="is-3" style="width:40%"></span></div></div></td>
+                <td><div class="metric-cell"><div class="num-line"><span>55.0%</span><span class="note">lines</span></div><div class="bar"><span class="is-3" style="width:55.0%"></span></div></div></td>
+                <td class="num"><span class="crap-cell">22.00 <span class="risk-pill" data-risk="3">moderate</span><span class="over-by">+14.00</span></span></td>
+              </tr>
+              
+              <tr>
+                <td><span class="fn-name">rs::improving</span><span class="fn-loc">10 LOC</span></td>
+                <td>1–10</td>
+                <td><div class="metric-cell"><div class="num-line"><span>4</span><span class="note">cognitive</span></div><div class="bar"><span class="is-2" style="width:20%"></span></div></div></td>
+                <td><div class="metric-cell"><div class="num-line"><span>85.0%</span><span class="note">lines</span></div><div class="bar"><span class="is-1" style="width:85.0%"></span></div></div></td>
+                <td class="num"><span class="crap-cell">6.00 <span class="risk-pill" data-risk="2">acceptable</span></span></td>
               </tr>
               
             </tbody>
@@ -1659,7 +1783,7 @@ pre code { background: transparent; padding: 0; }
         <summary>
           <span class="stripe"></span>
           <span class="caret">›</span>
-          <span class="sev-path">src/adapters/coverage/mod.rs</span>
+          <span class="sev-path">src/new.rs</span>
           <span class="sev-meta">
             <span><b>1</b> fn</span>
             <span>max CRAP <b>15.00</b></span>
@@ -1676,44 +1800,11 @@ pre code { background: transparent; padding: 0; }
             <tbody>
               
               <tr class="is-exceeds">
-                <td><span class="fn-name">parse_record</span><span class="fn-loc">10 LOC</span></td>
+                <td><span class="fn-name">rs::brand_new</span><span class="fn-loc">10 LOC</span></td>
                 <td>1–10</td>
-                <td><div class="metric-cell"><div class="num-line"><span>6</span><span class="note">cognitive</span></div><div class="bar"><span class="is-2" style="width:30%"></span></div></div></td>
-                <td><div class="metric-cell"><div class="num-line"><span>72.5%</span><span class="note">lines</span></div><div class="bar"><span class="is-2" style="width:72.5%"></span></div></div></td>
+                <td><div class="metric-cell"><div class="num-line"><span>10</span><span class="note">cognitive</span></div><div class="bar"><span class="is-3" style="width:50%"></span></div></div></td>
+                <td><div class="metric-cell"><div class="num-line"><span>40.0%</span><span class="note">lines</span></div><div class="bar"><span class="is-3" style="width:40.0%"></span></div></div></td>
                 <td class="num"><span class="crap-cell">15.00 <span class="risk-pill" data-risk="3">moderate</span><span class="over-by">+7.00</span></span></td>
-              </tr>
-              
-            </tbody>
-          </table>
-        </div>
-      </details>
-      
-      <details class="severity-card file-card" data-risk="1" data-exceeds="0">
-        <summary>
-          <span class="stripe"></span>
-          <span class="caret">›</span>
-          <span class="sev-path">src/lib.rs</span>
-          <span class="sev-meta">
-            <span><b>1</b> fn</span>
-            <span>max CRAP <b>3.00</b></span>
-            
-            <span>0 over</span>
-            
-          </span>
-        </summary>
-        <div class="severity-card-body">
-          <table class="file-fns">
-            <thead><tr>
-              <th>Function</th><th>Lines</th><th>Complexity</th><th>Coverage</th><th class="num">CRAP</th>
-            </tr></thead>
-            <tbody>
-              
-              <tr>
-                <td><span class="fn-name">simple_fn</span><span class="fn-loc">10 LOC</span></td>
-                <td>1–10</td>
-                <td><div class="metric-cell"><div class="num-line"><span>2</span><span class="note">cognitive</span></div><div class="bar"><span class="is-1" style="width:10%"></span></div></div></td>
-                <td><div class="metric-cell"><div class="num-line"><span>95.0%</span><span class="note">lines</span></div><div class="bar"><span class="is-1" style="width:95.0%"></span></div></div></td>
-                <td class="num"><span class="crap-cell">3.00 <span class="risk-pill" data-risk="1">low</span></span></td>
               </tr>
               
             </tbody>
@@ -1724,15 +1815,201 @@ pre code { background: transparent; padding: 0; }
     </div>
   </section>
   
+  </div>
+  <div class="tab-panel" data-tab="delta" role="tabpanel">
+    <section class="scope-banner delta-hero" aria-label="Rust Delta scope">
+      <p>
+        <strong>Comparing</strong> current run vs <code>baseline</code>.
+        <span class="verdict is-fail" aria-label="Delta verdict: REGRESSED">
+          <span class="verdict-glyph">▲</span>
+          REGRESSED
+        </span>
+        <span class="meta">
+          1 added · 0 removed · 2 modified ·
+          1 regression ·
+          1 improvement ·
+          1 new violation
+        </span>
+      </p>
+    </section>
+
+    <section class="delta-kpi-grid" aria-label="Rust Delta summary">
+      
+      <div class="delta-kpi" data-direction="up" data-regression="1">
+        <span class="delta-kpi-label">Exceeding threshold</span>
+        <div class="delta-kpi-ba">
+          <span class="before">1</span>
+          <span class="arrow" aria-hidden="true">→</span>
+          <span class="after">2</span>
+        </div>
+        
+        <span class="delta-chip" data-direction="up" data-regression="1">
+          <span class="chip-glyph" aria-hidden="true">▲</span>
+          <span class="chip-value">+1</span>
+        </span>
+        
+        
+        <span class="delta-kpi-foot">1 new function broke the threshold.</span>
+        
+      </div>
+      
+      <div class="delta-kpi" data-direction="up" data-regression="1">
+        <span class="delta-kpi-label">Max CRAP</span>
+        <div class="delta-kpi-ba">
+          <span class="before">14.00</span>
+          <span class="arrow" aria-hidden="true">→</span>
+          <span class="after">22.00</span>
+        </div>
+        
+        <span class="delta-chip" data-direction="up" data-regression="1">
+          <span class="chip-glyph" aria-hidden="true">▲</span>
+          <span class="chip-value">+8.00</span>
+        </span>
+        
+        
+      </div>
+      
+      <div class="delta-kpi" data-direction="up" data-regression="1">
+        <span class="delta-kpi-label">Average CRAP</span>
+        <div class="delta-kpi-ba">
+          <span class="before">12.00</span>
+          <span class="arrow" aria-hidden="true">→</span>
+          <span class="after">14.33</span>
+        </div>
+        
+        <span class="delta-chip" data-direction="up" data-regression="1">
+          <span class="chip-glyph" aria-hidden="true">▲</span>
+          <span class="chip-value">+2.33</span>
+        </span>
+        
+        
+        <span class="delta-kpi-foot">1 added · 0 removed · 2 modified</span>
+        
+      </div>
+      
+      <div class="delta-kpi" data-direction="flat">
+        <span class="delta-kpi-label">Avg coverage</span>
+        <div class="delta-kpi-ba">
+          <span class="before">0.0%</span>
+          <span class="arrow" aria-hidden="true">→</span>
+          <span class="after">0.0%</span>
+        </div>
+        
+        
+        <span class="delta-kpi-foot">Coverage unchanged.</span>
+        
+      </div>
+      
+    </section>
+
+    
+    <section aria-label="Rust regressions">
+      <h2>Regressions <span class="delta-section-count">1</span></h2>
+      <table class="delta-table regressions">
+        <thead><tr>
+          <th>Function</th><th class="num">Baseline CRAP</th><th class="num">Current CRAP</th><th>Coverage</th><th>Risk transition</th><th class="num">Δ</th>
+        </tr></thead>
+        <tbody>
+          
+          <tr data-exceeds="1">
+            <td>
+              <span class="fn-name">rs::regressing</span>
+              <span class="fn-loc">src/lib.rs L1–10</span>
+            </td>
+            <td class="num">10.00</td>
+            <td class="num">22.00</td>
+            <td><span class="ba-cell"><span class="b">70.0%</span> <span class="arrow" aria-hidden="true">→</span> <span class="a">55.0%</span></span></td>
+            <td>
+              <span class="transition-pill">
+                <span class="risk-pill" data-risk="2">acceptable</span>
+                <span class="arrow" aria-hidden="true">→</span>
+                <span class="risk-pill" data-risk="3">moderate</span>
+              </span>
+            </td>
+            <td class="num"><span class="delta-chip" data-direction="up" data-regression="1"><span class="chip-glyph" aria-hidden="true">▲</span> <span class="chip-value">+12.00</span></span></td>
+          </tr>
+          
+        </tbody>
+      </table>
+    </section>
+    
+
+    
+    <section aria-label="Rust improvements">
+      <h2>Improvements <span class="delta-section-count">1</span></h2>
+      <table class="delta-table improvements">
+        <thead><tr>
+          <th>Function</th><th class="num">Baseline CRAP</th><th class="num">Current CRAP</th><th>Coverage</th><th>Risk transition</th><th class="num">Δ</th>
+        </tr></thead>
+        <tbody>
+          
+          <tr>
+            <td>
+              <span class="fn-name">rs::improving</span>
+              <span class="fn-loc">src/lib.rs L1–10</span>
+            </td>
+            <td class="num">14.00</td>
+            <td class="num">6.00</td>
+            <td><span class="ba-cell"><span class="b">50.0%</span> <span class="arrow" aria-hidden="true">→</span> <span class="a">85.0%</span></span></td>
+            <td>
+              <span class="transition-pill">
+                <span class="risk-pill" data-risk="3">moderate</span>
+                <span class="arrow" aria-hidden="true">→</span>
+                <span class="risk-pill" data-risk="2">acceptable</span>
+              </span>
+            </td>
+            <td class="num"><span class="delta-chip" data-direction="down"><span class="chip-glyph" aria-hidden="true">▼</span> <span class="chip-value">-8.00</span></span></td>
+          </tr>
+          
+        </tbody>
+      </table>
+    </section>
+    
+
+    
+    <section aria-label="Rust new functions">
+      <h2>New functions <span class="delta-section-count">1</span></h2>
+      <table class="delta-table new-functions">
+        <thead><tr>
+          <th>Function</th><th class="num">Current CRAP</th><th>Coverage</th><th>Risk</th>
+        </tr></thead>
+        <tbody>
+          
+          <tr data-exceeds="1">
+            <td>
+              <span class="fn-name">rs::brand_new</span>
+              <span class="fn-loc">src/new.rs L1–10</span>
+            </td>
+            <td class="num">15.00</td>
+            <td class="num">40.0%</td>
+            <td><span class="risk-pill" data-risk="3">moderate</span></td>
+          </tr>
+          
+        </tbody>
+      </table>
+    </section>
+    
+
+    
+  </div>
 </div>
 
 <div class="lang-panel" data-lang="typescript">
+  <nav class="tabs" role="tablist" aria-label="TypeScript views">
+    <button class="tab" role="tab" aria-selected="true" data-tab="current" type="button">
+      Current run <span class="tab-count">1</span>
+    </button>
+    <button class="tab" role="tab" aria-selected="false" data-tab="delta" type="button">Delta vs baseline <span class="tab-dot" aria-hidden="true"></span>
+      <span class="tab-count">1 changed</span>
+    </button>
+  </nav>
+  <div class="tab-panel" data-tab="current" data-active role="tabpanel">
   <section class="scope-banner" aria-label="TypeScript scope">
     <p>
       <strong>1 of 1</strong>
       function exceeds threshold.
       
-      Worst offender scores <code>12.00</code>.
+      Worst offender scores <code>13.00</code>.
       
       <span class="meta">1 file · TypeScript adapter</span>
     </p>
@@ -1746,8 +2023,8 @@ pre code { background: transparent; padding: 0; }
     </div>
     <div class="kpi">
       <span class="kpi-label">Average CRAP</span>
-      <span class="kpi-value">12.00</span>
-      <span class="kpi-foot">median <code>12.00</code> · max <code>12.00</code></span>
+      <span class="kpi-value">13.00</span>
+      <span class="kpi-foot">median <code>13.00</code> · max <code>13.00</code></span>
     </div>
     <div class="kpi">
       <span class="kpi-label">Avg line coverage</span>
@@ -1788,10 +2065,10 @@ pre code { background: transparent; padding: 0; }
         <summary>
           <span class="stripe"></span>
           <span class="caret">›</span>
-          <span class="sev-path">apps/web/src/composer.ts</span>
+          <span class="sev-path">apps/web/src/parser.ts</span>
           <span class="sev-meta">
             <span><b>1</b> fn</span>
-            <span>max CRAP <b>12.00</b></span>
+            <span>max CRAP <b>13.00</b></span>
             
             <span class="over"><b>1 over</b></span>
             
@@ -1805,11 +2082,11 @@ pre code { background: transparent; padding: 0; }
             <tbody>
               
               <tr class="is-exceeds">
-                <td><span class="fn-name">parseInvoiceDraft</span><span class="fn-loc">10 LOC</span></td>
+                <td><span class="fn-name">ts::parser</span><span class="fn-loc">10 LOC</span></td>
                 <td>1–10</td>
-                <td><div class="metric-cell"><div class="num-line"><span>6</span><span class="note">cyclomatic</span></div><div class="bar"><span class="is-2" style="width:30%"></span></div></div></td>
-                <td><div class="metric-cell"><div class="num-line"><span>55.0%</span><span class="note">lines</span></div><div class="bar"><span class="is-3" style="width:55.0%"></span></div></div></td>
-                <td class="num"><span class="crap-cell">12.00 <span class="risk-pill" data-risk="3">moderate</span><span class="over-by">+4.00</span></span></td>
+                <td><div class="metric-cell"><div class="num-line"><span>7</span><span class="note">cyclomatic</span></div><div class="bar"><span class="is-3" style="width:35%"></span></div></div></td>
+                <td><div class="metric-cell"><div class="num-line"><span>60.0%</span><span class="note">lines</span></div><div class="bar"><span class="is-2" style="width:60.0%"></span></div></div></td>
+                <td class="num"><span class="crap-cell">13.00 <span class="risk-pill" data-risk="3">moderate</span><span class="over-by">+5.00</span></span></td>
               </tr>
               
             </tbody>
@@ -1820,6 +2097,131 @@ pre code { background: transparent; padding: 0; }
     </div>
   </section>
   
+  </div>
+  <div class="tab-panel" data-tab="delta" role="tabpanel">
+    <section class="scope-banner delta-hero" aria-label="TypeScript Delta scope">
+      <p>
+        <strong>Comparing</strong> current run vs <code>baseline</code>.
+        <span class="verdict is-fail" aria-label="Delta verdict: REGRESSED">
+          <span class="verdict-glyph">▲</span>
+          REGRESSED
+        </span>
+        <span class="meta">
+          0 added · 0 removed · 1 modified ·
+          1 regression ·
+          0 improvements ·
+          1 new violation
+        </span>
+      </p>
+    </section>
+
+    <section class="delta-kpi-grid" aria-label="TypeScript Delta summary">
+      
+      <div class="delta-kpi" data-direction="up" data-regression="1">
+        <span class="delta-kpi-label">Exceeding threshold</span>
+        <div class="delta-kpi-ba">
+          <span class="before">0</span>
+          <span class="arrow" aria-hidden="true">→</span>
+          <span class="after">1</span>
+        </div>
+        
+        <span class="delta-chip" data-direction="up" data-regression="1">
+          <span class="chip-glyph" aria-hidden="true">▲</span>
+          <span class="chip-value">+1</span>
+        </span>
+        
+        
+        <span class="delta-kpi-foot">1 new function broke the threshold.</span>
+        
+      </div>
+      
+      <div class="delta-kpi" data-direction="up" data-regression="1">
+        <span class="delta-kpi-label">Max CRAP</span>
+        <div class="delta-kpi-ba">
+          <span class="before">7.00</span>
+          <span class="arrow" aria-hidden="true">→</span>
+          <span class="after">13.00</span>
+        </div>
+        
+        <span class="delta-chip" data-direction="up" data-regression="1">
+          <span class="chip-glyph" aria-hidden="true">▲</span>
+          <span class="chip-value">+6.00</span>
+        </span>
+        
+        
+      </div>
+      
+      <div class="delta-kpi" data-direction="up" data-regression="1">
+        <span class="delta-kpi-label">Average CRAP</span>
+        <div class="delta-kpi-ba">
+          <span class="before">7.00</span>
+          <span class="arrow" aria-hidden="true">→</span>
+          <span class="after">13.00</span>
+        </div>
+        
+        <span class="delta-chip" data-direction="up" data-regression="1">
+          <span class="chip-glyph" aria-hidden="true">▲</span>
+          <span class="chip-value">+6.00</span>
+        </span>
+        
+        
+        <span class="delta-kpi-foot">0 added · 0 removed · 1 modified</span>
+        
+      </div>
+      
+      <div class="delta-kpi" data-direction="flat">
+        <span class="delta-kpi-label">Avg coverage</span>
+        <div class="delta-kpi-ba">
+          <span class="before">0.0%</span>
+          <span class="arrow" aria-hidden="true">→</span>
+          <span class="after">0.0%</span>
+        </div>
+        
+        
+        <span class="delta-kpi-foot">Coverage unchanged.</span>
+        
+      </div>
+      
+    </section>
+
+    
+    <section aria-label="TypeScript regressions">
+      <h2>Regressions <span class="delta-section-count">1</span></h2>
+      <table class="delta-table regressions">
+        <thead><tr>
+          <th>Function</th><th class="num">Baseline CRAP</th><th class="num">Current CRAP</th><th>Coverage</th><th>Risk transition</th><th class="num">Δ</th>
+        </tr></thead>
+        <tbody>
+          
+          <tr data-exceeds="1">
+            <td>
+              <span class="fn-name">ts::parser</span>
+              <span class="fn-loc">apps/web/src/parser.ts L1–10</span>
+            </td>
+            <td class="num">7.00</td>
+            <td class="num">13.00</td>
+            <td><span class="ba-cell"><span class="b">75.0%</span> <span class="arrow" aria-hidden="true">→</span> <span class="a">60.0%</span></span></td>
+            <td>
+              <span class="transition-pill">
+                <span class="risk-pill" data-risk="2">acceptable</span>
+                <span class="arrow" aria-hidden="true">→</span>
+                <span class="risk-pill" data-risk="3">moderate</span>
+              </span>
+            </td>
+            <td class="num"><span class="delta-chip" data-direction="up" data-regression="1"><span class="chip-glyph" aria-hidden="true">▲</span> <span class="chip-value">+6.00</span></span></td>
+          </tr>
+          
+        </tbody>
+      </table>
+    </section>
+    
+
+    
+
+    
+
+    
+  </div>
 </div>
 
 

--- a/crates/crap-core/src/bin/crap-render.rs
+++ b/crates/crap-core/src/bin/crap-render.rs
@@ -1,14 +1,15 @@
 //! `crap-render` — multi-language CRAP HTML renderer.
 //!
 //! Composes per-adapter JSON envelopes into a unified HTML report
-//! with a Language/Combined toggle. Used by the composite scorecard
-//! action in multi-language mode; also invocable manually for
-//! debugging.
+//! with a Language/Combined toggle and a Current/Delta View axis.
+//! Used by the composite scorecard action in multi-language mode;
+//! also invocable manually for debugging.
 //!
 //! ## CLI shape
 //!
 //! ```text
 //! crap-render --input <LANG>=<FILE> [--input <LANG>=<FILE>...] \
+//!             [--baseline <LANG>=<FILE> ...]                   \
 //!             [--format html] [--output <PATH>] [--threshold <N>]
 //! ```
 //!
@@ -19,6 +20,15 @@
 //! hard-coded "rust" by every emitting binary (a pre-existing bug
 //! tracked elsewhere) — pairing the language at the CLI sidesteps
 //! the field and stays N-adapter agnostic for future adapters.
+//!
+//! `--baseline <LANG>=<FILE>` is the optional baseline counterpart.
+//! Each baseline envelope is composed against the matching `--input`
+//! envelope (same `<LANG>` key) to produce a per-language delta. When
+//! supplied, the rendered HTML carries the Current/Delta View axis
+//! within each language panel and a cross-adapter Combined Delta
+//! ranking; languages without a baseline render the Delta tab
+//! disabled, signalling the asymmetric state to reviewers without
+//! suppressing other languages' deltas.
 //!
 //! ## Schema-version validation
 //!
@@ -33,7 +43,7 @@
 //! Two envelopes with the same `(tool_name, language)` tuple are
 //! refused — accidentally passing two `crap4rs.json` would otherwise
 //! double-render the same data; the error message points at the
-//! collision.
+//! collision. The same guard applies to baseline envelopes.
 
 use std::fs::{self, File};
 use std::io::BufReader;
@@ -46,6 +56,7 @@ use serde::Deserialize;
 
 use crap_core::adapters::reporters::{HtmlMultiOptions, format_html_multi};
 use crap_core::core::compose::compose_multi_lang;
+use crap_core::domain::delta::{self, AnalysisDelta, DeltaViewSpec};
 use crap_core::domain::multi_lang::LanguageBlock;
 use crap_core::domain::types::{AnalysisResult, ComplexityMetric};
 use crap_core::domain::view::{self, ViewSpec};
@@ -72,6 +83,17 @@ struct Cli {
     /// HTML.
     #[arg(long = "input", action = ArgAction::Append, required = true)]
     inputs: Vec<String>,
+
+    /// Optional baseline envelope paired with its language key,
+    /// formatted as `<LANG>=<FILE>`. When supplied, the matching
+    /// language (by `<LANG>` key) gains a Current/Delta View axis in
+    /// its panel and contributes to the cross-adapter Combined Delta
+    /// ranking. A baseline whose language key has no matching
+    /// `--input` is an error. Languages without a baseline still
+    /// render normally; their Delta tab is disabled with a tooltip
+    /// pointing reviewers to supply one.
+    #[arg(long = "baseline", action = ArgAction::Append)]
+    baselines: Vec<String>,
 
     /// Output format. Only `html` is supported in v0.7.0; the option
     /// exists so future formats (markdown, json wrappers) extend the
@@ -137,7 +159,7 @@ fn run(cli: Cli) -> Result<()> {
 
     let mut parsed: Vec<ParsedEnvelope> = Vec::with_capacity(cli.inputs.len());
     for spec in &cli.inputs {
-        parsed.push(parse_input_spec(spec)?);
+        parsed.push(parse_input_spec(spec, "input")?);
     }
 
     // Duplicate-language guard: refuse two envelopes for the same
@@ -153,6 +175,29 @@ fn run(cli: Cli) -> Result<()> {
         }
     }
 
+    // Parse optional baselines. Each baseline pairs by `<LANG>` key
+    // with one of the `--input` envelopes; a baseline whose key has
+    // no matching input is an operator error (typo / wrong file).
+    let mut baselines: Vec<ParsedEnvelope> = Vec::with_capacity(cli.baselines.len());
+    for spec in &cli.baselines {
+        baselines.push(parse_input_spec(spec, "baseline")?);
+    }
+    let mut seen_baselines: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    for env in &baselines {
+        if !seen_baselines.insert(env.language.as_str()) {
+            bail!(
+                "duplicate baseline for language '{}'. Each language key may appear at most once.",
+                env.language
+            );
+        }
+        if !parsed.iter().any(|e| e.language == env.language) {
+            bail!(
+                "--baseline for language '{}' has no matching --input. Each baseline must pair with an input by language key.",
+                env.language
+            );
+        }
+    }
+
     let threshold = cli.threshold.unwrap_or_else(|| {
         parsed
             .iter()
@@ -161,12 +206,29 @@ fn run(cli: Cli) -> Result<()> {
             .max(0.0)
     });
 
+    // Compose per-language `AnalysisDelta`s ahead of `LanguageBlock`
+    // construction so the rendered `DeltaView`s can borrow into
+    // owned storage that lives at least as long as the render call.
+    // The deltas vector is kept in 1:1 order alignment with
+    // `parsed`; `None` means this language has no baseline (Delta
+    // tab will render disabled in the report).
+    let analysis_deltas: Vec<Option<AnalysisDelta>> = parsed
+        .iter()
+        .map(|env| {
+            baselines
+                .iter()
+                .find(|b| b.language == env.language)
+                .map(|b| delta::compute(b.result.clone(), env.result.clone()))
+        })
+        .collect();
+
     // Build LanguageBlock list. The view + delta lifetimes borrow
     // from each ParsedEnvelope's result; we therefore keep `parsed`
-    // alive for the duration of rendering.
+    // and `analysis_deltas` alive for the duration of rendering.
     let blocks: Vec<LanguageBlock<'_>> = parsed
         .iter()
-        .map(|env| LanguageBlock {
+        .zip(analysis_deltas.iter())
+        .map(|(env, maybe_delta)| LanguageBlock {
             tool_name: tool_name_for_language(&env.language).to_string(),
             display_name: display_name_for_language(&env.language).to_string(),
             language: env.language.clone(),
@@ -174,7 +236,9 @@ fn run(cli: Cli) -> Result<()> {
             metric: env.metric,
             threshold: env.threshold,
             view: view::apply(&env.result, ViewSpec::default()),
-            delta: None,
+            delta: maybe_delta
+                .as_ref()
+                .map(|d| delta::apply(d, DeltaViewSpec::default())),
         })
         .collect();
 
@@ -193,18 +257,18 @@ fn run(cli: Cli) -> Result<()> {
     Ok(())
 }
 
-fn parse_input_spec(spec: &str) -> Result<ParsedEnvelope> {
+fn parse_input_spec(spec: &str, kind: &str) -> Result<ParsedEnvelope> {
     let (language, path_str) = spec
         .split_once('=')
-        .ok_or_else(|| anyhow!("invalid --input spec '{spec}': expected '<LANG>=<FILE>'"))?;
+        .ok_or_else(|| anyhow!("invalid --{kind} spec '{spec}': expected '<LANG>=<FILE>'"))?;
     let language = language.trim();
     let path = PathBuf::from(path_str.trim());
 
     if language.is_empty() {
-        bail!("invalid --input spec '{spec}': language key must not be empty");
+        bail!("invalid --{kind} spec '{spec}': language key must not be empty");
     }
     if path.as_os_str().is_empty() {
-        bail!("invalid --input spec '{spec}': file path must not be empty");
+        bail!("invalid --{kind} spec '{spec}': file path must not be empty");
     }
 
     // Stream the envelope via BufReader so very large analyses don't
@@ -267,20 +331,31 @@ mod tests {
 
     #[test]
     fn parse_input_spec_rejects_missing_equals() {
-        let err = parse_input_spec("crap4rs.json").unwrap_err();
+        let err = parse_input_spec("crap4rs.json", "input").unwrap_err();
         assert!(err.to_string().contains("expected '<LANG>=<FILE>'"));
     }
 
     #[test]
     fn parse_input_spec_rejects_empty_language() {
-        let err = parse_input_spec("=crap4rs.json").unwrap_err();
+        let err = parse_input_spec("=crap4rs.json", "input").unwrap_err();
         assert!(err.to_string().contains("language key must not be empty"));
     }
 
     #[test]
     fn parse_input_spec_rejects_empty_path() {
-        let err = parse_input_spec("rust=").unwrap_err();
+        let err = parse_input_spec("rust=", "input").unwrap_err();
         assert!(err.to_string().contains("file path must not be empty"));
+    }
+
+    /// Error messages use the supplied kind ("input" / "baseline")
+    /// so operators see the exact flag they need to fix.
+    #[test]
+    fn parse_input_spec_error_messages_reference_supplied_kind() {
+        let err = parse_input_spec("missing_equals", "baseline").unwrap_err();
+        assert!(
+            err.to_string().contains("--baseline"),
+            "error should reference the baseline flag, got: {err}"
+        );
     }
 
     #[test]

--- a/crates/crap-core/src/core/compose.rs
+++ b/crates/crap-core/src/core/compose.rs
@@ -14,11 +14,13 @@
 //! ratio ARE dimensionally consistent — they answer "how far over
 //! this adapter's own threshold" — and produce an honest ordering.
 
+use crate::domain::delta::FunctionChange;
 use crate::domain::multi_lang::{
-    CombinedSummary, LanguageBlock, MultiLangContext, RankedFunction, WorstRatio, risk_level_rank,
+    CombinedDelta, CombinedDeltaSummary, CombinedSummary, DeltaRowSnapshot, LanguageBlock,
+    MultiLangContext, RankedDeltaKind, RankedDeltaRow, RankedFunction, WorstRatio, risk_level_rank,
     safe_ratio,
 };
-use crate::domain::types::RiskDistribution;
+use crate::domain::types::{FunctionVerdict, RiskDistribution};
 use std::cmp::Ordering;
 
 /// Compose per-language blocks into a multi-language report context.
@@ -112,6 +114,164 @@ fn compute_combined_summary(blocks: &[LanguageBlock<'_>]) -> CombinedSummary {
         distribution,
         ordered_functions: ordered,
     }
+}
+
+/// Compose a cross-adapter Combined Delta aggregate, or `None` when
+/// no language supplied a baseline.
+///
+/// Returns `None` precisely when every block's `delta` field is
+/// `None` — the renderer uses that signal to suppress the View axis
+/// nav entirely (no language has a Delta to show).
+///
+/// When at least one language contributed a baseline, this returns
+/// `Some(CombinedDelta)` carrying:
+/// - Summed change counts across contributing languages
+/// - Display labels listing which languages contributed AND which
+///   are missing a baseline (so the renderer can surface the
+///   asymmetry to reviewers)
+/// - A workspace-wide ranked list of regressions + new functions,
+///   sorted by risk band desc then CRAP/threshold ratio desc within
+///   band (same dimensional-consistency rule as the Current-view
+///   Combined ranking)
+///
+/// Improvements are intentionally not surfaced in the ranked list —
+/// the Combined Delta affordance is regression-focused, matching the
+/// per-language delta reporter's separate-improvements-table
+/// arrangement at the chat1.md trim.
+pub fn compose_combined_delta(blocks: &[LanguageBlock<'_>]) -> Option<CombinedDelta> {
+    // Detect the no-baseline case up-front so we can short-circuit
+    // without allocating any intermediate state.
+    if blocks.iter().all(|b| b.delta.is_none()) {
+        return None;
+    }
+
+    let mut summary = CombinedDeltaSummary::default();
+    let mut contributing_languages: Vec<String> = Vec::new();
+    let mut missing_baseline_languages: Vec<String> = Vec::new();
+    let mut ordered_rows: Vec<RankedDeltaRow> = Vec::new();
+
+    for block in blocks {
+        match block.delta.as_ref() {
+            Some(delta_view) => {
+                summary.fold(&delta_view.full.summary);
+                contributing_languages.push(block.display_name.clone());
+                collect_ranked_rows(&mut ordered_rows, block, delta_view);
+            }
+            None => {
+                missing_baseline_languages.push(block.display_name.clone());
+            }
+        }
+    }
+
+    ordered_rows.sort_by(rank_delta_row_cmp);
+
+    Some(CombinedDelta {
+        summary,
+        contributing_languages,
+        missing_baseline_languages,
+        ordered_rows,
+    })
+}
+
+fn collect_ranked_rows(
+    out: &mut Vec<RankedDeltaRow>,
+    block: &LanguageBlock<'_>,
+    delta_view: &crate::domain::delta::DeltaView<'_>,
+) {
+    // Walk the un-truncated change list so a per-language `--top N`
+    // doesn't silently drop rows from the workspace ranking. The
+    // Combined Delta table applies its own ranking; per-language
+    // truncation is presentational, not authoritative.
+    for change in &delta_view.full.changes {
+        match change {
+            FunctionChange::Modified { baseline, current } => {
+                let crap_delta = current.scored.crap.value - baseline.scored.crap.value;
+                // Regression threshold matches the per-language
+                // reporter's 0.005 cutoff — a smaller delta rounds
+                // to "+0.00" in the {:.2} cell output and would
+                // look like a false flag.
+                if crap_delta >= 0.005 {
+                    out.push(make_ranked_row(
+                        block,
+                        Some(baseline),
+                        current,
+                        RankedDeltaKind::Regression,
+                    ));
+                }
+            }
+            FunctionChange::Added { current } => {
+                out.push(make_ranked_row(
+                    block,
+                    None,
+                    current,
+                    RankedDeltaKind::NewFunction,
+                ));
+            }
+            FunctionChange::Removed { .. } => {
+                // v1 design intentionally drops Removed-zero rows
+                // here for the same reason the per-language
+                // reporter does at chat1.md — Combined Delta is
+                // regression-focused; removed functions don't add
+                // risk.
+            }
+        }
+    }
+}
+
+fn make_ranked_row(
+    block: &LanguageBlock<'_>,
+    baseline: Option<&FunctionVerdict>,
+    current: &FunctionVerdict,
+    kind: RankedDeltaKind,
+) -> RankedDeltaRow {
+    let ratio = safe_ratio(current.scored.crap.value, block.threshold);
+    RankedDeltaRow {
+        language: block.language.clone(),
+        adapter_display: block.display_name.clone(),
+        kind,
+        baseline: baseline.map(snapshot_from_verdict),
+        current: snapshot_from_verdict(current),
+        threshold: block.threshold,
+        ratio,
+    }
+}
+
+fn snapshot_from_verdict(verdict: &FunctionVerdict) -> DeltaRowSnapshot {
+    DeltaRowSnapshot {
+        identity: verdict.scored.identity.clone(),
+        crap: verdict.scored.crap.value,
+        coverage_percent: verdict.scored.coverage_percent,
+        risk_level: verdict.scored.crap.risk_level,
+        exceeds: verdict.exceeds,
+    }
+}
+
+/// Comparator for [`RankedDeltaRow`]. Same rule as the Current-view
+/// ranking: risk level desc (per-adapter calibrated), then
+/// CRAP/threshold ratio desc (dimensionally consistent within band),
+/// then stable tie-break by qualified name asc + file path asc.
+fn rank_delta_row_cmp(a: &RankedDeltaRow, b: &RankedDeltaRow) -> Ordering {
+    let risk_cmp =
+        risk_level_rank(b.current.risk_level).cmp(&risk_level_rank(a.current.risk_level));
+    if risk_cmp != Ordering::Equal {
+        return risk_cmp;
+    }
+    let ratio_cmp = b.ratio.partial_cmp(&a.ratio).unwrap_or(Ordering::Equal);
+    if ratio_cmp != Ordering::Equal {
+        return ratio_cmp;
+    }
+    let name_cmp = a
+        .current
+        .identity
+        .qualified_name
+        .cmp(&b.current.identity.qualified_name);
+    if name_cmp != Ordering::Equal {
+        return name_cmp;
+    }
+    a.current
+        .identity
+        .file_path
+        .cmp(&b.current.identity.file_path)
 }
 
 /// Comparator for [`RankedFunction`]. Risk level desc, then ratio
@@ -473,5 +633,395 @@ mod tests {
         )]);
         let worst = ctx.combined.worst_ratio.expect("worst ratio should be set");
         assert!(worst.ratio.is_infinite());
+    }
+
+    // ── compose_combined_delta tests (View axis cross-adapter delta) ──
+
+    use crate::domain::delta::{self, DeltaViewSpec};
+
+    /// Build a `LanguageBlock` from a baseline + current pair. The
+    /// owned `AnalysisResult` for current is held on the holder; the
+    /// `DeltaView` borrows from an `AnalysisDelta` we construct in
+    /// the `block` accessor.
+    struct DeltaFixture {
+        baseline: AnalysisResult,
+        current: AnalysisResult,
+    }
+
+    impl DeltaFixture {
+        fn from_fixtures(baseline: Fixture, current: Fixture) -> Self {
+            Self {
+                baseline: baseline.result,
+                current: current.result,
+            }
+        }
+
+        fn block_with_baseline<'a>(
+            &'a self,
+            holder: &'a mut Option<crate::domain::delta::AnalysisDelta>,
+            tool_name: &str,
+            display_name: &str,
+            language: &str,
+            metric: ComplexityMetric,
+            threshold: f64,
+        ) -> LanguageBlock<'a> {
+            *holder = Some(delta::compute(self.baseline.clone(), self.current.clone()));
+            let analysis_delta = holder.as_ref().expect("just populated");
+            LanguageBlock {
+                tool_name: tool_name.to_string(),
+                display_name: display_name.to_string(),
+                language: language.to_string(),
+                tool_version: "0.0.0-test".to_string(),
+                metric,
+                threshold,
+                view: view::apply(&self.current, ViewSpec::default()),
+                delta: Some(delta::apply(analysis_delta, DeltaViewSpec::default())),
+            }
+        }
+    }
+
+    /// Verifies the no-baseline short-circuit. Composition should
+    /// return `None` cheaply so the renderer can suppress the View
+    /// axis nav entirely.
+    #[test]
+    fn compose_combined_delta_returns_none_when_no_block_has_baseline() {
+        let fx = Fixture::new(vec![(
+            "fn::any",
+            "src/x.rs",
+            5.0,
+            8.0,
+            RiskLevel::Low,
+            3,
+            80.0,
+        )]);
+        let block = fx.block("crap4rs", "Rust", "rust", ComplexityMetric::Cognitive, 8.0);
+        assert!(compose_combined_delta(&[block]).is_none());
+    }
+
+    /// Mismatched-baseline scenario: only one language supplied a
+    /// baseline. The aggregate must surface it as contributing and
+    /// list the other language under `missing_baseline_languages` so
+    /// the renderer can paint the disabled Delta tab + scope-banner
+    /// asymmetry note.
+    #[test]
+    fn compose_combined_delta_marks_missing_baselines() {
+        let baseline_rs = Fixture::new(vec![(
+            "rs::a",
+            "src/a.rs",
+            4.0,
+            8.0,
+            RiskLevel::Low,
+            3,
+            80.0,
+        )]);
+        let current_rs = Fixture::new(vec![(
+            "rs::a",
+            "src/a.rs",
+            6.0,
+            8.0,
+            RiskLevel::Acceptable,
+            5,
+            70.0,
+        )]);
+        let rs_dfx = DeltaFixture::from_fixtures(baseline_rs, current_rs);
+        let mut rs_delta = None;
+        let rs_block = rs_dfx.block_with_baseline(
+            &mut rs_delta,
+            "crap4rs",
+            "Rust",
+            "rust",
+            ComplexityMetric::Cognitive,
+            8.0,
+        );
+
+        let ts_fx = Fixture::new(vec![(
+            "ts::b",
+            "src/b.ts",
+            3.0,
+            8.0,
+            RiskLevel::Low,
+            3,
+            90.0,
+        )]);
+        let ts_block = ts_fx.block(
+            "crap4ts",
+            "TypeScript",
+            "typescript",
+            ComplexityMetric::Cyclomatic,
+            8.0,
+        );
+
+        let combined = compose_combined_delta(&[rs_block, ts_block])
+            .expect("at least one language has a baseline");
+        assert_eq!(
+            combined.contributing_languages,
+            vec!["Rust".to_string()],
+            "Only Rust contributed a baseline"
+        );
+        assert_eq!(
+            combined.missing_baseline_languages,
+            vec!["TypeScript".to_string()],
+            "TypeScript has no baseline; renderer paints disabled Delta tab on its panel"
+        );
+    }
+
+    /// Cross-adapter regression ranking: a Rust High-risk regression
+    /// must rank ahead of a TypeScript Moderate-risk regression, per
+    /// the dimensional-consistency rule (risk band desc, then
+    /// ratio).
+    #[test]
+    fn compose_combined_delta_ranks_high_risk_before_moderate_across_adapters() {
+        let baseline_rs = Fixture::new(vec![(
+            "rs::scary_fn",
+            "src/h.rs",
+            10.0,
+            8.0,
+            RiskLevel::Acceptable,
+            10,
+            60.0,
+        )]);
+        let current_rs = Fixture::new(vec![(
+            "rs::scary_fn",
+            "src/h.rs",
+            45.6,
+            8.0,
+            RiskLevel::High,
+            20,
+            30.0,
+        )]);
+        let rs_dfx = DeltaFixture::from_fixtures(baseline_rs, current_rs);
+
+        let baseline_ts = Fixture::new(vec![(
+            "ts::moderate_change",
+            "src/m.ts",
+            14.0,
+            8.0,
+            RiskLevel::Moderate,
+            8,
+            65.0,
+        )]);
+        let current_ts = Fixture::new(vec![(
+            "ts::moderate_change",
+            "src/m.ts",
+            20.0,
+            8.0,
+            RiskLevel::Moderate,
+            10,
+            60.0,
+        )]);
+        let ts_dfx = DeltaFixture::from_fixtures(baseline_ts, current_ts);
+
+        let mut rs_delta = None;
+        let mut ts_delta = None;
+        let blocks = vec![
+            rs_dfx.block_with_baseline(
+                &mut rs_delta,
+                "crap4rs",
+                "Rust",
+                "rust",
+                ComplexityMetric::Cognitive,
+                8.0,
+            ),
+            ts_dfx.block_with_baseline(
+                &mut ts_delta,
+                "crap4ts",
+                "TypeScript",
+                "typescript",
+                ComplexityMetric::Cyclomatic,
+                8.0,
+            ),
+        ];
+
+        let combined =
+            compose_combined_delta(&blocks).expect("both languages contributed baselines");
+        let names: Vec<&str> = combined
+            .ordered_rows
+            .iter()
+            .map(|r| r.current.identity.qualified_name.as_str())
+            .collect();
+        assert_eq!(
+            names,
+            vec!["rs::scary_fn", "ts::moderate_change"],
+            "High-risk Rust regression must rank ahead of Moderate-risk TS regression"
+        );
+        // Per-row kind identifies regressions.
+        for row in &combined.ordered_rows {
+            assert_eq!(row.kind, RankedDeltaKind::Regression);
+        }
+        // Aggregate summary AND-folds passed across contributing
+        // blocks. Neither baseline → current crossed the threshold
+        // (both stayed below or scored as regressions but didn't
+        // produce a new-violation count of 1), so the fold reflects
+        // each block's `DeltaSummary.passed`.
+        assert_eq!(combined.summary.regressions, 2);
+        assert_eq!(combined.summary.new_violations, 0);
+    }
+
+    /// Within-band tie-break: two Moderate-risk regressions from
+    /// different adapters must order by CRAP/threshold ratio desc.
+    /// Higher ratio first.
+    #[test]
+    fn compose_combined_delta_orders_within_band_by_ratio_desc() {
+        let baseline_rs = Fixture::new(vec![(
+            "rs::change",
+            "src/r.rs",
+            10.0,
+            8.0,
+            RiskLevel::Acceptable,
+            5,
+            70.0,
+        )]);
+        let current_rs = Fixture::new(vec![(
+            "rs::change",
+            "src/r.rs",
+            18.0,
+            8.0,
+            RiskLevel::Moderate,
+            8,
+            55.0,
+        )]);
+        let rs_dfx = DeltaFixture::from_fixtures(baseline_rs, current_rs);
+        // ratio_rs = 18.0 / 8.0 = 2.25
+
+        let baseline_ts = Fixture::new(vec![(
+            "ts::change",
+            "src/t.ts",
+            10.0,
+            8.0,
+            RiskLevel::Acceptable,
+            5,
+            70.0,
+        )]);
+        let current_ts = Fixture::new(vec![(
+            "ts::change",
+            "src/t.ts",
+            24.0,
+            8.0,
+            RiskLevel::Moderate,
+            10,
+            45.0,
+        )]);
+        let ts_dfx = DeltaFixture::from_fixtures(baseline_ts, current_ts);
+        // ratio_ts = 24.0 / 8.0 = 3.00 — higher ratio than rs
+
+        let mut rs_delta = None;
+        let mut ts_delta = None;
+        let blocks = vec![
+            rs_dfx.block_with_baseline(
+                &mut rs_delta,
+                "crap4rs",
+                "Rust",
+                "rust",
+                ComplexityMetric::Cognitive,
+                8.0,
+            ),
+            ts_dfx.block_with_baseline(
+                &mut ts_delta,
+                "crap4ts",
+                "TypeScript",
+                "typescript",
+                ComplexityMetric::Cyclomatic,
+                8.0,
+            ),
+        ];
+
+        let combined = compose_combined_delta(&blocks).expect("both contributed baselines");
+        let names: Vec<&str> = combined
+            .ordered_rows
+            .iter()
+            .map(|r| r.current.identity.qualified_name.as_str())
+            .collect();
+        assert_eq!(
+            names,
+            vec!["ts::change", "rs::change"],
+            "Within Moderate band, TS row at ratio 3.0 ranks ahead of RS row at ratio 2.25"
+        );
+    }
+
+    /// Added (new) functions surface in the ranked list with the
+    /// NewFunction kind, alongside regressions. Improvements are
+    /// intentionally suppressed — Combined Delta is
+    /// regression-focused.
+    #[test]
+    fn compose_combined_delta_includes_added_and_excludes_improvements() {
+        let baseline = Fixture::new(vec![
+            (
+                "fn::regressing",
+                "src/r.rs",
+                10.0,
+                8.0,
+                RiskLevel::Acceptable,
+                6,
+                70.0,
+            ),
+            (
+                "fn::improving",
+                "src/i.rs",
+                14.0,
+                8.0,
+                RiskLevel::Moderate,
+                8,
+                50.0,
+            ),
+        ]);
+        let current = Fixture::new(vec![
+            (
+                "fn::regressing",
+                "src/r.rs",
+                20.0,
+                8.0,
+                RiskLevel::Moderate,
+                10,
+                50.0,
+            ),
+            (
+                "fn::improving",
+                "src/i.rs",
+                6.0,
+                8.0,
+                RiskLevel::Acceptable,
+                4,
+                85.0,
+            ),
+            (
+                "fn::brand_new",
+                "src/n.rs",
+                12.0,
+                8.0,
+                RiskLevel::Moderate,
+                7,
+                55.0,
+            ),
+        ]);
+        let dfx = DeltaFixture::from_fixtures(baseline, current);
+        let mut delta_holder = None;
+        let block = dfx.block_with_baseline(
+            &mut delta_holder,
+            "crap4rs",
+            "Rust",
+            "rust",
+            ComplexityMetric::Cognitive,
+            8.0,
+        );
+
+        let combined = compose_combined_delta(&[block]).expect("Rust block contributed a baseline");
+        let kinds: Vec<(&str, RankedDeltaKind)> = combined
+            .ordered_rows
+            .iter()
+            .map(|r| (r.current.identity.qualified_name.as_str(), r.kind))
+            .collect();
+        // Regression + Added surface; improvement is excluded.
+        assert!(
+            kinds.contains(&("fn::regressing", RankedDeltaKind::Regression)),
+            "regression must surface"
+        );
+        assert!(
+            kinds.contains(&("fn::brand_new", RankedDeltaKind::NewFunction)),
+            "added (new) function must surface"
+        );
+        assert!(
+            !kinds.iter().any(|(n, _)| *n == "fn::improving"),
+            "improvement must NOT surface — Combined Delta is regression-focused"
+        );
     }
 }

--- a/crates/crap-core/src/core/compose.rs
+++ b/crates/crap-core/src/core/compose.rs
@@ -224,14 +224,20 @@ fn make_ranked_row(
     current: &FunctionVerdict,
     kind: RankedDeltaKind,
 ) -> RankedDeltaRow {
-    let ratio = safe_ratio(current.scored.crap.value, block.threshold);
+    // Ratio uses the per-function threshold (`current.threshold`)
+    // rather than `block.threshold` so per-function overrides are
+    // respected. Matches the Current-view's `compute_combined_summary`
+    // ranking, which keys off `verdict.threshold` for the same
+    // reason: the dimensionally-consistent comparand within a risk
+    // band is "how far over this row's own threshold."
+    let ratio = safe_ratio(current.scored.crap.value, current.threshold);
     RankedDeltaRow {
         language: block.language.clone(),
         adapter_display: block.display_name.clone(),
         kind,
         baseline: baseline.map(snapshot_from_verdict),
         current: snapshot_from_verdict(current),
-        threshold: block.threshold,
+        threshold: current.threshold,
         ratio,
     }
 }

--- a/crates/crap-core/src/domain/multi_lang.rs
+++ b/crates/crap-core/src/domain/multi_lang.rs
@@ -21,7 +21,7 @@
 //! amounts to producing a `LanguageBlock` from its envelope — no
 //! changes here.
 
-use crate::domain::delta::DeltaView;
+use crate::domain::delta::{DeltaSummary, DeltaView};
 use crate::domain::types::{ComplexityMetric, FunctionIdentity, RiskDistribution, RiskLevel};
 use crate::domain::view::AnalysisView;
 
@@ -164,6 +164,162 @@ pub struct RankedFunction {
     /// Complexity number (cognitive or cyclomatic per the adapter's
     /// `metric` field — see `LanguageBlock.metric`).
     pub complexity: u32,
+}
+
+/// Cross-adapter delta aggregation produced by composition when at
+/// least one adapter supplied a baseline.
+///
+/// Carries summed change counts (additive — each adapter scans
+/// disjoint source trees, so a Rust regression and a TypeScript
+/// regression are independent events) plus a workspace-wide ranking
+/// of regressions + new violations sorted by risk band desc, then
+/// CRAP/threshold ratio desc within band — the same
+/// dimensional-consistency rule that governs the Current-view
+/// Combined ranking.
+///
+/// Languages that did not supply a baseline contribute nothing here;
+/// their `LanguageBlock.delta` is `None` and the renderer surfaces
+/// the gap as a disabled Delta tab on that language's panel.
+#[derive(Debug, Default)]
+pub struct CombinedDelta {
+    /// Aggregate counts across every contributing language. Each
+    /// field sums the corresponding `DeltaSummary` field for
+    /// languages whose `LanguageBlock.delta` was `Some`.
+    pub summary: CombinedDeltaSummary,
+    /// Display labels of every language whose baseline contributed
+    /// to this aggregate (e.g. `["Rust", "TypeScript"]`). Renderers
+    /// surface this list so reviewers see which languages are
+    /// represented — crucial for the mismatched-baseline case where
+    /// the Combined Delta represents fewer languages than the
+    /// Combined Current view.
+    pub contributing_languages: Vec<String>,
+    /// Display labels of languages that did NOT supply a baseline.
+    /// Renderers surface this so reviewers understand the
+    /// asymmetry — Combined Delta cannot reason about a language
+    /// without a baseline.
+    pub missing_baseline_languages: Vec<String>,
+    /// Workspace-wide ranking of regressions + new violations. Sort
+    /// key: risk level desc (per-adapter calibrated), then
+    /// CRAP/threshold ratio desc within band. Stable tie-break by
+    /// qualified name asc + file path asc.
+    pub ordered_rows: Vec<RankedDeltaRow>,
+}
+
+/// Aggregate of `DeltaSummary` counts across multiple adapters. Each
+/// field is the sum of the corresponding field across every
+/// `LanguageBlock.delta` that was `Some`.
+///
+/// `passed` defaults to `true` (vacuous AND over zero contributors)
+/// and is AND-folded with each contributing language's
+/// `DeltaSummary.passed`. The Combined Delta aggregate only renders
+/// when at least one language contributed, so a `Default` aggregate
+/// is never rendered — the renderer reads `CombinedDelta` through an
+/// `Option<>`.
+#[derive(Debug, Clone, Copy)]
+pub struct CombinedDeltaSummary {
+    pub added: u32,
+    pub removed: u32,
+    pub modified: u32,
+    pub regressions: u32,
+    pub improvements: u32,
+    pub new_violations: u32,
+    /// True only when every contributing language passed (no new
+    /// violations on any adapter). AND-aggregated across contributing
+    /// blocks; starts `true` (vacuous AND over zero contributors).
+    pub passed: bool,
+}
+
+impl Default for CombinedDeltaSummary {
+    fn default() -> Self {
+        Self {
+            added: 0,
+            removed: 0,
+            modified: 0,
+            regressions: 0,
+            improvements: 0,
+            new_violations: 0,
+            passed: true,
+        }
+    }
+}
+
+/// One row of the Combined Delta ranked table — a single regression
+/// or new violation from any adapter, ready to render.
+///
+/// Carries enough adapter identity to paint the per-row adapter badge
+/// and threshold to compute the dimensionally-consistent ratio that
+/// drives within-band ordering.
+#[derive(Debug, Clone)]
+pub struct RankedDeltaRow {
+    /// Wire language tag of the source adapter.
+    pub language: String,
+    /// Human display label of the source adapter.
+    pub adapter_display: String,
+    /// Whether this row represents an Added (new) function or a
+    /// Modified function whose CRAP score regressed. Drives the
+    /// renderer's row labelling ("new violation" vs "regression").
+    pub kind: RankedDeltaKind,
+    /// Baseline function snapshot. `None` for Added (no baseline).
+    pub baseline: Option<DeltaRowSnapshot>,
+    /// Current function snapshot. Always present.
+    pub current: DeltaRowSnapshot,
+    /// Adapter threshold at the time of the current analysis.
+    /// Drives the dimensionally-consistent ratio (CRAP /
+    /// threshold) that orders rows within a risk band.
+    pub threshold: f64,
+    /// CRAP / threshold for the current row. Dimensionally
+    /// consistent within an adapter's risk band — see
+    /// [`safe_ratio`].
+    pub ratio: f64,
+}
+
+/// Two flavors of cross-adapter delta row the Combined Delta table
+/// surfaces. Improvements are not ranked here — only regressions and
+/// new violations are surfaced, matching the per-language delta
+/// reporter's regression-focused affordance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RankedDeltaKind {
+    /// A `Modified` change whose CRAP score increased by at least
+    /// the 0.005 cutoff (matches the per-language reporter).
+    Regression,
+    /// An `Added` change — a new function (whose risk may or may not
+    /// exceed threshold; both are surfaced so reviewers see the
+    /// surface area of new work).
+    NewFunction,
+}
+
+/// Per-row snapshot of identity + scoring used by both baseline and
+/// current sides of a `RankedDeltaRow`. Keeping this lightweight (no
+/// borrows back into the source `AnalysisDelta`) lets the renderer
+/// own its rendering data after composition, mirroring the same
+/// pattern used by `RankedFunction` for the Current-view combined
+/// table.
+#[derive(Debug, Clone)]
+pub struct DeltaRowSnapshot {
+    pub identity: FunctionIdentity,
+    pub crap: f64,
+    pub coverage_percent: f64,
+    pub risk_level: RiskLevel,
+    /// True when this snapshot exceeds its adapter's threshold (the
+    /// `exceeds` flag from `FunctionVerdict`). For the baseline
+    /// snapshot, this captures whether the baseline ALREADY exceeded
+    /// threshold; for current, whether it exceeds NOW.
+    pub exceeds: bool,
+}
+
+impl CombinedDeltaSummary {
+    /// Fold one per-language `DeltaSummary` into this aggregate.
+    /// Idempotent — called once per contributing language during
+    /// composition.
+    pub fn fold(&mut self, other: &DeltaSummary) {
+        self.added += other.added;
+        self.removed += other.removed;
+        self.modified += other.modified;
+        self.regressions += other.regressions;
+        self.improvements += other.improvements;
+        self.new_violations += other.new_violations;
+        self.passed = self.passed && other.passed;
+    }
 }
 
 /// Worst CRAP/threshold ratio observed across all adapters.

--- a/crates/crap-core/templates/html_multi_report.html
+++ b/crates/crap-core/templates/html_multi_report.html
@@ -125,6 +125,68 @@
   }
   .footer-adapters .adapter .ad-name { font-weight: 600; }
   .footer-adapters .adapter .ad-meta { color: var(--text-muted); font-weight: 400; }
+
+  /* ── View axis (Current / Delta) — reused per-language and on Combined ──
+     Hide inactive tab panels; the JS switcher sets data-active on the
+     panel matching the user's URL hash (default `#combined:current`).
+     Matches the single-language template's rule at html_report.html so
+     the affordance vocabulary stays consistent. */
+  [data-multi-lang] .tab-panel { display: none; }
+  [data-multi-lang] .tab-panel[data-active] { display: block; }
+
+  /* Disabled Delta tab (language has no baseline). Caller paints the
+     tooltip via `title`; we visually communicate disabled state by
+     dimming the label + denying pointer events. */
+  [data-multi-lang] .tabs .tab[disabled] {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+
+  /* Sakura's base `button:hover` paints a magenta background that
+     collides with the flat tab-nav design. The base `.tab` rule resets
+     transparent for resting; hover would inherit the magenta. Mirror
+     the single-language template's override so the View axis hover
+     state stays flat (color shift only). */
+  [data-multi-lang] .tab:hover,
+  [data-multi-lang] .tab:focus-visible {
+    background: transparent;
+    color: var(--text);
+  }
+
+  /* Per-row kind badge in the Combined Delta ranking table. Two
+     kinds: "regression" (modified, CRAP increased) and "new"
+     (newly-added function). Coloring uses risk tokens so the badge
+     vocabulary stays in the existing Sakura palette. */
+  .kind-pill {
+    display: inline-block;
+    padding: 0.1rem 0.5rem;
+    border-radius: 999px;
+    font-family: var(--font-mono);
+    font-size: var(--fs-small);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-label);
+    border: 1px solid var(--hairline);
+    background: var(--bg-elevated);
+    color: var(--text);
+  }
+  .kind-pill[data-kind="regression"] {
+    color: var(--risk-3);
+    border-color: color-mix(in srgb, var(--risk-3) 35%, var(--hairline));
+  }
+  .kind-pill[data-kind="new"] {
+    color: var(--risk-2);
+    border-color: color-mix(in srgb, var(--risk-2) 35%, var(--hairline));
+  }
+
+  /* Asymmetric-baseline note in the Combined Delta scope banner.
+     Painted as a subdued advisory line so it's visible without
+     fighting the verdict pill for attention. */
+  .missing-baseline-note {
+    margin: 0.25rem 0 0;
+    color: var(--text-muted);
+    font-size: var(--fs-small);
+  }
 </style>
 </head>
 <body data-multi-lang>
@@ -154,6 +216,24 @@
 
 <!-- ── Combined panel ──────────────────────────────────────────────── -->
 <div class="lang-panel" data-lang="combined" data-active>
+  {%- if has_view_axis %}
+  {# View axis only renders when at least one language supplied a
+     baseline; the no-baseline path matches the v0.7.0 multi-language
+     render byte-for-byte. -#}
+  <nav class="tabs" role="tablist" aria-label="Combined views">
+    <button class="tab" role="tab" aria-selected="true" data-tab="current" type="button">
+      Current run <span class="tab-count">{{ combined.total_functions }}</span>
+    </button>
+    {%- if let Some(cd) = combined_delta_panel %}
+    <button class="tab" role="tab" aria-selected="false" data-tab="delta" type="button">
+      Delta vs baseline
+      {%- if cd.summary.new_violations > 0 || cd.summary.regressions > 0 %} <span class="tab-dot" aria-hidden="true"></span>{% endif %}
+      <span class="tab-count">{{ cd.summary.regressions + cd.summary.new_violations }} changed</span>
+    </button>
+    {%- endif %}
+  </nav>
+  <div class="tab-panel" data-tab="current" data-active role="tabpanel">
+  {%- endif %}
   <section class="scope-banner" aria-label="Combined scope">
     <p>
       <strong>{{ combined.total_exceeding }} of {{ combined.total_functions }}</strong>
@@ -258,11 +338,127 @@
   {% else %}
   <div class="empty-state">No functions analyzed across any language.</div>
   {% endif %}
+  {%- if has_view_axis %}
+  </div>{# /tab-panel[current] for Combined #}
+  {%- if let Some(cd) = combined_delta_panel %}
+  <div class="tab-panel" data-tab="delta" role="tabpanel">
+    <section class="scope-banner delta-hero" aria-label="Combined Delta scope">
+      <p>
+        <strong>Comparing</strong> current run vs baseline across
+        {% if cd.contributing_languages.len() == 1 -%}
+        the {{ cd.contributing_languages[0] }} adapter.
+        {%- else -%}
+        {{ cd.contributing_languages.len() }} adapters
+        ({% for lang in cd.contributing_languages %}{% if !loop.first %}, {% endif %}{{ lang }}{% endfor %}).
+        {%- endif %}
+        <span class="verdict is-{{ cd.verdict_class }}" aria-label="Combined Delta verdict: {{ cd.verdict_label }}">
+          <span class="verdict-glyph">{{ cd.verdict_glyph }}</span>
+          {{ cd.verdict_label }}
+        </span>
+        <span class="meta">
+          {{ cd.summary.added }} added · {{ cd.summary.removed }} removed · {{ cd.summary.modified }} modified ·
+          {{ cd.summary.regressions }} {% if cd.summary.regressions == 1 %}regression{% else %}regressions{% endif %} ·
+          {{ cd.summary.improvements }} {% if cd.summary.improvements == 1 %}improvement{% else %}improvements{% endif %} ·
+          {{ cd.summary.new_violations }} new {% if cd.summary.new_violations == 1 %}violation{% else %}violations{% endif %}
+        </span>
+      </p>
+      {%- if !cd.missing_baseline_languages.is_empty() %}
+      <p class="missing-baseline-note">
+        {% for lang in cd.missing_baseline_languages %}{% if !loop.first %}, {% endif %}<strong>{{ lang }}</strong>{% endfor %}
+        {% if cd.missing_baseline_languages.len() == 1 -%}
+        has no baseline yet — its Delta tab is disabled until one is supplied.
+        {%- else -%}
+        have no baselines yet — their Delta tabs are disabled until baselines are supplied.
+        {%- endif %}
+      </p>
+      {%- endif %}
+    </section>
+
+    {%- if !cd.ranked_rows.is_empty() %}
+    <section aria-label="Combined Delta ranking">
+      <h2>Workspace regressions &amp; new functions <span class="muted">· by risk band, then CRAP/threshold ratio</span></h2>
+      <p class="ranked-note">
+        Cross-adapter delta ordering uses risk level (per-adapter calibrated) then
+        CRAP/threshold ratio. Raw CRAP scores are not dimensionally equivalent
+        across adapters with different complexity metrics; the per-language Delta
+        tabs below show within-adapter rankings.
+      </p>
+      <table class="ranked-table">
+        <thead><tr>
+          <th>Adapter</th>
+          <th>Function</th>
+          <th>File</th>
+          <th>Kind</th>
+          <th class="num">Baseline</th>
+          <th class="num">Current</th>
+          <th class="num">Δ</th>
+          <th class="num">Ratio</th>
+          <th>Risk</th>
+        </tr></thead>
+        <tbody>
+          {% for row in cd.ranked_rows %}
+          <tr data-lang="{{ row.language }}" data-kind="{{ row.kind_label }}"{% if row.exceeds %} data-exceeds="1"{% endif %}>
+            <td>
+              <span class="adapter-badge" title="{{ row.adapter_display }} adapter" aria-label="{{ row.adapter_display }} adapter">{{ row.badge_glyph }}</span>
+              <span class="sr-only">{{ row.adapter_display }}</span>
+            </td>
+            <td><span class="fn-name">{{ row.qualified_name }}</span></td>
+            <td><span class="fn-path">{{ row.file_path }} L{{ row.start_line }}–{{ row.end_line }}</span></td>
+            <td><span class="kind-pill" data-kind="{{ row.kind_label }}">{{ row.kind_label }}</span></td>
+            <td class="num">{% if !row.baseline_crap.is_empty() %}{{ row.baseline_crap }}{% else %}—{% endif %}</td>
+            <td class="num">{{ row.current_crap }}</td>
+            <td class="num">
+              {%- if !row.delta_value.is_empty() -%}
+              <span class="delta-chip" data-direction="{{ row.delta_direction }}" data-regression="1">
+                {%- if !row.delta_glyph.is_empty() %}<span class="chip-glyph" aria-hidden="true">{{ row.delta_glyph }}</span>{% endif %}
+                <span class="chip-value">{{ row.delta_value }}</span>
+              </span>
+              {%- else -%}
+              —
+              {%- endif %}
+            </td>
+            <td class="num">{{ row.ratio_display }}</td>
+            <td><span class="risk-pill" data-risk="{{ row.current_risk }}">{{ row.current_risk_label }}</span></td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </section>
+    {%- else %}
+    <div class="empty-state">No regressions or new functions across contributing languages.</div>
+    {%- endif %}
+  </div>{# /tab-panel[delta] for Combined #}
+  {%- endif %}
+  {%- endif %}
 </div>
 
 <!-- ── Per-language panels ─────────────────────────────────────────── -->
 {% for panel in language_panels %}
 <div class="lang-panel" data-lang="{{ panel.language }}">
+  {%- if has_view_axis %}
+  {# Per-language View axis. Languages with no baseline render the
+     Delta tab DISABLED so the layout stays symmetric across panels
+     (the absent-baseline asymmetry is communicated by the disabled
+     state itself plus the scope-banner note in the Combined Delta
+     view). -#}
+  <nav class="tabs" role="tablist" aria-label="{{ panel.display_name }} views">
+    <button class="tab" role="tab" aria-selected="true" data-tab="current" type="button">
+      Current run <span class="tab-count">{{ panel.current_tab_count }}</span>
+    </button>
+    {%- if panel.has_delta %}
+    <button class="tab" role="tab" aria-selected="false" data-tab="delta" type="button">
+      {%- if let Some(dp) = panel.delta_panel %}Delta vs {{ dp.baseline_ref }}{% endif %}
+      {%- if panel.delta_has_news %} <span class="tab-dot" aria-hidden="true"></span>{% endif %}
+      <span class="tab-count">{{ panel.delta_tab_count }} changed</span>
+    </button>
+    {%- else %}
+    <button class="tab" role="tab" aria-selected="false" data-tab="delta" type="button" disabled aria-disabled="true" title="no baseline available for {{ panel.display_name }}">
+      Delta vs baseline <span class="tab-count">—</span>
+    </button>
+    {%- endif %}
+  </nav>
+  <div class="tab-panel" data-tab="current" data-active role="tabpanel">
+  {%- endif %}
   <section class="scope-banner" aria-label="{{ panel.display_name }} scope">
     <p>
       <strong>{{ panel.exceeding_threshold }} of {{ panel.total_functions }}</strong>
@@ -364,6 +560,151 @@
   {% else %}
   <div class="empty-state">No functions analyzed by the {{ panel.display_name }} adapter.</div>
   {% endif %}
+  {%- if has_view_axis %}
+  </div>{# /tab-panel[current] for this language #}
+  {%- if let Some(dp) = panel.delta_panel %}
+  <div class="tab-panel" data-tab="delta" role="tabpanel">
+    {# Delta hero — verdict + summary line. -#}
+    <section class="scope-banner delta-hero" aria-label="{{ panel.display_name }} Delta scope">
+      <p>
+        <strong>Comparing</strong> current run vs <code>{{ dp.baseline_ref }}</code>.
+        <span class="verdict is-{{ dp.verdict_class }}" aria-label="Delta verdict: {{ dp.verdict_label }}">
+          <span class="verdict-glyph">{{ dp.verdict_glyph }}</span>
+          {{ dp.verdict_label }}
+        </span>
+        <span class="meta">
+          {{ dp.summary.added }} added · {{ dp.summary.removed }} removed · {{ dp.summary.modified }} modified ·
+          {{ dp.summary.regressions }} {% if dp.summary.regressions == 1 %}regression{% else %}regressions{% endif %} ·
+          {{ dp.summary.improvements }} {% if dp.summary.improvements == 1 %}improvement{% else %}improvements{% endif %} ·
+          {{ dp.summary.new_violations }} new {% if dp.summary.new_violations == 1 %}violation{% else %}violations{% endif %}
+        </span>
+      </p>
+    </section>
+
+    {# Delta KPI grid (4 tiles). -#}
+    <section class="delta-kpi-grid" aria-label="{{ panel.display_name }} Delta summary">
+      {% for kpi in dp.kpis %}
+      <div class="delta-kpi" data-direction="{{ kpi.direction }}"{% if kpi.is_regression %} data-regression="1"{% endif %}>
+        <span class="delta-kpi-label">{{ kpi.label }}</span>
+        <div class="delta-kpi-ba">
+          <span class="before">{{ kpi.before }}</span>
+          <span class="arrow" aria-hidden="true">→</span>
+          <span class="after">{{ kpi.after }}</span>
+        </div>
+        {% if !kpi.chip_value.is_empty() %}
+        <span class="delta-chip" data-direction="{{ kpi.direction }}"{% if kpi.is_regression %} data-regression="1"{% endif %}>
+          {% if !kpi.chip_glyph.is_empty() %}<span class="chip-glyph" aria-hidden="true">{{ kpi.chip_glyph }}</span>{% endif %}
+          <span class="chip-value">{{ kpi.chip_value }}</span>
+        </span>
+        {% endif %}
+        {% if !kpi.note.is_empty() %}
+        <span class="delta-kpi-foot">{{ kpi.note }}</span>
+        {% endif %}
+      </div>
+      {% endfor %}
+    </section>
+
+    {# Regressions table. -#}
+    {% if !dp.regressions.is_empty() %}
+    <section aria-label="{{ panel.display_name }} regressions">
+      <h2>Regressions <span class="delta-section-count">{{ dp.regressions.len() }}</span></h2>
+      <table class="delta-table regressions">
+        <thead><tr>
+          <th>Function</th><th class="num">Baseline CRAP</th><th class="num">Current CRAP</th><th>Coverage</th><th>Risk transition</th><th class="num">Δ</th>
+        </tr></thead>
+        <tbody>
+          {% for row in dp.regressions %}
+          <tr{% if row.exceeds %} data-exceeds="1"{% endif %}>
+            <td>
+              <span class="fn-name">{{ row.qualified_name }}</span>
+              <span class="fn-loc">{{ row.file }} L{{ row.start_line }}–{{ row.end_line }}</span>
+            </td>
+            <td class="num">{{ row.baseline_crap }}</td>
+            <td class="num">{{ row.current_crap }}</td>
+            <td><span class="ba-cell"><span class="b">{{ row.baseline_cov }}</span> <span class="arrow" aria-hidden="true">→</span> <span class="a">{{ row.current_cov }}</span></span></td>
+            <td>
+              <span class="transition-pill">
+                <span class="risk-pill" data-risk="{{ row.baseline_risk }}">{{ row.baseline_risk_label }}</span>
+                <span class="arrow" aria-hidden="true">→</span>
+                <span class="risk-pill" data-risk="{{ row.current_risk }}">{{ row.current_risk_label }}</span>
+              </span>
+            </td>
+            <td class="num"><span class="delta-chip" data-direction="{{ row.delta_direction }}" data-regression="1">{% if !row.delta_glyph.is_empty() %}<span class="chip-glyph" aria-hidden="true">{{ row.delta_glyph }}</span>{% endif %} <span class="chip-value">{{ row.delta_value }}</span></span></td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </section>
+    {% endif %}
+
+    {# Improvements table. -#}
+    {% if !dp.improvements.is_empty() %}
+    <section aria-label="{{ panel.display_name }} improvements">
+      <h2>Improvements <span class="delta-section-count">{{ dp.improvements.len() }}</span></h2>
+      <table class="delta-table improvements">
+        <thead><tr>
+          <th>Function</th><th class="num">Baseline CRAP</th><th class="num">Current CRAP</th><th>Coverage</th><th>Risk transition</th><th class="num">Δ</th>
+        </tr></thead>
+        <tbody>
+          {% for row in dp.improvements %}
+          <tr>
+            <td>
+              <span class="fn-name">{{ row.qualified_name }}</span>
+              <span class="fn-loc">{{ row.file }} L{{ row.start_line }}–{{ row.end_line }}</span>
+            </td>
+            <td class="num">{{ row.baseline_crap }}</td>
+            <td class="num">{{ row.current_crap }}</td>
+            <td><span class="ba-cell"><span class="b">{{ row.baseline_cov }}</span> <span class="arrow" aria-hidden="true">→</span> <span class="a">{{ row.current_cov }}</span></span></td>
+            <td>
+              <span class="transition-pill">
+                <span class="risk-pill" data-risk="{{ row.baseline_risk }}">{{ row.baseline_risk_label }}</span>
+                <span class="arrow" aria-hidden="true">→</span>
+                <span class="risk-pill" data-risk="{{ row.current_risk }}">{{ row.current_risk_label }}</span>
+              </span>
+            </td>
+            <td class="num"><span class="delta-chip" data-direction="{{ row.delta_direction }}">{% if !row.delta_glyph.is_empty() %}<span class="chip-glyph" aria-hidden="true">{{ row.delta_glyph }}</span>{% endif %} <span class="chip-value">{{ row.delta_value }}</span></span></td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </section>
+    {% endif %}
+
+    {# New functions table. -#}
+    {% if !dp.new_functions.is_empty() %}
+    <section aria-label="{{ panel.display_name }} new functions">
+      <h2>New functions <span class="delta-section-count">{{ dp.new_functions.len() }}</span></h2>
+      <table class="delta-table new-functions">
+        <thead><tr>
+          <th>Function</th><th class="num">Current CRAP</th><th>Coverage</th><th>Risk</th>
+        </tr></thead>
+        <tbody>
+          {% for row in dp.new_functions %}
+          <tr{% if row.exceeds %} data-exceeds="1"{% endif %}>
+            <td>
+              <span class="fn-name">{{ row.qualified_name }}</span>
+              <span class="fn-loc">{{ row.file }} L{{ row.start_line }}–{{ row.end_line }}</span>
+            </td>
+            <td class="num">{{ row.current_crap }}</td>
+            <td class="num">{{ row.current_cov }}</td>
+            <td><span class="risk-pill" data-risk="{{ row.current_risk }}">{{ row.current_risk_label }}</span></td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </section>
+    {% endif %}
+
+    {# Unchanged note (chat1.md trim — single-line note, not a full table). -#}
+    {% if dp.unchanged_count > 0 %}
+    <p class="delta-unchanged">
+      {{ dp.unchanged_count }} {% if dp.unchanged_count == 1 %}function{% else %}functions{% endif %}
+      unchanged (CRAP score within ±0.005). Expand the <strong>Current run</strong> tab to inspect {% if dp.unchanged_count == 1 %}it{% else %}them{% endif %}.
+    </p>
+    {% endif %}
+  </div>{# /tab-panel[delta] for this language #}
+  {%- endif %}
+  {%- endif %}
 </div>
 {% endfor %}
 
@@ -386,41 +727,138 @@
     if (stored === "dark") root.setAttribute("data-theme", "dark");
   })();
 
-  // ── Language switcher (segmented) ──────────────────────────────────
-  // Switches which .lang-panel is visible. URL hash routes by
-  // `#lang:tab` per breadboard D7; for v0.7.0 only the language axis
-  // is wired (no Delta tab axis yet — folded in once cross-language
-  // delta support lands). Default on first load: `#combined`.
+  // ── Two-axis switcher (Language × View) ────────────────────────────
+  // URL hash format is `#<lang>:<view>` where <lang> is one of the
+  // segmented Language buttons (e.g. "rust", "typescript", "combined")
+  // and <view> is one of the per-panel View buttons (e.g. "current",
+  // "delta"). Default on first load when no hash is supplied:
+  // `#combined:current`. Switching Language preserves View; switching
+  // View preserves Language. If the user navigates to a disabled
+  // tab (e.g. `#typescript:delta` when TypeScript has no baseline)
+  // we silently fall back to the language's `current` view rather
+  // than leaving a half-broken state on screen.
   (function () {
-    var buttons = [].slice.call(document.querySelectorAll('[data-multi-lang] .lang-nav [data-lang]'));
-    var panels = [].slice.call(document.querySelectorAll('[data-multi-lang] .lang-panel[data-lang]'));
-    if (buttons.length === 0 || panels.length === 0) return;
+    var langButtons = [].slice.call(document.querySelectorAll('[data-multi-lang] .lang-nav [data-lang]'));
+    var langPanels = [].slice.call(document.querySelectorAll('[data-multi-lang] .lang-panel[data-lang]'));
+    if (langButtons.length === 0 || langPanels.length === 0) return;
 
-    function activate(name) {
+    function currentLang() {
+      var active = document.querySelector('[data-multi-lang] .lang-panel[data-active]');
+      return active ? active.dataset.lang : null;
+    }
+
+    function currentView(panel) {
+      var active = panel ? panel.querySelector('.tab-panel[data-active]') : null;
+      return active ? active.dataset.tab : null;
+    }
+
+    // Test whether the per-language Delta tab is disabled — drives
+    // the fallback in setHash() when a stale hash points at a tab
+    // that doesn't exist for the resolved language.
+    function tabIsDisabled(panel, view) {
+      var btn = panel.querySelector('.tabs .tab[data-tab="' + view + '"]');
+      return !!(btn && btn.hasAttribute('disabled'));
+    }
+
+    function activateLang(name) {
       var matched = false;
-      buttons.forEach(function (b) {
+      langButtons.forEach(function (b) {
         var on = b.dataset.lang === name;
-        b.classList.toggle("is-active", on);
-        b.setAttribute("aria-pressed", String(on));
+        b.classList.toggle('is-active', on);
+        b.setAttribute('aria-pressed', String(on));
         if (on) matched = true;
       });
-      if (!matched) return;
-      panels.forEach(function (p) {
-        if (p.dataset.lang === name) p.setAttribute("data-active", "");
-        else p.removeAttribute("data-active");
+      if (!matched) return null;
+      var newPanel = null;
+      langPanels.forEach(function (p) {
+        if (p.dataset.lang === name) {
+          p.setAttribute('data-active', '');
+          newPanel = p;
+        } else {
+          p.removeAttribute('data-active');
+        }
       });
-      var hashTarget = "#" + name;
-      if (location.hash !== hashTarget) {
-        history.replaceState(null, "", hashTarget);
+      return newPanel;
+    }
+
+    function activateView(panel, view) {
+      if (!panel) return null;
+      // Resolve the View axis only when this language has a `.tabs`
+      // group. Panels without baselines may still expose a disabled
+      // Delta tab; if `view` targets it, fall back to `current` so
+      // the rendered state stays consistent.
+      var tabs = [].slice.call(panel.querySelectorAll('.tabs .tab[data-tab]'));
+      if (tabs.length === 0) return null;
+      var resolved = view;
+      if (tabIsDisabled(panel, view)) {
+        resolved = 'current';
+        if (typeof console !== 'undefined' && console.info) {
+          console.info('[crap-rs] Falling back to #' + panel.dataset.lang + ':current — Delta tab is disabled for this language.');
+        }
+      }
+      tabs.forEach(function (t) {
+        t.setAttribute('aria-selected', String(t.dataset.tab === resolved));
+      });
+      [].slice.call(panel.querySelectorAll('.tab-panel[data-tab]')).forEach(function (p) {
+        if (p.dataset.tab === resolved) p.setAttribute('data-active', '');
+        else p.removeAttribute('data-active');
+      });
+      return resolved;
+    }
+
+    function setHash(lang, view) {
+      var target = '#' + lang + (view ? ':' + view : '');
+      if (location.hash !== target) {
+        history.replaceState(null, '', target);
       }
     }
 
-    buttons.forEach(function (b) {
-      b.addEventListener("click", function () { activate(b.dataset.lang); });
+    function go(lang, view) {
+      var panel = activateLang(lang);
+      var actualView = panel ? activateView(panel, view || 'current') : null;
+      setHash(lang, actualView || view || 'current');
+    }
+
+    // Wire Language buttons. Clicking a Language preserves the
+    // currently-active View where possible (per shaping D6 state-
+    // preservation rule).
+    langButtons.forEach(function (b) {
+      b.addEventListener('click', function () {
+        var lang = b.dataset.lang;
+        // Read the current panel's active view BEFORE switching;
+        // we preserve it on the new panel where available.
+        var preservedView = currentView(document.querySelector('[data-multi-lang] .lang-panel[data-active]')) || 'current';
+        go(lang, preservedView);
+      });
     });
 
-    var hash = (location.hash || "").replace(/^#/, "").split(":")[0];
-    if (hash) activate(hash);
+    // Wire View buttons across every language panel. Use event
+    // delegation on each panel so the disabled-tab fallback runs
+    // through the same code path.
+    langPanels.forEach(function (panel) {
+      [].slice.call(panel.querySelectorAll('.tabs .tab[data-tab]')).forEach(function (tab) {
+        tab.addEventListener('click', function () {
+          if (tab.hasAttribute('disabled')) return;
+          var lang = panel.dataset.lang;
+          go(lang, tab.dataset.tab);
+        });
+      });
+    });
+
+    // Initial state — parse the URL hash if present, otherwise
+    // default to `#combined:current` per D7. Split on `:` to
+    // separate the two axes.
+    var rawHash = (location.hash || '').replace(/^#/, '');
+    var parts = rawHash.split(':');
+    var lang = parts[0] || 'combined';
+    var view = parts[1] || 'current';
+    // If the hash names a language that doesn't exist in this
+    // report (e.g. a stale `#go:current` link from a prior run),
+    // fall back to `combined` silently.
+    if (!langButtons.some(function (b) { return b.dataset.lang === lang; })) {
+      lang = 'combined';
+    }
+    go(lang, view);
   })();
 </script>
 

--- a/crates/crap-core/templates/html_multi_report.html
+++ b/crates/crap-core/templates/html_multi_report.html
@@ -216,10 +216,12 @@
 
 <!-- ── Combined panel ──────────────────────────────────────────────── -->
 <div class="lang-panel" data-lang="combined" data-active>
-  {%- if has_view_axis %}
-  {# View axis only renders when at least one language supplied a
-     baseline; the no-baseline path matches the v0.7.0 multi-language
-     render byte-for-byte. -#}
+  {# View axis renders unconditionally. When no language supplied a
+     baseline the Delta tab is rendered DISABLED with a tooltip naming
+     the no-baseline cause, mirroring the per-language fallback below.
+     Discoverability comes from the visible affordance: a consumer
+     downloading the rendered HTML in the no-baseline case still sees
+     the Current/Delta vocabulary and learns the feature exists. -#}
   <nav class="tabs" role="tablist" aria-label="Combined views">
     <button class="tab" role="tab" aria-selected="true" data-tab="current" type="button">
       Current run <span class="tab-count">{{ combined.total_functions }}</span>
@@ -230,10 +232,13 @@
       {%- if cd.summary.new_violations > 0 || cd.summary.regressions > 0 %} <span class="tab-dot" aria-hidden="true"></span>{% endif %}
       <span class="tab-count">{{ cd.summary.regressions + cd.summary.new_violations }} changed</span>
     </button>
+    {%- else %}
+    <button class="tab" role="tab" aria-selected="false" data-tab="delta" type="button" disabled aria-disabled="true" title="no baselines provided — pass --baseline to enable cross-adapter delta">
+      Delta vs baseline <span class="tab-count">—</span>
+    </button>
     {%- endif %}
   </nav>
   <div class="tab-panel" data-tab="current" data-active role="tabpanel">
-  {%- endif %}
   <section class="scope-banner" aria-label="Combined scope">
     <p>
       <strong>{{ combined.total_exceeding }} of {{ combined.total_functions }}</strong>
@@ -338,7 +343,6 @@
   {% else %}
   <div class="empty-state">No functions analyzed across any language.</div>
   {% endif %}
-  {%- if has_view_axis %}
   </div>{# /tab-panel[current] for Combined #}
   {%- if let Some(cd) = combined_delta_panel %}
   <div class="tab-panel" data-tab="delta" role="tabpanel">
@@ -429,18 +433,17 @@
     {%- endif %}
   </div>{# /tab-panel[delta] for Combined #}
   {%- endif %}
-  {%- endif %}
 </div>
 
 <!-- ── Per-language panels ─────────────────────────────────────────── -->
 {% for panel in language_panels %}
 <div class="lang-panel" data-lang="{{ panel.language }}">
-  {%- if has_view_axis %}
-  {# Per-language View axis. Languages with no baseline render the
-     Delta tab DISABLED so the layout stays symmetric across panels
-     (the absent-baseline asymmetry is communicated by the disabled
-     state itself plus the scope-banner note in the Combined Delta
-     view). -#}
+  {# Per-language View axis renders unconditionally. Languages with no
+     baseline render the Delta tab DISABLED with a no-baseline tooltip
+     so the layout stays symmetric across panels and the affordance
+     stays visible (the absent-baseline asymmetry is communicated by
+     the disabled state itself plus the scope-banner note in the
+     Combined Delta view). -#}
   <nav class="tabs" role="tablist" aria-label="{{ panel.display_name }} views">
     <button class="tab" role="tab" aria-selected="true" data-tab="current" type="button">
       Current run <span class="tab-count">{{ panel.current_tab_count }}</span>
@@ -458,7 +461,6 @@
     {%- endif %}
   </nav>
   <div class="tab-panel" data-tab="current" data-active role="tabpanel">
-  {%- endif %}
   <section class="scope-banner" aria-label="{{ panel.display_name }} scope">
     <p>
       <strong>{{ panel.exceeding_threshold }} of {{ panel.total_functions }}</strong>
@@ -560,7 +562,6 @@
   {% else %}
   <div class="empty-state">No functions analyzed by the {{ panel.display_name }} adapter.</div>
   {% endif %}
-  {%- if has_view_axis %}
   </div>{# /tab-panel[current] for this language #}
   {%- if let Some(dp) = panel.delta_panel %}
   <div class="tab-panel" data-tab="delta" role="tabpanel">
@@ -703,7 +704,6 @@
     </p>
     {% endif %}
   </div>{# /tab-panel[delta] for this language #}
-  {%- endif %}
   {%- endif %}
 </div>
 {% endfor %}

--- a/crates/crap4rs/tests/features/multi_lang_html.feature
+++ b/crates/crap4rs/tests/features/multi_lang_html.feature
@@ -73,3 +73,43 @@ Feature: Multi-language unified HTML report
     When the composite scorecard action runs with html-report set true and one language
     Then the workflow produces exactly one HTML artifact named after the adapter
     And the unified HTML render step does not execute
+
+  # ── View axis: Current/Delta tabs inside each language panel ───────
+
+  @wired
+  Scenario: Two-language input with baselines renders Current and Delta tabs in every panel
+    Given a crap4rs envelope and a crap4ts envelope with matching baselines for each language
+    When crap-render is invoked with both current envelopes plus both baseline envelopes
+    Then the HTML output contains a `<nav class="tabs"` element inside the Combined panel
+    And both per-language panels contain a `<nav class="tabs"` element with Current and Delta tabs
+    And no panel renders a disabled Delta tab when its language has a baseline
+
+  # ── View axis: mismatched baselines disable the missing-side Delta tab ─
+
+  @wired
+  Scenario: Mismatched baselines render a disabled Delta tab on the language without a baseline
+    Given a crap4rs envelope with a matching baseline and a crap4ts envelope without a baseline
+    When crap-render is invoked with both current envelopes and the Rust baseline only
+    Then the TypeScript panel renders the Delta tab with the disabled attribute
+    And the TypeScript Delta tab carries the no-baseline tooltip text
+    And the Rust panel renders the Delta tab without the disabled attribute
+    And the Combined Delta scope-banner names TypeScript as a language missing a baseline
+
+  # ── Combined Delta cross-adapter ranking ───────────────────────────
+
+  @wired
+  Scenario: Combined Delta ranks cross-adapter regressions by risk band desc then ratio desc
+    Given a Rust baseline plus a Rust current with one High-risk regression at ratio 5.7
+    And a TypeScript baseline plus a TypeScript current with one Moderate-risk regression at ratio 2.5
+    When crap-render is invoked with both pairs of envelopes
+    Then the Combined Delta tab panel lists the Rust High-risk regression before the TypeScript Moderate-risk regression
+    And each Combined Delta row carries an adapter badge identifying its source language
+
+  # ── URL hash deep-linking ──────────────────────────────────────────
+
+  @wired
+  Scenario: URL hash routing supports two-axis state with combined:current as the default
+    Given two language envelopes with baselines
+    When crap-render renders the unified HTML report
+    Then the rendered JS parses URL hashes of the shape `#<lang>:<view>`
+    And the rendered JS falls back to `#combined:current` when the URL carries no hash

--- a/crates/crap4rs/tests/features/multi_lang_html.feature
+++ b/crates/crap4rs/tests/features/multi_lang_html.feature
@@ -84,6 +84,16 @@ Feature: Multi-language unified HTML report
     And both per-language panels contain a `<nav class="tabs"` element with Current and Delta tabs
     And no panel renders a disabled Delta tab when its language has a baseline
 
+  # ── View axis: no-baseline path keeps the affordance visible ───────
+
+  @wired
+  Scenario: No-baseline multi-language input renders View nav with disabled Delta tab in every panel
+    Given a crap4rs JSON envelope and a crap4ts JSON envelope from one workspace
+    When crap-render is invoked with both envelopes and --format html
+    Then the HTML output contains exactly three `<nav class="tabs"` elements
+    And the Combined panel Delta tab is disabled with the cross-adapter no-baselines tooltip
+    And both per-language Delta tabs are disabled with their per-language no-baseline tooltip
+
   # ── View axis: mismatched baselines disable the missing-side Delta tab ─
 
   @wired

--- a/crates/crap4rs/tests/multi_lang_html_cucumber.rs
+++ b/crates/crap4rs/tests/multi_lang_html_cucumber.rs
@@ -927,6 +927,70 @@ fn then_js_default_hash_is_combined_current(world: &mut MultiLangWorld) {
     );
 }
 
+// ── No-baseline View axis Then steps ────────────────────────────────
+
+#[then("the HTML output contains exactly three `<nav class=\"tabs\"` elements")]
+fn then_three_view_navs(world: &mut MultiLangWorld) {
+    let out = world.stdout();
+    let count = out.matches(r#"<nav class="tabs""#).count();
+    assert_eq!(
+        count, 3,
+        "expected exactly 3 View navs in unified HTML (Combined + Rust + TypeScript); got {count}"
+    );
+}
+
+#[then("the Combined panel Delta tab is disabled with the cross-adapter no-baselines tooltip")]
+fn then_combined_delta_disabled_no_baselines(world: &mut MultiLangWorld) {
+    let out = world.stdout();
+    let nav_start = out
+        .find(r#"aria-label="Combined views""#)
+        .expect("Combined tabs nav present");
+    let close_off = out[nav_start..]
+        .find("</nav>")
+        .expect("Combined nav has closing tag");
+    let nav = &out[nav_start..nav_start + close_off];
+    assert!(
+        nav.contains("disabled") && nav.contains(r#"aria-disabled="true""#),
+        "Combined Delta tab must be disabled when no language supplied a baseline; got: {nav}"
+    );
+    // The Combined tooltip uses distinctive plural wording so it
+    // cannot collide with the per-language `title="no baseline
+    // available for <lang>"` literal asserted elsewhere in this
+    // file. Drift between Combined and per-language wording is
+    // caught by the assertion below in
+    // `then_both_lang_delta_disabled_no_baseline_tooltip`.
+    assert!(
+        nav.contains(
+            r#"title="no baselines provided — pass --baseline to enable cross-adapter delta""#
+        ),
+        "Combined Delta disabled tooltip must name the no-baselines cause; got: {nav}"
+    );
+}
+
+#[then("both per-language Delta tabs are disabled with their per-language no-baseline tooltip")]
+fn then_both_lang_delta_disabled_no_baseline_tooltip(world: &mut MultiLangWorld) {
+    let out = world.stdout();
+    for lang_label in ["Rust", "TypeScript"] {
+        let aria = format!(r#"aria-label="{lang_label} views""#);
+        let nav_start = out
+            .find(&aria)
+            .unwrap_or_else(|| panic!("{lang_label} tabs nav present"));
+        let close_off = out[nav_start..]
+            .find("</nav>")
+            .expect("per-language nav has closing tag");
+        let nav = &out[nav_start..nav_start + close_off];
+        assert!(
+            nav.contains("disabled") && nav.contains(r#"aria-disabled="true""#),
+            "{lang_label} Delta tab must be disabled when {lang_label} has no baseline; got: {nav}"
+        );
+        let expected_tooltip = format!(r#"title="no baseline available for {lang_label}""#);
+        assert!(
+            nav.contains(&expected_tooltip),
+            "{lang_label} Delta disabled tooltip must name the language ({expected_tooltip}); got: {nav}"
+        );
+    }
+}
+
 fn action_yml_path() -> PathBuf {
     // Walk up from CARGO_MANIFEST_DIR (= crates/crap4rs) to the
     // workspace root, then point at the composite action's yml.

--- a/crates/crap4rs/tests/multi_lang_html_cucumber.rs
+++ b/crates/crap4rs/tests/multi_lang_html_cucumber.rs
@@ -37,6 +37,9 @@ struct MultiLangWorld {
     /// Per-language envelope paths the scenario has produced. Keyed
     /// by language so duplicates can be intentionally tested.
     envelopes: Vec<(String, PathBuf)>,
+    /// Per-language baseline envelope paths (View axis scenarios).
+    /// Keyed by language; same dedup discipline as `envelopes`.
+    baselines: Vec<(String, PathBuf)>,
     /// Output of the last crap-render invocation. None until the
     /// scenario's When step has run.
     output: Option<Output>,
@@ -175,6 +178,16 @@ fn write_envelope(world: &mut MultiLangWorld, language: &str, filename: &str, bo
     world.envelopes.push((language.to_string(), path));
 }
 
+fn write_baseline(world: &mut MultiLangWorld, language: &str, filename: &str, body: &str) {
+    let dir = match world._tempdir.as_ref() {
+        Some(d) => d.path().to_path_buf(),
+        None => fresh_tempdir(world),
+    };
+    let path = dir.join(filename);
+    std::fs::write(&path, body).expect("write baseline envelope");
+    world.baselines.push((language.to_string(), path));
+}
+
 // ── Given steps ──────────────────────────────────────────────────────
 
 #[given("a crap4rs JSON envelope from a representative workspace")]
@@ -304,6 +317,171 @@ fn given_two_crap4rs_envelopes(world: &mut MultiLangWorld) {
     write_envelope(world, "rust", "b.json", &body);
 }
 
+#[given("a crap4rs envelope and a crap4ts envelope with matching baselines for each language")]
+fn given_two_lang_with_both_baselines(world: &mut MultiLangWorld) {
+    // Current envelopes — same shape as the existing two-language
+    // scenario so the rest of the structural assertions hold.
+    let rs_current = synth_envelope(
+        "rust",
+        "compute_crap",
+        "src/lib.rs",
+        "cognitive",
+        12.0,
+        8.0,
+        "moderate",
+        7,
+        65.0,
+    );
+    let ts_current = synth_envelope(
+        "typescript",
+        "parseInvoice",
+        "src/parse.ts",
+        "cyclomatic",
+        14.0,
+        8.0,
+        "moderate",
+        8,
+        55.0,
+    );
+    write_envelope(world, "rust", "crap4rs.json", &rs_current);
+    write_envelope(world, "typescript", "crap4ts.json", &ts_current);
+
+    // Baselines — earlier snapshots of the same identities so the
+    // delta computer pairs them as Modified rather than Added.
+    let rs_baseline = synth_envelope(
+        "rust",
+        "compute_crap",
+        "src/lib.rs",
+        "cognitive",
+        6.0,
+        8.0,
+        "acceptable",
+        4,
+        75.0,
+    );
+    let ts_baseline = synth_envelope(
+        "typescript",
+        "parseInvoice",
+        "src/parse.ts",
+        "cyclomatic",
+        8.0,
+        8.0,
+        "acceptable",
+        5,
+        70.0,
+    );
+    write_baseline(world, "rust", "crap4rs-baseline.json", &rs_baseline);
+    write_baseline(world, "typescript", "crap4ts-baseline.json", &ts_baseline);
+}
+
+#[given("a crap4rs envelope with a matching baseline and a crap4ts envelope without a baseline")]
+fn given_mismatched_baselines(world: &mut MultiLangWorld) {
+    let rs_current = synth_envelope(
+        "rust",
+        "compute_crap",
+        "src/lib.rs",
+        "cognitive",
+        10.0,
+        8.0,
+        "acceptable",
+        6,
+        70.0,
+    );
+    let ts_current = synth_envelope(
+        "typescript",
+        "parseInvoice",
+        "src/parse.ts",
+        "cyclomatic",
+        12.0,
+        8.0,
+        "moderate",
+        7,
+        65.0,
+    );
+    write_envelope(world, "rust", "crap4rs.json", &rs_current);
+    write_envelope(world, "typescript", "crap4ts.json", &ts_current);
+
+    let rs_baseline = synth_envelope(
+        "rust",
+        "compute_crap",
+        "src/lib.rs",
+        "cognitive",
+        5.0,
+        8.0,
+        "low",
+        3,
+        85.0,
+    );
+    write_baseline(world, "rust", "crap4rs-baseline.json", &rs_baseline);
+    // TypeScript: NO baseline supplied — the disabled-tab path under
+    // test.
+}
+
+#[given("a Rust baseline plus a Rust current with one High-risk regression at ratio 5.7")]
+fn given_rust_high_risk_regression(world: &mut MultiLangWorld) {
+    let rs_baseline = synth_envelope(
+        "rust",
+        "view::analyze_view",
+        "src/domain/view.rs",
+        "cognitive",
+        6.0,
+        8.0,
+        "acceptable",
+        4,
+        80.0,
+    );
+    let rs_current = synth_envelope(
+        "rust",
+        "view::analyze_view",
+        "src/domain/view.rs",
+        "cognitive",
+        45.6,
+        8.0,
+        "high",
+        20,
+        30.0,
+    );
+    write_baseline(world, "rust", "crap4rs-baseline.json", &rs_baseline);
+    write_envelope(world, "rust", "crap4rs.json", &rs_current);
+}
+
+#[given(
+    "a TypeScript baseline plus a TypeScript current with one Moderate-risk regression at ratio 2.5"
+)]
+fn given_typescript_moderate_regression(world: &mut MultiLangWorld) {
+    let ts_baseline = synth_envelope(
+        "typescript",
+        "parseInvoice",
+        "src/parse.ts",
+        "cyclomatic",
+        6.0,
+        8.0,
+        "acceptable",
+        4,
+        80.0,
+    );
+    let ts_current = synth_envelope(
+        "typescript",
+        "parseInvoice",
+        "src/parse.ts",
+        "cyclomatic",
+        20.0,
+        8.0,
+        "moderate",
+        10,
+        60.0,
+    );
+    write_baseline(world, "typescript", "crap4ts-baseline.json", &ts_baseline);
+    write_envelope(world, "typescript", "crap4ts.json", &ts_current);
+}
+
+#[given("two language envelopes with baselines")]
+fn given_two_language_envelopes_with_baselines(world: &mut MultiLangWorld) {
+    // Routed through the same helper as the explicit "matching
+    // baselines" Given so URL-hash scenarios share fixture data.
+    given_two_lang_with_both_baselines(world);
+}
+
 #[given("a workspace configured with a single language adapter")]
 fn given_workspace_single_language(world: &mut MultiLangWorld) {
     // Composite-action scenario: the contract under test is the
@@ -355,6 +533,41 @@ fn when_run_both_envelopes_default_format(world: &mut MultiLangWorld) {
     }
     let output = cmd.output().expect("run crap-render");
     world.output = Some(output);
+}
+
+#[when("crap-render is invoked with both current envelopes plus both baseline envelopes")]
+fn when_run_both_envelopes_with_both_baselines(world: &mut MultiLangWorld) {
+    let mut cmd = Command::cargo_bin("crap-render").expect("crap-render bin discoverable");
+    for (lang, path) in &world.envelopes {
+        cmd.arg("--input")
+            .arg(format!("{}={}", lang, path.display()));
+    }
+    for (lang, path) in &world.baselines {
+        cmd.arg("--baseline")
+            .arg(format!("{}={}", lang, path.display()));
+    }
+    cmd.arg("--format").arg("html");
+    let output = cmd.output().expect("run crap-render");
+    world.output = Some(output);
+}
+
+#[when("crap-render is invoked with both current envelopes and the Rust baseline only")]
+fn when_run_both_envelopes_with_rust_baseline_only(world: &mut MultiLangWorld) {
+    // The fixture Given step writes only the Rust baseline, so this
+    // is byte-identical in behavior to the "both baselines"
+    // invocation — but expressing it as a distinct step keeps the
+    // .feature file declarative about intent.
+    when_run_both_envelopes_with_both_baselines(world);
+}
+
+#[when("crap-render is invoked with both pairs of envelopes")]
+fn when_run_both_pairs_of_envelopes(world: &mut MultiLangWorld) {
+    when_run_both_envelopes_with_both_baselines(world);
+}
+
+#[when("crap-render renders the unified HTML report")]
+fn when_renders_unified_html(world: &mut MultiLangWorld) {
+    when_run_both_envelopes_with_both_baselines(world);
 }
 
 #[when("the composite scorecard action runs with html-report set true and one language")]
@@ -556,6 +769,161 @@ fn then_unified_render_skipped(world: &mut MultiLangWorld) {
             "if: inputs.html-report == 'true' && steps.presets.outputs.is_multi == 'true'"
         ),
         "Render unified HTML step must be gated on is_multi == 'true'"
+    );
+}
+
+// ── View axis Then steps ────────────────────────────────────────────
+
+#[then("the HTML output contains a `<nav class=\"tabs\"` element inside the Combined panel")]
+fn then_combined_has_tabs_nav(world: &mut MultiLangWorld) {
+    let out = world.stdout();
+    assert!(
+        out.contains(r#"<nav class="tabs" role="tablist" aria-label="Combined views">"#),
+        "Combined panel must carry View axis tabs when at least one language has a baseline"
+    );
+}
+
+#[then(
+    "both per-language panels contain a `<nav class=\"tabs\"` element with Current and Delta tabs"
+)]
+fn then_both_lang_panels_have_tabs(world: &mut MultiLangWorld) {
+    let out = world.stdout();
+    assert!(
+        out.contains(r#"<nav class="tabs" role="tablist" aria-label="Rust views">"#),
+        "Rust panel must carry View axis tabs"
+    );
+    assert!(
+        out.contains(r#"<nav class="tabs" role="tablist" aria-label="TypeScript views">"#),
+        "TypeScript panel must carry View axis tabs"
+    );
+}
+
+#[then("no panel renders a disabled Delta tab when its language has a baseline")]
+fn then_no_disabled_delta_tab(world: &mut MultiLangWorld) {
+    let out = world.stdout();
+    assert!(
+        !out.contains(r#"title="no baseline available"#),
+        "no panel should render the no-baseline disabled tooltip when all languages have baselines"
+    );
+}
+
+#[then("the TypeScript panel renders the Delta tab with the disabled attribute")]
+fn then_ts_delta_tab_disabled(world: &mut MultiLangWorld) {
+    let out = world.stdout();
+    let ts_nav_start = out
+        .find(r#"aria-label="TypeScript views""#)
+        .expect("TypeScript tabs nav present");
+    let next_close = out[ts_nav_start..].find("</nav>").unwrap();
+    let ts_nav = &out[ts_nav_start..ts_nav_start + next_close];
+    assert!(
+        ts_nav.contains("disabled"),
+        "TypeScript Delta tab must be disabled when TypeScript has no baseline; got: {ts_nav}"
+    );
+}
+
+#[then("the TypeScript Delta tab carries the no-baseline tooltip text")]
+fn then_ts_delta_tab_no_baseline_tooltip(world: &mut MultiLangWorld) {
+    let out = world.stdout();
+    let ts_nav_start = out
+        .find(r#"aria-label="TypeScript views""#)
+        .expect("TypeScript tabs nav present");
+    let next_close = out[ts_nav_start..].find("</nav>").unwrap();
+    let ts_nav = &out[ts_nav_start..ts_nav_start + next_close];
+    assert!(
+        ts_nav.contains(r#"title="no baseline available for TypeScript""#),
+        "Disabled Delta tab must carry the no-baseline tooltip; got: {ts_nav}"
+    );
+}
+
+#[then("the Rust panel renders the Delta tab without the disabled attribute")]
+fn then_rust_delta_tab_enabled(world: &mut MultiLangWorld) {
+    let out = world.stdout();
+    let rs_nav_start = out
+        .find(r#"aria-label="Rust views""#)
+        .expect("Rust tabs nav present");
+    let next_close = out[rs_nav_start..].find("</nav>").unwrap();
+    let rs_nav = &out[rs_nav_start..rs_nav_start + next_close];
+    assert!(
+        !rs_nav.contains("disabled"),
+        "Rust Delta tab must be enabled when Rust has a baseline; got: {rs_nav}"
+    );
+}
+
+#[then("the Combined Delta scope-banner names TypeScript as a language missing a baseline")]
+fn then_combined_delta_missing_baseline_note(world: &mut MultiLangWorld) {
+    let out = world.stdout();
+    assert!(
+        out.contains(r#"class="missing-baseline-note""#),
+        "Combined Delta hero must render the missing-baseline note"
+    );
+    assert!(
+        out.contains("<strong>TypeScript</strong>") && out.contains("has no baseline yet"),
+        "missing-baseline-note must name TypeScript: {out}"
+    );
+}
+
+#[then(
+    "the Combined Delta tab panel lists the Rust High-risk regression before the TypeScript Moderate-risk regression"
+)]
+fn then_combined_delta_ranks_rust_before_typescript(world: &mut MultiLangWorld) {
+    let out = world.stdout();
+    let combined_delta_start = out
+        .find(r#"data-tab="delta" role="tabpanel""#)
+        .expect("Combined Delta tab-panel must render");
+    let combined_delta_section = &out[combined_delta_start..];
+    let rs_pos = combined_delta_section
+        .find("view::analyze_view")
+        .expect("Rust High-risk regression must surface in Combined Delta");
+    let ts_pos = combined_delta_section
+        .find("parseInvoice")
+        .expect("TypeScript Moderate-risk regression must surface in Combined Delta");
+    assert!(
+        rs_pos < ts_pos,
+        "Rust High-risk regression must rank ahead of TypeScript Moderate-risk regression in Combined Delta (D2d sort: risk band desc, ratio desc within band)"
+    );
+}
+
+#[then("each Combined Delta row carries an adapter badge identifying its source language")]
+fn then_combined_delta_rows_carry_badges(world: &mut MultiLangWorld) {
+    let out = world.stdout();
+    let combined_delta_start = out
+        .find(r#"data-tab="delta" role="tabpanel""#)
+        .expect("Combined Delta tab-panel must render");
+    // Take everything between the opening of the Combined Delta tab
+    // panel and the next `</div>` that closes a tab-panel (which is
+    // our own).
+    let combined_delta_section = &out[combined_delta_start..];
+    assert!(
+        combined_delta_section.contains(r#"<span class="adapter-badge""#),
+        "Combined Delta rows must carry adapter-badge markup"
+    );
+}
+
+#[then("the rendered JS parses URL hashes of the shape `#<lang>:<view>`")]
+fn then_js_parses_two_axis_hash(world: &mut MultiLangWorld) {
+    let out = world.stdout();
+    // The JS does parts = rawHash.split(':') and reads parts[0] +
+    // parts[1] for lang and view. Verify the structural marker so
+    // we don't lock the exact JS text (which may evolve).
+    assert!(
+        out.contains("rawHash.split(':')"),
+        "rendered JS must split the URL hash on ':' to extract <lang> and <view> axes"
+    );
+}
+
+#[then("the rendered JS falls back to `#combined:current` when the URL carries no hash")]
+fn then_js_default_hash_is_combined_current(world: &mut MultiLangWorld) {
+    let out = world.stdout();
+    // Default fallback: `var lang = parts[0] || 'combined';` and
+    // `var view = parts[1] || 'current';`. Verify both literals so
+    // the default-target invariant is locked.
+    assert!(
+        out.contains("parts[0] || 'combined'"),
+        "rendered JS must default lang axis to 'combined' when URL hash is absent"
+    );
+    assert!(
+        out.contains("parts[1] || 'current'"),
+        "rendered JS must default view axis to 'current' when URL hash is absent"
     );
 }
 


### PR DESCRIPTION
## Summary

Adds the missing Current/Delta View axis (Sakura `.tabs` group) to the multi-language unified HTML report. PR #318 (ζ #315) shipped the Language axis (`.segmented` Rust/TypeScript/Combined) but missed the second axis the original /shape plan locked at D6. This is the gap follow-up.

Per-language panels now carry their own Current/Delta tabs when their `LanguageBlock` has a baseline; the Combined panel exposes its own Current/Delta tabs and surfaces a cross-adapter Combined Delta ranking. Languages without a baseline render the Delta tab DISABLED with a no-baseline tooltip — the mismatched-baseline asymmetry is visible without suppressing other languages' deltas. URL hash routing extends to the `#<lang>:<view>` format (default `#combined:current`); switching Language preserves View where possible; navigating to a disabled tab silently falls back to `current`.

Closes #326.

## What landed

- **Domain**: New types in `crap_core::domain::multi_lang` — `CombinedDelta`, `CombinedDeltaSummary`, `RankedDeltaRow`, `RankedDeltaKind`, `DeltaRowSnapshot`. N-adapter-agnostic; adding a future adapter that supplies a baseline contributes to Combined Delta with no code changes outside the calling site.
- **Compose**: `crap_core::core::compose::compose_combined_delta(blocks) -> Option<CombinedDelta>`. Returns `None` when no language supplied a baseline; the renderer uses that signal to suppress the View axis nav entirely.
- **Reporter**: `HtmlMultiReport` template context gains `has_view_axis` + `combined_delta_panel`; `LangPanel` gains `has_delta` + `delta_panel` + tab-count badges. Same `Option<Box<...>>` discipline ε used for the single-language Delta panel — the dominant no-baseline arm stays cheap.
- **Template**: Per-language `<nav class="tabs">` inside each `.lang-panel`; Combined panel exposes its own `<nav class="tabs">`; per-language and Combined Delta tab-panels render the regression-focused affordance (regressions + new functions for Combined; full delta KPI grid + Regressions/Improvements/New tables for per-language, mirroring ε's chat1.md trim). Delta-panel markup is duplicated rather than extracted to an Askama `{% include %}` partial — extraction risks Askama whitespace differences that would break the existing byte-identical passthrough lock.
- **JS**: Two-axis state machine in the inline `<script>`. Hash format `#<lang>:<view>`, default `#combined:current`, language-switch preserves view, view-switch preserves language, disabled-tab navigation silently falls back to `current`.
- **CLI**: `crap-render --baseline <LANG>=<FILE>` added (additive, fully optional). Each baseline pairs by language key with one of the `--input` envelopes; a baseline whose key has no matching input is an error.
- **Composite action**: `Render unified HTML` step conditionally passes `--baseline rust=$BASELINE` / `--baseline typescript=$BASELINE_TS` when each is non-empty.
- **Tests**: 5 new unit tests for `compose_combined_delta`; 8 new tests in `html::tests` covering the View axis structural assertions + 3 insta snapshot locks (no-baseline regenerated, both-baselines NEW, mismatched-baseline NEW); 4 new BDD scenarios in `multi_lang_html.feature` exercised through the new `--baseline` CLI surface.
- **Version**: crap-core 0.7.0 → 0.8.0 (MINOR — additive public surface; no breaking changes).
- **Docs**: CHANGELOG entry under [0.8.0]; scorecard README documents the two-axis nav vocabulary + the `#<lang>:<view>` URL hash format + the disabled-tab affordance.

## Back-compat

- Single-language passthrough (`multi.languages.len() == 1`) remains byte-identical to the single-binary `format_html` path. A new test (`multi_lang_single_language_passthrough_byte_identical_with_baseline`) locks the invariant WITH a baseline too — the View axis plumbing in the multi-lang glue does not leak into the n=1 short-circuit.
- Multi-language without baselines is functionally equivalent to v0.7.0 (the View axis nav and Combined Delta tab-panel are suppressed entirely). The inline CSS for View axis affordances is still rendered as static asset bytes; the existing `full_html_multi_two_language_snapshot` was regenerated to capture only the line-shift from the new CSS.
- Composite action callers who don't supply a baseline see no change.
- Wire-envelope canaries (3 in-process tests in `crap-core::tests::wire_envelope_*`) remain byte-identical — no envelope wire shape change.

## Test plan

- [x] `cargo build --workspace --all-targets` green
- [x] `cargo nextest run --workspace --all-targets` — 1199 tests pass
- [x] `cargo test --package crap4rs --test multi_lang_html_cucumber` — 10/10 BDD scenarios, 48/48 steps green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo +1.93 check --workspace --all-targets` (MSRV) green
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` clean
- [x] `cargo deny check` clean (no new deps)
- [x] 3 wire-envelope canaries byte-identical (no envelope shape change)
- [x] Single-language passthrough byte-identical WITH baseline (new test)
- [ ] CI matrix green on linux + macos-arm + macos-x86
- [ ] zizmor clean on modified `.github/actions/scorecard/action.yml` (CI gate)
- [x] `scripts/bdd-tracked-lint.py` clean — no new @unwired / @wip tags

## Deviations from spawn brief

- **4th BDD scenario reshaped from behavioral to structural**: the brief named "URL hash `#typescript:delta` deep-links into TypeScript Delta panel" — a runtime behavioral assertion. Without browser automation in the cucumber harness, the structural substitute is "the rendered JS parses `#<lang>:<view>` and defaults to `#combined:current`." The actual hash-driven activation is locked at the unit-test level in `html.rs` (View axis tests + insta snapshots). The brief's intent is covered; the surface differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multi-language reports now support a view axis with Current and Delta tabs when baselines are provided.
  * Combined Delta panel displays ranked regressions and new functions across all languages with cross-adapter comparison.
  * Two-axis URL hash navigation (`#lang:view`) for improved report navigation.

* **Documentation**
  * Updated navigation structure for unified multi-language reports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/breezy-bays-labs/crap-rs/pull/327?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->