### PR TITLE
docs: #337 — askama proc-macro-chain allowlist note + de-stale crap-core AGENTS.md text

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@
 - Testing: `cargo nextest run` for tests, `cargo clippy -- -D warnings` for lints, `cargo fmt --check` for formatting. Quick verify: all three chained.
 - Property tests use `proptest` — regression files in `proptest-regressions/` are committed to git, never gitignored.
 - Safety: do not push directly to `main`, always branch + PR. Do not modify `.github/workflows/*` unless the task clearly requires CI changes.
-- The `domain/` and `ports/` layers must stay language-agnostic (no `syn`, no LCOV types) — they are designed for future extraction into a shared `crap-core` library.
+- The `domain/` and `ports/` layers stay language-agnostic (no `syn`/`oxc`, no LCOV/Istanbul types) — they live in the shared `crap-core` library that every adapter links (`crap4rs` via `syn`, `crap4ts` via `oxc`); `crap-core` also ships the `crap-render` binary. Purity is enforced by the four-layer `ast-purity` CI job + `deny.toml`; the only allowed proc-macro-chain derives are `serde`, `thiserror`, and `askama` (the `Template` derive backing the HTML/markdown reporters).
 
 ## BDD hygiene
 

--- a/deny.toml
+++ b/deny.toml
@@ -67,11 +67,12 @@ deny = []
 # This `deny.toml` does NOT encode the per-crate transitive ban
 # via `bans.deny.wrappers`, because:
 #
-# - `crap-core` will legitimately use `serde` derive (and other
-#   proc-macro deps) once code lands in S2; cargo-deny treats
-#   proc-macros as graph nodes, so a naive `{ crate = "syn",
-#   wrappers = ["crap4rs"] }` would false-positive on the
-#   `serde_derive` chain.
+# - `crap-core` legitimately uses proc-macro-chain derives —
+#   `serde` (`serde_derive`), `thiserror` (`thiserror_impl`), and
+#   `askama` (the `Template` derive backing the HTML/markdown
+#   reporters). cargo-deny treats proc-macros as graph nodes, so a
+#   naive `{ crate = "syn", wrappers = ["crap4rs"] }` would
+#   false-positive on the `serde_derive` chain.
 # - Expanding `wrappers` to allow proc-macro chains
 #   (`serde_derive`, `thiserror_impl`, etc.) requires a fragile,
 #   ever-growing list — a new derive macro entering the workspace
@@ -92,9 +93,9 @@ deny = []
 #
 # Operator backstop: `cargo tree -p crap-core --invert syn` should
 # show only proc-macro chains (lines marked `(proc-macro)` like
-# `serde_derive`, `thiserror-impl`). Any non-proc-macro path from
-# `syn` back to `crap-core` is a real AST-library leak the two
-# mechanisms above missed.
+# `serde_derive`, `thiserror-impl`, and askama's `Template`-derive
+# chain). Any non-proc-macro path from `syn` back to `crap-core` is
+# a real AST-library leak the two mechanisms above missed.
 
 [sources]
 unknown-registry = "deny"


### PR DESCRIPTION
Tier-2 doc-accuracy follow-ups from the org askama allowlist ADR + crap-rs hexagonal ADR (ops#371). Comment/doc-only — no code or CI behavior change (askama already passes the `ast-purity` gate; the `deny.toml` edit is comment-only).

## Changes
- **`deny.toml`** AST-library policy comment: `crap-core`'s allowed proc-macro-chain derives are now stated as `serde`, `thiserror`, **and `askama`** (the `Template` derive behind the HTML/markdown reporters); operator-backstop note extended to mention askama's chain.
- **`AGENTS.md`**: `crap-core` is no longer described as "designed for future extraction" — it exists, is linked by `crap4rs` (`syn`) + `crap4ts` (`oxc`), and ships `crap-render`. Adds the Tier-2 invariant: purity is enforced by the four-layer `ast-purity` job + `deny.toml`; the proc-macro-chain allowlist is `serde`/`thiserror`/`askama`.

Closes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architectural guidance for domain and ports layer constraints, including derive macro restrictions and CI enforcement references.

* **Chores**
  * Clarified dependency policy documentation for proc-macro chain handling and verification processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/breezy-bays-labs/crap-rs/pull/338?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->