### PR TITLE
#331 — analyzer resolves workspace-relative coverage paths in both adapters

### DIFF
--- a/crates/crap-core/tests/snapshots/wire_envelope_crap4rs__envelope.snap
+++ b/crates/crap-core/tests/snapshots/wire_envelope_crap4rs__envelope.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/crap-core/tests/wire_envelope_crap4rs.rs
-assertion_line: 114
 expression: pretty
 ---
 {
@@ -15,10 +14,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -48,10 +47,10 @@ expression: pretty
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 6.0
+            "value": 2.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -72,10 +71,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -96,10 +95,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -129,10 +128,10 @@ expression: pretty
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 93.75,
           "crap": {
             "risk_level": "low",
-            "value": 6.0
+            "value": 2.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -148,7 +147,7 @@ expression: pretty
         "threshold": 8.0
       },
       {
-        "exceeds": true,
+        "exceeds": false,
         "scored": {
           "complexity": 4,
           "complexity_metric": "cognitive",
@@ -170,10 +169,10 @@ expression: pretty
               "nesting_depth": 1
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 94.73684210526316,
           "crap": {
-            "risk_level": "moderate",
-            "value": 20.0
+            "risk_level": "low",
+            "value": 4.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -194,10 +193,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -218,10 +217,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 85.71428571428571,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -242,10 +241,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -266,10 +265,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -285,7 +284,7 @@ expression: pretty
         "threshold": 8.0
       },
       {
-        "exceeds": true,
+        "exceeds": false,
         "scored": {
           "complexity": 3,
           "complexity_metric": "cognitive",
@@ -307,10 +306,10 @@ expression: pretty
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 71.42857142857143,
           "crap": {
-            "risk_level": "acceptable",
-            "value": 12.0
+            "risk_level": "low",
+            "value": 3.21
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -340,10 +339,10 @@ expression: pretty
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 90.0,
           "crap": {
             "risk_level": "low",
-            "value": 6.0
+            "value": 2.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -364,10 +363,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -383,7 +382,7 @@ expression: pretty
         "threshold": 8.0
       },
       {
-        "exceeds": true,
+        "exceeds": false,
         "scored": {
           "complexity": 7,
           "complexity_metric": "cognitive",
@@ -413,10 +412,10 @@ expression: pretty
               "nesting_depth": 2
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 82.6086956521739,
           "crap": {
-            "risk_level": "high",
-            "value": 56.0
+            "risk_level": "low",
+            "value": 7.26
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -446,10 +445,10 @@ expression: pretty
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 72.22222222222221,
           "crap": {
             "risk_level": "low",
-            "value": 6.0
+            "value": 2.09
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -465,7 +464,7 @@ expression: pretty
         "threshold": 8.0
       },
       {
-        "exceeds": true,
+        "exceeds": false,
         "scored": {
           "complexity": 4,
           "complexity_metric": "cognitive",
@@ -487,10 +486,10 @@ expression: pretty
               "nesting_depth": 1
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 42.10526315789473,
           "crap": {
-            "risk_level": "moderate",
-            "value": 20.0
+            "risk_level": "low",
+            "value": 7.1
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -511,10 +510,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 36.36363636363637,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.26
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -535,10 +534,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -559,10 +558,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -583,10 +582,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -607,10 +606,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -631,10 +630,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 83.33333333333334,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -655,10 +654,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 92.3076923076923,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -688,10 +687,10 @@ expression: pretty
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 6.0
+            "value": 2.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -712,10 +711,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -745,10 +744,10 @@ expression: pretty
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 85.71428571428571,
           "crap": {
             "risk_level": "low",
-            "value": 6.0
+            "value": 2.01
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -778,10 +777,10 @@ expression: pretty
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 6.0
+            "value": 2.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -811,10 +810,10 @@ expression: pretty
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 11.11111111111111,
           "crap": {
             "risk_level": "low",
-            "value": 6.0
+            "value": 4.81
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -830,7 +829,7 @@ expression: pretty
         "threshold": 8.0
       },
       {
-        "exceeds": true,
+        "exceeds": false,
         "scored": {
           "complexity": 7,
           "complexity_metric": "cognitive",
@@ -860,10 +859,10 @@ expression: pretty
               "nesting_depth": 2
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 82.75862068965517,
           "crap": {
-            "risk_level": "high",
-            "value": 56.0
+            "risk_level": "low",
+            "value": 7.25
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -879,7 +878,7 @@ expression: pretty
         "threshold": 8.0
       },
       {
-        "exceeds": true,
+        "exceeds": false,
         "scored": {
           "complexity": 4,
           "complexity_metric": "cognitive",
@@ -901,10 +900,10 @@ expression: pretty
               "nesting_depth": 1
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
-            "risk_level": "moderate",
-            "value": 20.0
+            "risk_level": "low",
+            "value": 4.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -958,10 +957,10 @@ expression: pretty
               "nesting_depth": 2
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 92.5925925925926,
           "crap": {
-            "risk_level": "high",
-            "value": 72.0
+            "risk_level": "acceptable",
+            "value": 8.03
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -991,10 +990,10 @@ expression: pretty
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 6.0
+            "value": 2.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -1024,10 +1023,10 @@ expression: pretty
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 6.0
+            "value": 2.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -1057,10 +1056,10 @@ expression: pretty
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 6.0
+            "value": 2.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -1081,10 +1080,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -1114,10 +1113,10 @@ expression: pretty
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 6.0
+            "value": 2.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -1138,10 +1137,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -1162,10 +1161,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -1186,10 +1185,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -1210,10 +1209,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -1243,10 +1242,10 @@ expression: pretty
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 6.0
+            "value": 2.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -1262,7 +1261,7 @@ expression: pretty
         "threshold": 8.0
       },
       {
-        "exceeds": true,
+        "exceeds": false,
         "scored": {
           "complexity": 3,
           "complexity_metric": "cognitive",
@@ -1284,10 +1283,10 @@ expression: pretty
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
-            "risk_level": "acceptable",
-            "value": 12.0
+            "risk_level": "low",
+            "value": 3.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -1303,7 +1302,7 @@ expression: pretty
         "threshold": 8.0
       },
       {
-        "exceeds": true,
+        "exceeds": false,
         "scored": {
           "complexity": 4,
           "complexity_metric": "cognitive",
@@ -1325,10 +1324,10 @@ expression: pretty
               "nesting_depth": 1
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
-            "risk_level": "moderate",
-            "value": 20.0
+            "risk_level": "low",
+            "value": 4.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -1344,7 +1343,7 @@ expression: pretty
         "threshold": 8.0
       },
       {
-        "exceeds": true,
+        "exceeds": false,
         "scored": {
           "complexity": 3,
           "complexity_metric": "cognitive",
@@ -1366,10 +1365,10 @@ expression: pretty
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
-            "risk_level": "acceptable",
-            "value": 12.0
+            "risk_level": "low",
+            "value": 3.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -1399,10 +1398,10 @@ expression: pretty
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 6.0
+            "value": 2.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -1423,10 +1422,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -1447,10 +1446,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -1471,10 +1470,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -1504,10 +1503,10 @@ expression: pretty
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 6.0
+            "value": 2.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -1528,10 +1527,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -1561,10 +1560,10 @@ expression: pretty
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 6.0
+            "value": 2.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -1585,10 +1584,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -1609,10 +1608,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -1633,10 +1632,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -1657,10 +1656,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -1681,10 +1680,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -1705,10 +1704,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 50.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.13
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -1729,10 +1728,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -1753,10 +1752,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -1777,10 +1776,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -1801,10 +1800,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -1825,10 +1824,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -1849,10 +1848,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -1873,10 +1872,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -1897,10 +1896,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -1921,10 +1920,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -1945,10 +1944,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -1969,10 +1968,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -1993,10 +1992,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -2017,10 +2016,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -2041,10 +2040,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -2065,10 +2064,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -2089,10 +2088,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -2113,10 +2112,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -2137,10 +2136,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -2161,10 +2160,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -2185,10 +2184,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -2209,10 +2208,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -2233,10 +2232,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -2257,10 +2256,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -2281,10 +2280,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -2305,10 +2304,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -2329,10 +2328,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -2353,10 +2352,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -2377,10 +2376,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -2401,10 +2400,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -2425,10 +2424,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -2449,10 +2448,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -2473,10 +2472,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -2497,10 +2496,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -2521,10 +2520,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -2545,10 +2544,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -2569,10 +2568,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -2593,10 +2592,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -2617,10 +2616,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -2641,10 +2640,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -2660,7 +2659,7 @@ expression: pretty
         "threshold": 8.0
       },
       {
-        "exceeds": true,
+        "exceeds": false,
         "scored": {
           "complexity": 3,
           "complexity_metric": "cognitive",
@@ -2682,10 +2681,10 @@ expression: pretty
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
-            "risk_level": "acceptable",
-            "value": 12.0
+            "risk_level": "low",
+            "value": 3.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -2706,10 +2705,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -2730,10 +2729,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -2763,10 +2762,10 @@ expression: pretty
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 6.0
+            "value": 2.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -2787,10 +2786,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -2820,10 +2819,10 @@ expression: pretty
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 6.0
+            "value": 2.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -2844,10 +2843,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -2868,10 +2867,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -2892,10 +2891,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -2925,10 +2924,10 @@ expression: pretty
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 6.0
+            "value": 2.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -2949,10 +2948,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -2973,10 +2972,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -2997,10 +2996,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -3021,10 +3020,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -3045,10 +3044,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -3069,10 +3068,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -3093,10 +3092,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -3117,10 +3116,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -3141,10 +3140,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -3165,10 +3164,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -3189,10 +3188,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -3213,10 +3212,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -3237,10 +3236,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -3261,10 +3260,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -3285,10 +3284,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -3309,10 +3308,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -3333,10 +3332,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -3357,10 +3356,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -3381,10 +3380,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -3405,10 +3404,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -3429,10 +3428,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -3462,10 +3461,10 @@ expression: pretty
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 6.0
+            "value": 2.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -3486,10 +3485,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
@@ -3507,22 +3506,104 @@ expression: pretty
       {
         "exceeds": false,
         "scored": {
-          "complexity": 1,
+          "complexity": 3,
           "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
+          "contributors": [
+            {
+              "column": 9,
+              "end_line": 82,
+              "increment": 1,
+              "kind": "if-branch",
+              "line": 80,
+              "nesting_depth": 0
+            },
+            {
+              "column": 9,
+              "end_line": 89,
+              "increment": 1,
+              "kind": "if-branch",
+              "line": 87,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 3.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
             "qualified_name": "LcovParser::normalize_path",
             "span": {
               "end_column": 5,
-              "end_line": 54,
+              "end_line": 96,
               "start_column": 5,
               "start_line": 45
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 8,
+          "complexity_metric": "cognitive",
+          "contributors": [
+            {
+              "column": 5,
+              "end_line": 127,
+              "increment": 1,
+              "kind": "for-loop",
+              "line": 115,
+              "nesting_depth": 0
+            },
+            {
+              "column": 9,
+              "end_line": 122,
+              "increment": 2,
+              "kind": "if-branch",
+              "line": 117,
+              "nesting_depth": 1
+            },
+            {
+              "column": 13,
+              "end_line": 121,
+              "increment": 1,
+              "kind": "continue",
+              "line": 121,
+              "nesting_depth": 2
+            },
+            {
+              "column": 9,
+              "end_line": 126,
+              "increment": 2,
+              "kind": "if-branch",
+              "line": 124,
+              "nesting_depth": 1
+            },
+            {
+              "column": 44,
+              "end_line": 124,
+              "increment": 1,
+              "kind": "logical-operator",
+              "line": 124,
+              "nesting_depth": 1
+            }
+          ],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 8.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "suffix_match_under",
+            "span": {
+              "end_column": 1,
+              "end_line": 129,
+              "start_column": 1,
+              "start_line": 99
             }
           }
         },
@@ -3536,26 +3617,26 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 71,
+              "end_line": 145,
               "increment": 1,
               "kind": "for-loop",
-              "line": 69,
+              "line": 143,
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 6.0
+            "value": 2.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
             "qualified_name": "LcovParser::parse_str",
             "span": {
               "end_column": 5,
-              "end_line": 75,
+              "end_line": 149,
               "start_column": 5,
-              "start_line": 58
+              "start_line": 132
             }
           }
         },
@@ -3569,26 +3650,26 @@ expression: pretty
           "contributors": [
             {
               "column": 72,
-              "end_line": 112,
+              "end_line": 186,
               "increment": 1,
               "kind": "try",
-              "line": 112,
+              "line": 186,
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 6.0
+            "value": 2.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
             "qualified_name": "LcovParser::parse",
             "span": {
               "end_column": 5,
-              "end_line": 114,
+              "end_line": 188,
               "start_column": 5,
-              "start_line": 81
+              "start_line": 155
             }
           }
         },
@@ -3602,123 +3683,123 @@ expression: pretty
           "contributors": [
             {
               "column": 73,
-              "end_line": 129,
+              "end_line": 203,
               "increment": 1,
               "kind": "try",
-              "line": 129,
+              "line": 203,
               "nesting_depth": 0
             },
             {
               "column": 9,
-              "end_line": 146,
+              "end_line": 220,
               "increment": 1,
               "kind": "for-loop",
-              "line": 132,
+              "line": 206,
               "nesting_depth": 0
             },
             {
               "column": 68,
-              "end_line": 133,
+              "end_line": 207,
               "increment": 1,
               "kind": "try",
-              "line": 133,
+              "line": 207,
               "nesting_depth": 1
             },
             {
               "column": 13,
-              "end_line": 137,
+              "end_line": 211,
               "increment": 2,
               "kind": "if-branch",
-              "line": 134,
+              "line": 208,
               "nesting_depth": 1
             },
             {
               "column": 17,
-              "end_line": 136,
+              "end_line": 210,
               "increment": 1,
               "kind": "continue",
-              "line": 136,
+              "line": 210,
               "nesting_depth": 2
             },
             {
               "column": 13,
-              "end_line": 145,
+              "end_line": 219,
               "increment": 2,
               "kind": "if-branch",
-              "line": 138,
+              "line": 212,
               "nesting_depth": 1
             },
             {
               "column": 17,
-              "end_line": 139,
+              "end_line": 213,
               "increment": 1,
               "kind": "logical-operator",
-              "line": 139,
+              "line": 213,
               "nesting_depth": 1
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
-            "risk_level": "high",
-            "value": 110.0
+            "risk_level": "acceptable",
+            "value": 10.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
             "qualified_name": "LcovParser::validate",
             "span": {
               "end_column": 5,
-              "end_line": 148,
+              "end_line": 222,
               "start_column": 5,
-              "start_line": 116
+              "start_line": 190
             }
           }
         },
         "threshold": 8.0
       },
       {
-        "exceeds": true,
+        "exceeds": false,
         "scored": {
           "complexity": 4,
           "complexity_metric": "cognitive",
           "contributors": [
             {
               "column": 5,
-              "end_line": 155,
+              "end_line": 229,
               "increment": 1,
               "kind": "if-branch",
-              "line": 152,
+              "line": 226,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 160,
+              "end_line": 234,
               "increment": 1,
               "kind": "if-branch",
-              "line": 157,
+              "line": 231,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 164,
+              "end_line": 238,
               "increment": 1,
               "kind": "if-branch",
-              "line": 162,
+              "line": 236,
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
-            "risk_level": "moderate",
-            "value": 20.0
+            "risk_level": "low",
+            "value": 4.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
             "qualified_name": "handle_parse_line",
             "span": {
               "end_column": 1,
-              "end_line": 165,
+              "end_line": 239,
               "start_column": 1,
-              "start_line": 151
+              "start_line": 225
             }
           }
         },
@@ -3732,108 +3813,108 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 177,
+              "end_line": 251,
               "increment": 1,
               "kind": "if-branch",
-              "line": 170,
+              "line": 244,
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 6.0
+            "value": 2.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
             "qualified_name": "start_source_file",
             "span": {
               "end_column": 1,
-              "end_line": 178,
+              "end_line": 252,
               "start_column": 1,
-              "start_line": 167
+              "start_line": 241
             }
           }
         },
         "threshold": 8.0
       },
       {
-        "exceeds": true,
+        "exceeds": false,
         "scored": {
           "complexity": 3,
           "complexity_metric": "cognitive",
           "contributors": [
             {
               "column": 5,
-              "end_line": 183,
+              "end_line": 257,
               "increment": 1,
               "kind": "if-branch",
-              "line": 181,
+              "line": 255,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 188,
+              "end_line": 262,
               "increment": 1,
               "kind": "match",
-              "line": 185,
+              "line": 259,
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 80.0,
           "crap": {
-            "risk_level": "acceptable",
-            "value": 12.0
+            "risk_level": "low",
+            "value": 3.07
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
             "qualified_name": "record_da",
             "span": {
               "end_column": 1,
-              "end_line": 189,
+              "end_line": 263,
               "start_column": 1,
-              "start_line": 180
+              "start_line": 254
             }
           }
         },
         "threshold": 8.0
       },
       {
-        "exceeds": true,
+        "exceeds": false,
         "scored": {
           "complexity": 3,
           "complexity_metric": "cognitive",
           "contributors": [
             {
               "column": 5,
-              "end_line": 194,
+              "end_line": 268,
               "increment": 1,
               "kind": "if-branch",
-              "line": 192,
+              "line": 266,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 201,
+              "end_line": 275,
               "increment": 1,
               "kind": "match",
-              "line": 196,
+              "line": 270,
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
-            "risk_level": "acceptable",
-            "value": 12.0
+            "risk_level": "low",
+            "value": 3.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
             "qualified_name": "record_brda",
             "span": {
               "end_column": 1,
-              "end_line": 202,
+              "end_line": 276,
               "start_column": 1,
-              "start_line": 191
+              "start_line": 265
             }
           }
         },
@@ -3845,84 +3926,84 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
             "qualified_name": "push_malformed_record",
             "span": {
               "end_column": 1,
-              "end_line": 211,
+              "end_line": 285,
               "start_column": 1,
-              "start_line": 204
+              "start_line": 278
             }
           }
         },
         "threshold": 8.0
       },
       {
-        "exceeds": true,
+        "exceeds": false,
         "scored": {
           "complexity": 6,
           "complexity_metric": "cognitive",
           "contributors": [
             {
               "column": 56,
-              "end_line": 216,
+              "end_line": 290,
               "increment": 1,
               "kind": "try",
-              "line": 216,
+              "line": 290,
               "nesting_depth": 0
             },
             {
               "column": 52,
-              "end_line": 218,
+              "end_line": 292,
               "increment": 1,
               "kind": "try",
-              "line": 218,
+              "line": 292,
               "nesting_depth": 0
             },
             {
               "column": 58,
-              "end_line": 219,
+              "end_line": 293,
               "increment": 1,
               "kind": "try",
-              "line": 219,
+              "line": 293,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 222,
+              "end_line": 296,
               "increment": 1,
               "kind": "if-branch",
-              "line": 220,
+              "line": 294,
               "nesting_depth": 0
             },
             {
               "column": 53,
-              "end_line": 223,
+              "end_line": 297,
               "increment": 1,
               "kind": "try",
-              "line": 223,
+              "line": 297,
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
-            "risk_level": "high",
-            "value": 42.0
+            "risk_level": "low",
+            "value": 6.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
             "qualified_name": "parse_da",
             "span": {
               "end_column": 1,
-              "end_line": 225,
+              "end_line": 299,
               "start_column": 1,
-              "start_line": 213
+              "start_line": 287
             }
           }
         },
@@ -3936,98 +4017,98 @@ expression: pretty
           "contributors": [
             {
               "column": 42,
-              "end_line": 232,
+              "end_line": 306,
               "increment": 1,
               "kind": "try",
-              "line": 232,
+              "line": 306,
               "nesting_depth": 0
             },
             {
               "column": 43,
-              "end_line": 233,
+              "end_line": 307,
               "increment": 1,
               "kind": "try",
-              "line": 233,
+              "line": 307,
               "nesting_depth": 0
             },
             {
               "column": 44,
-              "end_line": 234,
+              "end_line": 308,
               "increment": 1,
               "kind": "try",
-              "line": 234,
+              "line": 308,
               "nesting_depth": 0
             },
             {
               "column": 43,
-              "end_line": 235,
+              "end_line": 309,
               "increment": 1,
               "kind": "try",
-              "line": 235,
+              "line": 309,
               "nesting_depth": 0
             },
             {
               "column": 58,
-              "end_line": 237,
+              "end_line": 311,
               "increment": 1,
               "kind": "try",
-              "line": 237,
+              "line": 311,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 240,
+              "end_line": 314,
               "increment": 1,
               "kind": "if-branch",
-              "line": 238,
+              "line": 312,
               "nesting_depth": 0
             },
             {
               "column": 55,
-              "end_line": 241,
+              "end_line": 315,
               "increment": 1,
               "kind": "try",
-              "line": 241,
+              "line": 315,
               "nesting_depth": 0
             },
             {
               "column": 57,
-              "end_line": 242,
+              "end_line": 316,
               "increment": 1,
               "kind": "try",
-              "line": 242,
+              "line": 316,
               "nesting_depth": 0
             },
             {
               "column": 17,
-              "end_line": 247,
+              "end_line": 321,
               "increment": 1,
               "kind": "if-branch",
-              "line": 243,
+              "line": 317,
               "nesting_depth": 0
             },
             {
               "column": 54,
-              "end_line": 246,
+              "end_line": 320,
               "increment": 1,
               "kind": "try",
-              "line": 246,
+              "line": 320,
               "nesting_depth": 1
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 93.33333333333331,
           "crap": {
-            "risk_level": "high",
-            "value": 132.0
+            "risk_level": "acceptable",
+            "value": 11.04
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
             "qualified_name": "parse_brda",
             "span": {
               "end_column": 1,
-              "end_line": 250,
+              "end_line": 324,
               "start_column": 1,
-              "start_line": 227
+              "start_line": 301
             }
           }
         },
@@ -4041,108 +4122,108 @@ expression: pretty
           "contributors": [
             {
               "column": 52,
-              "end_line": 256,
+              "end_line": 330,
               "increment": 1,
               "kind": "let-else",
-              "line": 253,
+              "line": 327,
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 6.0
+            "value": 2.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
             "qualified_name": "flush_block",
             "span": {
               "end_column": 1,
-              "end_line": 261,
+              "end_line": 335,
               "start_column": 1,
-              "start_line": 252
+              "start_line": 326
             }
           }
         },
         "threshold": 8.0
       },
       {
-        "exceeds": true,
+        "exceeds": false,
         "scored": {
           "complexity": 3,
           "complexity_metric": "cognitive",
           "contributors": [
             {
               "column": 5,
-              "end_line": 270,
+              "end_line": 344,
               "increment": 1,
               "kind": "if-branch",
-              "line": 268,
+              "line": 342,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 275,
+              "end_line": 349,
               "increment": 1,
               "kind": "for-loop",
-              "line": 273,
+              "line": 347,
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
-            "risk_level": "acceptable",
-            "value": 12.0
+            "risk_level": "low",
+            "value": 3.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
             "qualified_name": "merge_line_block",
             "span": {
               "end_column": 1,
-              "end_line": 276,
+              "end_line": 350,
               "start_column": 1,
-              "start_line": 263
+              "start_line": 337
             }
           }
         },
         "threshold": 8.0
       },
       {
-        "exceeds": true,
+        "exceeds": false,
         "scored": {
           "complexity": 3,
           "complexity_metric": "cognitive",
           "contributors": [
             {
               "column": 5,
-              "end_line": 285,
+              "end_line": 359,
               "increment": 1,
               "kind": "if-branch",
-              "line": 283,
+              "line": 357,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 290,
+              "end_line": 364,
               "increment": 1,
               "kind": "for-loop",
-              "line": 288,
+              "line": 362,
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
-            "risk_level": "acceptable",
-            "value": 12.0
+            "risk_level": "low",
+            "value": 3.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
             "qualified_name": "merge_branch_block",
             "span": {
               "end_column": 1,
-              "end_line": 291,
+              "end_line": 365,
               "start_column": 1,
-              "start_line": 278
+              "start_line": 352
             }
           }
         },
@@ -4154,19 +4235,19 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
             "qualified_name": "merge_hits",
             "span": {
               "end_column": 1,
-              "end_line": 298,
+              "end_line": 372,
               "start_column": 1,
-              "start_line": 293
+              "start_line": 367
             }
           }
         },
@@ -4178,19 +4259,19 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
             "qualified_name": "merge_branch_value",
             "span": {
               "end_column": 1,
-              "end_line": 309,
+              "end_line": 383,
               "start_column": 1,
-              "start_line": 300
+              "start_line": 374
             }
           }
         },
@@ -4204,26 +4285,26 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 317,
+              "end_line": 391,
               "increment": 1,
               "kind": "match",
-              "line": 312,
+              "line": 386,
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 6.0
+            "value": 2.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
             "qualified_name": "merge_taken",
             "span": {
               "end_column": 1,
-              "end_line": 318,
+              "end_line": 392,
               "start_column": 1,
-              "start_line": 311
+              "start_line": 385
             }
           }
         },
@@ -4235,186 +4316,18 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
             "qualified_name": "clear_current_block",
             "span": {
               "end_column": 1,
-              "end_line": 323,
-              "start_column": 1,
-              "start_line": 320
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "build_parse_output",
-            "span": {
-              "end_column": 1,
-              "end_line": 351,
-              "start_column": 1,
-              "start_line": 325
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "to_line_coverage",
-            "span": {
-              "end_column": 1,
-              "end_line": 358,
-              "start_column": 1,
-              "start_line": 353
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "parser",
-            "span": {
-              "end_column": 5,
-              "end_line": 367,
-              "start_column": 5,
-              "start_line": 365
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "parse",
-            "span": {
-              "end_column": 5,
-              "end_line": 371,
-              "start_column": 5,
-              "start_line": 369
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "empty_input_returns_empty_output",
-            "span": {
-              "end_column": 5,
-              "end_line": 378,
-              "start_column": 5,
-              "start_line": 373
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "validate_str",
-            "span": {
-              "end_column": 5,
-              "end_line": 392,
-              "start_column": 5,
-              "start_line": 382
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "validate_empty_input_rejected",
-            "span": {
-              "end_column": 5,
               "end_line": 397,
-              "start_column": 5,
+              "start_column": 1,
               "start_line": 394
             }
           }
@@ -4427,18 +4340,18 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "validate_no_da_lines_rejected",
+            "qualified_name": "build_parse_output",
             "span": {
-              "end_column": 5,
-              "end_line": 402,
-              "start_column": 5,
+              "end_column": 1,
+              "end_line": 425,
+              "start_column": 1,
               "start_line": 399
             }
           }
@@ -4451,233 +4364,185 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "to_line_coverage",
+            "span": {
+              "end_column": 1,
+              "end_line": 432,
+              "start_column": 1,
+              "start_line": 427
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "parser",
+            "span": {
+              "end_column": 5,
+              "end_line": 441,
+              "start_column": 5,
+              "start_line": 439
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "parse",
+            "span": {
+              "end_column": 5,
+              "end_line": 445,
+              "start_column": 5,
+              "start_line": 443
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "empty_input_returns_empty_output",
+            "span": {
+              "end_column": 5,
+              "end_line": 452,
+              "start_column": 5,
+              "start_line": 447
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "validate_str",
+            "span": {
+              "end_column": 5,
+              "end_line": 466,
+              "start_column": 5,
+              "start_line": 456
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "validate_empty_input_rejected",
+            "span": {
+              "end_column": 5,
+              "end_line": 471,
+              "start_column": 5,
+              "start_line": 468
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "validate_no_da_lines_rejected",
+            "span": {
+              "end_column": 5,
+              "end_line": 476,
+              "start_column": 5,
+              "start_line": 473
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
             "qualified_name": "validate_da_outside_sf_block_rejected",
             "span": {
               "end_column": 5,
-              "end_line": 407,
-              "start_column": 5,
-              "start_line": 404
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "validate_malformed_da_rejected",
-            "span": {
-              "end_column": 5,
-              "end_line": 412,
-              "start_column": 5,
-              "start_line": 409
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "validate_single_da_inside_sf_block_passes",
-            "span": {
-              "end_column": 5,
-              "end_line": 417,
-              "start_column": 5,
-              "start_line": 414
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "validate_first_da_in_second_block_passes",
-            "span": {
-              "end_column": 5,
-              "end_line": 427,
-              "start_column": 5,
-              "start_line": 419
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "validate_missing_path_returns_open_error",
-            "span": {
-              "end_column": 5,
-              "end_line": 439,
-              "start_column": 5,
-              "start_line": 429
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "single_file_single_da",
-            "span": {
-              "end_column": 5,
-              "end_line": 449,
-              "start_column": 5,
-              "start_line": 441
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "multiple_da_lines",
-            "span": {
-              "end_column": 5,
-              "end_line": 459,
-              "start_column": 5,
-              "start_line": 451
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "multiple_source_files",
-            "span": {
-              "end_column": 5,
-              "end_line": 468,
-              "start_column": 5,
-              "start_line": 461
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "hit_count_preservation",
-            "span": {
-              "end_column": 5,
-              "end_line": 476,
-              "start_column": 5,
-              "start_line": 470
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "path_normalization_strips_prefix",
-            "span": {
-              "end_column": 5,
-              "end_line": 482,
+              "end_line": 481,
               "start_column": 5,
               "start_line": 478
             }
@@ -4691,19 +4556,19 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "non_matching_path_passes_through",
+            "qualified_name": "validate_malformed_da_rejected",
             "span": {
               "end_column": 5,
-              "end_line": 488,
+              "end_line": 486,
               "start_column": 5,
-              "start_line": 484
+              "start_line": 483
             }
           }
         },
@@ -4715,19 +4580,19 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "backslash_normalized_to_forward_slash",
+            "qualified_name": "validate_single_da_inside_sf_block_passes",
             "span": {
               "end_column": 5,
-              "end_line": 495,
+              "end_line": 491,
               "start_column": 5,
-              "start_line": 490
+              "start_line": 488
             }
           }
         },
@@ -4739,19 +4604,19 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "path_boundary_not_confused_by_prefix_substring",
+            "qualified_name": "validate_first_da_in_second_block_passes",
             "span": {
               "end_column": 5,
               "end_line": 501,
               "start_column": 5,
-              "start_line": 497
+              "start_line": 493
             }
           }
         },
@@ -4763,17 +4628,17 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "repeated_sf_blocks_merge_coverage",
+            "qualified_name": "validate_missing_path_returns_open_error",
             "span": {
               "end_column": 5,
-              "end_line": 515,
+              "end_line": 513,
               "start_column": 5,
               "start_line": 503
             }
@@ -4787,19 +4652,235 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "single_file_single_da",
+            "span": {
+              "end_column": 5,
+              "end_line": 523,
+              "start_column": 5,
+              "start_line": 515
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "multiple_da_lines",
+            "span": {
+              "end_column": 5,
+              "end_line": 533,
+              "start_column": 5,
+              "start_line": 525
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "multiple_source_files",
+            "span": {
+              "end_column": 5,
+              "end_line": 542,
+              "start_column": 5,
+              "start_line": 535
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "hit_count_preservation",
+            "span": {
+              "end_column": 5,
+              "end_line": 550,
+              "start_column": 5,
+              "start_line": 544
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "path_normalization_strips_prefix",
+            "span": {
+              "end_column": 5,
+              "end_line": 556,
+              "start_column": 5,
+              "start_line": 552
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "non_matching_path_passes_through",
+            "span": {
+              "end_column": 5,
+              "end_line": 562,
+              "start_column": 5,
+              "start_line": 558
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "backslash_normalized_to_forward_slash",
+            "span": {
+              "end_column": 5,
+              "end_line": 569,
+              "start_column": 5,
+              "start_line": 564
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "path_boundary_not_confused_by_prefix_substring",
+            "span": {
+              "end_column": 5,
+              "end_line": 575,
+              "start_column": 5,
+              "start_line": 571
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "repeated_sf_blocks_merge_coverage",
+            "span": {
+              "end_column": 5,
+              "end_line": 589,
+              "start_column": 5,
+              "start_line": 577
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
             "qualified_name": "duplicate_da_lines_sum_hits",
             "span": {
               "end_column": 5,
-              "end_line": 524,
+              "end_line": 598,
               "start_column": 5,
-              "start_line": 517
+              "start_line": 591
             }
           }
         },
@@ -4811,19 +4892,19 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
             "qualified_name": "duplicate_da_multiple_lines_sum_correctly",
             "span": {
               "end_column": 5,
-              "end_line": 536,
+              "end_line": 610,
               "start_column": 5,
-              "start_line": 526
+              "start_line": 600
             }
           }
         },
@@ -4837,26 +4918,26 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 552,
+              "end_line": 626,
               "increment": 1,
               "kind": "match",
-              "line": 543,
+              "line": 617,
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 6.0
+            "value": 2.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
             "qualified_name": "malformed_da_produces_diagnostic",
             "span": {
               "end_column": 5,
-              "end_line": 553,
+              "end_line": 627,
               "start_column": 5,
-              "start_line": 538
+              "start_line": 612
             }
           }
         },
@@ -4868,19 +4949,19 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
             "qualified_name": "malformed_da_does_not_stop_parsing",
             "span": {
               "end_column": 5,
-              "end_line": 561,
+              "end_line": 635,
               "start_column": 5,
-              "start_line": 555
+              "start_line": 629
             }
           }
         },
@@ -4892,194 +4973,17 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
             "qualified_name": "da_missing_hit_count_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 571,
-              "start_column": 5,
-              "start_line": 563
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "da_negative_hit_count_is_malformed",
-            "span": {
-              "end_column": 5,
-              "end_line": 581,
-              "start_column": 5,
-              "start_line": 573
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 2,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 9,
-              "end_line": 596,
-              "increment": 1,
-              "kind": "match",
-              "line": 587,
-              "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 6.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "da_line_zero_is_malformed",
-            "span": {
-              "end_column": 5,
-              "end_line": 597,
-              "start_column": 5,
-              "start_line": 583
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "end_of_record_is_ignored",
-            "span": {
-              "end_column": 5,
-              "end_line": 608,
-              "start_column": 5,
-              "start_line": 599
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "unterminated_final_block_emits_data",
-            "span": {
-              "end_column": 5,
-              "end_line": 615,
-              "start_column": 5,
-              "start_line": 610
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "empty_sf_path_emits_diagnostic",
-            "span": {
-              "end_column": 5,
-              "end_line": 626,
-              "start_column": 5,
-              "start_line": 617
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "da_with_checksum_field_is_accepted",
-            "span": {
-              "end_column": 5,
-              "end_line": 635,
-              "start_column": 5,
-              "start_line": 628
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "non_coverage_records_are_ignored",
-            "span": {
-              "end_column": 5,
-              "end_line": 649,
+              "end_line": 645,
               "start_column": 5,
               "start_line": 637
             }
@@ -5093,139 +4997,19 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "brda_and_da_records_parsed",
+            "qualified_name": "da_negative_hit_count_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 661,
+              "end_line": 655,
               "start_column": 5,
-              "start_line": 653
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "brda_dash_maps_to_none",
-            "span": {
-              "end_column": 5,
-              "end_line": 668,
-              "start_column": 5,
-              "start_line": 663
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "brda_numeric_maps_to_some",
-            "span": {
-              "end_column": 5,
-              "end_line": 675,
-              "start_column": 5,
-              "start_line": 670
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "brda_zero_maps_to_some_zero",
-            "span": {
-              "end_column": 5,
-              "end_line": 682,
-              "start_column": 5,
-              "start_line": 677
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "duplicate_brda_sum_taken",
-            "span": {
-              "end_column": 5,
-              "end_line": 692,
-              "start_column": 5,
-              "start_line": 684
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "brda_dash_and_numeric_merge",
-            "span": {
-              "end_column": 5,
-              "end_line": 700,
-              "start_column": 5,
-              "start_line": 694
+              "start_line": 647
             }
           }
         },
@@ -5239,24 +5023,120 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 715,
+              "end_line": 670,
               "increment": 1,
               "kind": "match",
-              "line": 706,
+              "line": 661,
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 6.0
+            "value": 2.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "malformed_brda_produces_diagnostic",
+            "qualified_name": "da_line_zero_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 716,
+              "end_line": 671,
+              "start_column": 5,
+              "start_line": 657
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "end_of_record_is_ignored",
+            "span": {
+              "end_column": 5,
+              "end_line": 682,
+              "start_column": 5,
+              "start_line": 673
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "unterminated_final_block_emits_data",
+            "span": {
+              "end_column": 5,
+              "end_line": 689,
+              "start_column": 5,
+              "start_line": 684
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "empty_sf_path_emits_diagnostic",
+            "span": {
+              "end_column": 5,
+              "end_line": 700,
+              "start_column": 5,
+              "start_line": 691
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "da_with_checksum_field_is_accepted",
+            "span": {
+              "end_column": 5,
+              "end_line": 709,
               "start_column": 5,
               "start_line": 702
             }
@@ -5270,19 +5150,19 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "brda_missing_fields_is_malformed",
+            "qualified_name": "non_coverage_records_are_ignored",
             "span": {
               "end_column": 5,
-              "end_line": 727,
+              "end_line": 723,
               "start_column": 5,
-              "start_line": 718
+              "start_line": 711
             }
           }
         },
@@ -5294,19 +5174,220 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "brda_and_da_records_parsed",
+            "span": {
+              "end_column": 5,
+              "end_line": 735,
+              "start_column": 5,
+              "start_line": 727
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "brda_dash_maps_to_none",
+            "span": {
+              "end_column": 5,
+              "end_line": 742,
+              "start_column": 5,
+              "start_line": 737
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "brda_numeric_maps_to_some",
+            "span": {
+              "end_column": 5,
+              "end_line": 749,
+              "start_column": 5,
+              "start_line": 744
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "brda_zero_maps_to_some_zero",
+            "span": {
+              "end_column": 5,
+              "end_line": 756,
+              "start_column": 5,
+              "start_line": 751
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "duplicate_brda_sum_taken",
+            "span": {
+              "end_column": 5,
+              "end_line": 766,
+              "start_column": 5,
+              "start_line": 758
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "brda_dash_and_numeric_merge",
+            "span": {
+              "end_column": 5,
+              "end_line": 774,
+              "start_column": 5,
+              "start_line": 768
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 2,
+          "complexity_metric": "cognitive",
+          "contributors": [
+            {
+              "column": 9,
+              "end_line": 789,
+              "increment": 1,
+              "kind": "match",
+              "line": 780,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
             "value": 2.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "malformed_brda_produces_diagnostic",
+            "span": {
+              "end_column": 5,
+              "end_line": 790,
+              "start_column": 5,
+              "start_line": 776
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "brda_missing_fields_is_malformed",
+            "span": {
+              "end_column": 5,
+              "end_line": 801,
+              "start_column": 5,
+              "start_line": 792
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
             "qualified_name": "brda_missing_taken_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 738,
+              "end_line": 812,
               "start_column": 5,
-              "start_line": 729
+              "start_line": 803
             }
           }
         },
@@ -5320,26 +5401,26 @@ expression: pretty
           "contributors": [
             {
               "column": 13,
-              "end_line": 757,
+              "end_line": 831,
               "increment": 1,
               "kind": "for-loop",
-              "line": 755,
+              "line": 829,
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 6.0
+            "value": 2.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
             "qualified_name": "repeated_sf_blocks_merge_branch_coverage",
             "span": {
               "end_column": 5,
-              "end_line": 767,
+              "end_line": 841,
               "start_column": 5,
-              "start_line": 740
+              "start_line": 814
             }
           }
         },
@@ -5351,19 +5432,19 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
             "qualified_name": "brda_line_zero_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 777,
+              "end_line": 851,
               "start_column": 5,
-              "start_line": 769
+              "start_line": 843
             }
           }
         },
@@ -5375,19 +5456,19 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
             "qualified_name": "no_brda_produces_none_branches",
             "span": {
               "end_column": 5,
-              "end_line": 783,
+              "end_line": 857,
               "start_column": 5,
-              "start_line": 779
+              "start_line": 853
             }
           }
         },
@@ -5399,52 +5480,52 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
             "qualified_name": "arb_da_line",
             "span": {
               "end_column": 5,
-              "end_line": 793,
+              "end_line": 867,
               "start_column": 5,
-              "start_line": 791
+              "start_line": 865
             }
           }
         },
         "threshold": 8.0
       },
       {
-        "exceeds": true,
+        "exceeds": false,
         "scored": {
           "complexity": 3,
           "complexity_metric": "cognitive",
           "contributors": [
             {
               "column": 13,
-              "end_line": 801,
+              "end_line": 875,
               "increment": 2,
               "kind": "for-loop",
-              "line": 798,
+              "line": 872,
               "nesting_depth": 1
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
-            "risk_level": "acceptable",
-            "value": 12.0
+            "risk_level": "low",
+            "value": 3.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
             "qualified_name": "arb_lcov_block",
             "span": {
               "end_column": 5,
-              "end_line": 805,
+              "end_line": 879,
               "start_column": 5,
-              "start_line": 795
+              "start_line": 869
             }
           }
         },
@@ -5456,19 +5537,19 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
             "qualified_name": "arb_lcov_input",
             "span": {
               "end_column": 5,
-              "end_line": 809,
+              "end_line": 883,
               "start_column": 5,
-              "start_line": 807
+              "start_line": 881
             }
           }
         },
@@ -5528,10 +5609,10 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "main.rs",
@@ -5654,35 +5735,35 @@ expression: pretty
     ],
     "passed": false,
     "summary": {
-      "average_complexity": 1.522167487684729,
-      "average_coverage": 0.0,
-      "average_crap": 5.724137931034483,
+      "average_complexity": 1.5637254901960784,
+      "average_coverage": 94.80431610650024,
+      "average_crap": 1.6434313725490195,
       "distribution": {
-        "acceptable": 9,
-        "high": 6,
-        "low": 183,
-        "moderate": 5
+        "acceptable": 3,
+        "high": 0,
+        "low": 201,
+        "moderate": 0
       },
-      "exceeding_threshold": 20,
+      "exceeding_threshold": 3,
       "max_complexity": 11,
       "max_crap": {
-        "risk_level": "high",
-        "value": 132.0
+        "risk_level": "acceptable",
+        "value": 11.04
       },
       "median_complexity": 1.0,
-      "median_coverage": 0.0,
-      "median_crap": 2.0,
+      "median_coverage": 100.0,
+      "median_crap": 1.0,
       "min_coverage": 0.0,
       "total_files": 5,
-      "total_functions": 203,
+      "total_functions": 204,
       "worst_function": {
         "file_path": "adapters/coverage/mod.rs",
         "qualified_name": "parse_brda",
         "span": {
           "end_column": 1,
-          "end_line": 250,
+          "end_line": 324,
           "start_column": 1,
-          "start_line": 227
+          "start_line": 301
         }
       }
     }
@@ -5692,7 +5773,7 @@ expression: pretty
   "timestamp": "[STRIPPED:timestamp]",
   "tool_version": "[STRIPPED:tool_version]",
   "view": {
-    "eligible_count": 203,
+    "eligible_count": 204,
     "grouped": null,
     "shown": [
       {
@@ -5703,98 +5784,98 @@ expression: pretty
           "contributors": [
             {
               "column": 42,
-              "end_line": 232,
+              "end_line": 306,
               "increment": 1,
               "kind": "try",
-              "line": 232,
+              "line": 306,
               "nesting_depth": 0
             },
             {
               "column": 43,
-              "end_line": 233,
+              "end_line": 307,
               "increment": 1,
               "kind": "try",
-              "line": 233,
+              "line": 307,
               "nesting_depth": 0
             },
             {
               "column": 44,
-              "end_line": 234,
+              "end_line": 308,
               "increment": 1,
               "kind": "try",
-              "line": 234,
+              "line": 308,
               "nesting_depth": 0
             },
             {
               "column": 43,
-              "end_line": 235,
+              "end_line": 309,
               "increment": 1,
               "kind": "try",
-              "line": 235,
+              "line": 309,
               "nesting_depth": 0
             },
             {
               "column": 58,
-              "end_line": 237,
+              "end_line": 311,
               "increment": 1,
               "kind": "try",
-              "line": 237,
+              "line": 311,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 240,
+              "end_line": 314,
               "increment": 1,
               "kind": "if-branch",
-              "line": 238,
+              "line": 312,
               "nesting_depth": 0
             },
             {
               "column": 55,
-              "end_line": 241,
+              "end_line": 315,
               "increment": 1,
               "kind": "try",
-              "line": 241,
+              "line": 315,
               "nesting_depth": 0
             },
             {
               "column": 57,
-              "end_line": 242,
+              "end_line": 316,
               "increment": 1,
               "kind": "try",
-              "line": 242,
+              "line": 316,
               "nesting_depth": 0
             },
             {
               "column": 17,
-              "end_line": 247,
+              "end_line": 321,
               "increment": 1,
               "kind": "if-branch",
-              "line": 243,
+              "line": 317,
               "nesting_depth": 0
             },
             {
               "column": 54,
-              "end_line": 246,
+              "end_line": 320,
               "increment": 1,
               "kind": "try",
-              "line": 246,
+              "line": 320,
               "nesting_depth": 1
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 93.33333333333331,
           "crap": {
-            "risk_level": "high",
-            "value": 132.0
+            "risk_level": "acceptable",
+            "value": 11.04
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
             "qualified_name": "parse_brda",
             "span": {
               "end_column": 1,
-              "end_line": 250,
+              "end_line": 324,
               "start_column": 1,
-              "start_line": 227
+              "start_line": 301
             }
           }
         },
@@ -5808,74 +5889,74 @@ expression: pretty
           "contributors": [
             {
               "column": 73,
-              "end_line": 129,
+              "end_line": 203,
               "increment": 1,
               "kind": "try",
-              "line": 129,
+              "line": 203,
               "nesting_depth": 0
             },
             {
               "column": 9,
-              "end_line": 146,
+              "end_line": 220,
               "increment": 1,
               "kind": "for-loop",
-              "line": 132,
+              "line": 206,
               "nesting_depth": 0
             },
             {
               "column": 68,
-              "end_line": 133,
+              "end_line": 207,
               "increment": 1,
               "kind": "try",
-              "line": 133,
+              "line": 207,
               "nesting_depth": 1
             },
             {
               "column": 13,
-              "end_line": 137,
+              "end_line": 211,
               "increment": 2,
               "kind": "if-branch",
-              "line": 134,
+              "line": 208,
               "nesting_depth": 1
             },
             {
               "column": 17,
-              "end_line": 136,
+              "end_line": 210,
               "increment": 1,
               "kind": "continue",
-              "line": 136,
+              "line": 210,
               "nesting_depth": 2
             },
             {
               "column": 13,
-              "end_line": 145,
+              "end_line": 219,
               "increment": 2,
               "kind": "if-branch",
-              "line": 138,
+              "line": 212,
               "nesting_depth": 1
             },
             {
               "column": 17,
-              "end_line": 139,
+              "end_line": 213,
               "increment": 1,
               "kind": "logical-operator",
-              "line": 139,
+              "line": 213,
               "nesting_depth": 1
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
-            "risk_level": "high",
-            "value": 110.0
+            "risk_level": "acceptable",
+            "value": 10.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
             "qualified_name": "LcovParser::validate",
             "span": {
               "end_column": 5,
-              "end_line": 148,
+              "end_line": 222,
               "start_column": 5,
-              "start_line": 116
+              "start_line": 190
             }
           }
         },
@@ -5920,10 +6001,10 @@ expression: pretty
               "nesting_depth": 2
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 92.5925925925926,
           "crap": {
-            "risk_level": "high",
-            "value": 72.0
+            "risk_level": "acceptable",
+            "value": 8.03
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -5939,7 +6020,72 @@ expression: pretty
         "threshold": 8.0
       },
       {
-        "exceeds": true,
+        "exceeds": false,
+        "scored": {
+          "complexity": 8,
+          "complexity_metric": "cognitive",
+          "contributors": [
+            {
+              "column": 5,
+              "end_line": 127,
+              "increment": 1,
+              "kind": "for-loop",
+              "line": 115,
+              "nesting_depth": 0
+            },
+            {
+              "column": 9,
+              "end_line": 122,
+              "increment": 2,
+              "kind": "if-branch",
+              "line": 117,
+              "nesting_depth": 1
+            },
+            {
+              "column": 13,
+              "end_line": 121,
+              "increment": 1,
+              "kind": "continue",
+              "line": 121,
+              "nesting_depth": 2
+            },
+            {
+              "column": 9,
+              "end_line": 126,
+              "increment": 2,
+              "kind": "if-branch",
+              "line": 124,
+              "nesting_depth": 1
+            },
+            {
+              "column": 44,
+              "end_line": 124,
+              "increment": 1,
+              "kind": "logical-operator",
+              "line": 124,
+              "nesting_depth": 1
+            }
+          ],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 8.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "suffix_match_under",
+            "span": {
+              "end_column": 1,
+              "end_line": 129,
+              "start_column": 1,
+              "start_line": 99
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
         "scored": {
           "complexity": 7,
           "complexity_metric": "cognitive",
@@ -5969,10 +6115,10 @@ expression: pretty
               "nesting_depth": 2
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 82.6086956521739,
           "crap": {
-            "risk_level": "high",
-            "value": 56.0
+            "risk_level": "low",
+            "value": 7.26
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -5988,7 +6134,7 @@ expression: pretty
         "threshold": 8.0
       },
       {
-        "exceeds": true,
+        "exceeds": false,
         "scored": {
           "complexity": 7,
           "complexity_metric": "cognitive",
@@ -6018,10 +6164,10 @@ expression: pretty
               "nesting_depth": 2
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 82.75862068965517,
           "crap": {
-            "risk_level": "high",
-            "value": 56.0
+            "risk_level": "low",
+            "value": 7.25
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -6037,113 +6183,7 @@ expression: pretty
         "threshold": 8.0
       },
       {
-        "exceeds": true,
-        "scored": {
-          "complexity": 6,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 56,
-              "end_line": 216,
-              "increment": 1,
-              "kind": "try",
-              "line": 216,
-              "nesting_depth": 0
-            },
-            {
-              "column": 52,
-              "end_line": 218,
-              "increment": 1,
-              "kind": "try",
-              "line": 218,
-              "nesting_depth": 0
-            },
-            {
-              "column": 58,
-              "end_line": 219,
-              "increment": 1,
-              "kind": "try",
-              "line": 219,
-              "nesting_depth": 0
-            },
-            {
-              "column": 5,
-              "end_line": 222,
-              "increment": 1,
-              "kind": "if-branch",
-              "line": 220,
-              "nesting_depth": 0
-            },
-            {
-              "column": 53,
-              "end_line": 223,
-              "increment": 1,
-              "kind": "try",
-              "line": 223,
-              "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "high",
-            "value": 42.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "parse_da",
-            "span": {
-              "end_column": 1,
-              "end_line": 225,
-              "start_column": 1,
-              "start_line": 213
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": true,
-        "scored": {
-          "complexity": 4,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 9,
-              "end_line": 125,
-              "increment": 1,
-              "kind": "if-branch",
-              "line": 108,
-              "nesting_depth": 0
-            },
-            {
-              "column": 29,
-              "end_line": 113,
-              "increment": 2,
-              "kind": "match",
-              "line": 110,
-              "nesting_depth": 1
-            }
-          ],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "moderate",
-            "value": 20.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "FunctionFinder::visit_trait_item_fn",
-            "span": {
-              "end_column": 5,
-              "end_line": 128,
-              "start_column": 5,
-              "start_line": 106
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": true,
+        "exceeds": false,
         "scored": {
           "complexity": 4,
           "complexity_metric": "cognitive",
@@ -6165,10 +6205,10 @@ expression: pretty
               "nesting_depth": 1
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 42.10526315789473,
           "crap": {
-            "risk_level": "moderate",
-            "value": 20.0
+            "risk_level": "low",
+            "value": 7.1
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
@@ -6184,1449 +6224,65 @@ expression: pretty
         "threshold": 8.0
       },
       {
-        "exceeds": true,
+        "exceeds": false,
         "scored": {
-          "complexity": 4,
+          "complexity": 6,
           "complexity_metric": "cognitive",
           "contributors": [
             {
-              "column": 5,
-              "end_line": 576,
-              "increment": 1,
-              "kind": "match",
-              "line": 552,
-              "nesting_depth": 0
-            },
-            {
-              "column": 13,
-              "end_line": 568,
-              "increment": 2,
-              "kind": "if-branch",
-              "line": 566,
-              "nesting_depth": 1
-            }
-          ],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "moderate",
-            "value": 20.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "count_cognitive_else",
-            "span": {
-              "end_column": 1,
-              "end_line": 577,
-              "start_column": 1,
-              "start_line": 547
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": true,
-        "scored": {
-          "complexity": 4,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 9,
-              "end_line": 770,
-              "increment": 1,
-              "kind": "if-branch",
-              "line": 761,
-              "nesting_depth": 0
-            },
-            {
-              "column": 13,
-              "end_line": 769,
-              "increment": 2,
-              "kind": "match",
-              "line": 762,
-              "nesting_depth": 1
-            }
-          ],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "moderate",
-            "value": 20.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "CyclomaticCounter::visit_expr_if",
-            "span": {
-              "end_column": 5,
-              "end_line": 771,
-              "start_column": 5,
-              "start_line": 752
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": true,
-        "scored": {
-          "complexity": 4,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 5,
-              "end_line": 155,
-              "increment": 1,
-              "kind": "if-branch",
-              "line": 152,
-              "nesting_depth": 0
-            },
-            {
-              "column": 5,
-              "end_line": 160,
-              "increment": 1,
-              "kind": "if-branch",
-              "line": 157,
-              "nesting_depth": 0
-            },
-            {
-              "column": 5,
-              "end_line": 164,
-              "increment": 1,
-              "kind": "if-branch",
-              "line": 162,
-              "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "moderate",
-            "value": 20.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "handle_parse_line",
-            "span": {
-              "end_column": 1,
-              "end_line": 165,
-              "start_column": 1,
-              "start_line": 151
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": true,
-        "scored": {
-          "complexity": 3,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 5,
-              "end_line": 198,
-              "increment": 1,
-              "kind": "if-branch",
-              "line": 194,
-              "nesting_depth": 0
-            },
-            {
-              "column": 9,
-              "end_line": 195,
-              "increment": 1,
-              "kind": "logical-operator",
-              "line": 195,
-              "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "acceptable",
-            "value": 12.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "extract_type_name",
-            "span": {
-              "end_column": 1,
-              "end_line": 201,
-              "start_column": 1,
-              "start_line": 192
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": true,
-        "scored": {
-          "complexity": 3,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 38,
-              "end_line": 738,
-              "increment": 1,
-              "kind": "let-else",
-              "line": 736,
-              "nesting_depth": 0
-            },
-            {
-              "column": 9,
-              "end_line": 749,
-              "increment": 1,
-              "kind": "if-branch",
-              "line": 741,
-              "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "acceptable",
-            "value": 12.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "CyclomaticCounter::visit_local",
-            "span": {
-              "end_column": 5,
-              "end_line": 750,
-              "start_column": 5,
-              "start_line": 735
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": true,
-        "scored": {
-          "complexity": 3,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 9,
-              "end_line": 781,
-              "increment": 1,
-              "kind": "for-loop",
-              "line": 774,
-              "nesting_depth": 0
-            },
-            {
-              "column": 9,
-              "end_line": 786,
-              "increment": 1,
-              "kind": "for-loop",
-              "line": 784,
-              "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "acceptable",
-            "value": 12.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "CyclomaticCounter::visit_expr_match",
-            "span": {
-              "end_column": 5,
-              "end_line": 787,
-              "start_column": 5,
-              "start_line": 773
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": true,
-        "scored": {
-          "complexity": 3,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 9,
-              "end_line": 1362,
-              "increment": 1,
-              "kind": "for-loop",
-              "line": 1356,
-              "nesting_depth": 0
-            },
-            {
-              "column": 9,
-              "end_line": 1369,
-              "increment": 1,
-              "kind": "for-loop",
-              "line": 1363,
-              "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "acceptable",
-            "value": 12.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "trait_default_and_concrete_override_have_disjoint_spans",
-            "span": {
-              "end_column": 5,
-              "end_line": 1370,
-              "start_column": 5,
-              "start_line": 1329
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": true,
-        "scored": {
-          "complexity": 3,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 5,
-              "end_line": 183,
-              "increment": 1,
-              "kind": "if-branch",
-              "line": 181,
-              "nesting_depth": 0
-            },
-            {
-              "column": 5,
-              "end_line": 188,
-              "increment": 1,
-              "kind": "match",
-              "line": 185,
-              "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "acceptable",
-            "value": 12.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "record_da",
-            "span": {
-              "end_column": 1,
-              "end_line": 189,
-              "start_column": 1,
-              "start_line": 180
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": true,
-        "scored": {
-          "complexity": 3,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 5,
-              "end_line": 194,
-              "increment": 1,
-              "kind": "if-branch",
-              "line": 192,
-              "nesting_depth": 0
-            },
-            {
-              "column": 5,
-              "end_line": 201,
-              "increment": 1,
-              "kind": "match",
-              "line": 196,
-              "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "acceptable",
-            "value": 12.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "record_brda",
-            "span": {
-              "end_column": 1,
-              "end_line": 202,
-              "start_column": 1,
-              "start_line": 191
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": true,
-        "scored": {
-          "complexity": 3,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 5,
-              "end_line": 270,
-              "increment": 1,
-              "kind": "if-branch",
-              "line": 268,
-              "nesting_depth": 0
-            },
-            {
-              "column": 5,
-              "end_line": 275,
-              "increment": 1,
-              "kind": "for-loop",
-              "line": 273,
-              "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "acceptable",
-            "value": 12.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "merge_line_block",
-            "span": {
-              "end_column": 1,
-              "end_line": 276,
-              "start_column": 1,
-              "start_line": 263
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": true,
-        "scored": {
-          "complexity": 3,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 5,
-              "end_line": 285,
-              "increment": 1,
-              "kind": "if-branch",
-              "line": 283,
-              "nesting_depth": 0
-            },
-            {
-              "column": 5,
+              "column": 56,
               "end_line": 290,
               "increment": 1,
-              "kind": "for-loop",
-              "line": 288,
-              "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "acceptable",
-            "value": 12.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "merge_branch_block",
-            "span": {
-              "end_column": 1,
-              "end_line": 291,
-              "start_column": 1,
-              "start_line": 278
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": true,
-        "scored": {
-          "complexity": 3,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 13,
-              "end_line": 801,
-              "increment": 2,
-              "kind": "for-loop",
-              "line": 798,
-              "nesting_depth": 1
-            }
-          ],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "acceptable",
-            "value": 12.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "arb_lcov_block",
-            "span": {
-              "end_column": 5,
-              "end_line": 805,
-              "start_column": 5,
-              "start_line": 795
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 2,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 78,
-              "end_line": 34,
-              "increment": 1,
               "kind": "try",
-              "line": 34,
+              "line": 290,
               "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 6.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "SynComplexityAdapter::extract",
-            "span": {
-              "end_column": 5,
-              "end_line": 45,
-              "start_column": 5,
-              "start_line": 27
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 2,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 25,
-              "end_line": 90,
-              "increment": 1,
-              "kind": "match",
-              "line": 87,
-              "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 6.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "FunctionFinder::visit_impl_item_fn",
-            "span": {
-              "end_column": 5,
-              "end_line": 104,
-              "start_column": 5,
-              "start_line": 85
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 2,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 15,
-              "end_line": 213,
-              "increment": 1,
-              "kind": "match",
-              "line": 210,
-              "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 6.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "count_complexity",
-            "span": {
-              "end_column": 1,
-              "end_line": 216,
-              "start_column": 1,
-              "start_line": 205
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 2,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 5,
-              "end_line": 290,
-              "increment": 1,
-              "kind": "match",
-              "line": 268,
-              "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 6.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "count_cognitive_expr",
-            "span": {
-              "end_column": 1,
-              "end_line": 291,
-              "start_column": 1,
-              "start_line": 263
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 2,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 5,
-              "end_line": 443,
-              "increment": 1,
-              "kind": "match",
-              "line": 440,
-              "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 6.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "count_cognitive_return",
-            "span": {
-              "end_column": 1,
-              "end_line": 444,
-              "start_column": 1,
-              "start_line": 435
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 2,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 5,
-              "end_line": 464,
-              "increment": 1,
-              "kind": "for-loop",
-              "line": 462,
-              "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 6.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "count_cognitive_call",
-            "span": {
-              "end_column": 1,
-              "end_line": 466,
-              "start_column": 1,
-              "start_line": 456
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 2,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 5,
-              "end_line": 476,
-              "increment": 1,
-              "kind": "for-loop",
-              "line": 474,
-              "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 6.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "count_cognitive_method_call",
-            "span": {
-              "end_column": 1,
-              "end_line": 478,
-              "start_column": 1,
-              "start_line": 468
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 2,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 5,
-              "end_line": 488,
-              "increment": 1,
-              "kind": "for-loop",
-              "line": 486,
-              "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 6.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "count_cognitive_tuple",
-            "span": {
-              "end_column": 1,
-              "end_line": 490,
-              "start_column": 1,
-              "start_line": 480
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 2,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 5,
-              "end_line": 634,
-              "increment": 1,
-              "kind": "match",
-              "line": 628,
-              "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 6.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "count_cognitive_binary_operands",
-            "span": {
-              "end_column": 1,
-              "end_line": 635,
-              "start_column": 1,
-              "start_line": 619
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 2,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 5,
-              "end_line": 649,
-              "increment": 1,
-              "kind": "match",
-              "line": 645,
-              "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 6.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "classify_binop",
-            "span": {
-              "end_column": 1,
-              "end_line": 650,
-              "start_column": 1,
-              "start_line": 644
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 2,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 5,
-              "end_line": 660,
-              "increment": 1,
-              "kind": "match",
-              "line": 653,
-              "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 6.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "binop_span",
-            "span": {
-              "end_column": 1,
-              "end_line": 661,
-              "start_column": 1,
-              "start_line": 652
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 2,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 5,
-              "end_line": 678,
-              "increment": 1,
-              "kind": "if-branch",
-              "line": 674,
-              "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 6.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "flatten_binary_ops_inner",
-            "span": {
-              "end_column": 1,
-              "end_line": 679,
-              "start_column": 1,
-              "start_line": 673
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 2,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 9,
-              "end_line": 732,
-              "increment": 1,
-              "kind": "match",
-              "line": 728,
-              "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 6.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "CyclomaticCounter::visit_stmt",
-            "span": {
-              "end_column": 5,
-              "end_line": 733,
-              "start_column": 5,
-              "start_line": 727
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 2,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 9,
-              "end_line": 792,
-              "increment": 1,
-              "kind": "if-branch",
-              "line": 790,
-              "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 6.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "CyclomaticCounter::visit_arm",
-            "span": {
-              "end_column": 5,
-              "end_line": 794,
-              "start_column": 5,
-              "start_line": 789
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 2,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 9,
-              "end_line": 832,
-              "increment": 1,
-              "kind": "if-branch",
-              "line": 829,
-              "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 6.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "CyclomaticCounter::visit_expr_binary",
-            "span": {
-              "end_column": 5,
-              "end_line": 835,
-              "start_column": 5,
-              "start_line": 828
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 2,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 9,
-              "end_line": 856,
-              "increment": 1,
-              "kind": "if-branch",
-              "line": 854,
-              "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 6.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "CyclomaticCounter::visit_expr_break",
-            "span": {
-              "end_column": 5,
-              "end_line": 857,
-              "start_column": 5,
-              "start_line": 847
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 2,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 9,
-              "end_line": 1398,
-              "increment": 1,
-              "kind": "match",
-              "line": 1395,
-              "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 6.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "invalid_source_returns_error",
-            "span": {
-              "end_column": 5,
-              "end_line": 1399,
-              "start_column": 5,
-              "start_line": 1391
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 2,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 9,
-              "end_line": 1428,
-              "increment": 1,
-              "kind": "for-loop",
-              "line": 1420,
-              "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 6.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "base_fn_empty_contributors",
-            "span": {
-              "end_column": 5,
-              "end_line": 1429,
-              "start_column": 5,
-              "start_line": 1418
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 2,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 9,
-              "end_line": 1474,
-              "increment": 1,
-              "kind": "for-loop",
-              "line": 1472,
-              "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 6.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "match_arm_contributor_cyclomatic",
-            "span": {
-              "end_column": 5,
-              "end_line": 1475,
-              "start_column": 5,
-              "start_line": 1461
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 2,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 9,
-              "end_line": 1791,
-              "increment": 1,
-              "kind": "for-loop",
-              "line": 1782,
-              "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 6.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "contributors_sorted_by_line",
-            "span": {
-              "end_column": 5,
-              "end_line": 1792,
-              "start_column": 5,
-              "start_line": 1773
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 2,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 9,
-              "end_line": 71,
-              "increment": 1,
-              "kind": "for-loop",
-              "line": 69,
-              "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 6.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "LcovParser::parse_str",
-            "span": {
-              "end_column": 5,
-              "end_line": 75,
-              "start_column": 5,
-              "start_line": 58
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 2,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 72,
-              "end_line": 112,
-              "increment": 1,
-              "kind": "try",
-              "line": 112,
-              "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 6.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "LcovParser::parse",
-            "span": {
-              "end_column": 5,
-              "end_line": 114,
-              "start_column": 5,
-              "start_line": 81
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 2,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 5,
-              "end_line": 177,
-              "increment": 1,
-              "kind": "if-branch",
-              "line": 170,
-              "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 6.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "start_source_file",
-            "span": {
-              "end_column": 1,
-              "end_line": 178,
-              "start_column": 1,
-              "start_line": 167
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 2,
-          "complexity_metric": "cognitive",
-          "contributors": [
+            },
             {
               "column": 52,
-              "end_line": 256,
+              "end_line": 292,
               "increment": 1,
-              "kind": "let-else",
-              "line": 253,
+              "kind": "try",
+              "line": 292,
               "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 6.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "flush_block",
-            "span": {
-              "end_column": 1,
-              "end_line": 261,
-              "start_column": 1,
-              "start_line": 252
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 2,
-          "complexity_metric": "cognitive",
-          "contributors": [
+            },
+            {
+              "column": 58,
+              "end_line": 293,
+              "increment": 1,
+              "kind": "try",
+              "line": 293,
+              "nesting_depth": 0
+            },
             {
               "column": 5,
-              "end_line": 317,
+              "end_line": 296,
               "increment": 1,
-              "kind": "match",
-              "line": 312,
+              "kind": "if-branch",
+              "line": 294,
+              "nesting_depth": 0
+            },
+            {
+              "column": 53,
+              "end_line": 297,
+              "increment": 1,
+              "kind": "try",
+              "line": 297,
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 0.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
             "value": 6.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "merge_taken",
+            "qualified_name": "parse_da",
             "span": {
               "end_column": 1,
-              "end_line": 318,
+              "end_line": 299,
               "start_column": 1,
-              "start_line": 311
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 2,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 9,
-              "end_line": 552,
-              "increment": 1,
-              "kind": "match",
-              "line": 543,
-              "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 6.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "malformed_da_produces_diagnostic",
-            "span": {
-              "end_column": 5,
-              "end_line": 553,
-              "start_column": 5,
-              "start_line": 538
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 2,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 9,
-              "end_line": 596,
-              "increment": 1,
-              "kind": "match",
-              "line": 587,
-              "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 6.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "da_line_zero_is_malformed",
-            "span": {
-              "end_column": 5,
-              "end_line": 597,
-              "start_column": 5,
-              "start_line": 583
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 2,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 9,
-              "end_line": 715,
-              "increment": 1,
-              "kind": "match",
-              "line": 706,
-              "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 6.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "malformed_brda_produces_diagnostic",
-            "span": {
-              "end_column": 5,
-              "end_line": 716,
-              "start_column": 5,
-              "start_line": 702
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 2,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 13,
-              "end_line": 757,
-              "increment": 1,
-              "kind": "for-loop",
-              "line": 755,
-              "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 6.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "repeated_sf_blocks_merge_branch_coverage",
-            "span": {
-              "end_column": 5,
-              "end_line": 767,
-              "start_column": 5,
-              "start_line": 740
+              "start_line": 287
             }
           }
         },
@@ -7668,118 +6324,31 @@ expression: pretty
       {
         "exceeds": false,
         "scored": {
-          "complexity": 1,
+          "complexity": 2,
           "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "SynComplexityAdapter::new",
-            "span": {
-              "end_column": 5,
-              "end_line": 23,
-              "start_column": 5,
-              "start_line": 21
+          "contributors": [
+            {
+              "column": 5,
+              "end_line": 488,
+              "increment": 1,
+              "kind": "for-loop",
+              "line": 486,
+              "nesting_depth": 0
             }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
+          ],
+          "coverage_percent": 11.11111111111111,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 4.81
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "FunctionFinder::visit_item_fn",
-            "span": {
-              "end_column": 5,
-              "end_line": 76,
-              "start_column": 5,
-              "start_line": 58
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "FunctionFinder::visit_item_impl",
-            "span": {
-              "end_column": 5,
-              "end_line": 83,
-              "start_column": 5,
-              "start_line": 78
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "FunctionFinder::visit_item_trait",
-            "span": {
-              "end_column": 5,
-              "end_line": 135,
-              "start_column": 5,
-              "start_line": 130
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "add_contributor",
+            "qualified_name": "count_cognitive_tuple",
             "span": {
               "end_column": 1,
-              "end_line": 159,
+              "end_line": 490,
               "start_column": 1,
-              "start_line": 140
+              "start_line": 480
             }
           }
         },
@@ -7788,22 +6357,80 @@ expression: pretty
       {
         "exceeds": false,
         "scored": {
-          "complexity": 1,
+          "complexity": 4,
           "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
+          "contributors": [
+            {
+              "column": 9,
+              "end_line": 125,
+              "increment": 1,
+              "kind": "if-branch",
+              "line": 108,
+              "nesting_depth": 0
+            },
+            {
+              "column": 29,
+              "end_line": 113,
+              "increment": 2,
+              "kind": "match",
+              "line": 110,
+              "nesting_depth": 1
+            }
+          ],
+          "coverage_percent": 94.73684210526316,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 4.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "end_line_of",
+            "qualified_name": "FunctionFinder::visit_trait_item_fn",
+            "span": {
+              "end_column": 5,
+              "end_line": 128,
+              "start_column": 5,
+              "start_line": 106
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 4,
+          "complexity_metric": "cognitive",
+          "contributors": [
+            {
+              "column": 5,
+              "end_line": 576,
+              "increment": 1,
+              "kind": "match",
+              "line": 552,
+              "nesting_depth": 0
+            },
+            {
+              "column": 13,
+              "end_line": 568,
+              "increment": 2,
+              "kind": "if-branch",
+              "line": 566,
+              "nesting_depth": 1
+            }
+          ],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 4.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "count_cognitive_else",
             "span": {
               "end_column": 1,
-              "end_line": 167,
+              "end_line": 577,
               "start_column": 1,
-              "start_line": 161
+              "start_line": 547
             }
           }
         },
@@ -7812,2158 +6439,39 @@ expression: pretty
       {
         "exceeds": false,
         "scored": {
-          "complexity": 1,
+          "complexity": 4,
           "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "span_of",
-            "span": {
-              "end_column": 1,
-              "end_line": 190,
-              "start_column": 1,
-              "start_line": 169
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "count_cognitive_block",
-            "span": {
-              "end_column": 1,
-              "end_line": 230,
-              "start_column": 1,
-              "start_line": 220
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "count_cognitive_while",
-            "span": {
-              "end_column": 1,
-              "end_line": 334,
-              "start_column": 1,
-              "start_line": 317
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "count_cognitive_for_loop",
-            "span": {
-              "end_column": 1,
-              "end_line": 353,
-              "start_column": 1,
-              "start_line": 336
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "count_cognitive_loop",
-            "span": {
-              "end_column": 1,
-              "end_line": 371,
-              "start_column": 1,
-              "start_line": 355
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "count_cognitive_binary",
-            "span": {
-              "end_column": 1,
-              "end_line": 385,
-              "start_column": 1,
-              "start_line": 377
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "count_cognitive_try",
-            "span": {
-              "end_column": 1,
-              "end_line": 401,
-              "start_column": 1,
-              "start_line": 387
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "count_cognitive_break",
-            "span": {
-              "end_column": 1,
-              "end_line": 417,
-              "start_column": 1,
-              "start_line": 403
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "count_cognitive_continue",
-            "span": {
-              "end_column": 1,
-              "end_line": 433,
-              "start_column": 1,
-              "start_line": 419
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "count_cognitive_closure",
-            "span": {
-              "end_column": 1,
-              "end_line": 454,
-              "start_column": 1,
-              "start_line": 448
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "flatten_binary_ops",
-            "span": {
-              "end_column": 1,
-              "end_line": 671,
-              "start_column": 1,
-              "start_line": 663
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "count_cyclomatic_block",
-            "span": {
-              "end_column": 1,
-              "end_line": 688,
-              "start_column": 1,
-              "start_line": 683
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "CyclomaticCounter::count_block",
-            "span": {
-              "end_column": 5,
-              "end_line": 705,
-              "start_column": 5,
-              "start_line": 697
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "CyclomaticCounter::bump",
-            "span": {
-              "end_column": 5,
-              "end_line": 717,
-              "start_column": 5,
-              "start_line": 707
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "CyclomaticCounter::with_nesting",
-            "span": {
-              "end_column": 5,
-              "end_line": 723,
-              "start_column": 5,
-              "start_line": 719
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "CyclomaticCounter::visit_expr_while",
-            "span": {
-              "end_column": 5,
-              "end_line": 805,
-              "start_column": 5,
-              "start_line": 796
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "CyclomaticCounter::visit_expr_for_loop",
-            "span": {
-              "end_column": 5,
-              "end_line": 816,
-              "start_column": 5,
-              "start_line": 807
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "CyclomaticCounter::visit_expr_loop",
-            "span": {
-              "end_column": 5,
-              "end_line": 826,
-              "start_column": 5,
-              "start_line": 818
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "CyclomaticCounter::visit_expr_try",
-            "span": {
-              "end_column": 5,
-              "end_line": 845,
-              "start_column": 5,
-              "start_line": 837
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "CyclomaticCounter::visit_expr_continue",
-            "span": {
-              "end_column": 5,
-              "end_line": 866,
-              "start_column": 5,
-              "start_line": 859
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "CyclomaticCounter::visit_expr_closure",
-            "span": {
-              "end_column": 5,
-              "end_line": 873,
-              "start_column": 5,
-              "start_line": 868
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "adapter",
-            "span": {
-              "end_column": 5,
-              "end_line": 884,
-              "start_column": 5,
-              "start_line": 882
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "load_fixture",
-            "span": {
-              "end_column": 5,
-              "end_line": 890,
-              "start_column": 5,
-              "start_line": 886
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "extract_fixture",
-            "span": {
-              "end_column": 5,
-              "end_line": 897,
-              "start_column": 5,
-              "start_line": 892
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "find_fn",
-            "span": {
-              "end_column": 5,
-              "end_line": 910,
-              "start_column": 5,
-              "start_line": 899
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "baseline_complexity_is_one_cognitive",
-            "span": {
-              "end_column": 5,
-              "end_line": 926,
-              "start_column": 5,
-              "start_line": 921
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "baseline_complexity_is_one_cyclomatic",
-            "span": {
-              "end_column": 5,
-              "end_line": 933,
-              "start_column": 5,
-              "start_line": 928
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "top_level_fn_identity",
-            "span": {
-              "end_column": 5,
-              "end_line": 944,
-              "start_column": 5,
-              "start_line": 937
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "impl_method_qualified_name",
-            "span": {
-              "end_column": 5,
-              "end_line": 952,
-              "start_column": 5,
-              "start_line": 946
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "span_accuracy",
-            "span": {
-              "end_column": 5,
-              "end_line": 975,
-              "start_column": 5,
-              "start_line": 954
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "span_carries_one_based_columns",
-            "span": {
-              "end_column": 5,
-              "end_line": 996,
-              "start_column": 5,
-              "start_line": 977
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "columns_are_exact_one_based_offsets_unindented",
-            "span": {
-              "end_column": 5,
-              "end_line": 1026,
-              "start_column": 5,
-              "start_line": 998
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "columns_are_exact_one_based_offsets_indented",
-            "span": {
-              "end_column": 5,
-              "end_line": 1051,
-              "start_column": 5,
-              "start_line": 1028
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "multiple_fns_returns_all",
-            "span": {
-              "end_column": 5,
-              "end_line": 1057,
-              "start_column": 5,
-              "start_line": 1053
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "async_fn_detected",
-            "span": {
-              "end_column": 5,
-              "end_line": 1065,
-              "start_column": 5,
-              "start_line": 1059
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "if_else_cognitive",
-            "span": {
-              "end_column": 5,
-              "end_line": 1075,
-              "start_column": 5,
-              "start_line": 1069
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "nested_if_cognitive_penalty",
-            "span": {
-              "end_column": 5,
-              "end_line": 1083,
-              "start_column": 5,
-              "start_line": 1077
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "else_is_not_counted_cognitive",
-            "span": {
-              "end_column": 5,
-              "end_line": 1092,
-              "start_column": 5,
-              "start_line": 1085
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "match_flat_cognitive",
-            "span": {
-              "end_column": 5,
-              "end_line": 1100,
-              "start_column": 5,
-              "start_line": 1094
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "if_else_cyclomatic",
-            "span": {
-              "end_column": 5,
-              "end_line": 1110,
-              "start_column": 5,
-              "start_line": 1104
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "nested_if_cyclomatic",
-            "span": {
-              "end_column": 5,
-              "end_line": 1118,
-              "start_column": 5,
-              "start_line": 1112
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "match_arms_cyclomatic",
-            "span": {
-              "end_column": 5,
-              "end_line": 1126,
-              "start_column": 5,
-              "start_line": 1120
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "cognitive_gte_cyclomatic_for_nested",
-            "span": {
-              "end_column": 5,
-              "end_line": 1139,
-              "start_column": 5,
-              "start_line": 1128
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "bool_same_sequence_cognitive",
-            "span": {
-              "end_column": 5,
-              "end_line": 1149,
-              "start_column": 5,
-              "start_line": 1143
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "bool_same_sequence_cyclomatic",
-            "span": {
-              "end_column": 5,
-              "end_line": 1157,
-              "start_column": 5,
-              "start_line": 1151
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "bool_operator_switch_cognitive",
-            "span": {
-              "end_column": 5,
-              "end_line": 1165,
-              "start_column": 5,
-              "start_line": 1159
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "bool_operator_switch_cyclomatic",
-            "span": {
-              "end_column": 5,
-              "end_line": 1173,
-              "start_column": 5,
-              "start_line": 1167
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "bool_in_condition_cognitive",
-            "span": {
-              "end_column": 5,
-              "end_line": 1181,
-              "start_column": 5,
-              "start_line": 1175
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "long_or_chain_cognitive",
-            "span": {
-              "end_column": 5,
-              "end_line": 1189,
-              "start_column": 5,
-              "start_line": 1183
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "alternating_operators_cognitive",
-            "span": {
-              "end_column": 5,
-              "end_line": 1197,
-              "start_column": 5,
-              "start_line": 1191
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "closure_in_parent_cognitive",
-            "span": {
-              "end_column": 5,
-              "end_line": 1210,
-              "start_column": 5,
-              "start_line": 1201
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "try_operator_cognitive",
-            "span": {
-              "end_column": 5,
-              "end_line": 1220,
-              "start_column": 5,
-              "start_line": 1214
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "try_operator_cyclomatic",
-            "span": {
-              "end_column": 5,
-              "end_line": 1228,
-              "start_column": 5,
-              "start_line": 1222
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "loop_with_break_cognitive",
-            "span": {
-              "end_column": 5,
-              "end_line": 1238,
-              "start_column": 5,
-              "start_line": 1232
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "loop_with_break_cyclomatic",
-            "span": {
-              "end_column": 5,
-              "end_line": 1246,
-              "start_column": 5,
-              "start_line": 1240
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "let_else_cognitive",
-            "span": {
-              "end_column": 5,
-              "end_line": 1256,
-              "start_column": 5,
-              "start_line": 1250
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "let_else_cyclomatic",
-            "span": {
-              "end_column": 5,
-              "end_line": 1264,
-              "start_column": 5,
-              "start_line": 1258
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "chained_try_cognitive",
-            "span": {
-              "end_column": 5,
-              "end_line": 1274,
-              "start_column": 5,
-              "start_line": 1268
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "chained_try_cyclomatic",
-            "span": {
-              "end_column": 5,
-              "end_line": 1282,
-              "start_column": 5,
-              "start_line": 1276
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "for_iterator_try_cognitive",
-            "span": {
-              "end_column": 5,
-              "end_line": 1290,
-              "start_column": 5,
-              "start_line": 1284
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "for_iterator_try_cyclomatic",
-            "span": {
-              "end_column": 5,
-              "end_line": 1298,
-              "start_column": 5,
-              "start_line": 1292
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "match_scrutinee_try_cognitive",
-            "span": {
-              "end_column": 5,
-              "end_line": 1306,
-              "start_column": 5,
-              "start_line": 1300
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "trait_default_method_found",
-            "span": {
-              "end_column": 5,
-              "end_line": 1316,
-              "start_column": 5,
-              "start_line": 1310
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "trait_method_without_default_not_found",
-            "span": {
-              "end_column": 5,
-              "end_line": 1327,
-              "start_column": 5,
-              "start_line": 1318
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "impl_method_no_branch",
-            "span": {
-              "end_column": 5,
-              "end_line": 1379,
-              "start_column": 5,
-              "start_line": 1374
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "impl_method_with_branch",
-            "span": {
-              "end_column": 5,
-              "end_line": 1387,
-              "start_column": 5,
-              "start_line": 1381
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "contributors_for",
-            "span": {
-              "end_column": 5,
-              "end_line": 1416,
-              "start_column": 5,
-              "start_line": 1409
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "if_branch_contributor_cognitive",
-            "span": {
-              "end_column": 5,
-              "end_line": 1438,
-              "start_column": 5,
-              "start_line": 1431
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "nested_if_nesting_increment",
-            "span": {
-              "end_column": 5,
-              "end_line": 1450,
-              "start_column": 5,
-              "start_line": 1440
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "match_contributor_cognitive",
-            "span": {
-              "end_column": 5,
-              "end_line": 1459,
-              "start_column": 5,
-              "start_line": 1452
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "try_contributor_cognitive",
-            "span": {
-              "end_column": 5,
-              "end_line": 1483,
-              "start_column": 5,
-              "start_line": 1477
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "try_contributor_cyclomatic",
-            "span": {
-              "end_column": 5,
-              "end_line": 1491,
-              "start_column": 5,
-              "start_line": 1485
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "let_else_contributor_cognitive",
-            "span": {
-              "end_column": 5,
-              "end_line": 1499,
-              "start_column": 5,
-              "start_line": 1493
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "let_else_contributor_cyclomatic",
-            "span": {
-              "end_column": 5,
-              "end_line": 1507,
-              "start_column": 5,
-              "start_line": 1501
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "loop_contributor_cognitive",
-            "span": {
-              "end_column": 5,
-              "end_line": 1515,
-              "start_column": 5,
-              "start_line": 1509
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "for_loop_contributor_cognitive",
-            "span": {
-              "end_column": 5,
-              "end_line": 1523,
-              "start_column": 5,
-              "start_line": 1517
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "for_loop_contributor_cyclomatic",
-            "span": {
-              "end_column": 5,
-              "end_line": 1531,
-              "start_column": 5,
-              "start_line": 1525
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "while_loop_contributor_cognitive",
-            "span": {
-              "end_column": 5,
-              "end_line": 1539,
-              "start_column": 5,
-              "start_line": 1533
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "while_loop_contributor_cyclomatic",
-            "span": {
-              "end_column": 5,
-              "end_line": 1547,
-              "start_column": 5,
-              "start_line": 1541
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "logical_operator_same_chain_cognitive",
-            "span": {
-              "end_column": 5,
-              "end_line": 1563,
-              "start_column": 5,
-              "start_line": 1549
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "logical_operator_switch_cognitive",
-            "span": {
-              "end_column": 5,
-              "end_line": 1578,
-              "start_column": 5,
-              "start_line": 1565
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "break_contributor",
-            "span": {
-              "end_column": 5,
-              "end_line": 1591,
-              "start_column": 5,
-              "start_line": 1580
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "continue_contributor",
-            "span": {
-              "end_column": 5,
-              "end_line": 1604,
-              "start_column": 5,
-              "start_line": 1593
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "unsafe_block_produces_no_unsafe_contributor",
-            "span": {
-              "end_column": 5,
-              "end_line": 1632,
-              "start_column": 5,
-              "start_line": 1606
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "closure_no_contributor",
-            "span": {
-              "end_column": 5,
-              "end_line": 1644,
-              "start_column": 5,
-              "start_line": 1634
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "nested_if_records_construct_end_line_and_nesting_depth_cognitive",
-            "span": {
-              "end_column": 5,
-              "end_line": 1677,
-              "start_column": 5,
-              "start_line": 1648
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "try_records_token_span_for_atomic_contributor",
-            "span": {
-              "end_column": 5,
-              "end_line": 1691,
-              "start_column": 5,
-              "start_line": 1679
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "for_with_continue_threads_nesting_depth_cognitive",
-            "span": {
-              "end_column": 5,
-              "end_line": 1713,
-              "start_column": 5,
-              "start_line": 1693
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "nested_if_records_nesting_depth_cyclomatic",
-            "span": {
-              "end_column": 5,
-              "end_line": 1732,
-              "start_column": 5,
-              "start_line": 1715
+          "contributors": [
+            {
+              "column": 9,
+              "end_line": 770,
+              "increment": 1,
+              "kind": "if-branch",
+              "line": 761,
+              "nesting_depth": 0
+            },
+            {
+              "column": 13,
+              "end_line": 769,
+              "increment": 2,
+              "kind": "match",
+              "line": 762,
+              "nesting_depth": 1
             }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
+          ],
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 4.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "for_with_continue_records_nesting_depth_cyclomatic",
+            "qualified_name": "CyclomaticCounter::visit_expr_if",
             "span": {
               "end_column": 5,
-              "end_line": 1752,
+              "end_line": 771,
               "start_column": 5,
-              "start_line": 1734
+              "start_line": 752
             }
           }
         },
@@ -9972,46 +6480,47 @@ expression: pretty
       {
         "exceeds": false,
         "scored": {
-          "complexity": 1,
+          "complexity": 4,
           "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "match_records_end_line_covering_arms_cognitive",
-            "span": {
-              "end_column": 5,
-              "end_line": 1771,
-              "start_column": 5,
-              "start_line": 1754
+          "contributors": [
+            {
+              "column": 5,
+              "end_line": 229,
+              "increment": 1,
+              "kind": "if-branch",
+              "line": 226,
+              "nesting_depth": 0
+            },
+            {
+              "column": 5,
+              "end_line": 234,
+              "increment": 1,
+              "kind": "if-branch",
+              "line": 231,
+              "nesting_depth": 0
+            },
+            {
+              "column": 5,
+              "end_line": 238,
+              "increment": 1,
+              "kind": "if-branch",
+              "line": 236,
+              "nesting_depth": 0
             }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
+          ],
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 4.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "LcovParser::new",
+            "qualified_name": "handle_parse_line",
             "span": {
-              "end_column": 5,
-              "end_line": 43,
-              "start_column": 5,
-              "start_line": 41
+              "end_column": 1,
+              "end_line": 239,
+              "start_column": 1,
+              "start_line": 225
             }
           }
         },
@@ -10020,20 +6529,242 @@ expression: pretty
       {
         "exceeds": false,
         "scored": {
-          "complexity": 1,
+          "complexity": 3,
           "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
+          "contributors": [
+            {
+              "column": 5,
+              "end_line": 198,
+              "increment": 1,
+              "kind": "if-branch",
+              "line": 194,
+              "nesting_depth": 0
+            },
+            {
+              "column": 9,
+              "end_line": 195,
+              "increment": 1,
+              "kind": "logical-operator",
+              "line": 195,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 71.42857142857143,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 3.21
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "extract_type_name",
+            "span": {
+              "end_column": 1,
+              "end_line": 201,
+              "start_column": 1,
+              "start_line": 192
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 3,
+          "complexity_metric": "cognitive",
+          "contributors": [
+            {
+              "column": 5,
+              "end_line": 257,
+              "increment": 1,
+              "kind": "if-branch",
+              "line": 255,
+              "nesting_depth": 0
+            },
+            {
+              "column": 5,
+              "end_line": 262,
+              "increment": 1,
+              "kind": "match",
+              "line": 259,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 80.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 3.07
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "record_da",
+            "span": {
+              "end_column": 1,
+              "end_line": 263,
+              "start_column": 1,
+              "start_line": 254
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 3,
+          "complexity_metric": "cognitive",
+          "contributors": [
+            {
+              "column": 38,
+              "end_line": 738,
+              "increment": 1,
+              "kind": "let-else",
+              "line": 736,
+              "nesting_depth": 0
+            },
+            {
+              "column": 9,
+              "end_line": 749,
+              "increment": 1,
+              "kind": "if-branch",
+              "line": 741,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 3.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "CyclomaticCounter::visit_local",
+            "span": {
+              "end_column": 5,
+              "end_line": 750,
+              "start_column": 5,
+              "start_line": 735
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 3,
+          "complexity_metric": "cognitive",
+          "contributors": [
+            {
+              "column": 9,
+              "end_line": 781,
+              "increment": 1,
+              "kind": "for-loop",
+              "line": 774,
+              "nesting_depth": 0
+            },
+            {
+              "column": 9,
+              "end_line": 786,
+              "increment": 1,
+              "kind": "for-loop",
+              "line": 784,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 3.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "CyclomaticCounter::visit_expr_match",
+            "span": {
+              "end_column": 5,
+              "end_line": 787,
+              "start_column": 5,
+              "start_line": 773
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 3,
+          "complexity_metric": "cognitive",
+          "contributors": [
+            {
+              "column": 9,
+              "end_line": 1362,
+              "increment": 1,
+              "kind": "for-loop",
+              "line": 1356,
+              "nesting_depth": 0
+            },
+            {
+              "column": 9,
+              "end_line": 1369,
+              "increment": 1,
+              "kind": "for-loop",
+              "line": 1363,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 3.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "trait_default_and_concrete_override_have_disjoint_spans",
+            "span": {
+              "end_column": 5,
+              "end_line": 1370,
+              "start_column": 5,
+              "start_line": 1329
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 3,
+          "complexity_metric": "cognitive",
+          "contributors": [
+            {
+              "column": 9,
+              "end_line": 82,
+              "increment": 1,
+              "kind": "if-branch",
+              "line": 80,
+              "nesting_depth": 0
+            },
+            {
+              "column": 9,
+              "end_line": 89,
+              "increment": 1,
+              "kind": "if-branch",
+              "line": 87,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 3.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
             "qualified_name": "LcovParser::normalize_path",
             "span": {
               "end_column": 5,
-              "end_line": 54,
+              "end_line": 96,
               "start_column": 5,
               "start_line": 45
             }
@@ -10044,22 +6775,39 @@ expression: pretty
       {
         "exceeds": false,
         "scored": {
-          "complexity": 1,
+          "complexity": 3,
           "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
+          "contributors": [
+            {
+              "column": 5,
+              "end_line": 268,
+              "increment": 1,
+              "kind": "if-branch",
+              "line": 266,
+              "nesting_depth": 0
+            },
+            {
+              "column": 5,
+              "end_line": 275,
+              "increment": 1,
+              "kind": "match",
+              "line": 270,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 3.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "push_malformed_record",
+            "qualified_name": "record_brda",
             "span": {
               "end_column": 1,
-              "end_line": 211,
+              "end_line": 276,
               "start_column": 1,
-              "start_line": 204
+              "start_line": 265
             }
           }
         },
@@ -10068,22 +6816,39 @@ expression: pretty
       {
         "exceeds": false,
         "scored": {
-          "complexity": 1,
+          "complexity": 3,
           "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
+          "contributors": [
+            {
+              "column": 5,
+              "end_line": 344,
+              "increment": 1,
+              "kind": "if-branch",
+              "line": 342,
+              "nesting_depth": 0
+            },
+            {
+              "column": 5,
+              "end_line": 349,
+              "increment": 1,
+              "kind": "for-loop",
+              "line": 347,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 3.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "merge_hits",
+            "qualified_name": "merge_line_block",
             "span": {
               "end_column": 1,
-              "end_line": 298,
+              "end_line": 350,
               "start_column": 1,
-              "start_line": 293
+              "start_line": 337
             }
           }
         },
@@ -10092,22 +6857,39 @@ expression: pretty
       {
         "exceeds": false,
         "scored": {
-          "complexity": 1,
+          "complexity": 3,
           "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
+          "contributors": [
+            {
+              "column": 5,
+              "end_line": 359,
+              "increment": 1,
+              "kind": "if-branch",
+              "line": 357,
+              "nesting_depth": 0
+            },
+            {
+              "column": 5,
+              "end_line": 364,
+              "increment": 1,
+              "kind": "for-loop",
+              "line": 362,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 3.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "merge_branch_value",
+            "qualified_name": "merge_branch_block",
             "span": {
               "end_column": 1,
-              "end_line": 309,
+              "end_line": 365,
               "start_column": 1,
-              "start_line": 300
+              "start_line": 352
             }
           }
         },
@@ -10116,22 +6898,64 @@ expression: pretty
       {
         "exceeds": false,
         "scored": {
-          "complexity": 1,
+          "complexity": 3,
           "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
+          "contributors": [
+            {
+              "column": 13,
+              "end_line": 875,
+              "increment": 2,
+              "kind": "for-loop",
+              "line": 872,
+              "nesting_depth": 1
+            }
+          ],
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 3.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "clear_current_block",
+            "qualified_name": "arb_lcov_block",
+            "span": {
+              "end_column": 5,
+              "end_line": 879,
+              "start_column": 5,
+              "start_line": 869
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 2,
+          "complexity_metric": "cognitive",
+          "contributors": [
+            {
+              "column": 5,
+              "end_line": 290,
+              "increment": 1,
+              "kind": "match",
+              "line": 268,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 72.22222222222221,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.09
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "count_cognitive_expr",
             "span": {
               "end_column": 1,
-              "end_line": 323,
+              "end_line": 291,
               "start_column": 1,
-              "start_line": 320
+              "start_line": 263
             }
           }
         },
@@ -10140,22 +6964,31 @@ expression: pretty
       {
         "exceeds": false,
         "scored": {
-          "complexity": 1,
+          "complexity": 2,
           "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
+          "contributors": [
+            {
+              "column": 5,
+              "end_line": 464,
+              "increment": 1,
+              "kind": "for-loop",
+              "line": 462,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 85.71428571428571,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 2.01
           },
           "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "build_parse_output",
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "count_cognitive_call",
             "span": {
               "end_column": 1,
-              "end_line": 351,
+              "end_line": 466,
               "start_column": 1,
-              "start_line": 325
+              "start_line": 456
             }
           }
         },
@@ -10164,22 +6997,97 @@ expression: pretty
       {
         "exceeds": false,
         "scored": {
-          "complexity": 1,
+          "complexity": 2,
           "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
+          "contributors": [
+            {
+              "column": 78,
+              "end_line": 34,
+              "increment": 1,
+              "kind": "try",
+              "line": 34,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
             "value": 2.0
           },
           "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "to_line_coverage",
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "SynComplexityAdapter::extract",
+            "span": {
+              "end_column": 5,
+              "end_line": 45,
+              "start_column": 5,
+              "start_line": 27
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 2,
+          "complexity_metric": "cognitive",
+          "contributors": [
+            {
+              "column": 25,
+              "end_line": 90,
+              "increment": 1,
+              "kind": "match",
+              "line": 87,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 93.75,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "FunctionFinder::visit_impl_item_fn",
+            "span": {
+              "end_column": 5,
+              "end_line": 104,
+              "start_column": 5,
+              "start_line": 85
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 2,
+          "complexity_metric": "cognitive",
+          "contributors": [
+            {
+              "column": 15,
+              "end_line": 213,
+              "increment": 1,
+              "kind": "match",
+              "line": 210,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 90.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "count_complexity",
             "span": {
               "end_column": 1,
-              "end_line": 358,
+              "end_line": 216,
               "start_column": 1,
-              "start_line": 353
+              "start_line": 205
             }
           }
         },
@@ -10188,22 +7096,31 @@ expression: pretty
       {
         "exceeds": false,
         "scored": {
-          "complexity": 1,
+          "complexity": 2,
           "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
+          "contributors": [
+            {
+              "column": 5,
+              "end_line": 443,
+              "increment": 1,
+              "kind": "match",
+              "line": 440,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
             "value": 2.0
           },
           "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "parser",
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "count_cognitive_return",
             "span": {
-              "end_column": 5,
-              "end_line": 367,
-              "start_column": 5,
-              "start_line": 365
+              "end_column": 1,
+              "end_line": 444,
+              "start_column": 1,
+              "start_line": 435
             }
           }
         },
@@ -10212,334 +7129,31 @@ expression: pretty
       {
         "exceeds": false,
         "scored": {
-          "complexity": 1,
+          "complexity": 2,
           "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "parse",
-            "span": {
-              "end_column": 5,
-              "end_line": 371,
-              "start_column": 5,
-              "start_line": 369
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "empty_input_returns_empty_output",
-            "span": {
-              "end_column": 5,
-              "end_line": 378,
-              "start_column": 5,
-              "start_line": 373
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "validate_str",
-            "span": {
-              "end_column": 5,
-              "end_line": 392,
-              "start_column": 5,
-              "start_line": 382
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "validate_empty_input_rejected",
-            "span": {
-              "end_column": 5,
-              "end_line": 397,
-              "start_column": 5,
-              "start_line": 394
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "validate_no_da_lines_rejected",
-            "span": {
-              "end_column": 5,
-              "end_line": 402,
-              "start_column": 5,
-              "start_line": 399
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "validate_da_outside_sf_block_rejected",
-            "span": {
-              "end_column": 5,
-              "end_line": 407,
-              "start_column": 5,
-              "start_line": 404
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "validate_malformed_da_rejected",
-            "span": {
-              "end_column": 5,
-              "end_line": 412,
-              "start_column": 5,
-              "start_line": 409
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "validate_single_da_inside_sf_block_passes",
-            "span": {
-              "end_column": 5,
-              "end_line": 417,
-              "start_column": 5,
-              "start_line": 414
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "validate_first_da_in_second_block_passes",
-            "span": {
-              "end_column": 5,
-              "end_line": 427,
-              "start_column": 5,
-              "start_line": 419
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "validate_missing_path_returns_open_error",
-            "span": {
-              "end_column": 5,
-              "end_line": 439,
-              "start_column": 5,
-              "start_line": 429
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "single_file_single_da",
-            "span": {
-              "end_column": 5,
-              "end_line": 449,
-              "start_column": 5,
-              "start_line": 441
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "multiple_da_lines",
-            "span": {
-              "end_column": 5,
-              "end_line": 459,
-              "start_column": 5,
-              "start_line": 451
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "multiple_source_files",
-            "span": {
-              "end_column": 5,
-              "end_line": 468,
-              "start_column": 5,
-              "start_line": 461
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "hit_count_preservation",
-            "span": {
-              "end_column": 5,
+          "contributors": [
+            {
+              "column": 5,
               "end_line": 476,
-              "start_column": 5,
-              "start_line": 470
+              "increment": 1,
+              "kind": "for-loop",
+              "line": 474,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "count_cognitive_method_call",
+            "span": {
+              "end_column": 1,
+              "end_line": 478,
+              "start_column": 1,
+              "start_line": 468
             }
           }
         },
@@ -10548,334 +7162,31 @@ expression: pretty
       {
         "exceeds": false,
         "scored": {
-          "complexity": 1,
+          "complexity": 2,
           "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "path_normalization_strips_prefix",
-            "span": {
-              "end_column": 5,
-              "end_line": 482,
-              "start_column": 5,
-              "start_line": 478
+          "contributors": [
+            {
+              "column": 5,
+              "end_line": 634,
+              "increment": 1,
+              "kind": "match",
+              "line": 628,
+              "nesting_depth": 0
             }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
+          ],
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
             "value": 2.0
           },
           "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "non_matching_path_passes_through",
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "count_cognitive_binary_operands",
             "span": {
-              "end_column": 5,
-              "end_line": 488,
-              "start_column": 5,
-              "start_line": 484
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "backslash_normalized_to_forward_slash",
-            "span": {
-              "end_column": 5,
-              "end_line": 495,
-              "start_column": 5,
-              "start_line": 490
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "path_boundary_not_confused_by_prefix_substring",
-            "span": {
-              "end_column": 5,
-              "end_line": 501,
-              "start_column": 5,
-              "start_line": 497
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "repeated_sf_blocks_merge_coverage",
-            "span": {
-              "end_column": 5,
-              "end_line": 515,
-              "start_column": 5,
-              "start_line": 503
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "duplicate_da_lines_sum_hits",
-            "span": {
-              "end_column": 5,
-              "end_line": 524,
-              "start_column": 5,
-              "start_line": 517
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "duplicate_da_multiple_lines_sum_correctly",
-            "span": {
-              "end_column": 5,
-              "end_line": 536,
-              "start_column": 5,
-              "start_line": 526
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "malformed_da_does_not_stop_parsing",
-            "span": {
-              "end_column": 5,
-              "end_line": 561,
-              "start_column": 5,
-              "start_line": 555
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "da_missing_hit_count_is_malformed",
-            "span": {
-              "end_column": 5,
-              "end_line": 571,
-              "start_column": 5,
-              "start_line": 563
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "da_negative_hit_count_is_malformed",
-            "span": {
-              "end_column": 5,
-              "end_line": 581,
-              "start_column": 5,
-              "start_line": 573
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "end_of_record_is_ignored",
-            "span": {
-              "end_column": 5,
-              "end_line": 608,
-              "start_column": 5,
-              "start_line": 599
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "unterminated_final_block_emits_data",
-            "span": {
-              "end_column": 5,
-              "end_line": 615,
-              "start_column": 5,
-              "start_line": 610
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "empty_sf_path_emits_diagnostic",
-            "span": {
-              "end_column": 5,
-              "end_line": 626,
-              "start_column": 5,
-              "start_line": 617
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "da_with_checksum_field_is_accepted",
-            "span": {
-              "end_column": 5,
+              "end_column": 1,
               "end_line": 635,
-              "start_column": 5,
-              "start_line": 628
+              "start_column": 1,
+              "start_line": 619
             }
           }
         },
@@ -10884,22 +7195,31 @@ expression: pretty
       {
         "exceeds": false,
         "scored": {
-          "complexity": 1,
+          "complexity": 2,
           "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "non_coverage_records_are_ignored",
-            "span": {
-              "end_column": 5,
+          "contributors": [
+            {
+              "column": 5,
               "end_line": 649,
-              "start_column": 5,
-              "start_line": 637
+              "increment": 1,
+              "kind": "match",
+              "line": 645,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "classify_binop",
+            "span": {
+              "end_column": 1,
+              "end_line": 650,
+              "start_column": 1,
+              "start_line": 644
             }
           }
         },
@@ -10908,22 +7228,31 @@ expression: pretty
       {
         "exceeds": false,
         "scored": {
-          "complexity": 1,
+          "complexity": 2,
           "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
+          "contributors": [
+            {
+              "column": 5,
+              "end_line": 660,
+              "increment": 1,
+              "kind": "match",
+              "line": 653,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
             "value": 2.0
           },
           "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "brda_and_da_records_parsed",
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "binop_span",
             "span": {
-              "end_column": 5,
+              "end_column": 1,
               "end_line": 661,
-              "start_column": 5,
-              "start_line": 653
+              "start_column": 1,
+              "start_line": 652
             }
           }
         },
@@ -10932,22 +7261,31 @@ expression: pretty
       {
         "exceeds": false,
         "scored": {
-          "complexity": 1,
+          "complexity": 2,
           "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
+          "contributors": [
+            {
+              "column": 5,
+              "end_line": 678,
+              "increment": 1,
+              "kind": "if-branch",
+              "line": 674,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
             "value": 2.0
           },
           "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "brda_dash_maps_to_none",
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "flatten_binary_ops_inner",
             "span": {
-              "end_column": 5,
-              "end_line": 668,
-              "start_column": 5,
-              "start_line": 663
+              "end_column": 1,
+              "end_line": 679,
+              "start_column": 1,
+              "start_line": 673
             }
           }
         },
@@ -10956,22 +7294,31 @@ expression: pretty
       {
         "exceeds": false,
         "scored": {
-          "complexity": 1,
+          "complexity": 2,
           "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
+          "contributors": [
+            {
+              "column": 9,
+              "end_line": 732,
+              "increment": 1,
+              "kind": "match",
+              "line": 728,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
             "value": 2.0
           },
           "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "brda_numeric_maps_to_some",
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "CyclomaticCounter::visit_stmt",
             "span": {
               "end_column": 5,
-              "end_line": 675,
+              "end_line": 733,
               "start_column": 5,
-              "start_line": 670
+              "start_line": 727
             }
           }
         },
@@ -10980,22 +7327,31 @@ expression: pretty
       {
         "exceeds": false,
         "scored": {
-          "complexity": 1,
+          "complexity": 2,
           "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
+          "contributors": [
+            {
+              "column": 9,
+              "end_line": 792,
+              "increment": 1,
+              "kind": "if-branch",
+              "line": 790,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
             "value": 2.0
           },
           "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "brda_zero_maps_to_some_zero",
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "CyclomaticCounter::visit_arm",
             "span": {
               "end_column": 5,
-              "end_line": 682,
+              "end_line": 794,
               "start_column": 5,
-              "start_line": 677
+              "start_line": 789
             }
           }
         },
@@ -11004,22 +7360,31 @@ expression: pretty
       {
         "exceeds": false,
         "scored": {
-          "complexity": 1,
+          "complexity": 2,
           "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
+          "contributors": [
+            {
+              "column": 9,
+              "end_line": 832,
+              "increment": 1,
+              "kind": "if-branch",
+              "line": 829,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
             "value": 2.0
           },
           "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "duplicate_brda_sum_taken",
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "CyclomaticCounter::visit_expr_binary",
             "span": {
               "end_column": 5,
-              "end_line": 692,
+              "end_line": 835,
               "start_column": 5,
-              "start_line": 684
+              "start_line": 828
             }
           }
         },
@@ -11028,22 +7393,31 @@ expression: pretty
       {
         "exceeds": false,
         "scored": {
-          "complexity": 1,
+          "complexity": 2,
           "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
+          "contributors": [
+            {
+              "column": 9,
+              "end_line": 856,
+              "increment": 1,
+              "kind": "if-branch",
+              "line": 854,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
             "value": 2.0
           },
           "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "brda_dash_and_numeric_merge",
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "CyclomaticCounter::visit_expr_break",
             "span": {
               "end_column": 5,
-              "end_line": 700,
+              "end_line": 857,
               "start_column": 5,
-              "start_line": 694
+              "start_line": 847
             }
           }
         },
@@ -11052,22 +7426,31 @@ expression: pretty
       {
         "exceeds": false,
         "scored": {
-          "complexity": 1,
+          "complexity": 2,
           "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
+          "contributors": [
+            {
+              "column": 9,
+              "end_line": 1398,
+              "increment": 1,
+              "kind": "match",
+              "line": 1395,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
             "value": 2.0
           },
           "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "brda_missing_fields_is_malformed",
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "invalid_source_returns_error",
             "span": {
               "end_column": 5,
-              "end_line": 727,
+              "end_line": 1399,
               "start_column": 5,
-              "start_line": 718
+              "start_line": 1391
             }
           }
         },
@@ -11076,22 +7459,31 @@ expression: pretty
       {
         "exceeds": false,
         "scored": {
-          "complexity": 1,
+          "complexity": 2,
           "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
+          "contributors": [
+            {
+              "column": 9,
+              "end_line": 1428,
+              "increment": 1,
+              "kind": "for-loop",
+              "line": 1420,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
             "value": 2.0
           },
           "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "brda_missing_taken_is_malformed",
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "base_fn_empty_contributors",
             "span": {
               "end_column": 5,
-              "end_line": 738,
+              "end_line": 1429,
               "start_column": 5,
-              "start_line": 729
+              "start_line": 1418
             }
           }
         },
@@ -11100,22 +7492,31 @@ expression: pretty
       {
         "exceeds": false,
         "scored": {
-          "complexity": 1,
+          "complexity": 2,
           "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
+          "contributors": [
+            {
+              "column": 9,
+              "end_line": 1474,
+              "increment": 1,
+              "kind": "for-loop",
+              "line": 1472,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
             "value": 2.0
           },
           "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "brda_line_zero_is_malformed",
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "match_arm_contributor_cyclomatic",
             "span": {
               "end_column": 5,
-              "end_line": 777,
+              "end_line": 1475,
               "start_column": 5,
-              "start_line": 769
+              "start_line": 1461
             }
           }
         },
@@ -11124,22 +7525,31 @@ expression: pretty
       {
         "exceeds": false,
         "scored": {
-          "complexity": 1,
+          "complexity": 2,
           "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
+          "contributors": [
+            {
+              "column": 9,
+              "end_line": 1791,
+              "increment": 1,
+              "kind": "for-loop",
+              "line": 1782,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
             "value": 2.0
           },
           "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "no_brda_produces_none_branches",
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "contributors_sorted_by_line",
             "span": {
               "end_column": 5,
-              "end_line": 783,
+              "end_line": 1792,
               "start_column": 5,
-              "start_line": 779
+              "start_line": 1773
             }
           }
         },
@@ -11148,22 +7558,31 @@ expression: pretty
       {
         "exceeds": false,
         "scored": {
-          "complexity": 1,
+          "complexity": 2,
           "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
+          "contributors": [
+            {
+              "column": 9,
+              "end_line": 145,
+              "increment": 1,
+              "kind": "for-loop",
+              "line": 143,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
             "value": 2.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "arb_da_line",
+            "qualified_name": "LcovParser::parse_str",
             "span": {
               "end_column": 5,
-              "end_line": 793,
+              "end_line": 149,
               "start_column": 5,
-              "start_line": 791
+              "start_line": 132
             }
           }
         },
@@ -11172,22 +7591,262 @@ expression: pretty
       {
         "exceeds": false,
         "scored": {
-          "complexity": 1,
+          "complexity": 2,
           "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
+          "contributors": [
+            {
+              "column": 72,
+              "end_line": 186,
+              "increment": 1,
+              "kind": "try",
+              "line": 186,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
             "value": 2.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "arb_lcov_input",
+            "qualified_name": "LcovParser::parse",
             "span": {
               "end_column": 5,
-              "end_line": 809,
+              "end_line": 188,
               "start_column": 5,
-              "start_line": 807
+              "start_line": 155
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 2,
+          "complexity_metric": "cognitive",
+          "contributors": [
+            {
+              "column": 5,
+              "end_line": 251,
+              "increment": 1,
+              "kind": "if-branch",
+              "line": 244,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "start_source_file",
+            "span": {
+              "end_column": 1,
+              "end_line": 252,
+              "start_column": 1,
+              "start_line": 241
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 2,
+          "complexity_metric": "cognitive",
+          "contributors": [
+            {
+              "column": 52,
+              "end_line": 330,
+              "increment": 1,
+              "kind": "let-else",
+              "line": 327,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "flush_block",
+            "span": {
+              "end_column": 1,
+              "end_line": 335,
+              "start_column": 1,
+              "start_line": 326
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 2,
+          "complexity_metric": "cognitive",
+          "contributors": [
+            {
+              "column": 5,
+              "end_line": 391,
+              "increment": 1,
+              "kind": "match",
+              "line": 386,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "merge_taken",
+            "span": {
+              "end_column": 1,
+              "end_line": 392,
+              "start_column": 1,
+              "start_line": 385
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 2,
+          "complexity_metric": "cognitive",
+          "contributors": [
+            {
+              "column": 9,
+              "end_line": 626,
+              "increment": 1,
+              "kind": "match",
+              "line": 617,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "malformed_da_produces_diagnostic",
+            "span": {
+              "end_column": 5,
+              "end_line": 627,
+              "start_column": 5,
+              "start_line": 612
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 2,
+          "complexity_metric": "cognitive",
+          "contributors": [
+            {
+              "column": 9,
+              "end_line": 670,
+              "increment": 1,
+              "kind": "match",
+              "line": 661,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "da_line_zero_is_malformed",
+            "span": {
+              "end_column": 5,
+              "end_line": 671,
+              "start_column": 5,
+              "start_line": 657
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 2,
+          "complexity_metric": "cognitive",
+          "contributors": [
+            {
+              "column": 9,
+              "end_line": 789,
+              "increment": 1,
+              "kind": "match",
+              "line": 780,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "malformed_brda_produces_diagnostic",
+            "span": {
+              "end_column": 5,
+              "end_line": 790,
+              "start_column": 5,
+              "start_line": 776
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 2,
+          "complexity_metric": "cognitive",
+          "contributors": [
+            {
+              "column": 13,
+              "end_line": 831,
+              "increment": 1,
+              "kind": "for-loop",
+              "line": 829,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "repeated_sf_blocks_merge_branch_coverage",
+            "span": {
+              "end_column": 5,
+              "end_line": 841,
+              "start_column": 5,
+              "start_line": 814
             }
           }
         },
@@ -11236,30 +7895,6 @@ expression: pretty
               "end_line": 85,
               "start_column": 5,
               "start_line": 76
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 0.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "main.rs",
-            "qualified_name": "main",
-            "span": {
-              "end_column": 1,
-              "end_line": 117,
-              "start_column": 1,
-              "start_line": 78
             }
           }
         },
@@ -11336,38 +7971,3566 @@ expression: pretty
           }
         },
         "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 36.36363636363637,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.26
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "count_cognitive_while",
+            "span": {
+              "end_column": 1,
+              "end_line": 334,
+              "start_column": 1,
+              "start_line": 317
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 50.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.13
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "find_fn",
+            "span": {
+              "end_column": 5,
+              "end_line": 910,
+              "start_column": 5,
+              "start_line": 899
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "SynComplexityAdapter::new",
+            "span": {
+              "end_column": 5,
+              "end_line": 23,
+              "start_column": 5,
+              "start_line": 21
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "FunctionFinder::visit_item_fn",
+            "span": {
+              "end_column": 5,
+              "end_line": 76,
+              "start_column": 5,
+              "start_line": 58
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "FunctionFinder::visit_item_impl",
+            "span": {
+              "end_column": 5,
+              "end_line": 83,
+              "start_column": 5,
+              "start_line": 78
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "FunctionFinder::visit_item_trait",
+            "span": {
+              "end_column": 5,
+              "end_line": 135,
+              "start_column": 5,
+              "start_line": 130
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 85.71428571428571,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "add_contributor",
+            "span": {
+              "end_column": 1,
+              "end_line": 159,
+              "start_column": 1,
+              "start_line": 140
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "end_line_of",
+            "span": {
+              "end_column": 1,
+              "end_line": 167,
+              "start_column": 1,
+              "start_line": 161
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "span_of",
+            "span": {
+              "end_column": 1,
+              "end_line": 190,
+              "start_column": 1,
+              "start_line": 169
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "count_cognitive_block",
+            "span": {
+              "end_column": 1,
+              "end_line": 230,
+              "start_column": 1,
+              "start_line": 220
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "count_cognitive_for_loop",
+            "span": {
+              "end_column": 1,
+              "end_line": 353,
+              "start_column": 1,
+              "start_line": 336
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "count_cognitive_loop",
+            "span": {
+              "end_column": 1,
+              "end_line": 371,
+              "start_column": 1,
+              "start_line": 355
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "count_cognitive_binary",
+            "span": {
+              "end_column": 1,
+              "end_line": 385,
+              "start_column": 1,
+              "start_line": 377
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "count_cognitive_try",
+            "span": {
+              "end_column": 1,
+              "end_line": 401,
+              "start_column": 1,
+              "start_line": 387
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 83.33333333333334,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "count_cognitive_break",
+            "span": {
+              "end_column": 1,
+              "end_line": 417,
+              "start_column": 1,
+              "start_line": 403
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 92.3076923076923,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "count_cognitive_continue",
+            "span": {
+              "end_column": 1,
+              "end_line": 433,
+              "start_column": 1,
+              "start_line": 419
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "count_cognitive_closure",
+            "span": {
+              "end_column": 1,
+              "end_line": 454,
+              "start_column": 1,
+              "start_line": 448
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "flatten_binary_ops",
+            "span": {
+              "end_column": 1,
+              "end_line": 671,
+              "start_column": 1,
+              "start_line": 663
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "count_cyclomatic_block",
+            "span": {
+              "end_column": 1,
+              "end_line": 688,
+              "start_column": 1,
+              "start_line": 683
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "CyclomaticCounter::count_block",
+            "span": {
+              "end_column": 5,
+              "end_line": 705,
+              "start_column": 5,
+              "start_line": 697
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "CyclomaticCounter::bump",
+            "span": {
+              "end_column": 5,
+              "end_line": 717,
+              "start_column": 5,
+              "start_line": 707
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "CyclomaticCounter::with_nesting",
+            "span": {
+              "end_column": 5,
+              "end_line": 723,
+              "start_column": 5,
+              "start_line": 719
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "CyclomaticCounter::visit_expr_while",
+            "span": {
+              "end_column": 5,
+              "end_line": 805,
+              "start_column": 5,
+              "start_line": 796
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "CyclomaticCounter::visit_expr_for_loop",
+            "span": {
+              "end_column": 5,
+              "end_line": 816,
+              "start_column": 5,
+              "start_line": 807
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "CyclomaticCounter::visit_expr_loop",
+            "span": {
+              "end_column": 5,
+              "end_line": 826,
+              "start_column": 5,
+              "start_line": 818
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "CyclomaticCounter::visit_expr_try",
+            "span": {
+              "end_column": 5,
+              "end_line": 845,
+              "start_column": 5,
+              "start_line": 837
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "CyclomaticCounter::visit_expr_continue",
+            "span": {
+              "end_column": 5,
+              "end_line": 866,
+              "start_column": 5,
+              "start_line": 859
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "CyclomaticCounter::visit_expr_closure",
+            "span": {
+              "end_column": 5,
+              "end_line": 873,
+              "start_column": 5,
+              "start_line": 868
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "adapter",
+            "span": {
+              "end_column": 5,
+              "end_line": 884,
+              "start_column": 5,
+              "start_line": 882
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "load_fixture",
+            "span": {
+              "end_column": 5,
+              "end_line": 890,
+              "start_column": 5,
+              "start_line": 886
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "extract_fixture",
+            "span": {
+              "end_column": 5,
+              "end_line": 897,
+              "start_column": 5,
+              "start_line": 892
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "baseline_complexity_is_one_cognitive",
+            "span": {
+              "end_column": 5,
+              "end_line": 926,
+              "start_column": 5,
+              "start_line": 921
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "baseline_complexity_is_one_cyclomatic",
+            "span": {
+              "end_column": 5,
+              "end_line": 933,
+              "start_column": 5,
+              "start_line": 928
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "top_level_fn_identity",
+            "span": {
+              "end_column": 5,
+              "end_line": 944,
+              "start_column": 5,
+              "start_line": 937
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "impl_method_qualified_name",
+            "span": {
+              "end_column": 5,
+              "end_line": 952,
+              "start_column": 5,
+              "start_line": 946
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "span_accuracy",
+            "span": {
+              "end_column": 5,
+              "end_line": 975,
+              "start_column": 5,
+              "start_line": 954
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "span_carries_one_based_columns",
+            "span": {
+              "end_column": 5,
+              "end_line": 996,
+              "start_column": 5,
+              "start_line": 977
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "columns_are_exact_one_based_offsets_unindented",
+            "span": {
+              "end_column": 5,
+              "end_line": 1026,
+              "start_column": 5,
+              "start_line": 998
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "columns_are_exact_one_based_offsets_indented",
+            "span": {
+              "end_column": 5,
+              "end_line": 1051,
+              "start_column": 5,
+              "start_line": 1028
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "multiple_fns_returns_all",
+            "span": {
+              "end_column": 5,
+              "end_line": 1057,
+              "start_column": 5,
+              "start_line": 1053
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "async_fn_detected",
+            "span": {
+              "end_column": 5,
+              "end_line": 1065,
+              "start_column": 5,
+              "start_line": 1059
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "if_else_cognitive",
+            "span": {
+              "end_column": 5,
+              "end_line": 1075,
+              "start_column": 5,
+              "start_line": 1069
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "nested_if_cognitive_penalty",
+            "span": {
+              "end_column": 5,
+              "end_line": 1083,
+              "start_column": 5,
+              "start_line": 1077
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "else_is_not_counted_cognitive",
+            "span": {
+              "end_column": 5,
+              "end_line": 1092,
+              "start_column": 5,
+              "start_line": 1085
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "match_flat_cognitive",
+            "span": {
+              "end_column": 5,
+              "end_line": 1100,
+              "start_column": 5,
+              "start_line": 1094
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "if_else_cyclomatic",
+            "span": {
+              "end_column": 5,
+              "end_line": 1110,
+              "start_column": 5,
+              "start_line": 1104
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "nested_if_cyclomatic",
+            "span": {
+              "end_column": 5,
+              "end_line": 1118,
+              "start_column": 5,
+              "start_line": 1112
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "match_arms_cyclomatic",
+            "span": {
+              "end_column": 5,
+              "end_line": 1126,
+              "start_column": 5,
+              "start_line": 1120
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "cognitive_gte_cyclomatic_for_nested",
+            "span": {
+              "end_column": 5,
+              "end_line": 1139,
+              "start_column": 5,
+              "start_line": 1128
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "bool_same_sequence_cognitive",
+            "span": {
+              "end_column": 5,
+              "end_line": 1149,
+              "start_column": 5,
+              "start_line": 1143
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "bool_same_sequence_cyclomatic",
+            "span": {
+              "end_column": 5,
+              "end_line": 1157,
+              "start_column": 5,
+              "start_line": 1151
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "bool_operator_switch_cognitive",
+            "span": {
+              "end_column": 5,
+              "end_line": 1165,
+              "start_column": 5,
+              "start_line": 1159
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "bool_operator_switch_cyclomatic",
+            "span": {
+              "end_column": 5,
+              "end_line": 1173,
+              "start_column": 5,
+              "start_line": 1167
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "bool_in_condition_cognitive",
+            "span": {
+              "end_column": 5,
+              "end_line": 1181,
+              "start_column": 5,
+              "start_line": 1175
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "long_or_chain_cognitive",
+            "span": {
+              "end_column": 5,
+              "end_line": 1189,
+              "start_column": 5,
+              "start_line": 1183
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "alternating_operators_cognitive",
+            "span": {
+              "end_column": 5,
+              "end_line": 1197,
+              "start_column": 5,
+              "start_line": 1191
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "closure_in_parent_cognitive",
+            "span": {
+              "end_column": 5,
+              "end_line": 1210,
+              "start_column": 5,
+              "start_line": 1201
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "try_operator_cognitive",
+            "span": {
+              "end_column": 5,
+              "end_line": 1220,
+              "start_column": 5,
+              "start_line": 1214
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "try_operator_cyclomatic",
+            "span": {
+              "end_column": 5,
+              "end_line": 1228,
+              "start_column": 5,
+              "start_line": 1222
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "loop_with_break_cognitive",
+            "span": {
+              "end_column": 5,
+              "end_line": 1238,
+              "start_column": 5,
+              "start_line": 1232
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "loop_with_break_cyclomatic",
+            "span": {
+              "end_column": 5,
+              "end_line": 1246,
+              "start_column": 5,
+              "start_line": 1240
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "let_else_cognitive",
+            "span": {
+              "end_column": 5,
+              "end_line": 1256,
+              "start_column": 5,
+              "start_line": 1250
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "let_else_cyclomatic",
+            "span": {
+              "end_column": 5,
+              "end_line": 1264,
+              "start_column": 5,
+              "start_line": 1258
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "chained_try_cognitive",
+            "span": {
+              "end_column": 5,
+              "end_line": 1274,
+              "start_column": 5,
+              "start_line": 1268
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "chained_try_cyclomatic",
+            "span": {
+              "end_column": 5,
+              "end_line": 1282,
+              "start_column": 5,
+              "start_line": 1276
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "for_iterator_try_cognitive",
+            "span": {
+              "end_column": 5,
+              "end_line": 1290,
+              "start_column": 5,
+              "start_line": 1284
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "for_iterator_try_cyclomatic",
+            "span": {
+              "end_column": 5,
+              "end_line": 1298,
+              "start_column": 5,
+              "start_line": 1292
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "match_scrutinee_try_cognitive",
+            "span": {
+              "end_column": 5,
+              "end_line": 1306,
+              "start_column": 5,
+              "start_line": 1300
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "trait_default_method_found",
+            "span": {
+              "end_column": 5,
+              "end_line": 1316,
+              "start_column": 5,
+              "start_line": 1310
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "trait_method_without_default_not_found",
+            "span": {
+              "end_column": 5,
+              "end_line": 1327,
+              "start_column": 5,
+              "start_line": 1318
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "impl_method_no_branch",
+            "span": {
+              "end_column": 5,
+              "end_line": 1379,
+              "start_column": 5,
+              "start_line": 1374
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "impl_method_with_branch",
+            "span": {
+              "end_column": 5,
+              "end_line": 1387,
+              "start_column": 5,
+              "start_line": 1381
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "contributors_for",
+            "span": {
+              "end_column": 5,
+              "end_line": 1416,
+              "start_column": 5,
+              "start_line": 1409
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "if_branch_contributor_cognitive",
+            "span": {
+              "end_column": 5,
+              "end_line": 1438,
+              "start_column": 5,
+              "start_line": 1431
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "nested_if_nesting_increment",
+            "span": {
+              "end_column": 5,
+              "end_line": 1450,
+              "start_column": 5,
+              "start_line": 1440
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "match_contributor_cognitive",
+            "span": {
+              "end_column": 5,
+              "end_line": 1459,
+              "start_column": 5,
+              "start_line": 1452
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "try_contributor_cognitive",
+            "span": {
+              "end_column": 5,
+              "end_line": 1483,
+              "start_column": 5,
+              "start_line": 1477
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "try_contributor_cyclomatic",
+            "span": {
+              "end_column": 5,
+              "end_line": 1491,
+              "start_column": 5,
+              "start_line": 1485
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "let_else_contributor_cognitive",
+            "span": {
+              "end_column": 5,
+              "end_line": 1499,
+              "start_column": 5,
+              "start_line": 1493
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "let_else_contributor_cyclomatic",
+            "span": {
+              "end_column": 5,
+              "end_line": 1507,
+              "start_column": 5,
+              "start_line": 1501
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "loop_contributor_cognitive",
+            "span": {
+              "end_column": 5,
+              "end_line": 1515,
+              "start_column": 5,
+              "start_line": 1509
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "for_loop_contributor_cognitive",
+            "span": {
+              "end_column": 5,
+              "end_line": 1523,
+              "start_column": 5,
+              "start_line": 1517
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "for_loop_contributor_cyclomatic",
+            "span": {
+              "end_column": 5,
+              "end_line": 1531,
+              "start_column": 5,
+              "start_line": 1525
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "while_loop_contributor_cognitive",
+            "span": {
+              "end_column": 5,
+              "end_line": 1539,
+              "start_column": 5,
+              "start_line": 1533
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "while_loop_contributor_cyclomatic",
+            "span": {
+              "end_column": 5,
+              "end_line": 1547,
+              "start_column": 5,
+              "start_line": 1541
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "logical_operator_same_chain_cognitive",
+            "span": {
+              "end_column": 5,
+              "end_line": 1563,
+              "start_column": 5,
+              "start_line": 1549
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "logical_operator_switch_cognitive",
+            "span": {
+              "end_column": 5,
+              "end_line": 1578,
+              "start_column": 5,
+              "start_line": 1565
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "break_contributor",
+            "span": {
+              "end_column": 5,
+              "end_line": 1591,
+              "start_column": 5,
+              "start_line": 1580
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "continue_contributor",
+            "span": {
+              "end_column": 5,
+              "end_line": 1604,
+              "start_column": 5,
+              "start_line": 1593
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "unsafe_block_produces_no_unsafe_contributor",
+            "span": {
+              "end_column": 5,
+              "end_line": 1632,
+              "start_column": 5,
+              "start_line": 1606
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "closure_no_contributor",
+            "span": {
+              "end_column": 5,
+              "end_line": 1644,
+              "start_column": 5,
+              "start_line": 1634
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "nested_if_records_construct_end_line_and_nesting_depth_cognitive",
+            "span": {
+              "end_column": 5,
+              "end_line": 1677,
+              "start_column": 5,
+              "start_line": 1648
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "try_records_token_span_for_atomic_contributor",
+            "span": {
+              "end_column": 5,
+              "end_line": 1691,
+              "start_column": 5,
+              "start_line": 1679
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "for_with_continue_threads_nesting_depth_cognitive",
+            "span": {
+              "end_column": 5,
+              "end_line": 1713,
+              "start_column": 5,
+              "start_line": 1693
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "nested_if_records_nesting_depth_cyclomatic",
+            "span": {
+              "end_column": 5,
+              "end_line": 1732,
+              "start_column": 5,
+              "start_line": 1715
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "for_with_continue_records_nesting_depth_cyclomatic",
+            "span": {
+              "end_column": 5,
+              "end_line": 1752,
+              "start_column": 5,
+              "start_line": 1734
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "match_records_end_line_covering_arms_cognitive",
+            "span": {
+              "end_column": 5,
+              "end_line": 1771,
+              "start_column": 5,
+              "start_line": 1754
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "LcovParser::new",
+            "span": {
+              "end_column": 5,
+              "end_line": 43,
+              "start_column": 5,
+              "start_line": 41
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "push_malformed_record",
+            "span": {
+              "end_column": 1,
+              "end_line": 285,
+              "start_column": 1,
+              "start_line": 278
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "merge_hits",
+            "span": {
+              "end_column": 1,
+              "end_line": 372,
+              "start_column": 1,
+              "start_line": 367
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "merge_branch_value",
+            "span": {
+              "end_column": 1,
+              "end_line": 383,
+              "start_column": 1,
+              "start_line": 374
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "clear_current_block",
+            "span": {
+              "end_column": 1,
+              "end_line": 397,
+              "start_column": 1,
+              "start_line": 394
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "build_parse_output",
+            "span": {
+              "end_column": 1,
+              "end_line": 425,
+              "start_column": 1,
+              "start_line": 399
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "to_line_coverage",
+            "span": {
+              "end_column": 1,
+              "end_line": 432,
+              "start_column": 1,
+              "start_line": 427
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "parser",
+            "span": {
+              "end_column": 5,
+              "end_line": 441,
+              "start_column": 5,
+              "start_line": 439
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "parse",
+            "span": {
+              "end_column": 5,
+              "end_line": 445,
+              "start_column": 5,
+              "start_line": 443
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "empty_input_returns_empty_output",
+            "span": {
+              "end_column": 5,
+              "end_line": 452,
+              "start_column": 5,
+              "start_line": 447
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "validate_str",
+            "span": {
+              "end_column": 5,
+              "end_line": 466,
+              "start_column": 5,
+              "start_line": 456
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "validate_empty_input_rejected",
+            "span": {
+              "end_column": 5,
+              "end_line": 471,
+              "start_column": 5,
+              "start_line": 468
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "validate_no_da_lines_rejected",
+            "span": {
+              "end_column": 5,
+              "end_line": 476,
+              "start_column": 5,
+              "start_line": 473
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "validate_da_outside_sf_block_rejected",
+            "span": {
+              "end_column": 5,
+              "end_line": 481,
+              "start_column": 5,
+              "start_line": 478
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "validate_malformed_da_rejected",
+            "span": {
+              "end_column": 5,
+              "end_line": 486,
+              "start_column": 5,
+              "start_line": 483
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "validate_single_da_inside_sf_block_passes",
+            "span": {
+              "end_column": 5,
+              "end_line": 491,
+              "start_column": 5,
+              "start_line": 488
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "validate_first_da_in_second_block_passes",
+            "span": {
+              "end_column": 5,
+              "end_line": 501,
+              "start_column": 5,
+              "start_line": 493
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "validate_missing_path_returns_open_error",
+            "span": {
+              "end_column": 5,
+              "end_line": 513,
+              "start_column": 5,
+              "start_line": 503
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "single_file_single_da",
+            "span": {
+              "end_column": 5,
+              "end_line": 523,
+              "start_column": 5,
+              "start_line": 515
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "multiple_da_lines",
+            "span": {
+              "end_column": 5,
+              "end_line": 533,
+              "start_column": 5,
+              "start_line": 525
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "multiple_source_files",
+            "span": {
+              "end_column": 5,
+              "end_line": 542,
+              "start_column": 5,
+              "start_line": 535
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "hit_count_preservation",
+            "span": {
+              "end_column": 5,
+              "end_line": 550,
+              "start_column": 5,
+              "start_line": 544
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "path_normalization_strips_prefix",
+            "span": {
+              "end_column": 5,
+              "end_line": 556,
+              "start_column": 5,
+              "start_line": 552
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "non_matching_path_passes_through",
+            "span": {
+              "end_column": 5,
+              "end_line": 562,
+              "start_column": 5,
+              "start_line": 558
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "backslash_normalized_to_forward_slash",
+            "span": {
+              "end_column": 5,
+              "end_line": 569,
+              "start_column": 5,
+              "start_line": 564
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "path_boundary_not_confused_by_prefix_substring",
+            "span": {
+              "end_column": 5,
+              "end_line": 575,
+              "start_column": 5,
+              "start_line": 571
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "repeated_sf_blocks_merge_coverage",
+            "span": {
+              "end_column": 5,
+              "end_line": 589,
+              "start_column": 5,
+              "start_line": 577
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "duplicate_da_lines_sum_hits",
+            "span": {
+              "end_column": 5,
+              "end_line": 598,
+              "start_column": 5,
+              "start_line": 591
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "duplicate_da_multiple_lines_sum_correctly",
+            "span": {
+              "end_column": 5,
+              "end_line": 610,
+              "start_column": 5,
+              "start_line": 600
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "malformed_da_does_not_stop_parsing",
+            "span": {
+              "end_column": 5,
+              "end_line": 635,
+              "start_column": 5,
+              "start_line": 629
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "da_missing_hit_count_is_malformed",
+            "span": {
+              "end_column": 5,
+              "end_line": 645,
+              "start_column": 5,
+              "start_line": 637
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "da_negative_hit_count_is_malformed",
+            "span": {
+              "end_column": 5,
+              "end_line": 655,
+              "start_column": 5,
+              "start_line": 647
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "end_of_record_is_ignored",
+            "span": {
+              "end_column": 5,
+              "end_line": 682,
+              "start_column": 5,
+              "start_line": 673
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "unterminated_final_block_emits_data",
+            "span": {
+              "end_column": 5,
+              "end_line": 689,
+              "start_column": 5,
+              "start_line": 684
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "empty_sf_path_emits_diagnostic",
+            "span": {
+              "end_column": 5,
+              "end_line": 700,
+              "start_column": 5,
+              "start_line": 691
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "da_with_checksum_field_is_accepted",
+            "span": {
+              "end_column": 5,
+              "end_line": 709,
+              "start_column": 5,
+              "start_line": 702
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "non_coverage_records_are_ignored",
+            "span": {
+              "end_column": 5,
+              "end_line": 723,
+              "start_column": 5,
+              "start_line": 711
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "brda_and_da_records_parsed",
+            "span": {
+              "end_column": 5,
+              "end_line": 735,
+              "start_column": 5,
+              "start_line": 727
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "brda_dash_maps_to_none",
+            "span": {
+              "end_column": 5,
+              "end_line": 742,
+              "start_column": 5,
+              "start_line": 737
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "brda_numeric_maps_to_some",
+            "span": {
+              "end_column": 5,
+              "end_line": 749,
+              "start_column": 5,
+              "start_line": 744
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "brda_zero_maps_to_some_zero",
+            "span": {
+              "end_column": 5,
+              "end_line": 756,
+              "start_column": 5,
+              "start_line": 751
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "duplicate_brda_sum_taken",
+            "span": {
+              "end_column": 5,
+              "end_line": 766,
+              "start_column": 5,
+              "start_line": 758
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "brda_dash_and_numeric_merge",
+            "span": {
+              "end_column": 5,
+              "end_line": 774,
+              "start_column": 5,
+              "start_line": 768
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "brda_missing_fields_is_malformed",
+            "span": {
+              "end_column": 5,
+              "end_line": 801,
+              "start_column": 5,
+              "start_line": 792
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "brda_missing_taken_is_malformed",
+            "span": {
+              "end_column": 5,
+              "end_line": 812,
+              "start_column": 5,
+              "start_line": 803
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "brda_line_zero_is_malformed",
+            "span": {
+              "end_column": 5,
+              "end_line": 851,
+              "start_column": 5,
+              "start_line": 843
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "no_brda_produces_none_branches",
+            "span": {
+              "end_column": 5,
+              "end_line": 857,
+              "start_column": 5,
+              "start_line": 853
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "arb_da_line",
+            "span": {
+              "end_column": 5,
+              "end_line": 867,
+              "start_column": 5,
+              "start_line": 865
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "arb_lcov_input",
+            "span": {
+              "end_column": 5,
+              "end_line": 883,
+              "start_column": 5,
+              "start_line": 881
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "main.rs",
+            "qualified_name": "main",
+            "span": {
+              "end_column": 1,
+              "end_line": 117,
+              "start_column": 1,
+              "start_line": 78
+            }
+          }
+        },
+        "threshold": 8.0
       }
     ],
     "shown_summary": {
-      "average_complexity": 1.522167487684729,
-      "average_coverage": 0.0,
-      "average_crap": 5.724137931034483,
+      "average_complexity": 1.5637254901960784,
+      "average_coverage": 94.80431610650024,
+      "average_crap": 1.6434313725490195,
       "distribution": {
-        "acceptable": 9,
-        "high": 6,
-        "low": 183,
-        "moderate": 5
+        "acceptable": 3,
+        "high": 0,
+        "low": 201,
+        "moderate": 0
       },
-      "exceeding_threshold": 20,
+      "exceeding_threshold": 3,
       "max_complexity": 11,
       "max_crap": {
-        "risk_level": "high",
-        "value": 132.0
+        "risk_level": "acceptable",
+        "value": 11.04
       },
       "median_complexity": 1.0,
-      "median_coverage": 0.0,
-      "median_crap": 2.0,
+      "median_coverage": 100.0,
+      "median_crap": 1.0,
       "min_coverage": 0.0,
       "total_files": 5,
-      "total_functions": 203,
+      "total_functions": 204,
       "worst_function": {
         "file_path": "adapters/coverage/mod.rs",
         "qualified_name": "parse_brda",
         "span": {
           "end_column": 1,
-          "end_line": 250,
+          "end_line": 324,
           "start_column": 1,
-          "start_line": 227
+          "start_line": 301
         }
       }
     },

--- a/crates/crap-core/tests/snapshots/wire_envelope_crap4rs__envelope.snap
+++ b/crates/crap-core/tests/snapshots/wire_envelope_crap4rs__envelope.snap
@@ -3506,37 +3506,45 @@ expression: pretty
       {
         "exceeds": false,
         "scored": {
-          "complexity": 3,
+          "complexity": 4,
           "complexity_metric": "cognitive",
           "contributors": [
             {
               "column": 9,
-              "end_line": 82,
+              "end_line": 94,
               "increment": 1,
               "kind": "if-branch",
-              "line": 80,
+              "line": 92,
+              "nesting_depth": 0
+            },
+            {
+              "column": 35,
+              "end_line": 92,
+              "increment": 1,
+              "kind": "logical-operator",
+              "line": 92,
               "nesting_depth": 0
             },
             {
               "column": 9,
-              "end_line": 89,
+              "end_line": 101,
               "increment": 1,
               "kind": "if-branch",
-              "line": 87,
+              "line": 99,
               "nesting_depth": 0
             }
           ],
           "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 3.0
+            "value": 4.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
             "qualified_name": "LcovParser::normalize_path",
             "span": {
               "end_column": 5,
-              "end_line": 96,
+              "end_line": 108,
               "start_column": 5,
               "start_line": 45
             }
@@ -3552,42 +3560,42 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 127,
+              "end_line": 139,
               "increment": 1,
               "kind": "for-loop",
-              "line": 115,
+              "line": 127,
               "nesting_depth": 0
             },
             {
               "column": 9,
-              "end_line": 122,
+              "end_line": 134,
               "increment": 2,
               "kind": "if-branch",
-              "line": 117,
+              "line": 129,
               "nesting_depth": 1
             },
             {
               "column": 13,
-              "end_line": 121,
+              "end_line": 133,
               "increment": 1,
               "kind": "continue",
-              "line": 121,
+              "line": 133,
               "nesting_depth": 2
             },
             {
               "column": 9,
-              "end_line": 126,
+              "end_line": 138,
               "increment": 2,
               "kind": "if-branch",
-              "line": 124,
+              "line": 136,
               "nesting_depth": 1
             },
             {
               "column": 44,
-              "end_line": 124,
+              "end_line": 136,
               "increment": 1,
               "kind": "logical-operator",
-              "line": 124,
+              "line": 136,
               "nesting_depth": 1
             }
           ],
@@ -3601,9 +3609,9 @@ expression: pretty
             "qualified_name": "suffix_match_under",
             "span": {
               "end_column": 1,
-              "end_line": 129,
+              "end_line": 141,
               "start_column": 1,
-              "start_line": 99
+              "start_line": 111
             }
           }
         },
@@ -3617,10 +3625,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 145,
+              "end_line": 157,
               "increment": 1,
               "kind": "for-loop",
-              "line": 143,
+              "line": 155,
               "nesting_depth": 0
             }
           ],
@@ -3634,9 +3642,9 @@ expression: pretty
             "qualified_name": "LcovParser::parse_str",
             "span": {
               "end_column": 5,
-              "end_line": 149,
+              "end_line": 161,
               "start_column": 5,
-              "start_line": 132
+              "start_line": 144
             }
           }
         },
@@ -3650,10 +3658,10 @@ expression: pretty
           "contributors": [
             {
               "column": 72,
-              "end_line": 186,
+              "end_line": 198,
               "increment": 1,
               "kind": "try",
-              "line": 186,
+              "line": 198,
               "nesting_depth": 0
             }
           ],
@@ -3667,9 +3675,9 @@ expression: pretty
             "qualified_name": "LcovParser::parse",
             "span": {
               "end_column": 5,
-              "end_line": 188,
+              "end_line": 200,
               "start_column": 5,
-              "start_line": 155
+              "start_line": 167
             }
           }
         },
@@ -3683,58 +3691,58 @@ expression: pretty
           "contributors": [
             {
               "column": 73,
-              "end_line": 203,
+              "end_line": 215,
               "increment": 1,
               "kind": "try",
-              "line": 203,
+              "line": 215,
               "nesting_depth": 0
             },
             {
               "column": 9,
-              "end_line": 220,
+              "end_line": 232,
               "increment": 1,
               "kind": "for-loop",
-              "line": 206,
+              "line": 218,
               "nesting_depth": 0
             },
             {
               "column": 68,
-              "end_line": 207,
+              "end_line": 219,
               "increment": 1,
               "kind": "try",
-              "line": 207,
+              "line": 219,
               "nesting_depth": 1
             },
             {
               "column": 13,
-              "end_line": 211,
+              "end_line": 223,
               "increment": 2,
               "kind": "if-branch",
-              "line": 208,
+              "line": 220,
               "nesting_depth": 1
             },
             {
               "column": 17,
-              "end_line": 210,
+              "end_line": 222,
               "increment": 1,
               "kind": "continue",
-              "line": 210,
+              "line": 222,
               "nesting_depth": 2
             },
             {
               "column": 13,
-              "end_line": 219,
+              "end_line": 231,
               "increment": 2,
               "kind": "if-branch",
-              "line": 212,
+              "line": 224,
               "nesting_depth": 1
             },
             {
               "column": 17,
-              "end_line": 213,
+              "end_line": 225,
               "increment": 1,
               "kind": "logical-operator",
-              "line": 213,
+              "line": 225,
               "nesting_depth": 1
             }
           ],
@@ -3748,9 +3756,9 @@ expression: pretty
             "qualified_name": "LcovParser::validate",
             "span": {
               "end_column": 5,
-              "end_line": 222,
+              "end_line": 234,
               "start_column": 5,
-              "start_line": 190
+              "start_line": 202
             }
           }
         },
@@ -3764,26 +3772,26 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 229,
+              "end_line": 241,
               "increment": 1,
               "kind": "if-branch",
-              "line": 226,
+              "line": 238,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 234,
+              "end_line": 246,
               "increment": 1,
               "kind": "if-branch",
-              "line": 231,
+              "line": 243,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 238,
+              "end_line": 250,
               "increment": 1,
               "kind": "if-branch",
-              "line": 236,
+              "line": 248,
               "nesting_depth": 0
             }
           ],
@@ -3797,9 +3805,9 @@ expression: pretty
             "qualified_name": "handle_parse_line",
             "span": {
               "end_column": 1,
-              "end_line": 239,
+              "end_line": 251,
               "start_column": 1,
-              "start_line": 225
+              "start_line": 237
             }
           }
         },
@@ -3813,26 +3821,26 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 251,
+              "end_line": 263,
               "increment": 1,
               "kind": "if-branch",
-              "line": 244,
+              "line": 256,
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 100.0,
+          "coverage_percent": 85.71428571428571,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 2.01
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
             "qualified_name": "start_source_file",
             "span": {
               "end_column": 1,
-              "end_line": 252,
+              "end_line": 264,
               "start_column": 1,
-              "start_line": 241
+              "start_line": 253
             }
           }
         },
@@ -3846,34 +3854,34 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 257,
+              "end_line": 269,
               "increment": 1,
               "kind": "if-branch",
-              "line": 255,
+              "line": 267,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 262,
+              "end_line": 274,
               "increment": 1,
               "kind": "match",
-              "line": 259,
+              "line": 271,
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 80.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 3.07
+            "value": 3.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
             "qualified_name": "record_da",
             "span": {
               "end_column": 1,
-              "end_line": 263,
+              "end_line": 275,
               "start_column": 1,
-              "start_line": 254
+              "start_line": 266
             }
           }
         },
@@ -3887,18 +3895,18 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 268,
+              "end_line": 280,
               "increment": 1,
               "kind": "if-branch",
-              "line": 266,
+              "line": 278,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 275,
+              "end_line": 287,
               "increment": 1,
               "kind": "match",
-              "line": 270,
+              "line": 282,
               "nesting_depth": 0
             }
           ],
@@ -3912,9 +3920,9 @@ expression: pretty
             "qualified_name": "record_brda",
             "span": {
               "end_column": 1,
-              "end_line": 276,
+              "end_line": 288,
               "start_column": 1,
-              "start_line": 265
+              "start_line": 277
             }
           }
         },
@@ -3936,9 +3944,9 @@ expression: pretty
             "qualified_name": "push_malformed_record",
             "span": {
               "end_column": 1,
-              "end_line": 285,
+              "end_line": 297,
               "start_column": 1,
-              "start_line": 278
+              "start_line": 290
             }
           }
         },
@@ -3952,58 +3960,58 @@ expression: pretty
           "contributors": [
             {
               "column": 56,
-              "end_line": 290,
+              "end_line": 302,
               "increment": 1,
               "kind": "try",
-              "line": 290,
+              "line": 302,
               "nesting_depth": 0
             },
             {
               "column": 52,
-              "end_line": 292,
+              "end_line": 304,
               "increment": 1,
               "kind": "try",
-              "line": 292,
+              "line": 304,
               "nesting_depth": 0
             },
             {
               "column": 58,
-              "end_line": 293,
+              "end_line": 305,
               "increment": 1,
               "kind": "try",
-              "line": 293,
+              "line": 305,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 296,
+              "end_line": 308,
               "increment": 1,
               "kind": "if-branch",
-              "line": 294,
+              "line": 306,
               "nesting_depth": 0
             },
             {
               "column": 53,
-              "end_line": 297,
+              "end_line": 309,
               "increment": 1,
               "kind": "try",
-              "line": 297,
+              "line": 309,
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 100.0,
+          "coverage_percent": 88.88888888888889,
           "crap": {
             "risk_level": "low",
-            "value": 6.0
+            "value": 6.05
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
             "qualified_name": "parse_da",
             "span": {
               "end_column": 1,
-              "end_line": 299,
+              "end_line": 311,
               "start_column": 1,
-              "start_line": 287
+              "start_line": 299
             }
           }
         },
@@ -4017,98 +4025,98 @@ expression: pretty
           "contributors": [
             {
               "column": 42,
-              "end_line": 306,
+              "end_line": 318,
               "increment": 1,
               "kind": "try",
-              "line": 306,
+              "line": 318,
               "nesting_depth": 0
             },
             {
               "column": 43,
-              "end_line": 307,
+              "end_line": 319,
               "increment": 1,
               "kind": "try",
-              "line": 307,
+              "line": 319,
               "nesting_depth": 0
             },
             {
               "column": 44,
-              "end_line": 308,
-              "increment": 1,
-              "kind": "try",
-              "line": 308,
-              "nesting_depth": 0
-            },
-            {
-              "column": 43,
-              "end_line": 309,
-              "increment": 1,
-              "kind": "try",
-              "line": 309,
-              "nesting_depth": 0
-            },
-            {
-              "column": 58,
-              "end_line": 311,
-              "increment": 1,
-              "kind": "try",
-              "line": 311,
-              "nesting_depth": 0
-            },
-            {
-              "column": 5,
-              "end_line": 314,
-              "increment": 1,
-              "kind": "if-branch",
-              "line": 312,
-              "nesting_depth": 0
-            },
-            {
-              "column": 55,
-              "end_line": 315,
-              "increment": 1,
-              "kind": "try",
-              "line": 315,
-              "nesting_depth": 0
-            },
-            {
-              "column": 57,
-              "end_line": 316,
-              "increment": 1,
-              "kind": "try",
-              "line": 316,
-              "nesting_depth": 0
-            },
-            {
-              "column": 17,
-              "end_line": 321,
-              "increment": 1,
-              "kind": "if-branch",
-              "line": 317,
-              "nesting_depth": 0
-            },
-            {
-              "column": 54,
               "end_line": 320,
               "increment": 1,
               "kind": "try",
               "line": 320,
+              "nesting_depth": 0
+            },
+            {
+              "column": 43,
+              "end_line": 321,
+              "increment": 1,
+              "kind": "try",
+              "line": 321,
+              "nesting_depth": 0
+            },
+            {
+              "column": 58,
+              "end_line": 323,
+              "increment": 1,
+              "kind": "try",
+              "line": 323,
+              "nesting_depth": 0
+            },
+            {
+              "column": 5,
+              "end_line": 326,
+              "increment": 1,
+              "kind": "if-branch",
+              "line": 324,
+              "nesting_depth": 0
+            },
+            {
+              "column": 55,
+              "end_line": 327,
+              "increment": 1,
+              "kind": "try",
+              "line": 327,
+              "nesting_depth": 0
+            },
+            {
+              "column": 57,
+              "end_line": 328,
+              "increment": 1,
+              "kind": "try",
+              "line": 328,
+              "nesting_depth": 0
+            },
+            {
+              "column": 17,
+              "end_line": 333,
+              "increment": 1,
+              "kind": "if-branch",
+              "line": 329,
+              "nesting_depth": 0
+            },
+            {
+              "column": 54,
+              "end_line": 332,
+              "increment": 1,
+              "kind": "try",
+              "line": 332,
               "nesting_depth": 1
             }
           ],
-          "coverage_percent": 93.33333333333331,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "acceptable",
-            "value": 11.04
+            "value": 11.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
             "qualified_name": "parse_brda",
             "span": {
               "end_column": 1,
-              "end_line": 324,
+              "end_line": 336,
               "start_column": 1,
-              "start_line": 301
+              "start_line": 313
             }
           }
         },
@@ -4122,10 +4130,10 @@ expression: pretty
           "contributors": [
             {
               "column": 52,
-              "end_line": 330,
+              "end_line": 342,
               "increment": 1,
               "kind": "let-else",
-              "line": 327,
+              "line": 339,
               "nesting_depth": 0
             }
           ],
@@ -4139,9 +4147,9 @@ expression: pretty
             "qualified_name": "flush_block",
             "span": {
               "end_column": 1,
-              "end_line": 335,
+              "end_line": 347,
               "start_column": 1,
-              "start_line": 326
+              "start_line": 338
             }
           }
         },
@@ -4155,18 +4163,18 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 344,
+              "end_line": 356,
               "increment": 1,
               "kind": "if-branch",
-              "line": 342,
+              "line": 354,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 349,
+              "end_line": 361,
               "increment": 1,
               "kind": "for-loop",
-              "line": 347,
+              "line": 359,
               "nesting_depth": 0
             }
           ],
@@ -4180,9 +4188,9 @@ expression: pretty
             "qualified_name": "merge_line_block",
             "span": {
               "end_column": 1,
-              "end_line": 350,
+              "end_line": 362,
               "start_column": 1,
-              "start_line": 337
+              "start_line": 349
             }
           }
         },
@@ -4196,18 +4204,18 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 359,
+              "end_line": 371,
               "increment": 1,
               "kind": "if-branch",
-              "line": 357,
+              "line": 369,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 364,
+              "end_line": 376,
               "increment": 1,
               "kind": "for-loop",
-              "line": 362,
+              "line": 374,
               "nesting_depth": 0
             }
           ],
@@ -4221,9 +4229,9 @@ expression: pretty
             "qualified_name": "merge_branch_block",
             "span": {
               "end_column": 1,
-              "end_line": 365,
+              "end_line": 377,
               "start_column": 1,
-              "start_line": 352
+              "start_line": 364
             }
           }
         },
@@ -4245,9 +4253,9 @@ expression: pretty
             "qualified_name": "merge_hits",
             "span": {
               "end_column": 1,
-              "end_line": 372,
+              "end_line": 384,
               "start_column": 1,
-              "start_line": 367
+              "start_line": 379
             }
           }
         },
@@ -4269,9 +4277,9 @@ expression: pretty
             "qualified_name": "merge_branch_value",
             "span": {
               "end_column": 1,
-              "end_line": 383,
+              "end_line": 395,
               "start_column": 1,
-              "start_line": 374
+              "start_line": 386
             }
           }
         },
@@ -4285,10 +4293,10 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 391,
+              "end_line": 403,
               "increment": 1,
               "kind": "match",
-              "line": 386,
+              "line": 398,
               "nesting_depth": 0
             }
           ],
@@ -4302,9 +4310,9 @@ expression: pretty
             "qualified_name": "merge_taken",
             "span": {
               "end_column": 1,
-              "end_line": 392,
+              "end_line": 404,
               "start_column": 1,
-              "start_line": 385
+              "start_line": 397
             }
           }
         },
@@ -4326,9 +4334,9 @@ expression: pretty
             "qualified_name": "clear_current_block",
             "span": {
               "end_column": 1,
-              "end_line": 397,
+              "end_line": 409,
               "start_column": 1,
-              "start_line": 394
+              "start_line": 406
             }
           }
         },
@@ -4350,9 +4358,9 @@ expression: pretty
             "qualified_name": "build_parse_output",
             "span": {
               "end_column": 1,
-              "end_line": 425,
+              "end_line": 437,
               "start_column": 1,
-              "start_line": 399
+              "start_line": 411
             }
           }
         },
@@ -4374,9 +4382,9 @@ expression: pretty
             "qualified_name": "to_line_coverage",
             "span": {
               "end_column": 1,
-              "end_line": 432,
+              "end_line": 444,
               "start_column": 1,
-              "start_line": 427
+              "start_line": 439
             }
           }
         },
@@ -4398,9 +4406,9 @@ expression: pretty
             "qualified_name": "parser",
             "span": {
               "end_column": 5,
-              "end_line": 441,
+              "end_line": 453,
               "start_column": 5,
-              "start_line": 439
+              "start_line": 451
             }
           }
         },
@@ -4422,9 +4430,9 @@ expression: pretty
             "qualified_name": "parse",
             "span": {
               "end_column": 5,
-              "end_line": 445,
+              "end_line": 457,
               "start_column": 5,
-              "start_line": 443
+              "start_line": 455
             }
           }
         },
@@ -4446,9 +4454,9 @@ expression: pretty
             "qualified_name": "empty_input_returns_empty_output",
             "span": {
               "end_column": 5,
-              "end_line": 452,
+              "end_line": 464,
               "start_column": 5,
-              "start_line": 447
+              "start_line": 459
             }
           }
         },
@@ -4470,9 +4478,9 @@ expression: pretty
             "qualified_name": "validate_str",
             "span": {
               "end_column": 5,
-              "end_line": 466,
+              "end_line": 478,
               "start_column": 5,
-              "start_line": 456
+              "start_line": 468
             }
           }
         },
@@ -4494,9 +4502,9 @@ expression: pretty
             "qualified_name": "validate_empty_input_rejected",
             "span": {
               "end_column": 5,
-              "end_line": 471,
+              "end_line": 483,
               "start_column": 5,
-              "start_line": 468
+              "start_line": 480
             }
           }
         },
@@ -4518,9 +4526,9 @@ expression: pretty
             "qualified_name": "validate_no_da_lines_rejected",
             "span": {
               "end_column": 5,
-              "end_line": 476,
+              "end_line": 488,
               "start_column": 5,
-              "start_line": 473
+              "start_line": 485
             }
           }
         },
@@ -4542,9 +4550,9 @@ expression: pretty
             "qualified_name": "validate_da_outside_sf_block_rejected",
             "span": {
               "end_column": 5,
-              "end_line": 481,
+              "end_line": 493,
               "start_column": 5,
-              "start_line": 478
+              "start_line": 490
             }
           }
         },
@@ -4566,9 +4574,9 @@ expression: pretty
             "qualified_name": "validate_malformed_da_rejected",
             "span": {
               "end_column": 5,
-              "end_line": 486,
+              "end_line": 498,
               "start_column": 5,
-              "start_line": 483
+              "start_line": 495
             }
           }
         },
@@ -4590,9 +4598,9 @@ expression: pretty
             "qualified_name": "validate_single_da_inside_sf_block_passes",
             "span": {
               "end_column": 5,
-              "end_line": 491,
+              "end_line": 503,
               "start_column": 5,
-              "start_line": 488
+              "start_line": 500
             }
           }
         },
@@ -4614,9 +4622,9 @@ expression: pretty
             "qualified_name": "validate_first_da_in_second_block_passes",
             "span": {
               "end_column": 5,
-              "end_line": 501,
+              "end_line": 513,
               "start_column": 5,
-              "start_line": 493
+              "start_line": 505
             }
           }
         },
@@ -4638,9 +4646,9 @@ expression: pretty
             "qualified_name": "validate_missing_path_returns_open_error",
             "span": {
               "end_column": 5,
-              "end_line": 513,
+              "end_line": 525,
               "start_column": 5,
-              "start_line": 503
+              "start_line": 515
             }
           }
         },
@@ -4662,9 +4670,9 @@ expression: pretty
             "qualified_name": "single_file_single_da",
             "span": {
               "end_column": 5,
-              "end_line": 523,
+              "end_line": 535,
               "start_column": 5,
-              "start_line": 515
+              "start_line": 527
             }
           }
         },
@@ -4686,9 +4694,9 @@ expression: pretty
             "qualified_name": "multiple_da_lines",
             "span": {
               "end_column": 5,
-              "end_line": 533,
+              "end_line": 545,
               "start_column": 5,
-              "start_line": 525
+              "start_line": 537
             }
           }
         },
@@ -4710,9 +4718,9 @@ expression: pretty
             "qualified_name": "multiple_source_files",
             "span": {
               "end_column": 5,
-              "end_line": 542,
+              "end_line": 554,
               "start_column": 5,
-              "start_line": 535
+              "start_line": 547
             }
           }
         },
@@ -4734,9 +4742,9 @@ expression: pretty
             "qualified_name": "hit_count_preservation",
             "span": {
               "end_column": 5,
-              "end_line": 550,
+              "end_line": 562,
               "start_column": 5,
-              "start_line": 544
+              "start_line": 556
             }
           }
         },
@@ -4758,9 +4766,9 @@ expression: pretty
             "qualified_name": "path_normalization_strips_prefix",
             "span": {
               "end_column": 5,
-              "end_line": 556,
+              "end_line": 568,
               "start_column": 5,
-              "start_line": 552
+              "start_line": 564
             }
           }
         },
@@ -4782,9 +4790,9 @@ expression: pretty
             "qualified_name": "non_matching_path_passes_through",
             "span": {
               "end_column": 5,
-              "end_line": 562,
+              "end_line": 574,
               "start_column": 5,
-              "start_line": 558
+              "start_line": 570
             }
           }
         },
@@ -4806,9 +4814,9 @@ expression: pretty
             "qualified_name": "backslash_normalized_to_forward_slash",
             "span": {
               "end_column": 5,
-              "end_line": 569,
+              "end_line": 581,
               "start_column": 5,
-              "start_line": 564
+              "start_line": 576
             }
           }
         },
@@ -4830,9 +4838,33 @@ expression: pretty
             "qualified_name": "path_boundary_not_confused_by_prefix_substring",
             "span": {
               "end_column": 5,
-              "end_line": 575,
+              "end_line": 587,
               "start_column": 5,
-              "start_line": 571
+              "start_line": 583
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "parentdir_sf_path_does_not_take_fast_path_is_file_probe",
+            "span": {
+              "end_column": 5,
+              "end_line": 622,
+              "start_column": 5,
+              "start_line": 589
             }
           }
         },
@@ -4854,9 +4886,9 @@ expression: pretty
             "qualified_name": "repeated_sf_blocks_merge_coverage",
             "span": {
               "end_column": 5,
-              "end_line": 589,
+              "end_line": 636,
               "start_column": 5,
-              "start_line": 577
+              "start_line": 624
             }
           }
         },
@@ -4878,9 +4910,9 @@ expression: pretty
             "qualified_name": "duplicate_da_lines_sum_hits",
             "span": {
               "end_column": 5,
-              "end_line": 598,
+              "end_line": 645,
               "start_column": 5,
-              "start_line": 591
+              "start_line": 638
             }
           }
         },
@@ -4902,9 +4934,9 @@ expression: pretty
             "qualified_name": "duplicate_da_multiple_lines_sum_correctly",
             "span": {
               "end_column": 5,
-              "end_line": 610,
+              "end_line": 657,
               "start_column": 5,
-              "start_line": 600
+              "start_line": 647
             }
           }
         },
@@ -4918,10 +4950,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 626,
+              "end_line": 673,
               "increment": 1,
               "kind": "match",
-              "line": 617,
+              "line": 664,
               "nesting_depth": 0
             }
           ],
@@ -4935,9 +4967,9 @@ expression: pretty
             "qualified_name": "malformed_da_produces_diagnostic",
             "span": {
               "end_column": 5,
-              "end_line": 627,
+              "end_line": 674,
               "start_column": 5,
-              "start_line": 612
+              "start_line": 659
             }
           }
         },
@@ -4959,9 +4991,9 @@ expression: pretty
             "qualified_name": "malformed_da_does_not_stop_parsing",
             "span": {
               "end_column": 5,
-              "end_line": 635,
+              "end_line": 682,
               "start_column": 5,
-              "start_line": 629
+              "start_line": 676
             }
           }
         },
@@ -4983,9 +5015,9 @@ expression: pretty
             "qualified_name": "da_missing_hit_count_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 645,
+              "end_line": 692,
               "start_column": 5,
-              "start_line": 637
+              "start_line": 684
             }
           }
         },
@@ -5007,9 +5039,9 @@ expression: pretty
             "qualified_name": "da_negative_hit_count_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 655,
+              "end_line": 702,
               "start_column": 5,
-              "start_line": 647
+              "start_line": 694
             }
           }
         },
@@ -5023,10 +5055,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 670,
+              "end_line": 717,
               "increment": 1,
               "kind": "match",
-              "line": 661,
+              "line": 708,
               "nesting_depth": 0
             }
           ],
@@ -5040,9 +5072,9 @@ expression: pretty
             "qualified_name": "da_line_zero_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 671,
+              "end_line": 718,
               "start_column": 5,
-              "start_line": 657
+              "start_line": 704
             }
           }
         },
@@ -5064,9 +5096,9 @@ expression: pretty
             "qualified_name": "end_of_record_is_ignored",
             "span": {
               "end_column": 5,
-              "end_line": 682,
+              "end_line": 729,
               "start_column": 5,
-              "start_line": 673
+              "start_line": 720
             }
           }
         },
@@ -5088,9 +5120,9 @@ expression: pretty
             "qualified_name": "unterminated_final_block_emits_data",
             "span": {
               "end_column": 5,
-              "end_line": 689,
+              "end_line": 736,
               "start_column": 5,
-              "start_line": 684
+              "start_line": 731
             }
           }
         },
@@ -5112,9 +5144,9 @@ expression: pretty
             "qualified_name": "empty_sf_path_emits_diagnostic",
             "span": {
               "end_column": 5,
-              "end_line": 700,
+              "end_line": 747,
               "start_column": 5,
-              "start_line": 691
+              "start_line": 738
             }
           }
         },
@@ -5136,9 +5168,9 @@ expression: pretty
             "qualified_name": "da_with_checksum_field_is_accepted",
             "span": {
               "end_column": 5,
-              "end_line": 709,
+              "end_line": 756,
               "start_column": 5,
-              "start_line": 702
+              "start_line": 749
             }
           }
         },
@@ -5160,9 +5192,9 @@ expression: pretty
             "qualified_name": "non_coverage_records_are_ignored",
             "span": {
               "end_column": 5,
-              "end_line": 723,
+              "end_line": 770,
               "start_column": 5,
-              "start_line": 711
+              "start_line": 758
             }
           }
         },
@@ -5184,9 +5216,9 @@ expression: pretty
             "qualified_name": "brda_and_da_records_parsed",
             "span": {
               "end_column": 5,
-              "end_line": 735,
+              "end_line": 782,
               "start_column": 5,
-              "start_line": 727
+              "start_line": 774
             }
           }
         },
@@ -5208,9 +5240,9 @@ expression: pretty
             "qualified_name": "brda_dash_maps_to_none",
             "span": {
               "end_column": 5,
-              "end_line": 742,
+              "end_line": 789,
               "start_column": 5,
-              "start_line": 737
+              "start_line": 784
             }
           }
         },
@@ -5232,9 +5264,9 @@ expression: pretty
             "qualified_name": "brda_numeric_maps_to_some",
             "span": {
               "end_column": 5,
-              "end_line": 749,
+              "end_line": 796,
               "start_column": 5,
-              "start_line": 744
+              "start_line": 791
             }
           }
         },
@@ -5256,9 +5288,9 @@ expression: pretty
             "qualified_name": "brda_zero_maps_to_some_zero",
             "span": {
               "end_column": 5,
-              "end_line": 756,
+              "end_line": 803,
               "start_column": 5,
-              "start_line": 751
+              "start_line": 798
             }
           }
         },
@@ -5280,9 +5312,9 @@ expression: pretty
             "qualified_name": "duplicate_brda_sum_taken",
             "span": {
               "end_column": 5,
-              "end_line": 766,
+              "end_line": 813,
               "start_column": 5,
-              "start_line": 758
+              "start_line": 805
             }
           }
         },
@@ -5304,9 +5336,9 @@ expression: pretty
             "qualified_name": "brda_dash_and_numeric_merge",
             "span": {
               "end_column": 5,
-              "end_line": 774,
+              "end_line": 821,
               "start_column": 5,
-              "start_line": 768
+              "start_line": 815
             }
           }
         },
@@ -5320,10 +5352,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 789,
+              "end_line": 836,
               "increment": 1,
               "kind": "match",
-              "line": 780,
+              "line": 827,
               "nesting_depth": 0
             }
           ],
@@ -5337,9 +5369,9 @@ expression: pretty
             "qualified_name": "malformed_brda_produces_diagnostic",
             "span": {
               "end_column": 5,
-              "end_line": 790,
+              "end_line": 837,
               "start_column": 5,
-              "start_line": 776
+              "start_line": 823
             }
           }
         },
@@ -5361,9 +5393,9 @@ expression: pretty
             "qualified_name": "brda_missing_fields_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 801,
+              "end_line": 848,
               "start_column": 5,
-              "start_line": 792
+              "start_line": 839
             }
           }
         },
@@ -5385,9 +5417,9 @@ expression: pretty
             "qualified_name": "brda_missing_taken_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 812,
+              "end_line": 859,
               "start_column": 5,
-              "start_line": 803
+              "start_line": 850
             }
           }
         },
@@ -5401,10 +5433,10 @@ expression: pretty
           "contributors": [
             {
               "column": 13,
-              "end_line": 831,
+              "end_line": 878,
               "increment": 1,
               "kind": "for-loop",
-              "line": 829,
+              "line": 876,
               "nesting_depth": 0
             }
           ],
@@ -5418,9 +5450,9 @@ expression: pretty
             "qualified_name": "repeated_sf_blocks_merge_branch_coverage",
             "span": {
               "end_column": 5,
-              "end_line": 841,
+              "end_line": 888,
               "start_column": 5,
-              "start_line": 814
+              "start_line": 861
             }
           }
         },
@@ -5442,9 +5474,9 @@ expression: pretty
             "qualified_name": "brda_line_zero_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 851,
+              "end_line": 898,
               "start_column": 5,
-              "start_line": 843
+              "start_line": 890
             }
           }
         },
@@ -5466,9 +5498,9 @@ expression: pretty
             "qualified_name": "no_brda_produces_none_branches",
             "span": {
               "end_column": 5,
-              "end_line": 857,
+              "end_line": 904,
               "start_column": 5,
-              "start_line": 853
+              "start_line": 900
             }
           }
         },
@@ -5490,9 +5522,9 @@ expression: pretty
             "qualified_name": "arb_da_line",
             "span": {
               "end_column": 5,
-              "end_line": 867,
+              "end_line": 914,
               "start_column": 5,
-              "start_line": 865
+              "start_line": 912
             }
           }
         },
@@ -5506,10 +5538,10 @@ expression: pretty
           "contributors": [
             {
               "column": 13,
-              "end_line": 875,
+              "end_line": 922,
               "increment": 2,
               "kind": "for-loop",
-              "line": 872,
+              "line": 919,
               "nesting_depth": 1
             }
           ],
@@ -5523,9 +5555,9 @@ expression: pretty
             "qualified_name": "arb_lcov_block",
             "span": {
               "end_column": 5,
-              "end_line": 879,
+              "end_line": 926,
               "start_column": 5,
-              "start_line": 869
+              "start_line": 916
             }
           }
         },
@@ -5547,9 +5579,9 @@ expression: pretty
             "qualified_name": "arb_lcov_input",
             "span": {
               "end_column": 5,
-              "end_line": 883,
+              "end_line": 930,
               "start_column": 5,
-              "start_line": 881
+              "start_line": 928
             }
           }
         },
@@ -5735,35 +5767,35 @@ expression: pretty
     ],
     "passed": false,
     "summary": {
-      "average_complexity": 1.5637254901960784,
-      "average_coverage": 94.80431610650024,
-      "average_crap": 1.6434313725490195,
+      "average_complexity": 1.5658536585365854,
+      "average_coverage": 94.8358552536385,
+      "average_crap": 1.6449268292682926,
       "distribution": {
         "acceptable": 3,
         "high": 0,
-        "low": 201,
+        "low": 202,
         "moderate": 0
       },
       "exceeding_threshold": 3,
       "max_complexity": 11,
       "max_crap": {
         "risk_level": "acceptable",
-        "value": 11.04
+        "value": 11.0
       },
       "median_complexity": 1.0,
       "median_coverage": 100.0,
       "median_crap": 1.0,
       "min_coverage": 0.0,
       "total_files": 5,
-      "total_functions": 204,
+      "total_functions": 205,
       "worst_function": {
         "file_path": "adapters/coverage/mod.rs",
         "qualified_name": "parse_brda",
         "span": {
           "end_column": 1,
-          "end_line": 324,
+          "end_line": 336,
           "start_column": 1,
-          "start_line": 301
+          "start_line": 313
         }
       }
     }
@@ -5773,7 +5805,7 @@ expression: pretty
   "timestamp": "[STRIPPED:timestamp]",
   "tool_version": "[STRIPPED:tool_version]",
   "view": {
-    "eligible_count": 204,
+    "eligible_count": 205,
     "grouped": null,
     "shown": [
       {
@@ -5784,98 +5816,98 @@ expression: pretty
           "contributors": [
             {
               "column": 42,
-              "end_line": 306,
+              "end_line": 318,
               "increment": 1,
               "kind": "try",
-              "line": 306,
+              "line": 318,
               "nesting_depth": 0
             },
             {
               "column": 43,
-              "end_line": 307,
+              "end_line": 319,
               "increment": 1,
               "kind": "try",
-              "line": 307,
+              "line": 319,
               "nesting_depth": 0
             },
             {
               "column": 44,
-              "end_line": 308,
-              "increment": 1,
-              "kind": "try",
-              "line": 308,
-              "nesting_depth": 0
-            },
-            {
-              "column": 43,
-              "end_line": 309,
-              "increment": 1,
-              "kind": "try",
-              "line": 309,
-              "nesting_depth": 0
-            },
-            {
-              "column": 58,
-              "end_line": 311,
-              "increment": 1,
-              "kind": "try",
-              "line": 311,
-              "nesting_depth": 0
-            },
-            {
-              "column": 5,
-              "end_line": 314,
-              "increment": 1,
-              "kind": "if-branch",
-              "line": 312,
-              "nesting_depth": 0
-            },
-            {
-              "column": 55,
-              "end_line": 315,
-              "increment": 1,
-              "kind": "try",
-              "line": 315,
-              "nesting_depth": 0
-            },
-            {
-              "column": 57,
-              "end_line": 316,
-              "increment": 1,
-              "kind": "try",
-              "line": 316,
-              "nesting_depth": 0
-            },
-            {
-              "column": 17,
-              "end_line": 321,
-              "increment": 1,
-              "kind": "if-branch",
-              "line": 317,
-              "nesting_depth": 0
-            },
-            {
-              "column": 54,
               "end_line": 320,
               "increment": 1,
               "kind": "try",
               "line": 320,
+              "nesting_depth": 0
+            },
+            {
+              "column": 43,
+              "end_line": 321,
+              "increment": 1,
+              "kind": "try",
+              "line": 321,
+              "nesting_depth": 0
+            },
+            {
+              "column": 58,
+              "end_line": 323,
+              "increment": 1,
+              "kind": "try",
+              "line": 323,
+              "nesting_depth": 0
+            },
+            {
+              "column": 5,
+              "end_line": 326,
+              "increment": 1,
+              "kind": "if-branch",
+              "line": 324,
+              "nesting_depth": 0
+            },
+            {
+              "column": 55,
+              "end_line": 327,
+              "increment": 1,
+              "kind": "try",
+              "line": 327,
+              "nesting_depth": 0
+            },
+            {
+              "column": 57,
+              "end_line": 328,
+              "increment": 1,
+              "kind": "try",
+              "line": 328,
+              "nesting_depth": 0
+            },
+            {
+              "column": 17,
+              "end_line": 333,
+              "increment": 1,
+              "kind": "if-branch",
+              "line": 329,
+              "nesting_depth": 0
+            },
+            {
+              "column": 54,
+              "end_line": 332,
+              "increment": 1,
+              "kind": "try",
+              "line": 332,
               "nesting_depth": 1
             }
           ],
-          "coverage_percent": 93.33333333333331,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "acceptable",
-            "value": 11.04
+            "value": 11.0
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
             "qualified_name": "parse_brda",
             "span": {
               "end_column": 1,
-              "end_line": 324,
+              "end_line": 336,
               "start_column": 1,
-              "start_line": 301
+              "start_line": 313
             }
           }
         },
@@ -5889,58 +5921,58 @@ expression: pretty
           "contributors": [
             {
               "column": 73,
-              "end_line": 203,
+              "end_line": 215,
               "increment": 1,
               "kind": "try",
-              "line": 203,
+              "line": 215,
               "nesting_depth": 0
             },
             {
               "column": 9,
-              "end_line": 220,
+              "end_line": 232,
               "increment": 1,
               "kind": "for-loop",
-              "line": 206,
+              "line": 218,
               "nesting_depth": 0
             },
             {
               "column": 68,
-              "end_line": 207,
+              "end_line": 219,
               "increment": 1,
               "kind": "try",
-              "line": 207,
+              "line": 219,
               "nesting_depth": 1
             },
             {
               "column": 13,
-              "end_line": 211,
+              "end_line": 223,
               "increment": 2,
               "kind": "if-branch",
-              "line": 208,
+              "line": 220,
               "nesting_depth": 1
             },
             {
               "column": 17,
-              "end_line": 210,
+              "end_line": 222,
               "increment": 1,
               "kind": "continue",
-              "line": 210,
+              "line": 222,
               "nesting_depth": 2
             },
             {
               "column": 13,
-              "end_line": 219,
+              "end_line": 231,
               "increment": 2,
               "kind": "if-branch",
-              "line": 212,
+              "line": 224,
               "nesting_depth": 1
             },
             {
               "column": 17,
-              "end_line": 213,
+              "end_line": 225,
               "increment": 1,
               "kind": "logical-operator",
-              "line": 213,
+              "line": 225,
               "nesting_depth": 1
             }
           ],
@@ -5954,9 +5986,9 @@ expression: pretty
             "qualified_name": "LcovParser::validate",
             "span": {
               "end_column": 5,
-              "end_line": 222,
+              "end_line": 234,
               "start_column": 5,
-              "start_line": 190
+              "start_line": 202
             }
           }
         },
@@ -6027,42 +6059,42 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 127,
+              "end_line": 139,
               "increment": 1,
               "kind": "for-loop",
-              "line": 115,
+              "line": 127,
               "nesting_depth": 0
             },
             {
               "column": 9,
-              "end_line": 122,
+              "end_line": 134,
               "increment": 2,
               "kind": "if-branch",
-              "line": 117,
+              "line": 129,
               "nesting_depth": 1
             },
             {
               "column": 13,
-              "end_line": 121,
+              "end_line": 133,
               "increment": 1,
               "kind": "continue",
-              "line": 121,
+              "line": 133,
               "nesting_depth": 2
             },
             {
               "column": 9,
-              "end_line": 126,
+              "end_line": 138,
               "increment": 2,
               "kind": "if-branch",
-              "line": 124,
+              "line": 136,
               "nesting_depth": 1
             },
             {
               "column": 44,
-              "end_line": 124,
+              "end_line": 136,
               "increment": 1,
               "kind": "logical-operator",
-              "line": 124,
+              "line": 136,
               "nesting_depth": 1
             }
           ],
@@ -6076,9 +6108,9 @@ expression: pretty
             "qualified_name": "suffix_match_under",
             "span": {
               "end_column": 1,
-              "end_line": 129,
+              "end_line": 141,
               "start_column": 1,
-              "start_line": 99
+              "start_line": 111
             }
           }
         },
@@ -6231,58 +6263,58 @@ expression: pretty
           "contributors": [
             {
               "column": 56,
-              "end_line": 290,
+              "end_line": 302,
               "increment": 1,
               "kind": "try",
-              "line": 290,
+              "line": 302,
               "nesting_depth": 0
             },
             {
               "column": 52,
-              "end_line": 292,
+              "end_line": 304,
               "increment": 1,
               "kind": "try",
-              "line": 292,
+              "line": 304,
               "nesting_depth": 0
             },
             {
               "column": 58,
-              "end_line": 293,
+              "end_line": 305,
               "increment": 1,
               "kind": "try",
-              "line": 293,
+              "line": 305,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 296,
+              "end_line": 308,
               "increment": 1,
               "kind": "if-branch",
-              "line": 294,
+              "line": 306,
               "nesting_depth": 0
             },
             {
               "column": 53,
-              "end_line": 297,
+              "end_line": 309,
               "increment": 1,
               "kind": "try",
-              "line": 297,
+              "line": 309,
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 100.0,
+          "coverage_percent": 88.88888888888889,
           "crap": {
             "risk_level": "low",
-            "value": 6.0
+            "value": 6.05
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
             "qualified_name": "parse_da",
             "span": {
               "end_column": 1,
-              "end_line": 299,
+              "end_line": 311,
               "start_column": 1,
-              "start_line": 287
+              "start_line": 299
             }
           }
         },
@@ -6484,27 +6516,76 @@ expression: pretty
           "complexity_metric": "cognitive",
           "contributors": [
             {
-              "column": 5,
-              "end_line": 229,
+              "column": 9,
+              "end_line": 94,
               "increment": 1,
               "kind": "if-branch",
-              "line": 226,
+              "line": 92,
+              "nesting_depth": 0
+            },
+            {
+              "column": 35,
+              "end_line": 92,
+              "increment": 1,
+              "kind": "logical-operator",
+              "line": 92,
+              "nesting_depth": 0
+            },
+            {
+              "column": 9,
+              "end_line": 101,
+              "increment": 1,
+              "kind": "if-branch",
+              "line": 99,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 4.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "LcovParser::normalize_path",
+            "span": {
+              "end_column": 5,
+              "end_line": 108,
+              "start_column": 5,
+              "start_line": 45
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 4,
+          "complexity_metric": "cognitive",
+          "contributors": [
+            {
+              "column": 5,
+              "end_line": 241,
+              "increment": 1,
+              "kind": "if-branch",
+              "line": 238,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 234,
+              "end_line": 246,
               "increment": 1,
               "kind": "if-branch",
-              "line": 231,
+              "line": 243,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 238,
+              "end_line": 250,
               "increment": 1,
               "kind": "if-branch",
-              "line": 236,
+              "line": 248,
               "nesting_depth": 0
             }
           ],
@@ -6518,9 +6599,9 @@ expression: pretty
             "qualified_name": "handle_parse_line",
             "span": {
               "end_column": 1,
-              "end_line": 239,
+              "end_line": 251,
               "start_column": 1,
-              "start_line": 225
+              "start_line": 237
             }
           }
         },
@@ -6562,47 +6643,6 @@ expression: pretty
               "end_line": 201,
               "start_column": 1,
               "start_line": 192
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 3,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 5,
-              "end_line": 257,
-              "increment": 1,
-              "kind": "if-branch",
-              "line": 255,
-              "nesting_depth": 0
-            },
-            {
-              "column": 5,
-              "end_line": 262,
-              "increment": 1,
-              "kind": "match",
-              "line": 259,
-              "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 80.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 3.07
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "record_da",
-            "span": {
-              "end_column": 1,
-              "end_line": 263,
-              "start_column": 1,
-              "start_line": 254
             }
           }
         },
@@ -6738,19 +6778,19 @@ expression: pretty
           "complexity_metric": "cognitive",
           "contributors": [
             {
-              "column": 9,
-              "end_line": 82,
+              "column": 5,
+              "end_line": 269,
               "increment": 1,
               "kind": "if-branch",
-              "line": 80,
+              "line": 267,
               "nesting_depth": 0
             },
             {
-              "column": 9,
-              "end_line": 89,
+              "column": 5,
+              "end_line": 274,
               "increment": 1,
-              "kind": "if-branch",
-              "line": 87,
+              "kind": "match",
+              "line": 271,
               "nesting_depth": 0
             }
           ],
@@ -6761,12 +6801,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "LcovParser::normalize_path",
+            "qualified_name": "record_da",
             "span": {
-              "end_column": 5,
-              "end_line": 96,
-              "start_column": 5,
-              "start_line": 45
+              "end_column": 1,
+              "end_line": 275,
+              "start_column": 1,
+              "start_line": 266
             }
           }
         },
@@ -6780,18 +6820,18 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 268,
+              "end_line": 280,
               "increment": 1,
               "kind": "if-branch",
-              "line": 266,
+              "line": 278,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 275,
+              "end_line": 287,
               "increment": 1,
               "kind": "match",
-              "line": 270,
+              "line": 282,
               "nesting_depth": 0
             }
           ],
@@ -6805,9 +6845,9 @@ expression: pretty
             "qualified_name": "record_brda",
             "span": {
               "end_column": 1,
-              "end_line": 276,
+              "end_line": 288,
               "start_column": 1,
-              "start_line": 265
+              "start_line": 277
             }
           }
         },
@@ -6821,18 +6861,18 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 344,
+              "end_line": 356,
               "increment": 1,
               "kind": "if-branch",
-              "line": 342,
+              "line": 354,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 349,
+              "end_line": 361,
               "increment": 1,
               "kind": "for-loop",
-              "line": 347,
+              "line": 359,
               "nesting_depth": 0
             }
           ],
@@ -6846,9 +6886,9 @@ expression: pretty
             "qualified_name": "merge_line_block",
             "span": {
               "end_column": 1,
-              "end_line": 350,
+              "end_line": 362,
               "start_column": 1,
-              "start_line": 337
+              "start_line": 349
             }
           }
         },
@@ -6862,18 +6902,18 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 359,
+              "end_line": 371,
               "increment": 1,
               "kind": "if-branch",
-              "line": 357,
+              "line": 369,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 364,
+              "end_line": 376,
               "increment": 1,
               "kind": "for-loop",
-              "line": 362,
+              "line": 374,
               "nesting_depth": 0
             }
           ],
@@ -6887,9 +6927,9 @@ expression: pretty
             "qualified_name": "merge_branch_block",
             "span": {
               "end_column": 1,
-              "end_line": 365,
+              "end_line": 377,
               "start_column": 1,
-              "start_line": 352
+              "start_line": 364
             }
           }
         },
@@ -6903,10 +6943,10 @@ expression: pretty
           "contributors": [
             {
               "column": 13,
-              "end_line": 875,
+              "end_line": 922,
               "increment": 2,
               "kind": "for-loop",
-              "line": 872,
+              "line": 919,
               "nesting_depth": 1
             }
           ],
@@ -6920,9 +6960,9 @@ expression: pretty
             "qualified_name": "arb_lcov_block",
             "span": {
               "end_column": 5,
-              "end_line": 879,
+              "end_line": 926,
               "start_column": 5,
-              "start_line": 869
+              "start_line": 916
             }
           }
         },
@@ -6989,6 +7029,39 @@ expression: pretty
               "end_line": 466,
               "start_column": 1,
               "start_line": 456
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 2,
+          "complexity_metric": "cognitive",
+          "contributors": [
+            {
+              "column": 5,
+              "end_line": 263,
+              "increment": 1,
+              "kind": "if-branch",
+              "line": 256,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 85.71428571428571,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.01
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "start_source_file",
+            "span": {
+              "end_column": 1,
+              "end_line": 264,
+              "start_column": 1,
+              "start_line": 253
             }
           }
         },
@@ -7563,10 +7636,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 145,
+              "end_line": 157,
               "increment": 1,
               "kind": "for-loop",
-              "line": 143,
+              "line": 155,
               "nesting_depth": 0
             }
           ],
@@ -7580,9 +7653,9 @@ expression: pretty
             "qualified_name": "LcovParser::parse_str",
             "span": {
               "end_column": 5,
-              "end_line": 149,
+              "end_line": 161,
               "start_column": 5,
-              "start_line": 132
+              "start_line": 144
             }
           }
         },
@@ -7596,10 +7669,10 @@ expression: pretty
           "contributors": [
             {
               "column": 72,
-              "end_line": 186,
+              "end_line": 198,
               "increment": 1,
               "kind": "try",
-              "line": 186,
+              "line": 198,
               "nesting_depth": 0
             }
           ],
@@ -7613,42 +7686,9 @@ expression: pretty
             "qualified_name": "LcovParser::parse",
             "span": {
               "end_column": 5,
-              "end_line": 188,
+              "end_line": 200,
               "start_column": 5,
-              "start_line": 155
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 2,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 5,
-              "end_line": 251,
-              "increment": 1,
-              "kind": "if-branch",
-              "line": 244,
-              "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 100.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "start_source_file",
-            "span": {
-              "end_column": 1,
-              "end_line": 252,
-              "start_column": 1,
-              "start_line": 241
+              "start_line": 167
             }
           }
         },
@@ -7662,10 +7702,10 @@ expression: pretty
           "contributors": [
             {
               "column": 52,
-              "end_line": 330,
+              "end_line": 342,
               "increment": 1,
               "kind": "let-else",
-              "line": 327,
+              "line": 339,
               "nesting_depth": 0
             }
           ],
@@ -7679,9 +7719,9 @@ expression: pretty
             "qualified_name": "flush_block",
             "span": {
               "end_column": 1,
-              "end_line": 335,
+              "end_line": 347,
               "start_column": 1,
-              "start_line": 326
+              "start_line": 338
             }
           }
         },
@@ -7695,10 +7735,10 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 391,
+              "end_line": 403,
               "increment": 1,
               "kind": "match",
-              "line": 386,
+              "line": 398,
               "nesting_depth": 0
             }
           ],
@@ -7712,9 +7752,9 @@ expression: pretty
             "qualified_name": "merge_taken",
             "span": {
               "end_column": 1,
-              "end_line": 392,
+              "end_line": 404,
               "start_column": 1,
-              "start_line": 385
+              "start_line": 397
             }
           }
         },
@@ -7728,10 +7768,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 626,
+              "end_line": 673,
               "increment": 1,
               "kind": "match",
-              "line": 617,
+              "line": 664,
               "nesting_depth": 0
             }
           ],
@@ -7745,9 +7785,9 @@ expression: pretty
             "qualified_name": "malformed_da_produces_diagnostic",
             "span": {
               "end_column": 5,
-              "end_line": 627,
+              "end_line": 674,
               "start_column": 5,
-              "start_line": 612
+              "start_line": 659
             }
           }
         },
@@ -7761,10 +7801,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 670,
+              "end_line": 717,
               "increment": 1,
               "kind": "match",
-              "line": 661,
+              "line": 708,
               "nesting_depth": 0
             }
           ],
@@ -7778,9 +7818,9 @@ expression: pretty
             "qualified_name": "da_line_zero_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 671,
+              "end_line": 718,
               "start_column": 5,
-              "start_line": 657
+              "start_line": 704
             }
           }
         },
@@ -7794,10 +7834,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 789,
+              "end_line": 836,
               "increment": 1,
               "kind": "match",
-              "line": 780,
+              "line": 827,
               "nesting_depth": 0
             }
           ],
@@ -7811,9 +7851,9 @@ expression: pretty
             "qualified_name": "malformed_brda_produces_diagnostic",
             "span": {
               "end_column": 5,
-              "end_line": 790,
+              "end_line": 837,
               "start_column": 5,
-              "start_line": 776
+              "start_line": 823
             }
           }
         },
@@ -7827,10 +7867,10 @@ expression: pretty
           "contributors": [
             {
               "column": 13,
-              "end_line": 831,
+              "end_line": 878,
               "increment": 1,
               "kind": "for-loop",
-              "line": 829,
+              "line": 876,
               "nesting_depth": 0
             }
           ],
@@ -7844,9 +7884,9 @@ expression: pretty
             "qualified_name": "repeated_sf_blocks_merge_branch_coverage",
             "span": {
               "end_column": 5,
-              "end_line": 841,
+              "end_line": 888,
               "start_column": 5,
-              "start_line": 814
+              "start_line": 861
             }
           }
         },
@@ -10340,9 +10380,9 @@ expression: pretty
             "qualified_name": "push_malformed_record",
             "span": {
               "end_column": 1,
-              "end_line": 285,
+              "end_line": 297,
               "start_column": 1,
-              "start_line": 278
+              "start_line": 290
             }
           }
         },
@@ -10364,9 +10404,9 @@ expression: pretty
             "qualified_name": "merge_hits",
             "span": {
               "end_column": 1,
-              "end_line": 372,
+              "end_line": 384,
               "start_column": 1,
-              "start_line": 367
+              "start_line": 379
             }
           }
         },
@@ -10388,9 +10428,9 @@ expression: pretty
             "qualified_name": "merge_branch_value",
             "span": {
               "end_column": 1,
-              "end_line": 383,
+              "end_line": 395,
               "start_column": 1,
-              "start_line": 374
+              "start_line": 386
             }
           }
         },
@@ -10412,9 +10452,9 @@ expression: pretty
             "qualified_name": "clear_current_block",
             "span": {
               "end_column": 1,
-              "end_line": 397,
+              "end_line": 409,
               "start_column": 1,
-              "start_line": 394
+              "start_line": 406
             }
           }
         },
@@ -10436,9 +10476,9 @@ expression: pretty
             "qualified_name": "build_parse_output",
             "span": {
               "end_column": 1,
-              "end_line": 425,
+              "end_line": 437,
               "start_column": 1,
-              "start_line": 399
+              "start_line": 411
             }
           }
         },
@@ -10460,9 +10500,9 @@ expression: pretty
             "qualified_name": "to_line_coverage",
             "span": {
               "end_column": 1,
-              "end_line": 432,
+              "end_line": 444,
               "start_column": 1,
-              "start_line": 427
+              "start_line": 439
             }
           }
         },
@@ -10484,9 +10524,9 @@ expression: pretty
             "qualified_name": "parser",
             "span": {
               "end_column": 5,
-              "end_line": 441,
+              "end_line": 453,
               "start_column": 5,
-              "start_line": 439
+              "start_line": 451
             }
           }
         },
@@ -10508,9 +10548,9 @@ expression: pretty
             "qualified_name": "parse",
             "span": {
               "end_column": 5,
-              "end_line": 445,
+              "end_line": 457,
               "start_column": 5,
-              "start_line": 443
+              "start_line": 455
             }
           }
         },
@@ -10532,9 +10572,9 @@ expression: pretty
             "qualified_name": "empty_input_returns_empty_output",
             "span": {
               "end_column": 5,
-              "end_line": 452,
+              "end_line": 464,
               "start_column": 5,
-              "start_line": 447
+              "start_line": 459
             }
           }
         },
@@ -10556,9 +10596,9 @@ expression: pretty
             "qualified_name": "validate_str",
             "span": {
               "end_column": 5,
-              "end_line": 466,
+              "end_line": 478,
               "start_column": 5,
-              "start_line": 456
+              "start_line": 468
             }
           }
         },
@@ -10580,9 +10620,9 @@ expression: pretty
             "qualified_name": "validate_empty_input_rejected",
             "span": {
               "end_column": 5,
-              "end_line": 471,
+              "end_line": 483,
               "start_column": 5,
-              "start_line": 468
+              "start_line": 480
             }
           }
         },
@@ -10604,9 +10644,9 @@ expression: pretty
             "qualified_name": "validate_no_da_lines_rejected",
             "span": {
               "end_column": 5,
-              "end_line": 476,
+              "end_line": 488,
               "start_column": 5,
-              "start_line": 473
+              "start_line": 485
             }
           }
         },
@@ -10628,9 +10668,9 @@ expression: pretty
             "qualified_name": "validate_da_outside_sf_block_rejected",
             "span": {
               "end_column": 5,
-              "end_line": 481,
+              "end_line": 493,
               "start_column": 5,
-              "start_line": 478
+              "start_line": 490
             }
           }
         },
@@ -10652,9 +10692,9 @@ expression: pretty
             "qualified_name": "validate_malformed_da_rejected",
             "span": {
               "end_column": 5,
-              "end_line": 486,
+              "end_line": 498,
               "start_column": 5,
-              "start_line": 483
+              "start_line": 495
             }
           }
         },
@@ -10676,9 +10716,9 @@ expression: pretty
             "qualified_name": "validate_single_da_inside_sf_block_passes",
             "span": {
               "end_column": 5,
-              "end_line": 491,
+              "end_line": 503,
               "start_column": 5,
-              "start_line": 488
+              "start_line": 500
             }
           }
         },
@@ -10700,9 +10740,9 @@ expression: pretty
             "qualified_name": "validate_first_da_in_second_block_passes",
             "span": {
               "end_column": 5,
-              "end_line": 501,
+              "end_line": 513,
               "start_column": 5,
-              "start_line": 493
+              "start_line": 505
             }
           }
         },
@@ -10724,9 +10764,9 @@ expression: pretty
             "qualified_name": "validate_missing_path_returns_open_error",
             "span": {
               "end_column": 5,
-              "end_line": 513,
+              "end_line": 525,
               "start_column": 5,
-              "start_line": 503
+              "start_line": 515
             }
           }
         },
@@ -10748,9 +10788,9 @@ expression: pretty
             "qualified_name": "single_file_single_da",
             "span": {
               "end_column": 5,
-              "end_line": 523,
+              "end_line": 535,
               "start_column": 5,
-              "start_line": 515
+              "start_line": 527
             }
           }
         },
@@ -10772,9 +10812,9 @@ expression: pretty
             "qualified_name": "multiple_da_lines",
             "span": {
               "end_column": 5,
-              "end_line": 533,
+              "end_line": 545,
               "start_column": 5,
-              "start_line": 525
+              "start_line": 537
             }
           }
         },
@@ -10796,9 +10836,9 @@ expression: pretty
             "qualified_name": "multiple_source_files",
             "span": {
               "end_column": 5,
-              "end_line": 542,
+              "end_line": 554,
               "start_column": 5,
-              "start_line": 535
+              "start_line": 547
             }
           }
         },
@@ -10820,9 +10860,9 @@ expression: pretty
             "qualified_name": "hit_count_preservation",
             "span": {
               "end_column": 5,
-              "end_line": 550,
+              "end_line": 562,
               "start_column": 5,
-              "start_line": 544
+              "start_line": 556
             }
           }
         },
@@ -10844,9 +10884,9 @@ expression: pretty
             "qualified_name": "path_normalization_strips_prefix",
             "span": {
               "end_column": 5,
-              "end_line": 556,
+              "end_line": 568,
               "start_column": 5,
-              "start_line": 552
+              "start_line": 564
             }
           }
         },
@@ -10868,9 +10908,9 @@ expression: pretty
             "qualified_name": "non_matching_path_passes_through",
             "span": {
               "end_column": 5,
-              "end_line": 562,
+              "end_line": 574,
               "start_column": 5,
-              "start_line": 558
+              "start_line": 570
             }
           }
         },
@@ -10892,9 +10932,9 @@ expression: pretty
             "qualified_name": "backslash_normalized_to_forward_slash",
             "span": {
               "end_column": 5,
-              "end_line": 569,
+              "end_line": 581,
               "start_column": 5,
-              "start_line": 564
+              "start_line": 576
             }
           }
         },
@@ -10916,9 +10956,33 @@ expression: pretty
             "qualified_name": "path_boundary_not_confused_by_prefix_substring",
             "span": {
               "end_column": 5,
-              "end_line": 575,
+              "end_line": 587,
               "start_column": 5,
-              "start_line": 571
+              "start_line": 583
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/coverage/mod.rs",
+            "qualified_name": "parentdir_sf_path_does_not_take_fast_path_is_file_probe",
+            "span": {
+              "end_column": 5,
+              "end_line": 622,
+              "start_column": 5,
+              "start_line": 589
             }
           }
         },
@@ -10940,9 +11004,9 @@ expression: pretty
             "qualified_name": "repeated_sf_blocks_merge_coverage",
             "span": {
               "end_column": 5,
-              "end_line": 589,
+              "end_line": 636,
               "start_column": 5,
-              "start_line": 577
+              "start_line": 624
             }
           }
         },
@@ -10964,9 +11028,9 @@ expression: pretty
             "qualified_name": "duplicate_da_lines_sum_hits",
             "span": {
               "end_column": 5,
-              "end_line": 598,
+              "end_line": 645,
               "start_column": 5,
-              "start_line": 591
+              "start_line": 638
             }
           }
         },
@@ -10988,9 +11052,9 @@ expression: pretty
             "qualified_name": "duplicate_da_multiple_lines_sum_correctly",
             "span": {
               "end_column": 5,
-              "end_line": 610,
+              "end_line": 657,
               "start_column": 5,
-              "start_line": 600
+              "start_line": 647
             }
           }
         },
@@ -11012,9 +11076,9 @@ expression: pretty
             "qualified_name": "malformed_da_does_not_stop_parsing",
             "span": {
               "end_column": 5,
-              "end_line": 635,
+              "end_line": 682,
               "start_column": 5,
-              "start_line": 629
+              "start_line": 676
             }
           }
         },
@@ -11036,9 +11100,9 @@ expression: pretty
             "qualified_name": "da_missing_hit_count_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 645,
+              "end_line": 692,
               "start_column": 5,
-              "start_line": 637
+              "start_line": 684
             }
           }
         },
@@ -11060,9 +11124,9 @@ expression: pretty
             "qualified_name": "da_negative_hit_count_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 655,
+              "end_line": 702,
               "start_column": 5,
-              "start_line": 647
+              "start_line": 694
             }
           }
         },
@@ -11084,9 +11148,9 @@ expression: pretty
             "qualified_name": "end_of_record_is_ignored",
             "span": {
               "end_column": 5,
-              "end_line": 682,
+              "end_line": 729,
               "start_column": 5,
-              "start_line": 673
+              "start_line": 720
             }
           }
         },
@@ -11108,9 +11172,9 @@ expression: pretty
             "qualified_name": "unterminated_final_block_emits_data",
             "span": {
               "end_column": 5,
-              "end_line": 689,
+              "end_line": 736,
               "start_column": 5,
-              "start_line": 684
+              "start_line": 731
             }
           }
         },
@@ -11132,9 +11196,9 @@ expression: pretty
             "qualified_name": "empty_sf_path_emits_diagnostic",
             "span": {
               "end_column": 5,
-              "end_line": 700,
+              "end_line": 747,
               "start_column": 5,
-              "start_line": 691
+              "start_line": 738
             }
           }
         },
@@ -11156,9 +11220,9 @@ expression: pretty
             "qualified_name": "da_with_checksum_field_is_accepted",
             "span": {
               "end_column": 5,
-              "end_line": 709,
+              "end_line": 756,
               "start_column": 5,
-              "start_line": 702
+              "start_line": 749
             }
           }
         },
@@ -11180,9 +11244,9 @@ expression: pretty
             "qualified_name": "non_coverage_records_are_ignored",
             "span": {
               "end_column": 5,
-              "end_line": 723,
+              "end_line": 770,
               "start_column": 5,
-              "start_line": 711
+              "start_line": 758
             }
           }
         },
@@ -11204,9 +11268,9 @@ expression: pretty
             "qualified_name": "brda_and_da_records_parsed",
             "span": {
               "end_column": 5,
-              "end_line": 735,
+              "end_line": 782,
               "start_column": 5,
-              "start_line": 727
+              "start_line": 774
             }
           }
         },
@@ -11228,9 +11292,9 @@ expression: pretty
             "qualified_name": "brda_dash_maps_to_none",
             "span": {
               "end_column": 5,
-              "end_line": 742,
+              "end_line": 789,
               "start_column": 5,
-              "start_line": 737
+              "start_line": 784
             }
           }
         },
@@ -11252,9 +11316,9 @@ expression: pretty
             "qualified_name": "brda_numeric_maps_to_some",
             "span": {
               "end_column": 5,
-              "end_line": 749,
+              "end_line": 796,
               "start_column": 5,
-              "start_line": 744
+              "start_line": 791
             }
           }
         },
@@ -11276,9 +11340,9 @@ expression: pretty
             "qualified_name": "brda_zero_maps_to_some_zero",
             "span": {
               "end_column": 5,
-              "end_line": 756,
+              "end_line": 803,
               "start_column": 5,
-              "start_line": 751
+              "start_line": 798
             }
           }
         },
@@ -11300,9 +11364,9 @@ expression: pretty
             "qualified_name": "duplicate_brda_sum_taken",
             "span": {
               "end_column": 5,
-              "end_line": 766,
+              "end_line": 813,
               "start_column": 5,
-              "start_line": 758
+              "start_line": 805
             }
           }
         },
@@ -11324,9 +11388,9 @@ expression: pretty
             "qualified_name": "brda_dash_and_numeric_merge",
             "span": {
               "end_column": 5,
-              "end_line": 774,
+              "end_line": 821,
               "start_column": 5,
-              "start_line": 768
+              "start_line": 815
             }
           }
         },
@@ -11348,9 +11412,9 @@ expression: pretty
             "qualified_name": "brda_missing_fields_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 801,
+              "end_line": 848,
               "start_column": 5,
-              "start_line": 792
+              "start_line": 839
             }
           }
         },
@@ -11372,9 +11436,9 @@ expression: pretty
             "qualified_name": "brda_missing_taken_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 812,
+              "end_line": 859,
               "start_column": 5,
-              "start_line": 803
+              "start_line": 850
             }
           }
         },
@@ -11396,9 +11460,9 @@ expression: pretty
             "qualified_name": "brda_line_zero_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 851,
+              "end_line": 898,
               "start_column": 5,
-              "start_line": 843
+              "start_line": 890
             }
           }
         },
@@ -11420,9 +11484,9 @@ expression: pretty
             "qualified_name": "no_brda_produces_none_branches",
             "span": {
               "end_column": 5,
-              "end_line": 857,
+              "end_line": 904,
               "start_column": 5,
-              "start_line": 853
+              "start_line": 900
             }
           }
         },
@@ -11444,9 +11508,9 @@ expression: pretty
             "qualified_name": "arb_da_line",
             "span": {
               "end_column": 5,
-              "end_line": 867,
+              "end_line": 914,
               "start_column": 5,
-              "start_line": 865
+              "start_line": 912
             }
           }
         },
@@ -11468,9 +11532,9 @@ expression: pretty
             "qualified_name": "arb_lcov_input",
             "span": {
               "end_column": 5,
-              "end_line": 883,
+              "end_line": 930,
               "start_column": 5,
-              "start_line": 881
+              "start_line": 928
             }
           }
         },
@@ -11502,35 +11566,35 @@ expression: pretty
       }
     ],
     "shown_summary": {
-      "average_complexity": 1.5637254901960784,
-      "average_coverage": 94.80431610650024,
-      "average_crap": 1.6434313725490195,
+      "average_complexity": 1.5658536585365854,
+      "average_coverage": 94.8358552536385,
+      "average_crap": 1.6449268292682926,
       "distribution": {
         "acceptable": 3,
         "high": 0,
-        "low": 201,
+        "low": 202,
         "moderate": 0
       },
       "exceeding_threshold": 3,
       "max_complexity": 11,
       "max_crap": {
         "risk_level": "acceptable",
-        "value": 11.04
+        "value": 11.0
       },
       "median_complexity": 1.0,
       "median_coverage": 100.0,
       "median_crap": 1.0,
       "min_coverage": 0.0,
       "total_files": 5,
-      "total_functions": 204,
+      "total_functions": 205,
       "worst_function": {
         "file_path": "adapters/coverage/mod.rs",
         "qualified_name": "parse_brda",
         "span": {
           "end_column": 1,
-          "end_line": 324,
+          "end_line": 336,
           "start_column": 1,
-          "start_line": 301
+          "start_line": 313
         }
       }
     },

--- a/crates/crap-examples/README.md
+++ b/crates/crap-examples/README.md
@@ -85,17 +85,21 @@ fail) when source-without-regen drift is detected.
 ```shell
 cargo llvm-cov nextest --package crap-examples \
   --lcov --output-path crates/crap-examples/lcov.info
-sed -i.bak 's|^SF:.*/crates/crap-examples/src/|SF:|' crates/crap-examples/lcov.info
+sed -i.bak "s|^SF:$PWD/||" crates/crap-examples/lcov.info
 rm -f crates/crap-examples/lcov.info.bak
 ```
 
-The `sed` step strips the absolute prefix that `cargo llvm-cov`
-emits by default. The adapters' coverage-to-function matcher joins
-the LCOV's `SF:` paths onto `--src` before lookup, so the committed
-fixture uses paths relative to `--src` (just the file basename in
-this single-directory case). The release-plz envelope build job's
-CI lint rejects any committed `lcov.info` with absolute `SF:` lines
-— stripping is mandatory.
+The `sed` step strips only the machine-specific absolute prefix that
+`cargo llvm-cov` emits by default, leaving **workspace-relative**
+`SF:` paths (`SF:crates/crap-examples/src/config_merger.rs`) — the
+natural shape coverage tooling produces when run from the workspace
+root. The adapters' coverage-to-function matcher resolves
+workspace-relative paths (and absolute and `--src`-relative ones)
+via a filesystem-validated longest-suffix match (crap-rs#331), so
+no further normalization is needed. The release-plz envelope build
+job's CI lint rejects any committed `lcov.info` with absolute `SF:`
+lines (machine-specific paths aren't portable) — stripping the
+`$PWD/` prefix is mandatory.
 
 ### TypeScript (`coverage-final.json`)
 
@@ -104,7 +108,7 @@ cd crates/crap-examples/ts
 npm install
 npm test -- --coverage
 cd ../../..
-jq --arg p "$PWD/crates/crap-examples/ts/" \
+jq --arg p "$PWD/" \
    'with_entries(.key |= ltrimstr($p) | .value.path |= ltrimstr($p))' \
    crates/crap-examples/ts/.vitest-coverage/coverage-final.json \
   > crates/crap-examples/coverage-final.json
@@ -112,10 +116,12 @@ jq --arg p "$PWD/crates/crap-examples/ts/" \
 
 The vitest config emits the Istanbul-shape coverage that `crap4ts`
 consumes (`v8` provider's JSON shape is incompatible — must be
-`@vitest/coverage-istanbul`). The `jq` step strips the absolute
-prefix vitest writes by default; same rationale as the LCOV step
-above. The committed envelope uses file basenames as keys
-(matching the structure the adapter resolves under `--src ts/`).
+`@vitest/coverage-istanbul`). The `jq` step strips only the
+machine-specific `$PWD/` prefix vitest writes by default, leaving
+**workspace-relative** `path` keys
+(`crates/crap-examples/ts/configMerger.ts`); same rationale as the
+LCOV step above. `crap4ts` resolves those to the walker's
+src-relative key via the same filesystem suffix match (crap-rs#331).
 
 ## Reading the envelope
 

--- a/crates/crap-examples/coverage-final.json
+++ b/crates/crap-examples/coverage-final.json
@@ -1,6 +1,6 @@
 {
-  "configMerger.ts": {
-    "path": "configMerger.ts",
+  "crates/crap-examples/ts/configMerger.ts": {
+    "path": "crates/crap-examples/ts/configMerger.ts",
     "statementMap": {
       "0": {
         "start": {
@@ -300,8 +300,8 @@
       ]
     }
   },
-  "csvParser.ts": {
-    "path": "csvParser.ts",
+  "crates/crap-examples/ts/csvParser.ts": {
+    "path": "crates/crap-examples/ts/csvParser.ts",
     "statementMap": {
       "0": {
         "start": {
@@ -976,8 +976,8 @@
       ]
     }
   },
-  "eventLog.ts": {
-    "path": "eventLog.ts",
+  "crates/crap-examples/ts/eventLog.ts": {
+    "path": "crates/crap-examples/ts/eventLog.ts",
     "statementMap": {
       "0": {
         "start": {
@@ -1245,8 +1245,8 @@
     },
     "b": {}
   },
-  "stringUtils.ts": {
-    "path": "stringUtils.ts",
+  "crates/crap-examples/ts/stringUtils.ts": {
+    "path": "crates/crap-examples/ts/stringUtils.ts",
     "statementMap": {
       "0": {
         "start": {

--- a/crates/crap-examples/lcov.info
+++ b/crates/crap-examples/lcov.info
@@ -1,4 +1,4 @@
-SF:config_merger.rs
+SF:crates/crap-examples/src/config_merger.rs
 FN:84,_RNvNtNtCs9n3ZUW95TYq_13crap_examples13config_merger5testss_28defaults_only_passes_through
 FN:100,_RNvNtNtCs9n3ZUW95TYq_13crap_examples13config_merger5testss_30merged_config_default_is_empty
 FN:94,_RNvNtNtCs9n3ZUW95TYq_13crap_examples13config_merger5testss_35env_overrides_defaults_at_top_level
@@ -61,7 +61,7 @@ BRH:0
 LF:45
 LH:36
 end_of_record
-SF:csv_parser.rs
+SF:crates/crap-examples/src/csv_parser.rs
 FN:78,_RNvNtNtCs9n3ZUW95TYq_13crap_examples10csv_parser5testss_21three_unquoted_fields
 FN:85,_RNvNtNtCs9n3ZUW95TYq_13crap_examples10csv_parser5testss_25newline_terminates_record
 FN:104,_RNvNtNtCs9n3ZUW95TYq_13crap_examples10csv_parser5testss_25unterminated_quote_errors
@@ -170,7 +170,7 @@ BRH:0
 LF:79
 LH:79
 end_of_record
-SF:event_log.rs
+SF:crates/crap-examples/src/event_log.rs
 FN:34,_RNvMNtCs9n3ZUW95TYq_13crap_examples9event_logNtB2_8EventLog3len
 FN:26,_RNvMNtCs9n3ZUW95TYq_13crap_examples9event_logNtB2_8EventLog3new
 FN:42,_RNvMNtCs9n3ZUW95TYq_13crap_examples9event_logNtB2_8EventLog4last
@@ -266,7 +266,7 @@ BRH:0
 LF:62
 LH:62
 end_of_record
-SF:string_utils.rs
+SF:crates/crap-examples/src/string_utils.rs
 FN:101,_RNvNtNtCs9n3ZUW95TYq_13crap_examples12string_utils5testss_24slugify_lowercases_ascii
 FN:135,_RNvNtNtCs9n3ZUW95TYq_13crap_examples12string_utils5testss_27pluralize_regular_appends_s
 FN:130,_RNvNtNtCs9n3ZUW95TYq_13crap_examples12string_utils5testss_29pluralize_empty_returns_empty

--- a/crates/crap4rs/src/adapters/coverage/mod.rs
+++ b/crates/crap4rs/src/adapters/coverage/mod.rs
@@ -42,16 +42,90 @@ impl LcovParser {
         Self { root_path }
     }
 
+    /// Reduce an `SF:` path to the source-root-relative key the walker
+    /// uses to identify functions (`FunctionIdentity::file_path`).
+    ///
+    /// Three shapes reach this function, all of which must collapse to
+    /// the same key the syn walker emits via `strip_prefix(options.src)`:
+    ///
+    /// 1. **Absolute, same-machine** (`SF:/ws/crates/foo/src/bar.rs`) —
+    ///    the dominant `cargo llvm-cov` shape when `--src` is canonical.
+    ///    The lexical `strip_prefix(root)` resolves it directly.
+    /// 2. **Already src-relative** (`SF:bar.rs`) — strip is a no-op and
+    ///    the lexical result already names the file under the root.
+    /// 3. **Workspace-relative** (`SF:crates/foo/src/bar.rs`) — the
+    ///    natural shape `cargo llvm-cov` emits when run from the
+    ///    workspace root. The orchestrator hands this parser the
+    ///    *canonical absolute* root, which a relative path cannot
+    ///    lexically strip, so the lexical result keeps the full
+    ///    workspace-relative path. The walker keys by the src-relative
+    ///    basename, so the two never matched and coverage silently
+    ///    dropped to 0 (crap-rs#331). A filesystem-validated
+    ///    longest-suffix match rescues this case.
+    ///
+    /// The suffix match does bounded `.is_file()` I/O — this parser is
+    /// no longer pure strip-prefix; it now converges with crap4ts's
+    /// `IstanbulCoverage::normalize_path`, which made the same trade for
+    /// cross-form portability (#215/#216).
     fn normalize_path(&self, path: &str) -> String {
         let fwd = path.replace('\\', "/");
         let root_fwd = self.root_path.to_string_lossy().replace('\\', "/");
         let p = Path::new(&fwd);
         let root = Path::new(&root_fwd);
-        p.strip_prefix(root)
-            .unwrap_or(p)
-            .to_string_lossy()
-            .into_owned()
+        let lexical = p.strip_prefix(root).unwrap_or(p);
+
+        // Fast path: the lexical strip already names a real file under
+        // the source root (shapes 1 and 2 above). Keep it verbatim — no
+        // suffix scan needed.
+        if root.join(lexical).is_file() {
+            return lexical.to_string_lossy().replace('\\', "/");
+        }
+
+        // Rescue path (#331): a workspace-relative `SF:` line couldn't
+        // strip the canonical absolute root. Recover the walker's key
+        // as the longest path suffix that resolves to a real file.
+        if let Some(suffix) = suffix_match_under(root, p) {
+            return suffix;
+        }
+
+        // Cross-machine fixtures and the parser's fake-path unit tests
+        // have no on-disk file to anchor against; preserve the
+        // historical lexical output so those keys (and their
+        // diagnostics) stay byte-identical.
+        lexical.to_string_lossy().replace('\\', "/")
     }
+}
+
+/// Find the longest suffix of `path` whose components, joined under
+/// `root`, resolve to a real file. Returns the root-relative,
+/// forward-slash-normalised suffix, or `None` if no suffix is reachable.
+///
+/// Iterates longest → shortest so a leaf filename that exists in
+/// multiple directories is disambiguated by the longest shared path —
+/// the structural truth, not the machine-specific prefix. Mirrors
+/// `crap4ts`'s `IstanbulCoverage::suffix_match_under` (#215).
+///
+/// `.is_file()` (one syscall, not `.exists()`) avoids a directory
+/// false-positive. Any suffix containing a `..` component is skipped
+/// before the syscall: `SF:` records are user-supplied, so a `..` that
+/// lexically passes `starts_with(root)` would resolve a real file
+/// *outside* `root` (mirrors crap4ts's #216 traversal guard).
+fn suffix_match_under(root: &Path, path: &Path) -> Option<String> {
+    let components: Vec<_> = path.components().collect();
+    for start in 0..components.len() {
+        let candidate_rel: PathBuf = components[start..].iter().collect();
+        if candidate_rel
+            .components()
+            .any(|c| c == std::path::Component::ParentDir)
+        {
+            continue;
+        }
+        let candidate_abs = root.join(&candidate_rel);
+        if candidate_abs.starts_with(root) && candidate_abs.is_file() {
+            return Some(candidate_rel.to_string_lossy().replace('\\', "/"));
+        }
+    }
+    None
 }
 
 impl LcovParser {

--- a/crates/crap4rs/src/adapters/coverage/mod.rs
+++ b/crates/crap4rs/src/adapters/coverage/mod.rs
@@ -77,7 +77,19 @@ impl LcovParser {
         // Fast path: the lexical strip already names a real file under
         // the source root (shapes 1 and 2 above). Keep it verbatim — no
         // suffix scan needed.
-        if root.join(lexical).is_file() {
+        //
+        // Traversal guard (mirrors crap4ts #216, ported into the
+        // suffix-match below too): `strip_prefix` is lexical, so a
+        // user-supplied `SF:/root/../outside/secret.rs` strips to
+        // `../outside/secret.rs` and `root.join(..).is_file()` would
+        // resolve — and thus probe the existence of — a file *outside*
+        // the source root. Reject any `..` here so a `..`-bearing path
+        // falls through to the suffix match, which skips `..` suffixes
+        // and re-anchors the clean tail under the root.
+        let lexical_has_parentdir = lexical
+            .components()
+            .any(|c| c == std::path::Component::ParentDir);
+        if !lexical_has_parentdir && root.join(lexical).is_file() {
             return lexical.to_string_lossy().replace('\\', "/");
         }
 
@@ -572,6 +584,41 @@ mod tests {
     fn path_boundary_not_confused_by_prefix_substring() {
         let output = parse("SF:/project-old/src/main.rs\nDA:1,1\nend_of_record\n");
         assert!(output.coverage.contains_key("/project-old/src/main.rs"));
+    }
+
+    #[test]
+    fn parentdir_sf_path_does_not_take_fast_path_is_file_probe() {
+        // crap-rs#333 / mirrors crap4ts #216. `SF:` records are
+        // user-supplied; a `..` makes the lexical `strip_prefix` succeed
+        // with a `..`-bearing relative result that `root.join(..).is_file()`
+        // resolves OUTSIDE the root — a traversal-escape existence oracle
+        // on the fast path. The fast path must reject `..` and fall
+        // through to the guarded suffix match, which re-anchors the clean
+        // tail under the root. Needs real on-disk files so the `is_file()`
+        // behaviour is actually exercised.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().canonicalize().expect("canonicalize tempdir");
+        std::fs::write(root.join("secret.rs"), "fn x() {}").expect("write secret.rs");
+        let leaf = root.file_name().unwrap().to_string_lossy().into_owned();
+        let parser = LcovParser::new(root.clone());
+
+        // `<root>/../<leaf>/secret.rs` lexically strips to
+        // `../<leaf>/secret.rs`; the pre-#333 fast path resolved that and
+        // returned the unusable `..` key.
+        let sf = format!("{}/../{leaf}/secret.rs", root.display());
+        let output = parser.parse_str(&format!("SF:{sf}\nDA:1,1\nend_of_record\n"));
+
+        assert!(
+            output.coverage.keys().all(|k| !k.contains("..")),
+            "no coverage key may contain `..`: {:?}",
+            output.coverage.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            output.coverage.contains_key("secret.rs"),
+            "the `..` path must re-anchor to the in-tree `secret.rs` via the \
+             guarded suffix match; keys = {:?}",
+            output.coverage.keys().collect::<Vec<_>>()
+        );
     }
 
     #[test]

--- a/crates/crap4rs/tests/path_matching_workspace_relative.rs
+++ b/crates/crap4rs/tests/path_matching_workspace_relative.rs
@@ -1,0 +1,128 @@
+//! Integration tests for issue #331 — coverage matching must work when
+//! `SF:` records use **workspace-relative** paths (the natural shape
+//! `cargo llvm-cov` emits, e.g. `SF:crates/foo/src/bar.rs`), regardless
+//! of whether `--src` is given as a bare-relative, `./`-relative, or
+//! absolute path.
+//!
+//! Pre-fix, `LcovParser::normalize_path` was a pure lexical
+//! `strip_prefix(root_path)`. The orchestrator hands it the
+//! **canonicalized absolute** source root, but the walker keys functions
+//! by `strip_prefix(options.src)` against the **raw** (often relative)
+//! `--src`. A workspace-relative `SF:` line cannot lexically strip an
+//! absolute root, so it kept the full path while the walker emitted the
+//! src-relative basename — the two never matched and every function
+//! reported `coverage_percent: 0`.
+//!
+//! These fixtures place a real source file on disk and emit
+//! workspace-relative `SF:` lines, so the filesystem-validated
+//! suffix-match fallback added in #331 is actually exercised.
+
+use std::path::Path;
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_crap4rs");
+
+const FIXTURE_SRC: &str = "\
+pub fn passing_a() -> i32 { 1 }
+pub fn passing_b() -> i32 { 2 }
+pub fn passing_c() -> i32 { 3 }
+";
+
+/// Lay out a workspace-shaped tree under `dir`:
+///   - `pkg/src/lib.rs` carrying `FIXTURE_SRC` (3 single-line fns).
+///   - `lcov.info` with **workspace-relative** `SF:` paths
+///     (`SF:pkg/src/lib.rs`) and full line hits.
+///
+/// The binary is invoked with `current_dir(dir)`, so `dir` plays the
+/// role of the workspace root that workspace-relative paths resolve
+/// against — exactly the `cargo llvm-cov` convention.
+fn setup_dir(dir: &Path) {
+    let src = dir.join("pkg").join("src");
+    std::fs::create_dir_all(&src).expect("create pkg/src");
+    std::fs::write(src.join("lib.rs"), FIXTURE_SRC).expect("write lib.rs fixture");
+
+    // Workspace-relative SF: path — what `cargo llvm-cov --lcov` emits
+    // when run from the workspace root without post-processing.
+    let lcov = "SF:pkg/src/lib.rs\nDA:1,1\nDA:2,1\nDA:3,1\nend_of_record\n";
+    std::fs::write(dir.join("lcov.info"), lcov).expect("write lcov.info fixture");
+}
+
+fn run_with_src(dir: &Path, src_arg: &str) -> std::process::Output {
+    Command::new(BINARY)
+        .current_dir(dir)
+        .args([
+            "--src",
+            src_arg,
+            "--coverage",
+            "lcov.info",
+            "--no-gitignore",
+            "--threshold",
+            "5",
+            "--no-fail",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("failed to run crap4rs binary")
+}
+
+/// Parse the binary's JSON envelope and return per-function coverage.
+fn coverage_percents(output: &std::process::Output) -> Vec<f64> {
+    assert!(
+        output.status.success(),
+        "binary exited non-zero (stderr=\n{}\n stdout=\n{})",
+        String::from_utf8_lossy(&output.stderr),
+        String::from_utf8_lossy(&output.stdout),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("stdout was not valid JSON: {e}\nraw stdout:\n{stdout}"));
+    let functions = json["result"]["functions"]
+        .as_array()
+        .expect("envelope must carry a result.functions array");
+    assert!(
+        !functions.is_empty(),
+        "expected at least one scored function; envelope = {json:#?}"
+    );
+    functions
+        .iter()
+        .map(|f| f["scored"]["coverage_percent"].as_f64().unwrap_or(-1.0))
+        .collect()
+}
+
+#[test]
+fn bare_relative_src_with_workspace_relative_coverage_matches() {
+    let dir = tempfile::tempdir().expect("create tempdir");
+    setup_dir(dir.path());
+
+    // Bare-relative `--src` (the natural Cargo-convention shape) paired
+    // with workspace-relative `SF:` paths. The three functions each
+    // occupy a single fully-hit line, so all must score exactly 100.0%.
+    let output = run_with_src(dir.path(), "pkg/src");
+
+    assert_eq!(
+        coverage_percents(&output),
+        vec![100.0, 100.0, 100.0],
+        "workspace-relative SF: paths must match the walker's src-relative \
+         keys under a bare-relative --src (see #331)"
+    );
+}
+
+#[test]
+fn absolute_src_with_workspace_relative_coverage_matches() {
+    let dir = tempfile::tempdir().expect("create tempdir");
+    setup_dir(dir.path());
+
+    // Absolute `--src` paired with workspace-relative `SF:` paths. This
+    // row is only reachable through the filesystem suffix-match fallback
+    // — there is no relative root to lexically strip an absolute SF
+    // against, so a pure-lexical fix cannot satisfy it.
+    let abs_src = dir.path().join("pkg").join("src");
+    let output = run_with_src(dir.path(), &abs_src.to_string_lossy());
+
+    assert_eq!(
+        coverage_percents(&output),
+        vec![100.0, 100.0, 100.0],
+        "workspace-relative SF: paths must match under an absolute --src too (see #331)"
+    );
+}

--- a/crates/crap4ts/src/adapters/coverage/mod.rs
+++ b/crates/crap4ts/src/adapters/coverage/mod.rs
@@ -112,38 +112,46 @@ impl IstanbulCoverage {
     /// Resolve `raw` to a workspace-relative path under
     /// `effective_src`, or `None` if it can't be resolved.
     ///
-    /// Two-arm strategy:
+    /// Two-arm strategy, dispatched on whether `raw` is absolute:
     ///
-    /// 1. **Strip-prefix fast path (pure, no I/O).** Join relative
-    ///    entries against `effective_src`, then strip the canonical
-    ///    `effective_src` prefix. This succeeds whenever the coverage
-    ///    payload was captured on the same machine/tree being analyzed
+    /// 1. **Strip-prefix fast path (absolute, same-machine — pure, no
+    ///    I/O).** Strip the canonical `effective_src` prefix from an
+    ///    absolute `raw`. This succeeds whenever the coverage payload
+    ///    was captured on the same machine/tree being analyzed
     ///    (jest/vitest/nyc on the local checkout). The orchestrator
     ///    pre-canonicalizes `effective_src`, so no `canonicalize()`
-    ///    walk is needed here.
+    ///    walk is needed here. **Relative `raw` skips this arm** — a
+    ///    lexical `effective_src.join(raw)` + `strip_prefix` round-trips
+    ///    a relative path to itself, which for a workspace-relative
+    ///    `path` (`crates/foo/ts/bar.ts`, the natural shape a coverage
+    ///    tool emits from the workspace root) is a *nonexistent* file.
+    ///    The old code accepted that invalid result and shadowed arm 2,
+    ///    so coverage silently dropped to 0 (crap-rs#331).
     /// 2. **Suffix-reachability fallback (bounded `.is_file()` I/O,
-    ///    #215).** When the coverage was captured on a *different*
-    ///    machine (a portable fixture: coverage produced on machine A,
-    ///    analyzed on machine B), the entry's absolute path shares no
-    ///    prefix with the local `effective_src` and arm 1 returns
-    ///    `None`. Arm 2 then walks the path's components longest →
-    ///    shortest, joining each suffix under `effective_src` and
-    ///    accepting the first suffix that resolves to a real file. The
-    ///    longest matching suffix wins, which deterministically
+    ///    #215).** Handles two cases: a *relative* `raw` (routed here
+    ///    directly per arm 1 above), and a cross-machine *absolute*
+    ///    `raw` (portable fixture: coverage produced on machine A,
+    ///    analyzed on machine B) whose path shares no prefix with the
+    ///    local `effective_src`. Arm 2 walks the path's components
+    ///    longest → shortest, joining each suffix under `effective_src`
+    ///    and accepting the first suffix that resolves to a real file.
+    ///    The longest matching suffix wins, which deterministically
     ///    disambiguates a leaf filename (e.g. `index.ts`) that exists
     ///    in multiple directories — the longer shared path is the
     ///    structural truth; the machine-specific absolute prefix is
     ///    noise. If two equal-length suffixes could both match (only
     ///    reachable via symlinks/odd trees), the first found wins.
     ///
-    /// This is *not* a pure function and no longer mirrors
-    /// `crap4rs::adapters::coverage::LcovParser::normalize_path` (which
-    /// remains pure strip-prefix): the fallback does bounded,
+    /// This is *not* a pure function: the fallback does bounded,
     /// OS-cached filesystem I/O (~components × `.is_file()` syscalls).
-    /// That trade buys cross-machine fixture portability. When even the
-    /// suffix match fails, this returns `None` and the caller emits
-    /// `PathUnresolved` as before — the diagnostic-and-skip contract
-    /// (D16) is preserved as the final arm.
+    /// That trade buys cross-machine fixture portability *and*
+    /// cross-form (`absolute` / `workspace-relative` / `src-relative`)
+    /// `path` resolution. `crap4rs`'s `LcovParser::normalize_path`
+    /// converged on the same filesystem-validated fallback in #331, so
+    /// the two adapters now resolve coverage paths identically. When
+    /// even the suffix match fails, this returns `None` and the caller
+    /// emits `PathUnresolved` as before — the diagnostic-and-skip
+    /// contract (D16) is preserved as the final arm.
     ///
     /// **Traversal guard (authoritative, #216).** The relative path
     /// returned from *either* arm is rejected (`None`) if it contains a
@@ -162,19 +170,25 @@ impl IstanbulCoverage {
     /// defect.)
     fn normalize_path(&self, raw: &str) -> Option<PathBuf> {
         let path = PathBuf::from(raw);
-        let joined = if path.is_absolute() {
-            path
+        let candidate = if path.is_absolute() {
+            // Arm 1: strip the canonical effective_src prefix (W2.4 fast
+            // path — same-machine absolute capture). Cross-machine
+            // absolute paths don't share a prefix — fall through to the
+            // suffix match (arm 2, #215).
+            if let Ok(stripped) = path.strip_prefix(&self.effective_src) {
+                stripped.to_path_buf()
+            } else {
+                self.suffix_match_under(&path)?
+            }
         } else {
-            self.effective_src.join(raw)
-        };
-        // Arm 1: strip the canonical effective_src prefix (W2.4 fast
-        // path — same-machine capture). Arm 2: cross-machine absolute
-        // paths don't share a prefix — find the longest path suffix
-        // that resolves to a real file under effective_src (#215).
-        let candidate = if let Ok(stripped) = joined.strip_prefix(&self.effective_src) {
-            stripped.to_path_buf()
-        } else {
-            self.suffix_match_under(&joined)?
+            // Relative `raw` (workspace-relative or already src-relative).
+            // A lexical `effective_src.join(raw)` + `strip_prefix` would
+            // round-trip to `raw` verbatim — a nonexistent file for the
+            // workspace-relative case — and shadow arm 2 (crap-rs#331).
+            // Route straight to the filesystem suffix match, which
+            // resolves both `crates/foo/ts/bar.ts` and bare `bar.ts` to
+            // the walker's src-relative key.
+            self.suffix_match_under(&path)?
         };
         // Authoritative traversal guard (#216): both `strip_prefix`
         // and `starts_with` are lexical, so a `..`-containing result

--- a/crates/crap4ts/tests/path_matching_workspace_relative.rs
+++ b/crates/crap4ts/tests/path_matching_workspace_relative.rs
@@ -1,0 +1,133 @@
+//! Integration tests for issue #331 — Istanbul coverage matching must
+//! work when `path` keys are **workspace-relative** (e.g.
+//! `crates/foo/ts/bar.ts`), regardless of whether `--src` is a
+//! bare-relative or absolute path.
+//!
+//! Pre-fix, `IstanbulCoverage::normalize_path` arm 1 lexically joined a
+//! relative `path` under the canonical `effective_src` and stripped the
+//! prefix back off, yielding the workspace-relative path verbatim — a
+//! string that doesn't resolve to a real file and never matches the
+//! walker's src-relative key. Arm 1 returned `Some(invalid)` *before*
+//! arm 2's filesystem-validated suffix match could fire, so every
+//! function reported `coverage_percent: 0`.
+//!
+//! These fixtures place a real `.ts` file on disk and use
+//! workspace-relative `path` keys, so the suffix-match fallback is
+//! actually exercised.
+
+use std::path::{Path, PathBuf};
+
+use assert_cmd::Command;
+
+/// A single-line, fully-covered TS function. Its body occupies line 1,
+/// which the coverage fixture below marks hit — so the matched function
+/// must score exactly 100.0%.
+const ADD_TS: &str = "export function add(a: number, b: number): number { return a + b; }\n";
+
+/// Workspace-relative Istanbul coverage for `pkg/ts/add.ts`. The top
+/// level key AND the `path` field are workspace-relative — the natural
+/// shape a coverage tool emits when run from the workspace root.
+const COVERAGE_JSON: &str = r#"{
+    "pkg/ts/add.ts": {
+        "path": "pkg/ts/add.ts",
+        "statementMap": {
+            "0": { "start": { "line": 1, "column": 0 }, "end": { "line": 1, "column": 68 } }
+        },
+        "s": { "0": 3 },
+        "branchMap": {},
+        "b": {},
+        "fnMap": {},
+        "f": {}
+    }
+}"#;
+
+/// Lay out a workspace-shaped tree under a canonicalised tempdir:
+///   - `pkg/ts/add.ts` carrying `ADD_TS`.
+///   - `coverage-final.json` with workspace-relative `path` keys.
+///
+/// Returns `(TempDir, canonical_root)`. The binary is invoked with
+/// `current_dir(canonical_root)`, so the root plays the role of the
+/// workspace root that relative paths resolve against.
+fn setup_dir() -> (tempfile::TempDir, PathBuf) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    // Canonicalize: macOS /tmp redirects to /private/tmp, and the
+    // orchestrator canonicalizes `effective_src`. Without this the
+    // suffix-match anchors against a different prefix than the walker.
+    let canonical = std::fs::canonicalize(tmp.path()).expect("canonicalize tempdir");
+
+    let ts_dir = canonical.join("pkg").join("ts");
+    std::fs::create_dir_all(&ts_dir).expect("create pkg/ts");
+    std::fs::write(ts_dir.join("add.ts"), ADD_TS).expect("write add.ts");
+    std::fs::write(canonical.join("coverage-final.json"), COVERAGE_JSON)
+        .expect("write coverage-final.json");
+
+    (tmp, canonical)
+}
+
+/// Run `crap4ts --src <src_arg> --coverage coverage-final.json` with
+/// `current_dir(root)` and return the matched function's coverage
+/// percent for `add`.
+fn add_coverage_percent(root: &Path, src_arg: &str) -> f64 {
+    let out = Command::cargo_bin("crap4ts")
+        .expect("crap4ts binary discoverable")
+        .current_dir(root)
+        .args([
+            "--src",
+            src_arg,
+            "--coverage",
+            "coverage-final.json",
+            "--threshold",
+            "16",
+            "--no-fail",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("crap4ts executes");
+
+    assert!(
+        out.status.success(),
+        "crap4ts exited non-zero: stdout={}\nstderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let value: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("crap4ts --format json emits valid JSON");
+    let functions = value["result"]["functions"]
+        .as_array()
+        .expect("envelope must carry a result.functions array");
+    let add = functions
+        .iter()
+        .find(|f| f["scored"]["identity"]["qualified_name"] == "add")
+        .unwrap_or_else(|| panic!("expected an `add` function in the envelope; got {value:#}"));
+    add["scored"]["coverage_percent"]
+        .as_f64()
+        .expect("coverage_percent is a number")
+}
+
+#[test]
+fn bare_relative_src_with_workspace_relative_coverage_matches() {
+    let (_tmp, root) = setup_dir();
+    // Bare-relative `--src` + workspace-relative `path` keys. `add`
+    // occupies a single fully-hit line, so it must score 100.0%.
+    assert_eq!(
+        add_coverage_percent(&root, "pkg/ts"),
+        100.0,
+        "workspace-relative coverage paths must match the walker's \
+         src-relative key under a bare-relative --src (see #331)"
+    );
+}
+
+#[test]
+fn absolute_src_with_workspace_relative_coverage_matches() {
+    let (_tmp, root) = setup_dir();
+    // Absolute `--src` + workspace-relative `path` keys — only reachable
+    // through the filesystem suffix-match fallback (arm 1's lexical
+    // strip produces a nonexistent path here).
+    let abs_src = root.join("pkg").join("ts");
+    assert_eq!(
+        add_coverage_percent(&root, &abs_src.to_string_lossy()),
+        100.0,
+        "workspace-relative coverage paths must match under an absolute --src too (see #331)"
+    );
+}


### PR DESCRIPTION
## Summary

Both adapters' coverage-to-function matchers produced **0% coverage**
when `--src` was any form and committed coverage records used
**workspace-relative** paths (`SF:crates/foo/src/bar.rs` for LCOV;
`"crates/foo/ts/bar.ts"` keys for Istanbul) — the natural shape
`cargo llvm-cov` / vitest emit from the workspace root. Each adapter
had a distinct root cause; both produced the same surface symptom
(empty join → every function `coverage_percent: 0`).

The fix gives both adapters the same **filesystem-validated
longest-suffix fallback**: when a coverage path can't be reduced to
the walker's src-relative key by a lexical prefix strip, recover the
key as the longest path suffix that resolves to a real file under the
source root. This is exactly the cross-machine resolution crap4ts
already had for absolute paths (#215); the two adapters now resolve
coverage paths identically.

Closes #331

## Root causes & fixes

**crap4rs** (`crates/crap4rs/src/adapters/coverage/mod.rs`) —
`LcovParser::normalize_path` was a pure lexical
`strip_prefix(root).unwrap_or(p)`. The orchestrator hands it the
canonical *absolute* root, but the syn walker keys functions by
`strip_prefix(options.src)` against the *raw* (often relative)
`--src`. A workspace-relative `SF:` line can't lexically strip an
absolute root, so it kept the full path while the walker emitted the
src-relative basename. Fix: **additive** fallback — keep the lexical
result when it already names a real file under the root (absolute
same-machine + already-src-relative, unchanged), else suffix-match,
else preserve the historical lexical output (fake-path unit tests
untouched). Ports crap4ts's #216 `..` traversal guard.

**crap4ts** (`crates/crap4ts/src/adapters/coverage/mod.rs`) — arm 1
lexically joined a relative `path` under `effective_src` then stripped
the prefix off, round-tripping a workspace-relative key to itself (a
nonexistent file) and returning `Some(invalid)` *before* arm 2's
suffix match could fire. Fix: dispatch on absoluteness — absolute raws
keep the arm-1 fast path (+ arm-2 cross-machine fallback); relative
raws route straight to the suffix match.

## L24 workaround reverted

PR #314 stripped the `crates/crap-examples/` coverage fixtures all the
way to file basenames to dodge this bug. With the matcher fixed, the
fixtures now carry workspace-relative paths and the regen recipes in
`crates/crap-examples/README.md` strip only the machine-specific
`$PWD/` prefix. Verified against the real release-plz invocation
(`--src ./crates/crap-examples/(src|ts)`): crap4rs matches 43/43
functions; crap4ts matches its covered subset.

## Wire-envelope canary drift — documented (per canary contract)

`crap-core::wire_envelope_crap4rs` drifts. Its `crap4rs-self.lcov`
fixture carries **dead-worktree absolute paths** that never resolved
pre-fix, so the committed snapshot encoded **all-0% coverage** — a
latent bug the canary was silently locking. The suffix-match now
resolves those cross-tree paths against the current checkout, so the
snapshot reflects real coverage.

- **No shape drift**: key-set diff between old and new snapshot is
  empty (no added/removed keys, no type changes).
- **Content drift only**: coverage values 0 → real, the resulting
  CRAP/`passed`/`risk_level` cascade, and `total_functions` 203 → 204
  (the new `suffix_match_under` function, self-analyzed).

The fixture is intentionally **not** regenerated: it's consumed by 5
tests, and its cross-tree paths now legitimately exercise the
cross-machine suffix-match path.

## TDD

Failing-first integration tests added for both adapters
(`path_matching_workspace_relative.rs`), modeled on
`config_src_path_strip.rs` — real tempdir, real source files,
workspace-relative coverage, under both bare-relative and absolute
`--src`. The absolute-`--src` row is only satisfiable by the
filesystem fallback (no relative root exists to lexically strip an
absolute coverage path), which is why a pure-lexical fix was rejected.

## Verification

- `cargo nextest run --workspace --all-targets` — 1234/1234 green
- `cargo fmt --check` / `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo +1.93 check --workspace --all-targets` (MSRV) — clean
- `cargo doc --workspace --no-deps` (`-D warnings`) — clean
- Absolute-SF CI lint passes (workspace-relative is not absolute)
- `mutants-skip-lint` / `bdd-tracked-lint` unaffected (no `cargo_bin` literal in a scanned scope/gate-bin; no `.feature` changes)

## Back-compat

Additive only. Absolute same-machine and `--src`-relative coverage
paths take the unchanged lexical fast path; the suffix fallback fires
only when lexical resolution fails. The wire-envelope shape is
byte-stable (values-only drift). No public API or schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)