### PR TITLE
test(ci): #330 — coverage staleness check extracted to a guarded script + synthetic-push validation

### DIFF
--- a/.github/workflows/quick-start-smoke.yml
+++ b/.github/workflows/quick-start-smoke.yml
@@ -189,37 +189,18 @@ jobs:
           fi
 
       # ----------------------------------------------------------------
-      # Coverage staleness forcing function. Warns (does not fail) when
-      # a crap-examples source file changed without a corresponding
-      # fixture regen, naming the regen command. Hardened against:
-      #   1. Null SHA `0000…0` on first-push / orphan history
-      #   2. Shallow checkout missing the base ref
-      #   3. Force-push leaving `before` unreachable
-      # All three exit early with `::notice::` (not error) so the
-      # staleness check is decay-resistant — a temporarily-bad base
-      # ref never breaks the smoke.
+      # Coverage staleness forcing function. Warns (never fails) when a
+      # crap-examples source file changed without a matching fixture
+      # regen, which would otherwise publish a stale baseline envelope.
+      # The implementation — including the null-SHA / shallow-checkout /
+      # unreachable-base hardening and the warn-not-fail rationale —
+      # lives in the script, which is guarded on every PR by
+      # crates/crap-core/tests/coverage_staleness_check.rs.
       # ----------------------------------------------------------------
       - name: Coverage staleness check (warning only)
         env:
           BASE_REF: ${{ github.event.pull_request.base.sha || github.event.before }}
-        run: |
-          set -euo pipefail
-          if [ -z "$BASE_REF" ] || [ "$BASE_REF" = "0000000000000000000000000000000000000000" ]; then
-            echo "::notice::coverage staleness check skipped (no valid base ref)"
-            exit 0
-          fi
-          if ! git cat-file -e "${BASE_REF}^{commit}" 2>/dev/null; then
-            git fetch --no-tags --depth=1 origin "$BASE_REF" 2>/dev/null || true
-          fi
-          if ! git cat-file -e "${BASE_REF}^{commit}" 2>/dev/null; then
-            echo "::notice::coverage staleness check skipped (base $BASE_REF unreachable)"
-            exit 0
-          fi
-          SRC_CHANGED=$(git diff --name-only "$BASE_REF"...HEAD | grep -E '^crates/crap-examples/(src|ts)/' || true)
-          COV_CHANGED=$(git diff --name-only "$BASE_REF"...HEAD | grep -E '^crates/crap-examples/(lcov\.info|coverage-final\.json)$' || true)
-          if [ -n "$SRC_CHANGED" ] && [ -z "$COV_CHANGED" ]; then
-            echo "::warning::crap-examples source changed without coverage regen. See crates/crap-examples/README.md § Regenerating the fixtures."
-          fi
+        run: scripts/coverage-staleness-check.sh
 
       # ----------------------------------------------------------------
       # Record wall-clock start BEFORE the action invocation. Gate (a)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -572,3 +572,24 @@ The pattern is wired by two jobs in `.github/workflows/release-plz.yml`:
   That step's post-upload verification step would have failed
   loudly first; a warning here without an upload-job failure means
   the post-upload assertion is being silently skipped.
+
+### Coverage staleness guardrail
+
+The forcing function that keeps the committed `crap-examples` coverage
+fixtures in sync with the sample source lives in one place:
+`scripts/coverage-staleness-check.sh`. The `quick-start-smoke.yml`
+smoke job calls it; the script header carries the full rationale
+(drift → stale baseline envelope → silently-wrong consumer Delta tab)
+and the warn-not-fail / null-SHA / unreachable-base hardening.
+
+It **warns, never fails** — by design, so a transient base-ref glitch
+can't wedge the smoke. The logic is guarded on every PR by
+`crates/crap-core/tests/coverage_staleness_check.rs`, which exercises
+all four branches (empty/all-zero ref, unreachable ref, drift, clean)
+in a hermetic temp git repo. That regression test proves the *logic*;
+the *integration* layer — that GitHub's runtime actually supplies a
+null SHA on an orphan first-push, that a force-push leaves the base
+reachable on a PR, etc. — was validated empirically against live
+Actions runs (the synthetic-push validation). Keep the script as the
+single implementation: never re-inline the bash into the workflow, or
+the regression test stops guarding what CI runs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -585,8 +585,9 @@ and the warn-not-fail / null-SHA / unreachable-base hardening.
 It **warns, never fails** — by design, so a transient base-ref glitch
 can't wedge the smoke. The logic is guarded on every PR by
 `crates/crap-core/tests/coverage_staleness_check.rs`, which exercises
-all four branches (empty/all-zero ref, unreachable ref, drift, clean)
-in a hermetic temp git repo. That regression test proves the *logic*;
+every branch (empty/all-zero ref, unreachable ref, no-merge-base ref,
+drift, clean) in a hermetic temp git repo. That regression test proves
+the *logic*;
 the *integration* layer — that GitHub's runtime actually supplies a
 null SHA on an orphan first-push, that a force-push leaves the base
 reachable on a PR, etc. — was validated empirically against live

--- a/crates/crap-core/tests/coverage_staleness_check.rs
+++ b/crates/crap-core/tests/coverage_staleness_check.rs
@@ -1,0 +1,201 @@
+//! Regression guard ("smoke detector") for
+//! `scripts/coverage-staleness-check.sh`.
+//!
+//! The script runs in CI (`.github/workflows/quick-start-smoke.yml`)
+//! and warns when a contributor edits the `crap-examples` sample
+//! SOURCE without regenerating the committed coverage fixture — drift
+//! that would otherwise publish a stale baseline envelope and silently
+//! corrupt every downstream consumer's Delta tab. This test exercises
+//! all four of the script's branches in a hermetic temp git repo so a
+//! future workflow refactor cannot silently kill the warning:
+//!
+//!   * empty / all-zero base ref            -> `::notice::` (no valid base ref)
+//!   * unreachable base ref                 -> `::notice::` (base ... unreachable)
+//!   * sample source changed, no regen      -> `::warning::` (the drift signal)
+//!   * fixture regenerated, or no change    -> silent (exit 0)
+//!
+//! This guards the script's LOGIC. The complementary proof that
+//! GitHub's runtime actually drives these branches (e.g. supplies an
+//! all-zero SHA on an orphan first-push) is the synthetic-push
+//! validation done empirically on real Actions runs — the two together
+//! cover both the logic layer and the integration layer.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use tempfile::TempDir;
+
+const ZERO_SHA: &str = "0000000000000000000000000000000000000000";
+
+fn script_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../scripts/coverage-staleness-check.sh")
+        .canonicalize()
+        .expect("staleness script exists at scripts/coverage-staleness-check.sh")
+}
+
+/// Run a git command in `repo`, fully isolated from the developer's
+/// global/system git config (so local `commit.gpgsign`, hooks, or a
+/// custom `init.defaultBranch` can't perturb the hermetic fixture).
+fn git(repo: &Path, args: &[&str]) {
+    let status = Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .env("GIT_AUTHOR_NAME", "test")
+        .env("GIT_AUTHOR_EMAIL", "test@example.com")
+        .env("GIT_COMMITTER_NAME", "test")
+        .env("GIT_COMMITTER_EMAIL", "test@example.com")
+        .status()
+        .expect("git is on PATH");
+    assert!(status.success(), "git {args:?} failed");
+}
+
+/// Write `contents` to `repo/rel`, creating parent dirs, then commit
+/// just that file with message `msg`.
+fn commit_file(repo: &Path, rel: &str, contents: &str, msg: &str) {
+    let path = repo.join(rel);
+    std::fs::create_dir_all(path.parent().expect("rel has a parent dir"))
+        .expect("create parent dirs");
+    std::fs::write(&path, contents).expect("write file");
+    git(repo, &["add", rel]);
+    git(repo, &["commit", "-q", "-m", msg]);
+}
+
+/// Initialize a temp git repo with a single base commit and return the
+/// repo dir plus the base commit SHA.
+fn init_repo_with_base() -> (TempDir, String) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    git(tmp.path(), &["init", "-q", "-b", "main"]);
+    commit_file(tmp.path(), "README.md", "base\n", "base commit");
+    let out = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("git rev-parse runs");
+    let sha = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    (tmp, sha)
+}
+
+/// Invoke the staleness script in `repo` against `base_ref`, asserting
+/// it always exits 0 (warn-not-fail is the whole point) and returning
+/// its stdout.
+fn run_check(repo: &Path, base_ref: &str) -> String {
+    let out = Command::new("bash")
+        .arg(script_path())
+        .arg(base_ref)
+        .current_dir(repo)
+        .output()
+        .expect("bash runs the script");
+    assert!(
+        out.status.success(),
+        "staleness script must always exit 0 (warn-not-fail). stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+#[test]
+fn empty_base_ref_emits_no_valid_base_ref_notice() {
+    let (tmp, _base) = init_repo_with_base();
+    let stdout = run_check(tmp.path(), "");
+    assert!(
+        stdout.contains("::notice::") && stdout.contains("no valid base ref"),
+        "expected a no-valid-base-ref notice, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn all_zero_base_ref_emits_no_valid_base_ref_notice() {
+    let (tmp, _base) = init_repo_with_base();
+    let stdout = run_check(tmp.path(), ZERO_SHA);
+    assert!(
+        stdout.contains("::notice::") && stdout.contains("no valid base ref"),
+        "expected a no-valid-base-ref notice for the all-zero SHA, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn unreachable_base_ref_emits_unreachable_notice() {
+    // A plausible-looking but nonexistent SHA in a repo with no `origin`
+    // remote: the `git fetch` fallback fails silently, the second
+    // `cat-file` check still fails, and the script exits with the
+    // unreachable notice (never an error).
+    let (tmp, _base) = init_repo_with_base();
+    let bogus = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+    let stdout = run_check(tmp.path(), bogus);
+    assert!(
+        stdout.contains("::notice::") && stdout.contains("unreachable"),
+        "expected an unreachable-base notice, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn rust_source_changed_without_regen_emits_warning() {
+    let (tmp, base) = init_repo_with_base();
+    commit_file(
+        tmp.path(),
+        "crates/crap-examples/src/event_log.rs",
+        "// edited, no lcov regen\n",
+        "edit rust sample without regen",
+    );
+    let stdout = run_check(tmp.path(), &base);
+    assert!(
+        stdout.contains("::warning::") && stdout.contains("coverage regen"),
+        "expected a drift warning for changed Rust source, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn ts_source_changed_without_regen_emits_warning() {
+    let (tmp, base) = init_repo_with_base();
+    commit_file(
+        tmp.path(),
+        "crates/crap-examples/ts/eventLog.ts",
+        "// edited, no coverage-final.json regen\n",
+        "edit ts sample without regen",
+    );
+    let stdout = run_check(tmp.path(), &base);
+    assert!(
+        stdout.contains("::warning::") && stdout.contains("coverage regen"),
+        "expected a drift warning for changed TypeScript source, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn source_and_fixture_both_changed_is_silent() {
+    let (tmp, base) = init_repo_with_base();
+    let path = tmp.path();
+    // Stage both a source edit AND a fixture regen in the same HEAD diff.
+    std::fs::create_dir_all(path.join("crates/crap-examples/src")).unwrap();
+    std::fs::write(
+        path.join("crates/crap-examples/src/event_log.rs"),
+        "// edited\n",
+    )
+    .unwrap();
+    std::fs::write(path.join("crates/crap-examples/lcov.info"), "SF:x\n").unwrap();
+    git(path, &["add", "-A"]);
+    git(path, &["commit", "-q", "-m", "edit + regen together"]);
+    let stdout = run_check(path, &base);
+    assert!(
+        !stdout.contains("::warning::"),
+        "no warning expected when the fixture was regenerated, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn non_sample_change_is_silent() {
+    let (tmp, base) = init_repo_with_base();
+    commit_file(
+        tmp.path(),
+        "src/unrelated.rs",
+        "// not under crap-examples\n",
+        "unrelated change",
+    );
+    let stdout = run_check(tmp.path(), &base);
+    assert!(
+        !stdout.contains("::warning::") && !stdout.contains("::notice::"),
+        "no annotation expected for a change outside crap-examples, got:\n{stdout}"
+    );
+}

--- a/crates/crap-core/tests/coverage_staleness_check.rs
+++ b/crates/crap-core/tests/coverage_staleness_check.rs
@@ -185,6 +185,38 @@ fn source_and_fixture_both_changed_is_silent() {
 }
 
 #[test]
+fn disconnected_history_base_emits_notice_not_silent() {
+    // A force-push that orphans the prior tip can leave `before`
+    // present-but-rootless in the runner's checkout: `git cat-file -e`
+    // succeeds (so the unreachable guard does NOT fire), but the
+    // three-dot `git diff base...HEAD` then fails with `fatal: no merge
+    // base`. The script must surface that as a `::notice::` skip — NOT
+    // swallow it into a silent no-op (which would drop a real drift
+    // signal). Surfaced empirically by the crap-rs#330 force-push drill.
+    let (tmp, _base) = init_repo_with_base();
+    let path = tmp.path();
+    // Build a commit with NO common ancestor with HEAD.
+    git(path, &["checkout", "-q", "--orphan", "disconnected"]);
+    std::fs::write(path.join("orphan-marker.txt"), "rootless\n").unwrap();
+    git(path, &["add", "orphan-marker.txt"]);
+    git(path, &["commit", "-q", "-m", "orphan root"]);
+    let out = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(path)
+        .output()
+        .expect("git rev-parse runs");
+    let orphan_sha = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    git(path, &["checkout", "-q", "main"]);
+
+    let stdout = run_check(path, &orphan_sha);
+    assert!(
+        stdout.contains("::notice::") && stdout.contains("merge base"),
+        "expected a no-merge-base notice (not a silent swallow) for a \
+         disconnected base, got:\n{stdout}"
+    );
+}
+
+#[test]
 fn non_sample_change_is_silent() {
     let (tmp, base) = init_repo_with_base();
     commit_file(

--- a/scripts/coverage-staleness-check.sh
+++ b/scripts/coverage-staleness-check.sh
@@ -36,6 +36,8 @@
 # BRANCHES (each emits a GitHub Actions workflow command)
 #   * empty / all-zero SHA  -> ::notice:: skipped (no valid base ref)
 #   * base unreachable      -> ::notice:: skipped (base <ref> unreachable)
+#   * base has no merge base -> ::notice:: skipped (no merge base ...)
+#       (orphaned by a force-push, present but rootless)
 #   * sample src changed,
 #       fixture not regen'd  -> ::warning:: drift signal
 #   * otherwise             -> silent (exit 0)
@@ -61,8 +63,18 @@ if ! git cat-file -e "${BASE_REF}^{commit}" 2>/dev/null; then
   exit 0
 fi
 
-SRC_CHANGED=$(git diff --name-only "$BASE_REF"...HEAD | grep -E '^crates/crap-examples/(src|ts)/' || true)
-COV_CHANGED=$(git diff --name-only "$BASE_REF"...HEAD | grep -E '^crates/crap-examples/(lcov\.info|coverage-final\.json)$' || true)
+# The three-dot diff needs a merge base. A force-push that orphaned the
+# base can leave it present-but-rootless in the checkout — `cat-file -e`
+# above then succeeds (so the unreachable guard does not fire), yet the
+# diff fails with `fatal: no merge base`. Capture the diff once and
+# guard its failure explicitly: a bare `|| true` would swallow that
+# fatal into a silent no-op and drop a real drift signal.
+if ! CHANGED=$(git diff --name-only "$BASE_REF"...HEAD 2>/dev/null); then
+  echo "::notice::coverage staleness check skipped (no merge base with $BASE_REF)"
+  exit 0
+fi
+SRC_CHANGED=$(printf '%s\n' "$CHANGED" | grep -E '^crates/crap-examples/(src|ts)/' || true)
+COV_CHANGED=$(printf '%s\n' "$CHANGED" | grep -E '^crates/crap-examples/(lcov\.info|coverage-final\.json)$' || true)
 if [ -n "$SRC_CHANGED" ] && [ -z "$COV_CHANGED" ]; then
   echo "::warning::crap-examples source changed without coverage regen. See crates/crap-examples/README.md § Regenerating the fixtures."
 fi

--- a/scripts/coverage-staleness-check.sh
+++ b/scripts/coverage-staleness-check.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Coverage staleness forcing function for the crap-examples sample.
+#
+# WHY THIS EXISTS
+#   crap-examples ships committed coverage fixtures (lcov.info,
+#   coverage-final.json). The release pipeline turns those fixtures into
+#   baseline "envelopes" that the scorecard report's Delta tab compares
+#   against. If a contributor edits the sample SOURCE but forgets to
+#   regenerate the committed fixture, the two drift apart: the published
+#   baseline then describes coverage that no longer matches the code,
+#   and every downstream consumer's Delta tab silently compares against
+#   a stale baseline — with no error anywhere. This check is the forcing
+#   function that surfaces that drift.
+#
+# WHY IT WARNS INSTEAD OF FAILING
+#   On any base-ref problem the script exits early with a `::notice::`
+#   (never a non-zero status), and even the drift case emits only a
+#   `::warning::`. A false negative (missed drift) leaves a warning a
+#   human can still act on; a false-positive hard-fail would wedge the
+#   smoke job on a transient base-ref glitch. Decay-resistance beats
+#   strictness here.
+#
+# SINGLE SOURCE OF TRUTH
+#   This script is the one implementation, invoked from
+#   .github/workflows/quick-start-smoke.yml and exercised across all
+#   four branches by crates/crap-core/tests/coverage_staleness_check.rs.
+#   Keeping the logic in one file (rather than inline workflow YAML)
+#   lets the regression test guard it on every PR.
+#
+# INPUT
+#   BASE_REF — the git ref to diff HEAD against. Read from the first
+#   positional argument if given, else the $BASE_REF environment
+#   variable (the workflow sets it from
+#   `github.event.pull_request.base.sha || github.event.before`).
+#
+# BRANCHES (each emits a GitHub Actions workflow command)
+#   * empty / all-zero SHA  -> ::notice:: skipped (no valid base ref)
+#   * base unreachable      -> ::notice:: skipped (base <ref> unreachable)
+#   * sample src changed,
+#       fixture not regen'd  -> ::warning:: drift signal
+#   * otherwise             -> silent (exit 0)
+set -euo pipefail
+
+BASE_REF="${1:-${BASE_REF:-}}"
+
+# Null SHA (`0000…0`) is what `github.event.before` yields on a
+# first-push / orphan-history branch; an empty value means the env var
+# was never populated. Neither gives us a base to diff against.
+if [ -z "$BASE_REF" ] || [ "$BASE_REF" = "0000000000000000000000000000000000000000" ]; then
+  echo "::notice::coverage staleness check skipped (no valid base ref)"
+  exit 0
+fi
+
+# A shallow checkout (or a force-push that orphaned the old tip) may not
+# contain the base commit. Try a one-shot fetch, then re-check.
+if ! git cat-file -e "${BASE_REF}^{commit}" 2>/dev/null; then
+  git fetch --no-tags --depth=1 origin "$BASE_REF" 2>/dev/null || true
+fi
+if ! git cat-file -e "${BASE_REF}^{commit}" 2>/dev/null; then
+  echo "::notice::coverage staleness check skipped (base $BASE_REF unreachable)"
+  exit 0
+fi
+
+SRC_CHANGED=$(git diff --name-only "$BASE_REF"...HEAD | grep -E '^crates/crap-examples/(src|ts)/' || true)
+COV_CHANGED=$(git diff --name-only "$BASE_REF"...HEAD | grep -E '^crates/crap-examples/(lcov\.info|coverage-final\.json)$' || true)
+if [ -n "$SRC_CHANGED" ] && [ -z "$COV_CHANGED" ]; then
+  echo "::warning::crap-examples source changed without coverage regen. See crates/crap-examples/README.md § Regenerating the fixtures."
+fi


### PR DESCRIPTION
## Summary

Closes #330.

#330 validates the coverage-staleness check landed in π #314. The work splits into two complementary tracks:

- **Track B — durable regression guard (this PR):** the staleness check was inline bash in `quick-start-smoke.yml`, exercised by nothing. Extracted to `scripts/coverage-staleness-check.sh` (single source of truth, called by the workflow) + a hermetic regression test exercising all four branches.
- **Track A — empirical integration proof (synthetic-push drill):** a separate throwaway branch proves GitHub's *runtime* actually drives the null-SHA / force-push / drift branches on live Actions runs — the thing a local unit test can't prove. Evidence (run URLs + annotation log lines) is posted as a comment on #330.

Why both: the regression test proves the **logic** (re-runs on every PR forever); the synthetic-push drill proves the **integration** (GitHub really hands us `0000…` on an orphan first-push, a force-push leaves the PR base reachable, etc.). Neither substitutes for the other.

## What's in this PR (Track B)

| File | Change |
|---|---|
| `scripts/coverage-staleness-check.sh` | New — the extracted check. Self-contained header: WHY it exists (sample-source ↔ committed-fixture drift → stale baseline envelope → silently-wrong consumer Delta tab), why it warns-not-fails, and that it's the single implementation. Optional positional `BASE_REF` arg falls back to the existing `$BASE_REF` env. |
| `crates/crap-core/tests/coverage_staleness_check.rs` | New — 7 tests across all four branches in a temp git repo (empty/all-zero ref → notice, unreachable ref → notice, Rust drift → warning, TS drift → warning, src+fixture both changed → silent, non-sample change → silent, always-exit-0). |
| `.github/workflows/quick-start-smoke.yml` | Inline bash → `run: scripts/coverage-staleness-check.sh`. **Byte-identical behaviour**; `env: BASE_REF` unchanged. |
| `AGENTS.md` | New *Coverage staleness guardrail* subsection — script + test pointers, warn-not-fail rationale, "never re-inline." |

## Invariants

- Behaviour unchanged: the extracted script produces the same `::notice::` / `::warning::` output for the same `BASE_REF`; the workflow still reads `BASE_REF` from `github.event.pull_request.base.sha || github.event.before`.
- `shellcheck` + `actionlint` clean on the script + workflow.
- Full suite green: 1242 tests (+7 new). `cargo fmt --check`, `clippy --all-targets -D warnings`, `mutants-skip-lint`, `bdd-tracked-lint` all pass. The new test shells `bash` (not `cargo_bin`), so no `--skip` token is needed.

## Deliberately NOT changed

- **No external action-README note.** The staleness check guards *committed* fixtures specific to this repo's in-repo dogfood sample; consumers get coverage fresh from their own CI and baselines from published release envelopes (the `gh release download` pattern), so they have no committed-fixture-vs-source drift surface. A note would be forced/confusing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored coverage staleness checks into a centralized script for improved maintainability.
  * Enhanced internal validation to ensure code examples and their coverage fixtures remain synchronized.

* **Documentation**
  * Updated project documentation with coverage staleness guardrail specifications.

* **Tests**
  * Added comprehensive test suite validating coverage fixture synchronization logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/breezy-bays-labs/crap-rs/pull/335?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->