### PR TITLE
feat(core+ci): #336 — base-gated multi-root src + separate production scorecard from examples dogfood

### DIFF
--- a/.github/actions/scorecard/README.md
+++ b/.github/actions/scorecard/README.md
@@ -216,6 +216,90 @@ containing the combined `markdown` output (both per-language sections
 stacked). Aggregator workflows reading the split outputs and
 re-rendering elsewhere should still set `comment-mode: 'none'`.
 
+## Multi-root source
+
+A project split across several source roots — a Cargo workspace with
+multiple crates, a monorepo with several packages — can be analyzed in
+one invocation by passing `src:` as a newline-separated list (the YAML
+`|` block-scalar convention). The action splits it into one `--src`
+flag per non-blank line; the analyzer discovers functions under every
+root and unions them into a single scorecard, joined against the one
+shared `coverage:` file.
+
+```yaml
+- uses: breezy-bays-labs/crap-rs/.github/actions/scorecard@v1
+  with:
+    languages: rust
+    src: |
+      crates/crap-core/src
+      crates/crap4rs/src
+      crates/crap4ts/src
+    coverage: lcov.info
+    gate-mode: gate-on-analysis
+```
+
+Notes:
+
+- **Single-line `src:` is byte-identical** to before multi-root
+  existed — the common case is untouched.
+- **Keep each line free of leading whitespace.** A space-indented line
+  becomes `--src "  path"`, which the walker can't resolve ("no source
+  files found").
+- **Identity base is decided by root count.** A single root keys
+  function `file_path` relative to that root (`lib.rs`); multiple roots
+  key relative to the git toplevel (`crates/crap-core/src/lib.rs`) so
+  same-named files in different crates stay globally unique and never
+  bleed coverage into one another. Multi-root therefore requires a git
+  work tree — outside one, the action errors rather than silently
+  mis-joining. (Background: ADR `adr-multi-root-identity-base`.)
+- **Prefer explicit per-crate roots over the workspace root.** Listing
+  `crates/a/src`, `crates/b/src` is boundary-safe; pointing `src:` at
+  the repository root pulls in build artifacts and vendored code.
+- `src-ts:` accepts the same multi-root list for the TypeScript side in
+  multi-language mode.
+
+## Two distinct scorecards on one PR
+
+Run two scorecards on the same PR — e.g. a gated production scorecard
+plus a report-only examples/teaching one — by giving each its own
+`comment-header` (so the sticky comments don't collide) AND its own
+`comment-preamble` (so a reader can tell them apart at a glance):
+
+```yaml
+# Production gate
+- uses: breezy-bays-labs/crap-rs/.github/actions/scorecard@v1
+  with:
+    languages: rust
+    src: |
+      crates/crap-core/src
+      crates/crap4rs/src
+    coverage: lcov.info
+    gate-mode: gate-on-analysis
+    comment-mode: sticky
+    comment-header: crap-scorecard-production
+    comment-preamble: |
+      **Production CRAP scorecard** — gates real source against the
+      threshold.
+
+# Examples dogfood (report-only)
+- uses: breezy-bays-labs/crap-rs/.github/actions/scorecard@v1
+  with:
+    languages: rust
+    src: crates/examples/src
+    coverage: examples-lcov.info
+    gate-mode: report-only
+    comment-mode: sticky
+    comment-header: crap-scorecard-examples
+    comment-preamble: |
+      **Examples dogfood — intentionally spans risk bands; not
+      production code.**
+```
+
+The preamble prepends above the rendered scorecard body in the sticky
+comment; an empty `comment-preamble` (the default) leaves the body
+byte-identical to before the input existed. The composed body is also
+exposed verbatim on the `sticky-message` output for aggregator reuse.
+
 ## HTML report
 
 For PR reviews that benefit from the full file-by-file scorecard (KPI
@@ -566,8 +650,8 @@ row; the aggregator owns the comment.
 | `language` | `auto` | `rust`, `typescript`, or `auto` (infer from coverage extension). Superseded by `languages` (preset) when both are set |
 | `coverage` | (required) | Path to LCOV (`.info`) for Rust, Istanbul JSON for TS. In multi-language mode, carries the Rust LCOV (paired with `coverage-ts:`) |
 | `coverage-ts` | `''` | (paired) TypeScript Istanbul JSON path. Required in multi-language mode; ignored in single-language mode. See [Multi-language](#multi-language) |
-| `src` | `.` | Source root passed to the analyzer. In multi-language mode, carries the Rust source root |
-| `src-ts` | `''` | (paired) TypeScript source root. Required in multi-language mode; ignored in single-language mode. See [Multi-language](#multi-language) |
+| `src` | `.` | Source root passed to the analyzer. In multi-language mode, carries the Rust source root. **Multi-root (crap-rs#336):** accepts a newline-separated list of roots (YAML `\|` block scalar) — the action splits it into one `--src` per non-blank line, unioning their functions into one scorecard against a single `coverage:` file. A single-line value is byte-identical to before. See [Multi-root source](#multi-root-source) |
+| `src-ts` | `''` | (paired) TypeScript source root. Required in multi-language mode; ignored in single-language mode. Accepts the same newline-separated multi-root list as `src:`. See [Multi-language](#multi-language) |
 | `baseline` | `''` | Path to a previously-captured CRAP JSON envelope. Empty = no delta. In multi-language mode, carries the Rust baseline |
 | `baseline-ts` | `''` | (paired) TypeScript baseline JSON envelope. Optional even in multi-language mode (per-language); a language without a baseline contributes neutrally to AND/SUM aggregation. See [Multi-language](#multi-language) |
 | `threshold` | `15` | Threshold for violations (user-visible default; the action.yml default is empty so the preset resolver can tell explicit from default — see [Presets — Raw wins on conflict](#raw-wins-on-conflict)) |
@@ -576,6 +660,7 @@ row; the aggregator owns the comment.
 | `analysis-gate` | `false` | Exit non-zero if the analysis itself fails. User-visible default; empty internally — see [Presets](#presets) |
 | `comment-mode` | `none` | `none` (outputs only) or `sticky` (post/update sticky comment) |
 | `comment-header` | `crap-scorecard` | Sticky-comment identifier |
+| `comment-preamble` | `''` | Markdown prepended above the rendered scorecard in the sticky-comment body. Use it to label a scorecard's scope — e.g. a production scorecard naming the gated crates vs. an examples one marked "teaching sample". Empty = byte-identical to before. Honored in single- and multi-language modes. See [Two distinct scorecards on one PR](#two-distinct-scorecards-on-one-pr) |
 | `version` | `latest` | crap4rs version to install (`latest` or pinned tag) |
 | `annotations` | `false` | When `true`, emit `::warning` workflow commands so findings render inline on the PR Files Changed tab (see [Inline annotations](#inline-annotations)) |
 | `annotation-limit` | `''` | Cap on emitted annotations when `annotations: true`. Empty defers to the adapter's default (10) or `[output] annotation_limit` from `config`. Range 1..=100 |
@@ -590,7 +675,8 @@ row; the aggregator owns the comment.
 
 | Name | Notes |
 |---|---|
-| `markdown` | The rendered scorecard — drop into aggregator comments verbatim. Multi-language: combined under `## CRAP scorecard` wrapper with per-language `### Rust (crap4rs)` / `### TypeScript (crap4ts)` H3 sections. Single-language: raw adapter markdown (back-compat) |
+| `markdown` | The rendered scorecard — drop into aggregator comments verbatim. Multi-language: combined under `## CRAP scorecard` wrapper with per-language `### Rust (crap4rs)` / `### TypeScript (crap4ts)` H3 sections. Single-language: raw adapter markdown (back-compat). Preamble-free (the bare scorecard) |
+| `sticky-message` | The composed sticky-comment body: `comment-preamble` prepended above the scorecard, plus the optional HTML download link (when `html-report: true`). The exact text the sticky step publishes. Distinct from `markdown` (which is preamble-free). Surfaced for spot-checks + aggregator reuse (crap-rs#336) |
 | `row-json` | `Row::CrapDelta` JSON object — for aggregators that re-render with full layout control. See [Structured row output](#structured-row-output-outputsrow-json). **Empty in multi-language mode** + `::warning::` directing consumers to `row-json-rust` / `row-json-typescript` |
 | `row-json-rust` | (multi-language split) `Row::CrapDelta` JSON for the Rust dispatch when Rust is in the resolved language set. Populated in both single-language `rust` and multi-language modes; empty otherwise. See [Multi-language — Split outputs](#split-outputs) |
 | `row-json-typescript` | (multi-language split) `Row::CrapDelta` JSON for the TypeScript dispatch when TypeScript is in the resolved language set. Populated in both single-language `typescript` and multi-language modes; empty otherwise. See [Multi-language — Split outputs](#split-outputs) |

--- a/.github/actions/scorecard/action.yml
+++ b/.github/actions/scorecard/action.yml
@@ -193,6 +193,19 @@ inputs:
       can post distinct sticky comments by varying this header.
     required: false
     default: 'crap-scorecard'
+  comment-preamble:
+    description: |
+      Markdown prepended to the composed sticky-comment body, above the
+      rendered scorecard. Use it to label a scorecard's scope so two
+      scorecards on the same PR are unambiguous — e.g. a production
+      scorecard naming the gated crates vs. an examples scorecard
+      marked "teaching sample; not production code" (crap-rs#336).
+      Honored in both single- and multi-language modes (it prepends to
+      the `Compose sticky message` step's body, which runs for both).
+      Empty default (`''`) produces a byte-identical comment to before
+      this input existed.
+    required: false
+    default: ''
   version:
     description: |
       `crap4rs` version to install. `latest` (default) resolves to the most
@@ -258,6 +271,17 @@ outputs:
   markdown:
     description: 'The rendered markdown scorecard. Consume directly in aggregator bots.'
     value: ${{ steps.run.outputs.markdown }}
+  sticky-message:
+    description: |
+      The composed sticky-comment body: the optional `comment-preamble`
+      prepended above the rendered scorecard, plus the optional HTML
+      download link (when `html-report: true`). This is the exact text
+      the `Post sticky PR comment` step would publish. Distinct from
+      `markdown` (which is the bare scorecard, preamble-free). Surfaced
+      so callers can spot-check the preamble wiring and so aggregator
+      bots that compose their own comment can reuse the assembled body
+      (crap-rs#336).
+    value: ${{ steps.compose.outputs.message }}
   row-json:
     description: |
       The `Row::CrapDelta` JSON object emitted by the dispatched
@@ -941,7 +965,17 @@ runs:
           envelope="$RUNNER_TEMP/${BIN}-envelope.json"
           markdown_file="$RUNNER_TEMP/${BIN}-scorecard.md"
           row_json_file="$RUNNER_TEMP/${BIN}-row.json"
-          common=(--coverage "$LANG_COVERAGE" --src "$LANG_SRC" --threshold "$THRESHOLD")
+          # Multi-root (crap-rs#336): `src`/`src-ts` accept a
+          # newline-separated list of roots (the GHA multiline-input
+          # convention); split into one `--src <root>` per non-blank
+          # line. A single-line value yields exactly one `--src` (byte-
+          # identical to before this PR); blank lines are skipped so a
+          # trailing newline never produces an empty `--src ""` (which
+          # would silently re-scope the walker to CWD).
+          common=(--coverage "$LANG_COVERAGE" --threshold "$THRESHOLD")
+          while IFS= read -r src_root; do
+            [ -n "$src_root" ] && common+=(--src "$src_root")
+          done <<<"$LANG_SRC"
           [ -n "$CONFIG" ] && common+=(--config "$CONFIG")
           if [ -n "$LANG_BASELINE" ]; then
             common+=(--baseline "$LANG_BASELINE")
@@ -1295,7 +1329,13 @@ runs:
               exit 1
               ;;
           esac
-          args=(--coverage "$LANG_COVERAGE" --src "$LANG_SRC" --threshold "$THRESHOLD" --no-fail --format github-annotations)
+          # Multi-root (crap-rs#336): same newline-split as the Run
+          # analysis loop, so annotations cover every root rather than
+          # silently only the first under multi-root.
+          args=(--coverage "$LANG_COVERAGE" --threshold "$THRESHOLD" --no-fail --format github-annotations)
+          while IFS= read -r src_root; do
+            [ -n "$src_root" ] && args+=(--src "$src_root")
+          done <<<"$LANG_SRC"
           [ -n "$CONFIG" ] && args+=(--config "$CONFIG")
           if [ -n "$per_lang_budget" ]; then
             # Multi-language: the shared GH per-step cap is the hard
@@ -1491,6 +1531,9 @@ runs:
         HTML_REPORT: ${{ inputs.html-report }}
         IS_MULTI: ${{ steps.presets.outputs.is_multi }}
         LANGUAGE: ${{ steps.lang.outputs.language }}
+        # Caller-supplied markdown prepended above the scorecard body
+        # (crap-rs#336). Empty → byte-identical to before this input.
+        COMMENT_PREAMBLE: ${{ inputs.comment-preamble }}
         HTML_URL_RUST: ${{ steps.upload-rust.outputs.artifact-url }}
         HTML_URL_TS: ${{ steps.upload-typescript.outputs.artifact-url }}
         # PR ζ (#315): unified artifact URL produced by the
@@ -1501,12 +1544,21 @@ runs:
       run: |
         set -euo pipefail
         composed_file="$RUNNER_TEMP/scorecard-sticky-message.md"
+        # Prepend the caller's preamble (crap-rs#336) above the body when
+        # non-empty, followed by a blank line so the markdown body starts
+        # a fresh block regardless of how the preamble ended. Empty
+        # preamble writes nothing → the body is byte-identical to before
+        # this input existed.
+        : > "$composed_file"
+        if [ -n "$COMMENT_PREAMBLE" ]; then
+          printf '%s\n\n' "$COMMENT_PREAMBLE" >> "$composed_file"
+        fi
         if [ "$LANGUAGE" = "multi" ]; then
-          cat "$RUNNER_TEMP/scorecard-combined.md" > "$composed_file"
+          cat "$RUNNER_TEMP/scorecard-combined.md" >> "$composed_file"
         elif [ "$LANGUAGE" = "rust" ]; then
-          cat "$RUNNER_TEMP/crap4rs-scorecard.md" > "$composed_file"
+          cat "$RUNNER_TEMP/crap4rs-scorecard.md" >> "$composed_file"
         else
-          cat "$RUNNER_TEMP/crap4ts-scorecard.md" > "$composed_file"
+          cat "$RUNNER_TEMP/crap4ts-scorecard.md" >> "$composed_file"
         fi
 
         if [ "$HTML_REPORT" = "true" ]; then

--- a/.github/actions/scorecard/action.yml
+++ b/.github/actions/scorecard/action.yml
@@ -974,6 +974,10 @@ runs:
           # would silently re-scope the walker to CWD).
           common=(--coverage "$LANG_COVERAGE" --threshold "$THRESHOLD")
           while IFS= read -r src_root; do
+            # Strip a trailing CR so a CRLF-checkout / Windows-runner
+            # consumer doesn't emit `--src "crates/foo/src\r"`, which
+            # fails the directory check (gemini PR #344).
+            src_root="${src_root%$'\r'}"
             [ -n "$src_root" ] && common+=(--src "$src_root")
           done <<<"$LANG_SRC"
           [ -n "$CONFIG" ] && common+=(--config "$CONFIG")
@@ -1334,6 +1338,9 @@ runs:
           # silently only the first under multi-root.
           args=(--coverage "$LANG_COVERAGE" --threshold "$THRESHOLD" --no-fail --format github-annotations)
           while IFS= read -r src_root; do
+            # Strip a trailing CR (CRLF-checkout / Windows-runner) so the
+            # annotations loop doesn't emit `--src "…\r"` (gemini PR #344).
+            src_root="${src_root%$'\r'}"
             [ -n "$src_root" ] && args+=(--src "$src_root")
           done <<<"$LANG_SRC"
           [ -n "$CONFIG" ] && args+=(--config "$CONFIG")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -655,6 +655,82 @@ jobs:
           fi
           echo "comment-preamble: prepend ✓, empty byte-identity ✓"
 
+  scorecard-production:
+    # ----------------------------------------------------------------
+    # Production CRAP scorecard — the repo's FIRST CRAP-threshold gate
+    # on production source (crap-rs#336). PURELY ADDITIVE: it removes
+    # no existing gate. #295 created the production scorecard analyzing
+    # crap-core/src; #314 repointed that slot to crap-examples/src, so
+    # production lost its gate. This restores it across the full prod
+    # crate set — crap-core + crap4rs + crap4ts src — via multi-root
+    # `--src` (the examples scorecard stays in quick-start-smoke.yml).
+    #
+    # Binary provenance is load-bearing: the published crap4rs predates
+    # the repeatable-`--src` capability this PR ships, so the gate MUST
+    # run THIS PR's binary (built + staged below). `version` is left
+    # unset (default `latest`) so the action's pre-installed-detection
+    # short-circuits its binstall and uses the staged binary. Gating
+    # this PR's source with this PR's analyzer is the whole point.
+    # ----------------------------------------------------------------
+    name: Scorecard — production crates (gated)
+    runs-on: ubuntu-latest
+    needs: [coverage]
+    permissions:
+      # contents: read for checkout; pull-requests: write for the
+      # distinct `crap-scorecard-production` sticky comment on PRs.
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # tracks @stable branch
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: lcov
+
+      - name: Build PR binary
+        run: cargo build --release --package crap4rs
+
+      - name: Stage PR binary as pre-installed adapter
+        run: |
+          set -euo pipefail
+          # The public scorecard action short-circuits its binstall when
+          # `crap4rs --version` resolves on PATH AND `version: latest`.
+          # $HOME/.cargo/bin is pre-pended to PATH on ubuntu-latest, so
+          # staging the PR-built binary there makes the action dogfood
+          # THIS PR's repeatable-`--src` capability instead of the
+          # published binary (which lacks it). Same shape as the
+          # multi-language smoke job's staging step.
+          mkdir -p "$HOME/.cargo/bin"
+          install -m 0755 ./target/release/crap4rs "$HOME/.cargo/bin/crap4rs"
+          crap4rs --version
+
+      - name: Production scorecard (gate-on-analysis)
+        uses: ./.github/actions/scorecard
+        with:
+          languages: rust
+          # Multi-root: the full production crate set, one root per line
+          # (newline-split into repeated `--src` by the action). Excludes
+          # crap-examples by construction — boundary-safe per-crate roots,
+          # never the recursive workspace root.
+          src: |
+            crates/crap-core/src
+            crates/crap4rs/src
+            crates/crap4ts/src
+          coverage: lcov.info
+          gate-mode: gate-on-analysis
+          threshold-preset: default
+          comment-mode: sticky
+          comment-header: crap-scorecard-production
+          comment-preamble: |
+            **Production CRAP scorecard** — gates `crap-core`, `crap4rs`,
+            and `crap4ts` source. This is real production code held to the
+            threshold; the separate _quickstart-smoke_ scorecard analyzes
+            `crap-examples` (an intentionally bad teaching sample), not
+            production.
+
   scorecard-smoke-ts:
     # Sibling of `scorecard-smoke-rust` for the TypeScript dispatch
     # path. Build crap4ts from the PR, stage it on PATH (the only

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -599,6 +599,62 @@ jobs:
           fi
           echo "default + threshold:$EXPECTED → threshold=$EXPECTED (no conflict, no warning) ✓"
 
+      # ----------------------------------------------------------------
+      # comment-preamble spot-check (crap-rs#336 acceptance gate).
+      #
+      # Invoke the action twice with identical inputs except
+      # `comment-preamble` (a sentinel vs empty), `comment-mode: none`,
+      # and assert on the new `sticky-message` output: the with-preamble
+      # body STARTS WITH the sentinel; the empty-preamble body does NOT
+      # contain it. Relational assertions (startswith + absence) through
+      # the real action.yml compose logic — robust against trailing-
+      # newline normalization across the $GITHUB_OUTPUT heredoc boundary
+      # that an exact-byte equality would trip on. All interpolations
+      # flow through env: (the sentinel is an action-author constant,
+      # not user input, but the indirection keeps the workflow uniform).
+      # ----------------------------------------------------------------
+      - name: Preamble spot-check — with sentinel
+        id: preamble-with
+        uses: ./.github/actions/scorecard
+        with:
+          coverage: lcov.info
+          src: crates/crap4rs/src
+          threshold: ${{ env.CRAP_SMOKE_THRESHOLD }}
+          comment-preamble: 'CRAP_PREAMBLE_SENTINEL — spot-check marker'
+          comment-mode: 'none'
+      - name: Preamble spot-check — empty
+        id: preamble-empty
+        uses: ./.github/actions/scorecard
+        with:
+          coverage: lcov.info
+          src: crates/crap4rs/src
+          threshold: ${{ env.CRAP_SMOKE_THRESHOLD }}
+          comment-mode: 'none'
+      - name: Assert preamble prepends and empty is preamble-free
+        env:
+          WITH_MSG: ${{ steps.preamble-with.outputs.sticky-message }}
+          EMPTY_MSG: ${{ steps.preamble-empty.outputs.sticky-message }}
+        run: |
+          set -euo pipefail
+          sentinel='CRAP_PREAMBLE_SENTINEL'
+          # 1. With-preamble body starts with the sentinel (preamble
+          #    prepended ABOVE the scorecard body).
+          case "$WITH_MSG" in
+            "$sentinel"*) ;;
+            *)
+              echo "::error::preamble-spot: sticky-message did not start with the preamble sentinel"
+              printf '%s\n' "$WITH_MSG" | head -3
+              exit 1
+              ;;
+          esac
+          # 2. Empty-preamble body does NOT contain the sentinel
+          #    (byte-identity preserved — preamble truly empty).
+          if printf '%s' "$EMPTY_MSG" | grep -q "$sentinel"; then
+            echo "::error::preamble-spot: empty-preamble sticky-message unexpectedly contains the sentinel"
+            exit 1
+          fi
+          echo "comment-preamble: prepend ✓, empty byte-identity ✓"
+
   scorecard-smoke-ts:
     # Sibling of `scorecard-smoke-rust` for the TypeScript dispatch
     # path. Build crap4ts from the PR, stage it on PATH (the only

--- a/.github/workflows/quick-start-smoke.yml
+++ b/.github/workflows/quick-start-smoke.yml
@@ -221,9 +221,18 @@ jobs:
       #
       # `gate-mode: report-only` — crap-examples scores poorly by
       # design (config_merger ~40 CRAP, slugify ~24); gating on its
-      # threshold would fail the smoke on the intended pedagogy. The
-      # bare-adapter gates (f)/(g)/(h) below still exercise gate
-      # posture against crap-core/src, which is production code.
+      # threshold would fail the smoke on the intended pedagogy.
+      #
+      # This scorecard is NOT a production gate — it is the labeled
+      # examples/teaching surface (see the `comment-preamble` below).
+      # The repo's production CRAP-threshold gate lives in ci.yml's
+      # `scorecard-production` job (crap-rs#336), which gates the real
+      # crap-core/crap4rs/crap4ts source. Gates (f)/(g)/(h) below are
+      # `--no-fail` FORMAT/INVARIANT checks (metric-default, table
+      # render, scorecard-row JSON shape) run against crap-core/src —
+      # NOT CRAP-threshold gates, and they assert nothing about CRAP
+      # scores. (Corrected crap-rs#336: the prior comment here wrongly
+      # claimed f/g/h "exercise gate posture against crap-core/src".)
       #
       # `run-mode` flips conditionally on the fetch outcome:
       #   * success → `both` — analysis + delta; enabled Delta tab
@@ -245,6 +254,12 @@ jobs:
           gate-mode: report-only
           comment-mode: sticky
           comment-header: 'crap-scorecard-quickstart-smoke'
+          comment-preamble: |
+            **Examples dogfood — intentionally spans risk bands; not
+            production code.** This scorecard analyzes `crap-examples`, a
+            teaching sample built to exercise every CRAP risk band. For
+            the production gate over real source, see the
+            _crap-scorecard-production_ comment (crap-rs#336).
           html-report: true
           languages: rust,typescript
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -260,6 +260,44 @@ input's file extension (`.info` / `.lcov` → crap4rs, `.json`
 Callers may override detection by setting `inputs.language` to
 `rust` or `typescript` explicitly.
 
+### Multi-root `--src` + the two-scorecard model (crap-rs#336)
+
+`--src` is **repeatable** (`Vec<PathBuf>`): a single run can analyze
+several source roots and union their functions into one scorecard,
+joined against a single shared `--coverage`. The action's `src:` /
+`src-ts:` inputs accept a newline-separated list (YAML `|` block scalar)
+and split it into repeated `--src`. A single root stays byte-identical
+to before multi-root existed.
+
+**`IdentityBase` (one-liner):** function `file_path` (and coverage-SF
+normalization) is relativized to a run identity base decided ONCE from
+the root count — `len()==1 ⇒ src-relative` (byte-identical back-compat;
+load-bearing for #334's config `src=[...]`), `len()>1 ⇒
+git-toplevel-relative` (globally-unique keys across crates sharing
+internal names like `adapters/mod.rs`; no coverage bleed). Multi-root
+outside a git work tree is a HARD ERROR, never a silent basename strip.
+Resolved in `cli::prepare_pipeline` between input validation and the
+coverage-factory call, threaded to BOTH consumers (identity +
+coverage). ADR: `adr-multi-root-identity-base.md`.
+
+**Two scorecards, two surfaces:** the repo runs a **production** CRAP
+gate and an **examples** dogfood as distinct sticky comments.
+- *Production* — `scorecard-production` job in `.github/workflows/ci.yml`,
+  `gate-mode: gate-on-analysis`, multi-root over the three prod crate
+  src roots (`crap-core` + `crap4rs` + `crap4ts`),
+  `comment-header: crap-scorecard-production`. Builds + stages THIS PR's
+  binary on PATH (the published binary lacks repeatable `--src`), so the
+  gate dogfoods the PR's own analyzer.
+- *Examples* — the invocation in `.github/workflows/quick-start-smoke.yml`,
+  `gate-mode: report-only`, multi-language over `crap-examples`,
+  `comment-header: crap-scorecard-quickstart-smoke`.
+
+Each carries a `comment-preamble` labeling its scope (production-crates
+vs intentionally-bad teaching sample). The preamble is the stopgap
+disambiguator until #334 lands `[output].title`; it prepends to the
+sticky body and leaves an empty preamble byte-identical. The composed
+body is also exposed on the action's `sticky-message` output.
+
 ### Cross-adapter `--format scorecard-row` parity
 
 `crap4rs` and `crap4ts` both route `--format scorecard-row` through

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Run `crap4rs --help` for the canonical full reference. Grouped here as in `--hel
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--coverage <FILE>` | required for analysis | Path to the LCOV coverage file. Not required for `completions`/`init`. |
-| `--src <DIR>` | `src` | Root directory of source files to analyze. |
+| `--src <DIR>` | `src` | Root directory of source files to analyze. **Repeatable** — pass `--src` more than once (`--src crates/a/src --src crates/b/src`) to union several roots into one report against a single `--coverage`. A single `--src` is unchanged; multiple roots key function paths relative to the git toplevel (requires a git work tree). |
 | `--metric <METRIC>` | `cognitive` | `cognitive` (default) or `cyclomatic`. |
 | `--config <FILE>` | auto-discovered | Explicit config file path; bypasses `crap4rs.toml` auto-discovery. |
 | `--view <NAME>` | — | Resolve a saved view preset from the config (see [Saved view presets](#saved-view-presets---view-name)). |

--- a/crates/crap-core/src/bin/crap-render.rs
+++ b/crates/crap-core/src/bin/crap-render.rs
@@ -153,50 +153,11 @@ fn main() -> ExitCode {
 }
 
 fn run(cli: Cli) -> Result<()> {
-    if cli.inputs.is_empty() {
-        bail!("at least one --input <LANG>=<FILE> argument is required");
-    }
-
-    let mut parsed: Vec<ParsedEnvelope> = Vec::with_capacity(cli.inputs.len());
-    for spec in &cli.inputs {
-        parsed.push(parse_input_spec(spec, "input")?);
-    }
-
-    // Duplicate-language guard: refuse two envelopes for the same
-    // language key. This catches the common operator mistake of
-    // passing two crap4rs.json by accident.
-    let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
-    for env in &parsed {
-        if !seen.insert(env.language.as_str()) {
-            bail!(
-                "duplicate input for language '{}'. Each language key may appear at most once.",
-                env.language
-            );
-        }
-    }
-
-    // Parse optional baselines. Each baseline pairs by `<LANG>` key
-    // with one of the `--input` envelopes; a baseline whose key has
-    // no matching input is an operator error (typo / wrong file).
-    let mut baselines: Vec<ParsedEnvelope> = Vec::with_capacity(cli.baselines.len());
-    for spec in &cli.baselines {
-        baselines.push(parse_input_spec(spec, "baseline")?);
-    }
-    let mut seen_baselines: std::collections::HashSet<&str> = std::collections::HashSet::new();
-    for env in &baselines {
-        if !seen_baselines.insert(env.language.as_str()) {
-            bail!(
-                "duplicate baseline for language '{}'. Each language key may appear at most once.",
-                env.language
-            );
-        }
-        if !parsed.iter().any(|e| e.language == env.language) {
-            bail!(
-                "--baseline for language '{}' has no matching --input. Each baseline must pair with an input by language key.",
-                env.language
-            );
-        }
-    }
+    // Parse + validate every `--input` and `--baseline` spec up front.
+    // Extracted so `run` itself stays a flat compose-and-render
+    // pipeline (the validation loops carried the bulk of its cognitive
+    // complexity).
+    let (parsed, baselines) = parse_and_validate_envelopes(&cli)?;
 
     let threshold = cli.threshold.unwrap_or_else(|| {
         parsed
@@ -254,6 +215,63 @@ fn run(cli: Cli) -> Result<()> {
         None => print!("{rendered}"),
     }
 
+    Ok(())
+}
+
+/// Parse and validate every `--input` / `--baseline` spec.
+///
+/// Returns the parsed input envelopes and baseline envelopes. Enforces,
+/// in order: at least one `--input`; no duplicate input language key;
+/// no duplicate baseline language key; every baseline pairs with an
+/// input by language key. Extracted from `run` (crap-rs#336, Commit 2)
+/// so the orchestrator stays a flat pipeline — behavior-preserving;
+/// the error strings are unchanged (pinned by the `crap_render_cli`
+/// characterization tests).
+fn parse_and_validate_envelopes(cli: &Cli) -> Result<(Vec<ParsedEnvelope>, Vec<ParsedEnvelope>)> {
+    if cli.inputs.is_empty() {
+        bail!("at least one --input <LANG>=<FILE> argument is required");
+    }
+
+    let mut parsed: Vec<ParsedEnvelope> = Vec::with_capacity(cli.inputs.len());
+    for spec in &cli.inputs {
+        parsed.push(parse_input_spec(spec, "input")?);
+    }
+    guard_unique_languages(&parsed, "input")?;
+
+    // Parse optional baselines. Each baseline pairs by `<LANG>` key
+    // with one of the `--input` envelopes; a baseline whose key has
+    // no matching input is an operator error (typo / wrong file).
+    let mut baselines: Vec<ParsedEnvelope> = Vec::with_capacity(cli.baselines.len());
+    for spec in &cli.baselines {
+        baselines.push(parse_input_spec(spec, "baseline")?);
+    }
+    guard_unique_languages(&baselines, "baseline")?;
+    for env in &baselines {
+        if !parsed.iter().any(|e| e.language == env.language) {
+            bail!(
+                "--baseline for language '{}' has no matching --input. Each baseline must pair with an input by language key.",
+                env.language
+            );
+        }
+    }
+
+    Ok((parsed, baselines))
+}
+
+/// Refuse two envelopes for the same language key. `kind` is `"input"`
+/// or `"baseline"`, naming the offending stream in the error so the
+/// operator knows which flag to fix (this catches the common mistake of
+/// passing two crap4rs.json by accident).
+fn guard_unique_languages(envelopes: &[ParsedEnvelope], kind: &str) -> Result<()> {
+    let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    for env in envelopes {
+        if !seen.insert(env.language.as_str()) {
+            bail!(
+                "duplicate {kind} for language '{}'. Each language key may appear at most once.",
+                env.language
+            );
+        }
+    }
     Ok(())
 }
 

--- a/crates/crap-core/src/cli/mod.rs
+++ b/crates/crap-core/src/cli/mod.rs
@@ -13,7 +13,7 @@ use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::time::SystemTime;
 
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
 use clap::{Args, CommandFactory, FromArgMatches, Parser, Subcommand, ValueEnum, ValueHint};
 use clap_complete::Shell as ClapShell;
 
@@ -292,9 +292,17 @@ pub struct InputArgs {
     #[arg(long, value_name = "FILE", value_hint = ValueHint::FilePath)]
     pub coverage: Option<PathBuf>,
 
-    /// Root directory of source files to analyze [default: src]
+    /// Root directory of source files to analyze [default: src].
+    ///
+    /// Repeatable: pass `--src` more than once to analyze several roots
+    /// in a single run (e.g. `--src crates/a/src --src crates/b/src`).
+    /// The functions discovered under every root are unioned into one
+    /// report, joined against a single shared `--coverage` file. A
+    /// single `--src` is byte-identical to the pre-multi-root behavior;
+    /// when omitted, falls back to the config TOML's `src` then `src`
+    /// (crap-rs#336).
     #[arg(long, value_name = "DIR", value_hint = ValueHint::DirPath)]
-    pub src: Option<PathBuf>,
+    pub src: Vec<PathBuf>,
 
     /// Complexity metric to use
     #[arg(long, value_enum)]
@@ -1065,7 +1073,11 @@ where
 /// needs except the coverage path (which is validated separately and
 /// may be borrowed from `cli`).
 struct EffectiveInputs {
-    src: PathBuf,
+    /// Source roots after CLI / config / default merging. Always
+    /// non-empty (empty CLI Vec falls back to config `src` then the
+    /// `["src"]` default). Single-root runs hold one entry — the
+    /// byte-identical back-compat case (crap-rs#336).
+    src: Vec<PathBuf>,
     metric: ComplexityMetric,
     threshold_config: ThresholdConfig,
     threshold: f64,
@@ -1099,12 +1111,20 @@ fn merge_effective_inputs(
     file_config: &Option<FileConfig>,
     meta: &AdapterMeta,
 ) -> EffectiveInputs {
-    let src = cli
-        .input
-        .src
-        .clone()
-        .or_else(|| file_config.as_ref().and_then(|c| c.src.clone()))
-        .unwrap_or_else(|| PathBuf::from("src"));
+    // `--src` is repeatable (crap-rs#336). An empty CLI Vec defers to
+    // the config TOML's single `src` (wrapped to one root), then to the
+    // `["src"]` default — preserving the pre-multi-root precedence. A
+    // non-empty CLI Vec wins over config wholesale (CLI overrides config,
+    // same as every other field).
+    let src = if cli.input.src.is_empty() {
+        file_config
+            .as_ref()
+            .and_then(|c| c.src.clone())
+            .map(|s| vec![s])
+            .unwrap_or_else(|| vec![PathBuf::from("src")])
+    } else {
+        cli.input.src.clone()
+    };
     let metric: ComplexityMetric = cli
         .input
         .metric
@@ -1143,29 +1163,128 @@ fn validate_runtime_inputs<'a>(
         );
     };
 
-    validate_inputs(
-        coverage_path,
-        &inputs.src,
-        inputs.threshold,
-        meta.coverage_hint,
-    )?;
+    // Validate every `--src` root (crap-rs#336). `validate_inputs`
+    // gates the coverage file once (first root) plus each root's
+    // existence; the threshold check is root-independent so it runs on
+    // the first call only.
+    for (idx, root) in inputs.src.iter().enumerate() {
+        if idx == 0 {
+            validate_inputs(coverage_path, root, inputs.threshold, meta.coverage_hint)?;
+        } else {
+            validate_src_root(root)?;
+        }
+    }
 
     if let Some(diff_ref) = cli.filter.diff.as_deref() {
         validate_diff_ref(diff_ref)?;
-        preflight_git_worktree(&inputs.src)?;
+        // Any root resolves the same work tree; preflight the first.
+        if let Some(first) = inputs.src.first() {
+            preflight_git_worktree(first)?;
+        }
     }
 
     Ok(coverage_path)
+}
+
+/// Resolve the run [`IdentityBase`] from the `--src` root count
+/// (crap-rs#336). This is the **fallible** step the α' design mandates
+/// between input validation and the coverage-factory call: a single
+/// root yields src-relative identity (byte-identical back-compat);
+/// multiple roots yield git-toplevel-relative identity (collision-free
+/// across crates that share crate-internal names).
+///
+/// Multi-root with an unresolvable git toplevel is a HARD ERROR naming
+/// the offending root — never a silent basename strip, which would
+/// reintroduce the cross-crate coverage bleed the dual regime exists to
+/// prevent.
+fn resolve_identity_base(inputs: &EffectiveInputs) -> Result<crate::core::identity::IdentityBase> {
+    use crate::core::identity::IdentityBase;
+
+    let roots = &inputs.src;
+    if roots.len() <= 1 {
+        // Single root (or the impossible empty case, which merge already
+        // backfilled to `["src"]`): src-relative identity, holding the
+        // original root so the strip base matches the discovery root.
+        let root = roots
+            .first()
+            .cloned()
+            .unwrap_or_else(|| PathBuf::from("src"));
+        return Ok(IdentityBase::SrcRelative(root));
+    }
+
+    // Multi-root: anchor on the git toplevel. Any root resolves the same
+    // work tree; resolve from the first and compute each root's
+    // toplevel-relative prefix.
+    let first_canonical = crate::core::canonicalize_src(&roots[0]);
+    let toplevel = crate::core::git_toplevel(&first_canonical).with_context(|| {
+        format!(
+            "multi-root analysis requires a git work tree, but the git toplevel could not be \
+             resolved from {}\n  \
+             hint: multiple --src roots are keyed git-toplevel-relative to stay globally unique; \
+             run inside a git repository, or pass a single --src for src-relative analysis",
+            roots[0].display()
+        )
+    })?;
+
+    let mut root_prefixes = Vec::with_capacity(roots.len());
+    for root in roots {
+        let canonical = crate::core::canonicalize_src(root);
+        let prefix = canonical
+            .strip_prefix(&toplevel)
+            .with_context(|| {
+                format!(
+                    "--src directory {} is not inside the git repository at {}\n  \
+                     hint: every --src root must live within the same git work tree",
+                    canonical.display(),
+                    toplevel.display(),
+                )
+            })?
+            .to_string_lossy()
+            .replace('\\', "/");
+        root_prefixes.push((root.clone(), prefix));
+    }
+
+    Ok(IdentityBase::RepoRelative {
+        toplevel,
+        root_prefixes,
+    })
+}
+
+/// Validate that a `--src` root exists and is a directory. The
+/// per-root counterpart to `validate_inputs`'s src check, used for the
+/// 2nd..Nth roots in a multi-root run (the coverage + threshold checks
+/// run once, on the first root).
+fn validate_src_root(src: &Path) -> Result<()> {
+    match std::fs::metadata(src) {
+        Ok(m) if m.is_dir() => Ok(()),
+        Ok(_) => bail!(
+            "source path is not a directory: {}\n  \
+             hint: pass --src <DIR> pointing to your source root",
+            src.display()
+        ),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => bail!(
+            "source directory not found: {}\n  \
+             hint: pass --src <DIR> pointing to your source root",
+            src.display()
+        ),
+        Err(e) => bail!(
+            "cannot access source directory: {}: {e}\n  \
+             hint: check directory permissions",
+            src.display()
+        ),
+    }
 }
 
 fn build_analyze_options(
     cli: &Cli,
     inputs: &EffectiveInputs,
     coverage: &Path,
+    identity_base: crate::core::identity::IdentityBase,
     meta: &AdapterMeta,
 ) -> AnalyzeOptions {
     AnalyzeOptions {
         src: inputs.src.clone(),
+        identity_base,
         coverage: coverage.to_path_buf(),
         threshold_config: inputs.threshold_config.clone(),
         metric: inputs.metric,
@@ -1236,14 +1355,33 @@ where
     let inputs = merge_effective_inputs(cli, &file_config, meta);
     let coverage_path = validate_runtime_inputs(cli, &inputs, meta)?;
 
-    // Canonicalize the effective `src` (post-config-merge) and hand
-    // it to the adapter's factory closure. `validate_runtime_inputs`
-    // already gated on existence; `canonicalize_src`'s fallback path
-    // is purely defensive against TOCTOU between the two `metadata`
-    // calls and emits a warning on the error arm so the regression is
-    // observable instead of silent.
-    let src_canonical = crate::core::canonicalize_src(&inputs.src);
-    let coverage = coverage_factory(&src_canonical);
+    // Resolve the run identity base ONCE, in this fallible step between
+    // validation and the coverage-factory call (crap-rs#336, CEng F-2):
+    // single root ⇒ src-relative (byte-identical back-compat); multiple
+    // roots ⇒ git-toplevel-relative (hard error if the toplevel is
+    // unresolvable). The same base is threaded to BOTH consumers —
+    // function identity (`AnalyzeOptions.identity_base`) AND coverage-SF
+    // normalization (the factory path below) — so they never diverge.
+    let identity_base = resolve_identity_base(&inputs)?;
+
+    // Canonicalize the first `--src` root (post-config-merge).
+    // `validate_runtime_inputs` already gated on existence;
+    // `canonicalize_src`'s fallback path is purely defensive against
+    // TOCTOU between the two `metadata` calls and emits a warning on the
+    // error arm so the regression is observable instead of silent.
+    let src_canonical = inputs
+        .src
+        .first()
+        .map(|first| crate::core::canonicalize_src(first))
+        .unwrap_or_else(|| PathBuf::from("src"));
+
+    // Hand the factory the identity base's coverage root: `src_canonical`
+    // in single-root mode (byte-identical to before multi-root), the git
+    // toplevel in multi-root mode. The closure stays `FnOnce(&Path)`
+    // (CEng F-3) — `LcovParser::new(root)` + `normalize_path`'s
+    // suffix-match rescue re-anchor SF records to whatever base it's
+    // handed, so the join key shares the identity base.
+    let coverage = coverage_factory(&identity_base.coverage_root(&src_canonical));
 
     // Adapter-aware pre-flight runs after construction so
     // `CoveragePort::validate` can apply its own structural check
@@ -1251,7 +1389,7 @@ where
     // before the full parse pass. See ADR D-coverage-validate.
     preflight_checks(coverage_path, &*coverage, meta)?;
 
-    let options = build_analyze_options(cli, &inputs, coverage_path, meta);
+    let options = build_analyze_options(cli, &inputs, coverage_path, identity_base, meta);
 
     let analysis = crate::core::analyze(&options, complexity, &*coverage)?;
     apply_diagnostics(cli, &analysis.diagnostics);
@@ -1926,7 +2064,9 @@ mod tests {
     fn minimal_valid_args() {
         let cli = parse(&["--coverage", "lcov.info"]).unwrap();
         assert_eq!(cli.input.coverage.as_deref(), Some(Path::new("lcov.info")));
-        assert_eq!(cli.input.src, None);
+        // `--src` is repeatable (crap-rs#336); absent → empty Vec, which
+        // `merge_effective_inputs` backfills to the config/default root.
+        assert_eq!(cli.input.src, Vec::<PathBuf>::new());
     }
 
     #[test]
@@ -2075,7 +2215,26 @@ mod tests {
     #[test]
     fn custom_src() {
         let cli = parse(&["--coverage", "lcov.info", "--src", "crates/"]).unwrap();
-        assert_eq!(cli.input.src, Some(PathBuf::from("crates/")));
+        assert_eq!(cli.input.src, vec![PathBuf::from("crates/")]);
+    }
+
+    #[test]
+    fn repeated_src_collects_all_roots() {
+        // `--src` is repeatable (crap-rs#336): clap auto-appends each
+        // occurrence into the `Vec<PathBuf>`, preserving order.
+        let cli = parse(&[
+            "--coverage",
+            "lcov.info",
+            "--src",
+            "crates/a/src",
+            "--src",
+            "crates/b/src",
+        ])
+        .unwrap();
+        assert_eq!(
+            cli.input.src,
+            vec![PathBuf::from("crates/a/src"), PathBuf::from("crates/b/src"),]
+        );
     }
 
     #[test]
@@ -2775,7 +2934,7 @@ mod tests {
     fn merge_effective_inputs_default_src() {
         let cli = parse(&["--coverage", "lcov.info"]).unwrap();
         let inputs = merge_effective_inputs(&cli, &None, &fake_meta());
-        assert_eq!(inputs.src, PathBuf::from("src"));
+        assert_eq!(inputs.src, vec![PathBuf::from("src")]);
     }
 
     #[test]
@@ -2786,7 +2945,7 @@ mod tests {
             ..FileConfig::default()
         });
         let inputs = merge_effective_inputs(&cli, &file_config, &fake_meta());
-        assert_eq!(inputs.src, PathBuf::from("crates/"));
+        assert_eq!(inputs.src, vec![PathBuf::from("crates/")]);
     }
 
     #[test]
@@ -2797,7 +2956,31 @@ mod tests {
             ..FileConfig::default()
         });
         let inputs = merge_effective_inputs(&cli, &file_config, &fake_meta());
-        assert_eq!(inputs.src, PathBuf::from("from-config/"));
+        assert_eq!(inputs.src, vec![PathBuf::from("from-config/")]);
+    }
+
+    #[test]
+    fn merge_effective_inputs_repeated_cli_src_collects_roots() {
+        // Multi-root (crap-rs#336): repeated `--src` flows through to a
+        // multi-entry `EffectiveInputs.src`, CLI winning over config.
+        let cli = parse(&[
+            "--coverage",
+            "lcov.info",
+            "--src",
+            "crates/a/src",
+            "--src",
+            "crates/b/src",
+        ])
+        .unwrap();
+        let file_config = Some(FileConfig {
+            src: Some(PathBuf::from("from-config/")),
+            ..FileConfig::default()
+        });
+        let inputs = merge_effective_inputs(&cli, &file_config, &fake_meta());
+        assert_eq!(
+            inputs.src,
+            vec![PathBuf::from("crates/a/src"), PathBuf::from("crates/b/src"),]
+        );
     }
 
     #[test]

--- a/crates/crap-core/src/cli/mod.rs
+++ b/crates/crap-core/src/cli/mod.rs
@@ -3001,6 +3001,109 @@ mod tests {
         );
     }
 
+    // ── resolve_identity_base tests (crap-rs#336 α' base gating) ────────
+
+    /// Minimal `EffectiveInputs` carrying only the `src` roots the base
+    /// resolver reads; the rest are filler.
+    fn inputs_with_roots(roots: Vec<PathBuf>) -> EffectiveInputs {
+        EffectiveInputs {
+            src: roots,
+            metric: ComplexityMetric::Cognitive,
+            threshold_config: crate::domain::threshold::ThresholdConfig::default(),
+            threshold: 15.0,
+            exclude: Vec::new(),
+            annotation_limit: 10,
+        }
+    }
+
+    /// Lay out a temp git repo with a `crate-x/src` directory and return
+    /// the canonicalized repo root.
+    fn temp_git_repo() -> tempfile::TempDir {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join("crate-x/src")).unwrap();
+        std::fs::create_dir_all(tmp.path().join("crate-y/src")).unwrap();
+        for args in [
+            ["init", "-q"].as_slice(),
+            ["config", "user.email", "t@t.t"].as_slice(),
+            ["config", "user.name", "t"].as_slice(),
+        ] {
+            assert!(
+                std::process::Command::new("git")
+                    .current_dir(tmp.path())
+                    .args(args)
+                    .status()
+                    .unwrap()
+                    .success()
+            );
+        }
+        tmp
+    }
+
+    #[test]
+    fn resolve_identity_base_single_root_is_src_relative() {
+        let inputs = inputs_with_roots(vec![PathBuf::from("crates/crap-core/src")]);
+        let base = resolve_identity_base(&inputs).unwrap();
+        assert_eq!(
+            base,
+            crate::core::identity::IdentityBase::SrcRelative(PathBuf::from("crates/crap-core/src"))
+        );
+    }
+
+    #[test]
+    fn resolve_identity_base_multi_root_is_git_toplevel_relative() {
+        let tmp = temp_git_repo();
+        let top = tmp.path().canonicalize().unwrap();
+        let a = top.join("crate-x/src");
+        let b = top.join("crate-y/src");
+        let inputs = inputs_with_roots(vec![a.clone(), b.clone()]);
+
+        let base = resolve_identity_base(&inputs).unwrap();
+        match base {
+            crate::core::identity::IdentityBase::RepoRelative {
+                toplevel,
+                root_prefixes,
+            } => {
+                assert_eq!(toplevel, top);
+                assert_eq!(
+                    root_prefixes,
+                    vec![
+                        (a, "crate-x/src".to_string()),
+                        (b, "crate-y/src".to_string()),
+                    ]
+                );
+            }
+            other => panic!("expected RepoRelative, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_identity_base_multi_root_outside_git_is_hard_error() {
+        // The anti-basename-strip guard: multiple roots with no
+        // resolvable git toplevel must ERROR (naming the offending
+        // root), NOT silently degrade to a basename strip — which would
+        // reintroduce the cross-crate coverage bleed the dual regime
+        // exists to prevent.
+        let tmp = tempfile::tempdir().unwrap();
+        // No `git init` — this dir is outside any work tree. Use two
+        // distinct subdirs so it's genuinely a multi-root request.
+        std::fs::create_dir_all(tmp.path().join("a")).unwrap();
+        std::fs::create_dir_all(tmp.path().join("b")).unwrap();
+        let a = tmp.path().join("a");
+        let b = tmp.path().join("b");
+        let inputs = inputs_with_roots(vec![a.clone(), b]);
+
+        let err = resolve_identity_base(&inputs).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("git work tree") || msg.contains("git toplevel"),
+            "error should name the unresolvable git toplevel; got: {msg}"
+        );
+        assert!(
+            msg.contains(&a.display().to_string()),
+            "error should name the offending root; got: {msg}"
+        );
+    }
+
     #[test]
     fn merge_effective_inputs_uses_adapter_default_metric_cognitive() {
         // Replaces the pre-W2.5 `merge_effective_inputs_default_metric_is_cognitive`

--- a/crates/crap-core/src/cli/mod.rs
+++ b/crates/crap-core/src/cli/mod.rs
@@ -1163,10 +1163,23 @@ fn validate_runtime_inputs<'a>(
         );
     };
 
-    // Validate every `--src` root (crap-rs#336). `validate_inputs`
-    // gates the coverage file once (first root) plus each root's
-    // existence; the threshold check is root-independent so it runs on
-    // the first call only.
+    validate_src_roots(coverage_path, inputs, meta)?;
+    validate_diff_preflight(cli, inputs)?;
+
+    Ok(coverage_path)
+}
+
+/// Validate the coverage file, the threshold, and every `--src` root
+/// (crap-rs#336). `validate_inputs` gates the coverage file + threshold
+/// once (on the first root) plus that root's existence; the 2nd..Nth
+/// roots get the directory-only `validate_src_root` check. Extracted
+/// from `validate_runtime_inputs` so the multi-root loop's branches
+/// don't inflate the orchestrator's complexity.
+fn validate_src_roots(
+    coverage_path: &Path,
+    inputs: &EffectiveInputs,
+    meta: &AdapterMeta,
+) -> Result<()> {
     for (idx, root) in inputs.src.iter().enumerate() {
         if idx == 0 {
             validate_inputs(coverage_path, root, inputs.threshold, meta.coverage_hint)?;
@@ -1174,16 +1187,21 @@ fn validate_runtime_inputs<'a>(
             validate_src_root(root)?;
         }
     }
+    Ok(())
+}
 
-    if let Some(diff_ref) = cli.filter.diff.as_deref() {
-        validate_diff_ref(diff_ref)?;
-        // Any root resolves the same work tree; preflight the first.
-        if let Some(first) = inputs.src.first() {
-            preflight_git_worktree(first)?;
-        }
+/// When `--diff` is set, validate the ref and pre-flight the git work
+/// tree. Any `--src` root resolves the same work tree, so the first
+/// root anchors the pre-flight. No-op when `--diff` is absent.
+fn validate_diff_preflight(cli: &Cli, inputs: &EffectiveInputs) -> Result<()> {
+    let Some(diff_ref) = cli.filter.diff.as_deref() else {
+        return Ok(());
+    };
+    validate_diff_ref(diff_ref)?;
+    if let Some(first) = inputs.src.first() {
+        preflight_git_worktree(first)?;
     }
-
-    Ok(coverage_path)
+    Ok(())
 }
 
 /// Resolve the run [`IdentityBase`] from the `--src` root count

--- a/crates/crap-core/src/core/identity.rs
+++ b/crates/crap-core/src/core/identity.rs
@@ -1,0 +1,223 @@
+//! Run identity base — the single path-space every function's
+//! `file_path` and every coverage `SF:` record is relativized against.
+//!
+//! A CRAP run declares ONE identity base, decided from the count of
+//! `--src` roots (the policy lives in `cli`, resolved once between
+//! input validation and the coverage-factory call). The base is then
+//! threaded to BOTH consumers — function identity (`extract_complexities`)
+//! and coverage-SF normalization (the LCOV adapter constructed in
+//! `cli::prepare_pipeline`). Keeping the two consumers on one base is the
+//! load-bearing invariant: if they diverge (identity goes one way, SF
+//! keys the other), the coverage join misses 100% of the time.
+//!
+//! Two regimes, never mixed within one run:
+//!
+//! - **Single root** ⇒ [`IdentityBase::SrcRelative`]. Identity strips the
+//!   original (typically relative) `--src` root, exactly as before
+//!   multi-root existed. This path is **byte-identical** to the
+//!   pre-multi-root output — the wire-envelope canaries enforce it.
+//! - **Multiple roots** ⇒ [`IdentityBase::RepoRelative`]. Identity is
+//!   keyed on the git toplevel so paths stay globally unique across
+//!   crates that share crate-internal relative names (`adapters/mod.rs`,
+//!   `lib.rs`). Each root carries its own toplevel-relative prefix; a
+//!   discovered file's key is `<root_prefix>/<file-relative-to-root>`.
+//!   Mirrors the bridge `compute_diff_regions` already performs.
+//!
+//! Why this lives in `core` (not `domain`): it is a list-of-roots
+//! orchestration concern, language-agnostic, with no CRAP-formula or
+//! reporter coupling — it survives the future `crap-core` extraction
+//! intact.
+
+use std::path::{Path, PathBuf};
+
+/// The path-space a run relativizes function identity and coverage SF
+/// records against. Decided once from the `--src` root count.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IdentityBase {
+    /// Single-root run: identity strips the original `--src` root. The
+    /// held path is the *original* (relative-or-absolute) `--src` value,
+    /// matching the discovery root so `strip_prefix` never fails. This
+    /// is byte-identical to the pre-multi-root behavior.
+    ///
+    /// The default variant holds `"src"` — matching the historical
+    /// `AnalyzeOptions::default().src` of `PathBuf::from("src")`.
+    SrcRelative(PathBuf),
+
+    /// Multi-root run: identity is git-toplevel-relative. `toplevel` is
+    /// the absolute git work-tree root the coverage factory anchors on;
+    /// `root_prefixes` pairs each original `--src` root with its
+    /// toplevel-relative prefix (forward-slash-normalised, possibly
+    /// empty if a root IS the toplevel).
+    RepoRelative {
+        /// Absolute git toplevel — handed to the coverage factory so
+        /// LCOV SF normalization shares the identity base.
+        toplevel: PathBuf,
+        /// `(original_root, toplevel_relative_prefix)` per `--src` root.
+        root_prefixes: Vec<(PathBuf, String)>,
+    },
+}
+
+impl Default for IdentityBase {
+    /// `SrcRelative("src")` — matches the historical
+    /// `AnalyzeOptions::default().src` of `PathBuf::from("src")`, so a
+    /// `..AnalyzeOptions::default()` spread stays single-root byte-identical.
+    fn default() -> Self {
+        IdentityBase::SrcRelative(PathBuf::from("src"))
+    }
+}
+
+impl IdentityBase {
+    /// The path handed to the coverage-adapter factory so SF
+    /// normalization anchors on the same base as identity.
+    ///
+    /// - `SrcRelative` ⇒ the canonicalized single src root (today's
+    ///   wiring — the factory has always received the canonical
+    ///   absolute path, NOT the original relative one).
+    /// - `RepoRelative` ⇒ the absolute git toplevel.
+    pub fn coverage_root(&self, src_canonical: &Path) -> PathBuf {
+        match self {
+            // The factory receives `src_canonical` (the canonicalized
+            // single root), preserving the pre-multi-root contract
+            // byte-for-byte. The `SrcRelative` payload (the *original*
+            // root) is only the identity strip base, not the coverage
+            // anchor — the two consumers legitimately receive different
+            // path-spaces in single-root mode, and that asymmetry is
+            // exactly what keeps the output byte-identical.
+            IdentityBase::SrcRelative(_) => src_canonical.to_path_buf(),
+            IdentityBase::RepoRelative { toplevel, .. } => toplevel.clone(),
+        }
+    }
+
+    /// Relativize a discovered file to a forward-slash-normalised
+    /// identity key.
+    ///
+    /// `originating_root` is the `--src` root the file was discovered
+    /// under (in single-root mode there is only one). The key is:
+    /// - `SrcRelative` ⇒ `file` stripped of the held src root.
+    /// - `RepoRelative` ⇒ `<root_prefix>/<file stripped of originating_root>`,
+    ///   where `root_prefix` is the originating root's toplevel-relative
+    ///   prefix.
+    ///
+    /// Panics only on the same invariant the pre-multi-root code
+    /// asserted: a discovered file must be under the root it was
+    /// discovered through (a file-walker bug otherwise).
+    pub fn relativize(&self, file: &Path, originating_root: &Path) -> String {
+        match self {
+            IdentityBase::SrcRelative(base) => strip_to_slashed(file, base),
+            IdentityBase::RepoRelative { root_prefixes, .. } => {
+                let prefix = root_prefixes
+                    .iter()
+                    .find(|(root, _)| root == originating_root)
+                    .map(|(_, prefix)| prefix.as_str())
+                    .unwrap_or("");
+                let rel = strip_to_slashed(file, originating_root);
+                if prefix.is_empty() {
+                    rel
+                } else {
+                    format!("{prefix}/{rel}")
+                }
+            }
+        }
+    }
+}
+
+/// Strip `root` from `file` and forward-slash-normalise. Panics if
+/// `file` is not under `root` — the file-walker invariant.
+fn strip_to_slashed(file: &Path, root: &Path) -> String {
+    file.strip_prefix(root)
+        .expect("discovered file should be under the source root")
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn src_relative_strips_original_root() {
+        let base = IdentityBase::SrcRelative(PathBuf::from("crates/crap-core/src"));
+        let key = base.relativize(
+            Path::new("crates/crap-core/src/adapters/mod.rs"),
+            Path::new("crates/crap-core/src"),
+        );
+        assert_eq!(key, "adapters/mod.rs");
+    }
+
+    #[test]
+    fn src_relative_coverage_root_is_canonical_not_original() {
+        // The factory has always received the *canonical* path, never
+        // the original relative one — preserving byte-identical output.
+        let base = IdentityBase::SrcRelative(PathBuf::from("src"));
+        let canonical = Path::new("/abs/project/src");
+        assert_eq!(
+            base.coverage_root(canonical),
+            PathBuf::from("/abs/project/src")
+        );
+    }
+
+    #[test]
+    fn repo_relative_prefixes_with_root_toplevel_prefix() {
+        let base = IdentityBase::RepoRelative {
+            toplevel: PathBuf::from("/abs/project"),
+            root_prefixes: vec![
+                (
+                    PathBuf::from("crates/crap-core/src"),
+                    "crates/crap-core/src".to_string(),
+                ),
+                (
+                    PathBuf::from("crates/crap4rs/src"),
+                    "crates/crap4rs/src".to_string(),
+                ),
+            ],
+        };
+        let a = base.relativize(
+            Path::new("crates/crap-core/src/adapters/mod.rs"),
+            Path::new("crates/crap-core/src"),
+        );
+        let b = base.relativize(
+            Path::new("crates/crap4rs/src/adapters/mod.rs"),
+            Path::new("crates/crap4rs/src"),
+        );
+        assert_eq!(a, "crates/crap-core/src/adapters/mod.rs");
+        assert_eq!(b, "crates/crap4rs/src/adapters/mod.rs");
+        // Same crate-internal relative name, distinct global keys — the
+        // collision the dual regime exists to prevent.
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn repo_relative_coverage_root_is_toplevel() {
+        let base = IdentityBase::RepoRelative {
+            toplevel: PathBuf::from("/abs/project"),
+            root_prefixes: vec![],
+        };
+        // src_canonical argument is ignored in the multi-root regime.
+        assert_eq!(
+            base.coverage_root(Path::new("/ignored")),
+            PathBuf::from("/abs/project")
+        );
+    }
+
+    #[test]
+    fn repo_relative_empty_prefix_when_root_is_toplevel() {
+        let base = IdentityBase::RepoRelative {
+            toplevel: PathBuf::from("/abs/project"),
+            root_prefixes: vec![(PathBuf::from("/abs/project"), String::new())],
+        };
+        let key = base.relativize(Path::new("/abs/project/lib.rs"), Path::new("/abs/project"));
+        assert_eq!(key, "lib.rs");
+    }
+
+    #[test]
+    fn windows_backslashes_normalised_to_forward() {
+        let base = IdentityBase::SrcRelative(PathBuf::from("src"));
+        // strip_prefix is component-wise so this exercises the
+        // to_string_lossy().replace('\\', "/") normalisation only when
+        // the original components contained backslashes; on unix the
+        // path "src/a/b.rs" already uses forward slashes. The assertion
+        // pins the slash-normalisation contract regardless of platform.
+        let key = base.relativize(Path::new("src/a/b.rs"), Path::new("src"));
+        assert_eq!(key, "a/b.rs");
+    }
+}

--- a/crates/crap-core/src/core/identity.rs
+++ b/crates/crap-core/src/core/identity.rs
@@ -105,11 +105,18 @@ impl IdentityBase {
         match self {
             IdentityBase::SrcRelative(base) => strip_to_slashed(file, base),
             IdentityBase::RepoRelative { root_prefixes, .. } => {
+                // A missing originating_root is a multi-root invariant
+                // violation (root_prefixes is built from the same root
+                // set), so fail loud rather than silently keying with an
+                // empty prefix — a wrong key reintroduces the cross-crate
+                // collision α' exists to prevent. A legitimately-empty
+                // prefix (a root that IS the toplevel) is the `Some("")`
+                // case, handled by the `is_empty()` branch below.
                 let prefix = root_prefixes
                     .iter()
                     .find(|(root, _)| root == originating_root)
                     .map(|(_, prefix)| prefix.as_str())
-                    .unwrap_or("");
+                    .expect("multi-root invariant: a discovered file's originating root must be present in root_prefixes");
                 let rel = strip_to_slashed(file, originating_root);
                 if prefix.is_empty() {
                     rel

--- a/crates/crap-core/src/core/mod.rs
+++ b/crates/crap-core/src/core/mod.rs
@@ -302,13 +302,18 @@ impl<'a, P: ParseDiagnostic> AnalysisContext<'a, P> {
                 }
             }
         }
-        // Re-sort by identity key for deterministic output regardless of
-        // root order (the union must be order-independent).
-        source_files.sort_by(|a, b| {
-            let ka = self.options.identity_base.relativize(&a.path, &a.root);
-            let kb = self.options.identity_base.relativize(&b.path, &b.root);
-            ka.cmp(&kb)
-        });
+        // Sort by the discovered PATH (PathBuf order), NOT the
+        // relativized identity-key string. The walker's pre-multi-root
+        // `files.sort()` was PathBuf-Ord (component-wise); String-Ord on
+        // the slash-joined key diverges when a sibling file/dir pair
+        // straddles the separator (`foo.rs` vs `foo/…`: `.` 0x2E < `/`
+        // 0x2F flips them). Since nothing downstream re-sorts
+        // `result.functions`, discovery order reaches the JSON envelope —
+        // so PathBuf-Ord here is load-bearing for single-root
+        // byte-identity. Full paths are globally unique across roots, so
+        // PathBuf-Ord is also a deterministic, order-independent union
+        // key for multi-root.
+        source_files.sort_by(|a, b| a.path.cmp(&b.path));
 
         let files_found = source_files.len();
         ensure_source_files_found(&source_files, &self.options.src, &extensions)?;

--- a/crates/crap-core/src/core/mod.rs
+++ b/crates/crap-core/src/core/mod.rs
@@ -12,6 +12,7 @@
 //! (mixed-dispatch-strategy).
 
 pub mod compose;
+pub mod identity;
 pub mod walker;
 
 use std::path::{Path, PathBuf};
@@ -35,8 +36,19 @@ use crate::ports::{ComplexityPort, CoveragePort, DiffPort, ParseDiagnostic, Pars
 /// Options for running a CRAP analysis.
 #[derive(Debug)]
 pub struct AnalyzeOptions {
-    /// Root directory of source files to analyze.
-    pub src: PathBuf,
+    /// Source roots to analyze. A single root is the back-compat case
+    /// (byte-identical to the pre-multi-root `PathBuf` field); multiple
+    /// roots union their discovered functions into one report (#336).
+    /// Empty defers to the config/default `["src"]` upstream in the CLI
+    /// merge layer — by the time options reach `analyze`, this is
+    /// non-empty.
+    pub src: Vec<PathBuf>,
+    /// The path-space function identity and coverage SF records are
+    /// relativized against (#336). Decided ONCE from `src.len()` in the
+    /// CLI layer: single root ⇒ src-relative (byte-identical
+    /// back-compat); multiple roots ⇒ git-toplevel-relative
+    /// (collision-free + bleed-free). See [`identity::IdentityBase`].
+    pub identity_base: identity::IdentityBase,
     /// Path to the coverage file (adapter-specific format: LCOV for
     /// crap4rs, Istanbul JSON for crap4ts, etc.).
     pub coverage: PathBuf,
@@ -83,8 +95,20 @@ pub struct AnalysisOutput<P: ParseDiagnostic> {
     pub diagnostics: AnalysisDiagnostics<P>,
 }
 
+/// A discovered source file paired with the `--src` root it was found
+/// under. The originating root is what `IdentityBase::relativize` strips
+/// against, so a file's identity key is unambiguous even when several
+/// roots share crate-internal relative names (`adapters/mod.rs`).
+#[derive(Debug, Clone)]
+struct DiscoveredFile {
+    /// The `--src` root this file was discovered under.
+    root: PathBuf,
+    /// The full discovered path (relative to CWD, as the walker emits).
+    path: PathBuf,
+}
+
 struct DiscoveredSources {
-    source_files: Vec<PathBuf>,
+    source_files: Vec<DiscoveredFile>,
     files_found: usize,
 }
 
@@ -96,7 +120,8 @@ struct ExtractedComplexities {
 impl Default for AnalyzeOptions {
     fn default() -> Self {
         Self {
-            src: PathBuf::from("src"),
+            src: vec![PathBuf::from("src")],
+            identity_base: identity::IdentityBase::default(),
             coverage: PathBuf::from("lcov.info"),
             threshold_config: ThresholdConfig::default(),
             metric: ComplexityMetric::default(),
@@ -147,6 +172,11 @@ struct AnalysisContext<'a, P: ParseDiagnostic> {
     options: &'a AnalyzeOptions,
     complexity: &'a dyn ComplexityPort,
     coverage: &'a dyn CoveragePort<Diagnostic = P>,
+    /// Canonicalized first `--src` root. Used only by the `--diff` path
+    /// (`compute_diff_regions`) to locate the git work tree. Single-root
+    /// runs canonicalize the only root (byte-identical to before
+    /// multi-root); multi-root runs share the git toplevel via
+    /// `options.identity_base`, so this is just the diff anchor.
     src_canonical: PathBuf,
 }
 
@@ -160,7 +190,15 @@ impl<'a, P: ParseDiagnostic> AnalysisContext<'a, P> {
             options,
             complexity,
             coverage,
-            src_canonical: canonicalize_src(&options.src),
+            // The diff anchor is the first root. Single-root: the only
+            // root (byte-identical). Multi-root: any root resolves the
+            // same git work tree, so the first is a fine anchor; the
+            // identity base carries the toplevel for relativization.
+            src_canonical: options
+                .src
+                .first()
+                .map(|first| canonicalize_src(first))
+                .unwrap_or_else(|| PathBuf::from("src")),
         }
     }
 
@@ -239,12 +277,39 @@ impl<'a, P: ParseDiagnostic> AnalysisContext<'a, P> {
 
     fn discover_sources(&self) -> Result<DiscoveredSources> {
         let extensions: Vec<&str> = self.options.extensions.iter().map(String::as_str).collect();
-        let source_files = discover_source_files(
-            &self.options.src,
-            &self.options.exclude,
-            self.options.respect_gitignore,
-            &extensions,
-        )?;
+
+        // Discover under every `--src` root, tagging each file with the
+        // root it was found under so `IdentityBase::relativize` strips
+        // against the right base. Union + dedup on the global identity
+        // key: an overlapping root must not double-count a function's
+        // file (the union semantics #336 promises).
+        let mut source_files: Vec<DiscoveredFile> = Vec::new();
+        let mut seen_keys: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for root in &self.options.src {
+            let found = discover_source_files(
+                root,
+                &self.options.exclude,
+                self.options.respect_gitignore,
+                &extensions,
+            )?;
+            for path in found {
+                let key = self.options.identity_base.relativize(&path, root);
+                if seen_keys.insert(key) {
+                    source_files.push(DiscoveredFile {
+                        root: root.clone(),
+                        path,
+                    });
+                }
+            }
+        }
+        // Re-sort by identity key for deterministic output regardless of
+        // root order (the union must be order-independent).
+        source_files.sort_by(|a, b| {
+            let ka = self.options.identity_base.relativize(&a.path, &a.root);
+            let kb = self.options.identity_base.relativize(&b.path, &b.root);
+            ka.cmp(&kb)
+        });
+
         let files_found = source_files.len();
         ensure_source_files_found(&source_files, &self.options.src, &extensions)?;
 
@@ -256,7 +321,7 @@ impl<'a, P: ParseDiagnostic> AnalysisContext<'a, P> {
 
     fn load_diff_data(
         &self,
-        source_files: &[PathBuf],
+        source_files: &[DiscoveredFile],
     ) -> Result<Option<std::collections::HashMap<String, FileChangeKind>>> {
         self.options
             .diff_ref
@@ -265,7 +330,7 @@ impl<'a, P: ParseDiagnostic> AnalysisContext<'a, P> {
                 compute_diff_regions(
                     diff_ref,
                     &self.src_canonical,
-                    &self.options.src,
+                    &self.options.identity_base,
                     source_files,
                 )
             })
@@ -305,14 +370,21 @@ impl<'a, P: ParseDiagnostic> AnalysisContext<'a, P> {
             })
     }
 
-    fn extract_complexities(&self, source_files: &[PathBuf]) -> Result<ExtractedComplexities> {
+    fn extract_complexities(
+        &self,
+        source_files: &[DiscoveredFile],
+    ) -> Result<ExtractedComplexities> {
         let mut all_complexities = Vec::new();
         let mut files_unparseable = 0usize;
 
-        for file_path in source_files {
-            let source = std::fs::read_to_string(file_path)
-                .with_context(|| format!("failed to read source file: {}", file_path.display()))?;
-            let relative = src_relative_path(file_path, &self.options.src);
+        for DiscoveredFile { root, path } in source_files {
+            let source = std::fs::read_to_string(path)
+                .with_context(|| format!("failed to read source file: {}", path.display()))?;
+            // Relativize via the run identity base, stripping against the
+            // root this file was discovered under (#336). Single-root
+            // mode reproduces the historical `src_relative_path` strip
+            // byte-for-byte.
+            let relative = self.options.identity_base.relativize(path, root);
 
             match self
                 .complexity
@@ -352,7 +424,11 @@ impl<'a, P: ParseDiagnostic> AnalysisContext<'a, P> {
         diff_data: Option<&std::collections::HashMap<String, FileChangeKind>>,
     ) -> Option<AnalysisOutput<P>> {
         let diff_result = diff_data?;
-        retain_changed_source_files(&mut discovered.source_files, &self.options.src, diff_result);
+        retain_changed_source_files(
+            &mut discovered.source_files,
+            &self.options.identity_base,
+            diff_result,
+        );
         if !discovered.source_files.is_empty() {
             return None;
         }
@@ -415,8 +491,8 @@ pub(crate) fn canonicalize_src(src: &Path) -> PathBuf {
 }
 
 fn ensure_source_files_found(
-    source_files: &[PathBuf],
-    src: &Path,
+    source_files: &[DiscoveredFile],
+    src: &[PathBuf],
     extensions: &[&str],
 ) -> Result<()> {
     if source_files.is_empty() {
@@ -441,20 +517,31 @@ fn ensure_source_files_found(
         bail!(
             "no source files found in {}\n  \
              hint: check that --src points to a directory containing {} files",
-            src.display(),
+            display_roots(src),
             pretty,
         );
     }
     Ok(())
 }
 
+/// Render one-or-more `--src` roots for an error message: a single root
+/// prints as its bare path (back-compat with the pre-multi-root
+/// wording); multiple roots print as a comma-separated list.
+fn display_roots(roots: &[PathBuf]) -> String {
+    roots
+        .iter()
+        .map(|r| r.display().to_string())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
 fn retain_changed_source_files(
-    source_files: &mut Vec<PathBuf>,
-    src_root: &Path,
+    source_files: &mut Vec<DiscoveredFile>,
+    identity_base: &identity::IdentityBase,
     diff_result: &std::collections::HashMap<String, FileChangeKind>,
 ) {
-    source_files.retain(|path| {
-        let rel = src_relative_path(path, src_root);
+    source_files.retain(|DiscoveredFile { root, path }| {
+        let rel = identity_base.relativize(path, root);
         diff_result.contains_key(&rel)
     });
 }
@@ -470,12 +557,15 @@ fn retain_changed_functions(
     });
 }
 
-fn ensure_functions_extracted(all_complexities: &[FunctionComplexity], src: &Path) -> Result<()> {
+fn ensure_functions_extracted(
+    all_complexities: &[FunctionComplexity],
+    src: &[PathBuf],
+) -> Result<()> {
     if all_complexities.is_empty() {
         bail!(
             "no functions extracted from source files in {}\n  \
              hint: check that source files contain valid function definitions for the selected adapter",
-            src.display()
+            display_roots(src)
         );
     }
     Ok(())
@@ -650,70 +740,91 @@ fn src_relative_path(path: &Path, src_root: &Path) -> String {
         .replace('\\', "/")
 }
 
-/// Compute diff regions for the given ref, reconciling repo-root-relative paths
-/// from `git diff` with src-relative paths used by the complexity adapter.
+/// Compute diff regions for the given ref, reconciling repo-root-relative
+/// paths from `git diff` with the run's identity keys.
+///
+/// `git diff` emits repo-relative paths; the analyzer keys functions on
+/// the run identity base (src-relative single-root, toplevel-relative
+/// multi-root). This bridges the two by mapping each discovered file's
+/// repo-relative path to its identity key, querying git with the
+/// repo-relative paths, then re-keying the result to identity keys so
+/// the diff filter compares like with like.
+///
+/// Single-root: the repo-relative→identity-key map reproduces the old
+/// `src_prefix` strip exactly (byte-identical). Multi-root: identity
+/// keys ARE toplevel-relative, so the map is the identity (no prefix
+/// juggling) — Q5 collapses for free under the common base.
 fn compute_diff_regions(
     diff_ref: &str,
     src_canonical: &Path,
-    src_original: &Path,
-    source_files: &[PathBuf],
+    identity_base: &identity::IdentityBase,
+    source_files: &[DiscoveredFile],
 ) -> Result<std::collections::HashMap<String, FileChangeKind>> {
     let diff_adapter = GitDiffAdapter::new();
 
-    // Git diff outputs paths relative to repo root, but the complexity
-    // adapter uses paths relative to options.src. We bridge via src_prefix.
+    // Any `--src` root resolves the same work tree; the first root's
+    // canonical path is the diff anchor.
     let repo_root = git_toplevel(src_canonical)?;
-    let src_prefix = src_canonical
-        .strip_prefix(&repo_root)
-        .with_context(|| {
-            format!(
-                "--src directory {} is not inside the git repository at {}\n  \
-                 hint: --diff requires --src to be within the git work tree",
-                src_canonical.display(),
-                repo_root.display(),
-            )
-        })?
-        .to_string_lossy()
-        .replace('\\', "/");
 
-    // Paths passed to `git diff -- <paths>` must be repo-relative.
-    // source_files use the original (possibly symlinked) src path.
-    let repo_relative_paths: Vec<String> = source_files
-        .iter()
-        .map(|p| {
-            let src_rel = src_relative_path(p, src_original);
-            if src_prefix.is_empty() {
-                src_rel
-            } else {
-                format!("{src_prefix}/{src_rel}")
-            }
-        })
-        .collect();
+    // Build the bridge: for each discovered file, its repo-relative
+    // path (what `git diff -- <paths>` expects) ↔ its identity key
+    // (what the analyzer keys functions on).
+    let mut repo_to_identity: std::collections::HashMap<String, String> =
+        std::collections::HashMap::new();
+    let mut repo_relative_paths: Vec<String> = Vec::with_capacity(source_files.len());
+    for DiscoveredFile { root, path } in source_files {
+        let identity_key = identity_base.relativize(path, root);
+        let repo_rel = repo_relative_path(path, root, &repo_root)?;
+        repo_relative_paths.push(repo_rel.clone());
+        repo_to_identity.insert(repo_rel, identity_key);
+    }
 
     let raw_diff = diff_adapter
         .changed_regions(diff_ref, &repo_root, &repo_relative_paths)
         .map_err(|e| anyhow::anyhow!(e))?;
 
-    // Strip src_prefix from diff result keys to get src-relative paths
-    let prefix_with_slash = if src_prefix.is_empty() {
-        String::new()
-    } else {
-        format!("{src_prefix}/")
-    };
+    // Re-key git's repo-relative output to identity keys via the bridge.
+    // Entries with no discovered-file match are dropped (the diff only
+    // matters for files we're analyzing).
     Ok(raw_diff
         .into_iter()
-        .filter_map(|(path, kind)| {
-            if prefix_with_slash.is_empty() {
-                Some((path, kind))
-            } else {
-                path.strip_prefix(&prefix_with_slash)
-                    .map(|stripped| (stripped.to_string(), kind))
-            }
+        .filter_map(|(repo_path, kind)| {
+            repo_to_identity
+                .get(&repo_path)
+                .map(|identity_key| (identity_key.clone(), kind))
         })
         .collect())
 }
 
-fn git_toplevel(from_dir: &Path) -> Result<PathBuf> {
+/// Repo-relative path of a discovered file: canonicalize the originating
+/// root, strip the git toplevel to get the root's repo prefix, then
+/// append the file's path relative to that root.
+fn repo_relative_path(file: &Path, root: &Path, repo_root: &Path) -> Result<String> {
+    let root_canonical = canonicalize_src(root);
+    let root_prefix = root_canonical
+        .strip_prefix(repo_root)
+        .with_context(|| {
+            format!(
+                "--src directory {} is not inside the git repository at {}\n  \
+                 hint: --diff requires --src to be within the git work tree",
+                root_canonical.display(),
+                repo_root.display(),
+            )
+        })?
+        .to_string_lossy()
+        .replace('\\', "/");
+    let file_rel = src_relative_path(file, root);
+    Ok(if root_prefix.is_empty() {
+        file_rel
+    } else {
+        format!("{root_prefix}/{file_rel}")
+    })
+}
+
+/// Resolve the git work-tree root from `from_dir`. `pub(crate)` so the
+/// CLI's `resolve_identity_base` can anchor the multi-root identity base
+/// on the same toplevel the diff path uses.
+pub(crate) fn git_toplevel(from_dir: &Path) -> Result<PathBuf> {
     let output = std::process::Command::new("git")
         .current_dir(from_dir)
         .args(["rev-parse", "--show-toplevel"])

--- a/crates/crap-core/tests/crap_render_cli.rs
+++ b/crates/crap-core/tests/crap_render_cli.rs
@@ -409,9 +409,10 @@ fn crap_render_accepts_schema_version_1_for_legacy_envelopes() {
 
 #[test]
 fn crap_render_rejects_baseline_without_matching_input() {
-    // Characterization (crap-rs#336, Commit 2): a `--baseline` whose
-    // language key has no matching `--input` is an operator error. Pins
-    // the branch before `run`'s validation is extracted to a helper.
+    // Characterization (crap-rs#336): a `--baseline` whose language key
+    // has no matching `--input` is an operator error. Asserts the
+    // validation stays actionable now that `run`'s checks live in an
+    // extracted helper.
     let tmp = TempDir::new().unwrap();
     let rs_path = tmp.path().join("rs.json");
     let ts_baseline = tmp.path().join("ts-baseline.json");
@@ -439,9 +440,9 @@ fn crap_render_rejects_baseline_without_matching_input() {
 
 #[test]
 fn crap_render_rejects_duplicate_baseline() {
-    // Characterization (crap-rs#336, Commit 2): two `--baseline` for the
-    // same language key is an operator error. Pins the branch before
-    // `run`'s validation is extracted.
+    // Characterization (crap-rs#336): two `--baseline` for the same
+    // language key is an operator error. Asserts this stays an operator
+    // error now that `run`'s validation lives in an extracted helper.
     let tmp = TempDir::new().unwrap();
     let rs_path = tmp.path().join("rs.json");
     let base_a = tmp.path().join("base-a.json");

--- a/crates/crap-core/tests/crap_render_cli.rs
+++ b/crates/crap-core/tests/crap_render_cli.rs
@@ -406,3 +406,64 @@ fn crap_render_accepts_schema_version_1_for_legacy_envelopes() {
         String::from_utf8_lossy(&out.stderr)
     );
 }
+
+#[test]
+fn crap_render_rejects_baseline_without_matching_input() {
+    // Characterization (crap-rs#336, Commit 2): a `--baseline` whose
+    // language key has no matching `--input` is an operator error. Pins
+    // the branch before `run`'s validation is extracted to a helper.
+    let tmp = TempDir::new().unwrap();
+    let rs_path = tmp.path().join("rs.json");
+    let ts_baseline = tmp.path().join("ts-baseline.json");
+    fs::write(&rs_path, MINIMAL_ENVELOPE_V2).unwrap();
+    fs::write(&ts_baseline, MINIMAL_ENVELOPE_TS_V2).unwrap();
+
+    let out = Command::cargo_bin("crap-render")
+        .unwrap()
+        .arg("--input")
+        .arg(format!("rust={}", rs_path.display()))
+        .arg("--baseline")
+        .arg(format!("typescript={}", ts_baseline.display()))
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "baseline with no matching input → non-zero exit"
+    );
+    let stderr = String::from_utf8(out.stderr).unwrap();
+    assert!(
+        stderr.contains("has no matching --input"),
+        "stderr should name the unmatched baseline; got: {stderr}"
+    );
+}
+
+#[test]
+fn crap_render_rejects_duplicate_baseline() {
+    // Characterization (crap-rs#336, Commit 2): two `--baseline` for the
+    // same language key is an operator error. Pins the branch before
+    // `run`'s validation is extracted.
+    let tmp = TempDir::new().unwrap();
+    let rs_path = tmp.path().join("rs.json");
+    let base_a = tmp.path().join("base-a.json");
+    let base_b = tmp.path().join("base-b.json");
+    fs::write(&rs_path, MINIMAL_ENVELOPE_V2).unwrap();
+    fs::write(&base_a, MINIMAL_ENVELOPE_V2).unwrap();
+    fs::write(&base_b, MINIMAL_ENVELOPE_V2).unwrap();
+
+    let out = Command::cargo_bin("crap-render")
+        .unwrap()
+        .arg("--input")
+        .arg(format!("rust={}", rs_path.display()))
+        .arg("--baseline")
+        .arg(format!("rust={}", base_a.display()))
+        .arg("--baseline")
+        .arg(format!("rust={}", base_b.display()))
+        .output()
+        .unwrap();
+    assert!(!out.status.success(), "duplicate baseline → non-zero exit");
+    let stderr = String::from_utf8(out.stderr).unwrap();
+    assert!(
+        stderr.contains("duplicate baseline for language 'rust'"),
+        "stderr should name the duplicate baseline; got: {stderr}"
+    );
+}

--- a/crates/crap4rs/src/lib.rs
+++ b/crates/crap4rs/src/lib.rs
@@ -80,6 +80,13 @@ pub mod core {
     pub use crap_core::core::AnalyzeOptions;
     pub use crap_core::core::analyze;
 
+    /// Multi-root run identity base (crap-rs#336). Re-exported so
+    /// library consumers (and crap4rs integration tests) can construct
+    /// `AnalyzeOptions { identity_base, .. }` for multi-root analysis.
+    pub mod identity {
+        pub use crap_core::core::identity::IdentityBase;
+    }
+
     /// v0.4 alias of `crap_core::core::AnalysisOutput<P>`,
     /// concretized to the LCOV adapter's diagnostic shape.
     pub type AnalysisOutput =

--- a/crates/crap4rs/tests/analyze_integration.rs
+++ b/crates/crap4rs/tests/analyze_integration.rs
@@ -5,6 +5,7 @@
 
 use crap4rs::adapters::complexity::SynComplexityAdapter;
 use crap4rs::adapters::coverage::LcovParser;
+use crap4rs::core::identity::IdentityBase;
 use crap4rs::core::{AnalyzeOptions, analyze};
 use crap4rs::domain::threshold::ThresholdConfig;
 use crap4rs::domain::types::ComplexityMetric;
@@ -38,7 +39,8 @@ fn self_referential_analysis() {
     std::fs::write(&lcov_path, &lcov).unwrap();
 
     let opts = AnalyzeOptions {
-        src: src.clone(),
+        identity_base: IdentityBase::SrcRelative(src.clone()),
+        src: vec![src.clone()],
         coverage: lcov_path,
         threshold_config: ThresholdConfig {
             global: 30.0,
@@ -101,7 +103,8 @@ fn self_referential_with_cyclomatic() {
 
     let (cx, cov) = adapters(&src);
     let opts = AnalyzeOptions {
-        src,
+        identity_base: IdentityBase::SrcRelative(src.clone()),
+        src: vec![src],
         coverage: lcov_path,
         threshold_config: ThresholdConfig {
             global: 30.0,
@@ -137,7 +140,8 @@ fn self_referential_known_functions_present() {
 
     let (cx, cov) = adapters(&src);
     let opts = AnalyzeOptions {
-        src,
+        identity_base: IdentityBase::SrcRelative(src.clone()),
+        src: vec![src],
         coverage: lcov_path,
         threshold_config: ThresholdConfig {
             global: 30.0,
@@ -188,7 +192,8 @@ fn exclude_pattern_filters_correctly() {
 
     // Analyze all files
     let all_opts = AnalyzeOptions {
-        src: src.clone(),
+        identity_base: IdentityBase::SrcRelative(src.clone()),
+        src: vec![src.clone()],
         coverage: lcov_path.clone(),
         threshold_config: ThresholdConfig {
             global: 100.0,
@@ -204,7 +209,8 @@ fn exclude_pattern_filters_correctly() {
 
     // Analyze with adapter exclusion
     let filtered_opts = AnalyzeOptions {
-        src,
+        identity_base: IdentityBase::SrcRelative(src.clone()),
+        src: vec![src],
         coverage: lcov_path,
         threshold_config: ThresholdConfig {
             global: 100.0,

--- a/crates/crap4rs/tests/analyze_pipeline_tests.rs
+++ b/crates/crap4rs/tests/analyze_pipeline_tests.rs
@@ -16,6 +16,7 @@ use std::path::Path;
 
 use crap4rs::adapters::complexity::SynComplexityAdapter;
 use crap4rs::adapters::coverage::LcovParser;
+use crap4rs::core::identity::IdentityBase;
 use crap4rs::core::{AnalyzeOptions, analyze};
 use crap4rs::domain::threshold::{DEFAULT_THRESHOLD, ThresholdConfig, ThresholdOverride};
 use crap4rs::domain::types::{ComplexityMetric, CoverageMetric};
@@ -74,7 +75,8 @@ fn analyze_returns_results_for_simple_project() {
     let (cx, cov) = adapters(&src);
 
     let opts = AnalyzeOptions {
-        src,
+        identity_base: IdentityBase::SrcRelative(src.clone()),
+        src: vec![src],
         coverage: dir.path().join("lcov.info"),
         threshold_config: ThresholdConfig {
             global: DEFAULT_THRESHOLD,
@@ -102,7 +104,8 @@ fn analyze_simple_fn_fully_covered_has_low_crap() {
     let (cx, cov) = adapters(&src);
 
     let opts = AnalyzeOptions {
-        src,
+        identity_base: IdentityBase::SrcRelative(src.clone()),
+        src: vec![src],
         coverage: dir.path().join("lcov.info"),
         threshold_config: ThresholdConfig {
             global: DEFAULT_THRESHOLD,
@@ -134,7 +137,8 @@ fn analyze_branching_fn_partial_coverage_higher_crap() {
     let (cx, cov) = adapters(&src);
 
     let opts = AnalyzeOptions {
-        src,
+        identity_base: IdentityBase::SrcRelative(src.clone()),
+        src: vec![src],
         coverage: dir.path().join("lcov.info"),
         threshold_config: ThresholdConfig {
             global: DEFAULT_THRESHOLD,
@@ -166,7 +170,8 @@ fn analyze_pass_when_all_below_threshold() {
     let (cx, cov) = adapters(&src);
 
     let opts = AnalyzeOptions {
-        src,
+        identity_base: IdentityBase::SrcRelative(src.clone()),
+        src: vec![src],
         coverage: dir.path().join("lcov.info"),
         threshold_config: ThresholdConfig {
             global: 100.0,
@@ -194,7 +199,8 @@ fn analyze_at_exact_threshold_does_not_exceed() {
     // simple() has CC=1, 100% coverage → CRAP=1.0
     // Set threshold to exactly 1.0 — should NOT exceed
     let opts = AnalyzeOptions {
-        src,
+        identity_base: IdentityBase::SrcRelative(src.clone()),
+        src: vec![src],
         coverage: dir.path().join("lcov.info"),
         threshold_config: ThresholdConfig {
             global: 1.0,
@@ -226,7 +232,8 @@ fn analyze_fail_when_above_threshold() {
     let (cx, cov) = adapters(&src);
 
     let opts = AnalyzeOptions {
-        src,
+        identity_base: IdentityBase::SrcRelative(src.clone()),
+        src: vec![src],
         coverage: dir.path().join("lcov.info"),
         threshold_config: ThresholdConfig {
             global: 0.5,
@@ -258,7 +265,8 @@ fn analyze_no_functions_extracted_errors() {
 
     let (cx, cov) = adapters(&src_dir);
     let opts = AnalyzeOptions {
-        src: src_dir,
+        identity_base: IdentityBase::SrcRelative(src_dir.clone()),
+        src: vec![src_dir],
         coverage: dir.path().join("lcov.info"),
         respect_gitignore: false,
         extensions: vec!["rs".to_string()],
@@ -282,7 +290,8 @@ fn analyze_empty_src_dir_errors() {
 
     let (cx, cov) = adapters(&src_dir);
     let opts = AnalyzeOptions {
-        src: src_dir,
+        identity_base: IdentityBase::SrcRelative(src_dir.clone()),
+        src: vec![src_dir],
         coverage: dir.path().join("lcov.info"),
         extensions: vec!["rs".to_string()],
         ..AnalyzeOptions::default()
@@ -301,7 +310,8 @@ fn analyze_missing_coverage_file_errors() {
 
     let (cx, cov) = adapters(&src_dir);
     let opts = AnalyzeOptions {
-        src: src_dir,
+        identity_base: IdentityBase::SrcRelative(src_dir.clone()),
+        src: vec![src_dir],
         coverage: dir.path().join("nonexistent.info"),
         extensions: vec!["rs".to_string()],
         ..AnalyzeOptions::default()
@@ -334,7 +344,8 @@ fn analyze_exclude_pattern_filters_files() {
 
     let (cx, cov) = adapters(&src_dir);
     let opts = AnalyzeOptions {
-        src: src_dir,
+        identity_base: IdentityBase::SrcRelative(src_dir.clone()),
+        src: vec![src_dir],
         coverage: dir.path().join("lcov.info"),
         exclude: vec!["tests/**".to_string()],
         respect_gitignore: false,
@@ -360,7 +371,8 @@ fn analyze_with_cyclomatic_metric() {
     let (cx, cov) = adapters(&src);
 
     let opts = AnalyzeOptions {
-        src,
+        identity_base: IdentityBase::SrcRelative(src.clone()),
+        src: vec![src],
         coverage: dir.path().join("lcov.info"),
         metric: ComplexityMetric::Cyclomatic,
         extensions: vec!["rs".to_string()],
@@ -381,7 +393,8 @@ fn summary_computed_correctly() {
     let (cx, cov) = adapters(&src);
 
     let opts = AnalyzeOptions {
-        src,
+        identity_base: IdentityBase::SrcRelative(src.clone()),
+        src: vec![src],
         coverage: dir.path().join("lcov.info"),
         threshold_config: ThresholdConfig {
             global: DEFAULT_THRESHOLD,
@@ -410,7 +423,8 @@ fn analyze_diff_ref_none_is_backward_compat() {
     let (cx, cov) = adapters(&src);
 
     let opts = AnalyzeOptions {
-        src,
+        identity_base: IdentityBase::SrcRelative(src.clone()),
+        src: vec![src],
         coverage: dir.path().join("lcov.info"),
         diff_ref: None,
         respect_gitignore: false,
@@ -431,7 +445,8 @@ fn analyze_returns_diagnostics() {
     let (cx, cov) = adapters(&src);
 
     let opts = AnalyzeOptions {
-        src,
+        identity_base: IdentityBase::SrcRelative(src.clone()),
+        src: vec![src],
         coverage: dir.path().join("lcov.info"),
         threshold_config: ThresholdConfig {
             global: DEFAULT_THRESHOLD,
@@ -475,7 +490,8 @@ fn analyze_diagnostics_counts_no_coverage_functions() {
 
     let (cx, cov) = adapters(&src_dir);
     let opts = AnalyzeOptions {
-        src: src_dir,
+        identity_base: IdentityBase::SrcRelative(src_dir.clone()),
+        src: vec![src_dir],
         coverage: dir.path().join("lcov.info"),
         respect_gitignore: false,
         extensions: vec!["rs".to_string()],
@@ -506,7 +522,8 @@ fn analyze_diagnostics_surfaces_parse_diagnostics() {
 
     let (cx, cov) = adapters(&src_dir);
     let opts = AnalyzeOptions {
-        src: src_dir,
+        identity_base: IdentityBase::SrcRelative(src_dir.clone()),
+        src: vec![src_dir],
         coverage: dir.path().join("lcov.info"),
         respect_gitignore: false,
         extensions: vec!["rs".to_string()],
@@ -525,7 +542,8 @@ fn analyze_with_per_path_overrides() {
     let (cx, cov) = adapters(&src);
 
     let opts = AnalyzeOptions {
-        src,
+        identity_base: IdentityBase::SrcRelative(src.clone()),
+        src: vec![src],
         coverage: dir.path().join("lcov.info"),
         threshold_config: ThresholdConfig {
             global: 100.0,
@@ -590,7 +608,8 @@ pub fn with_branch(x: i32) -> &'static str {
 
     let (cx, cov) = adapters(&src_dir);
     let opts = AnalyzeOptions {
-        src: src_dir,
+        identity_base: IdentityBase::SrcRelative(src_dir.clone()),
+        src: vec![src_dir],
         coverage: dir.path().join("lcov.info"),
         respect_gitignore: false,
         extensions: vec!["rs".to_string()],

--- a/crates/crap4rs/tests/diff_integration.rs
+++ b/crates/crap4rs/tests/diff_integration.rs
@@ -5,6 +5,7 @@
 
 use crap4rs::adapters::complexity::SynComplexityAdapter;
 use crap4rs::adapters::coverage::LcovParser;
+use crap4rs::core::identity::IdentityBase;
 use crap4rs::core::{AnalysisOutput, AnalyzeOptions, analyze};
 use crap4rs::domain::threshold::ThresholdConfig;
 use crap4rs::domain::types::ComplexityMetric;
@@ -17,7 +18,8 @@ use std::process::Command;
 /// constructs adapters internally.
 fn analyze_with_adapters(opts: &AnalyzeOptions) -> anyhow::Result<AnalysisOutput> {
     let cx = SynComplexityAdapter::new();
-    let cov = LcovParser::new(opts.src.clone());
+    // Single-root diff tests: anchor the LCOV parser on the only root.
+    let cov = LcovParser::new(opts.src[0].clone());
     analyze(opts, &cx, &cov)
 }
 
@@ -57,7 +59,8 @@ fn write_lcov(dir: &Path, files: &[(&str, &[(usize, u64)])]) {
 
 fn make_opts(dir: &Path, diff_ref: Option<&str>) -> AnalyzeOptions {
     AnalyzeOptions {
-        src: dir.join("src"),
+        identity_base: IdentityBase::SrcRelative(dir.join("src")),
+        src: vec![dir.join("src")],
         coverage: dir.join("lcov.info"),
         threshold_config: ThresholdConfig {
             global: 30.0,

--- a/crates/crap4rs/tests/features/multi_root_src.feature
+++ b/crates/crap4rs/tests/features/multi_root_src.feature
@@ -29,7 +29,7 @@ Feature: Multi-root source analysis — one scorecard across several source root
 
   @unwired
   Scenario: Multiple --src roots union their functions into one report
-    # tracked: crap-rs#336 — multi_root_src harness wiring lands with the feature
+    # tracked: crap-rs#169 — behavior covered by proptest + multi_root_integration.rs; cucumber-harness wiring deferred to the BDD umbrella
     When the operator runs `crap4rs --coverage lcov.info --src crate-a/src --src crate-b/src --format json`
     Then the JSON envelope includes every function discovered under `crate-a/src`
     And the JSON envelope includes every function discovered under `crate-b/src`
@@ -37,7 +37,7 @@ Feature: Multi-root source analysis — one scorecard across several source root
 
   @unwired
   Scenario: Union is order-independent and deduplicates overlapping roots
-    # tracked: crap-rs#336 — multi_root_src harness wiring lands with the feature
+    # tracked: crap-rs#169 — behavior covered by proptest + multi_root_integration.rs; cucumber-harness wiring deferred to the BDD umbrella
     When the operator analyzes roots `[A, B]` and separately `[B, A]`
     Then both runs report the identical function set
     And a function discovered under two overlapping roots appears exactly once
@@ -46,14 +46,14 @@ Feature: Multi-root source analysis — one scorecard across several source root
 
   @unwired
   Scenario: A single --src root yields src-relative identity (byte-identical back-compat)
-    # tracked: crap-rs#336 — multi_root_src harness wiring lands with the feature
+    # tracked: crap-rs#169 — behavior covered by proptest + multi_root_integration.rs; cucumber-harness wiring deferred to the BDD umbrella
     When the operator runs `crap4rs --coverage lcov.info --src crate-a/src --format json`
     Then each function `file_path` is relative to `crate-a/src` (e.g. `lib.rs`)
     And the JSON envelope is byte-identical to the pre-multi-root single-root output
 
   @unwired
   Scenario: Multiple --src roots yield git-toplevel-relative identity
-    # tracked: crap-rs#336 — multi_root_src harness wiring lands with the feature
+    # tracked: crap-rs#169 — behavior covered by proptest + multi_root_integration.rs; cucumber-harness wiring deferred to the BDD umbrella
     When the operator runs `crap4rs --coverage lcov.info --src crate-a/src --src crate-b/src --format json`
     Then each function `file_path` is relative to the git toplevel (e.g. `crate-a/src/lib.rs`)
     And two same-named files in different roots have distinct `file_path` keys
@@ -62,7 +62,7 @@ Feature: Multi-root source analysis — one scorecard across several source root
 
   @unwired
   Scenario: Same-named files in different roots do not bleed coverage
-    # tracked: crap-rs#336 — multi_root_src harness wiring lands with the feature
+    # tracked: crap-rs#169 — behavior covered by proptest + multi_root_integration.rs; cucumber-harness wiring deferred to the BDD umbrella
     Given `crate-a/src/adapters/mod.rs` and `crate-b/src/adapters/mod.rs` both exist
     And the shared coverage file covers both with different hit counts
     When the operator analyzes both roots in one run
@@ -71,7 +71,7 @@ Feature: Multi-root source analysis — one scorecard across several source root
 
   @unwired
   Scenario: Multi-root with an unresolvable git toplevel is a hard error
-    # tracked: crap-rs#336 — multi_root_src harness wiring lands with the feature
+    # tracked: crap-rs#169 — behavior covered by proptest + multi_root_integration.rs; cucumber-harness wiring deferred to the BDD umbrella
     Given the operator runs outside any git working tree
     When the operator passes more than one --src root
     Then crap4rs exits with an actionable error naming the unresolvable toplevel
@@ -81,7 +81,7 @@ Feature: Multi-root source analysis — one scorecard across several source root
 
   @unwired
   Scenario: comment-preamble prepends caller markdown to the sticky comment
-    # tracked: crap-rs#336 — action-integration scenarios wire at the CI layer, not the cli harness
+    # tracked: crap-rs#169 — action-integration scenarios wire at the CI layer (BDD umbrella), not the cli harness
     Given the scorecard action is invoked with a non-empty `comment-preamble`
     When the action composes the sticky comment
     Then the preamble markdown appears above the rendered scorecard body
@@ -89,7 +89,7 @@ Feature: Multi-root source analysis — one scorecard across several source root
 
   @unwired
   Scenario: Production and examples scorecards post distinct, non-colliding comments
-    # tracked: crap-rs#336 — action-integration scenarios wire at the CI layer, not the cli harness
+    # tracked: crap-rs#169 — action-integration scenarios wire at the CI layer (BDD umbrella), not the cli harness
     Given the production scorecard uses `comment-header: crap-scorecard-production`
     And the examples scorecard uses `comment-header: crap-scorecard-quickstart-smoke`
     When both run on the same pull request

--- a/crates/crap4rs/tests/features/multi_root_src.feature
+++ b/crates/crap4rs/tests/features/multi_root_src.feature
@@ -1,0 +1,97 @@
+Feature: Multi-root source analysis — one scorecard across several source roots
+
+  A project split across multiple source roots (e.g. a Cargo workspace
+  with several crates) can be analyzed in a single invocation by passing
+  `--src` more than once. The functions discovered under every root are
+  unioned into one scorecard, joined against a single shared coverage
+  file.
+
+  # Vocabulary used in scenarios:
+  #   "the operator"      — the human or script invoking crap4rs
+  #   "the JSON envelope" — terminal stdout when --format json
+  #   "the run identity base" — the path every function's `file_path`
+  #                         is relativized to. Single-root runs use the
+  #                         src root (back-compat); multi-root runs use
+  #                         the git toplevel so paths stay globally
+  #                         unique across roots.
+  #
+  # Design contract (see shaping.md L2/L3a + adr-multi-root-identity-base):
+  #   The identity base is decided ONCE from the root count and applied
+  #   to BOTH function identity and coverage-SF normalization. A run is
+  #   either single-root/src-relative OR multi-root/toplevel-relative —
+  #   the two regimes never mix within one run.
+  #
+  # Self-CRAP regression invariant: the multi-root code path must not
+  # introduce any crap-core/crap4rs/crap4ts function with CRAP above 15;
+  # the production scorecard gate enforces this.
+
+  # ── union semantics ────────────────────────────────────────────────
+
+  @unwired
+  Scenario: Multiple --src roots union their functions into one report
+    # tracked: crap-rs#336 — multi_root_src harness wiring lands with the feature
+    When the operator runs `crap4rs --coverage lcov.info --src crate-a/src --src crate-b/src --format json`
+    Then the JSON envelope includes every function discovered under `crate-a/src`
+    And the JSON envelope includes every function discovered under `crate-b/src`
+    And the summary `total_functions` equals the count across both roots
+
+  @unwired
+  Scenario: Union is order-independent and deduplicates overlapping roots
+    # tracked: crap-rs#336 — multi_root_src harness wiring lands with the feature
+    When the operator analyzes roots `[A, B]` and separately `[B, A]`
+    Then both runs report the identical function set
+    And a function discovered under two overlapping roots appears exactly once
+
+  # ── identity base (the α' contract) ────────────────────────────────
+
+  @unwired
+  Scenario: A single --src root yields src-relative identity (byte-identical back-compat)
+    # tracked: crap-rs#336 — multi_root_src harness wiring lands with the feature
+    When the operator runs `crap4rs --coverage lcov.info --src crate-a/src --format json`
+    Then each function `file_path` is relative to `crate-a/src` (e.g. `lib.rs`)
+    And the JSON envelope is byte-identical to the pre-multi-root single-root output
+
+  @unwired
+  Scenario: Multiple --src roots yield git-toplevel-relative identity
+    # tracked: crap-rs#336 — multi_root_src harness wiring lands with the feature
+    When the operator runs `crap4rs --coverage lcov.info --src crate-a/src --src crate-b/src --format json`
+    Then each function `file_path` is relative to the git toplevel (e.g. `crate-a/src/lib.rs`)
+    And two same-named files in different roots have distinct `file_path` keys
+
+  # ── coverage join under multi-root (no collision, no bleed) ─────────
+
+  @unwired
+  Scenario: Same-named files in different roots do not bleed coverage
+    # tracked: crap-rs#336 — multi_root_src harness wiring lands with the feature
+    Given `crate-a/src/adapters/mod.rs` and `crate-b/src/adapters/mod.rs` both exist
+    And the shared coverage file covers both with different hit counts
+    When the operator analyzes both roots in one run
+    Then each `adapters/mod.rs` function is joined to its own root's coverage
+    And neither file's coverage is attributed to the other
+
+  @unwired
+  Scenario: Multi-root with an unresolvable git toplevel is a hard error
+    # tracked: crap-rs#336 — multi_root_src harness wiring lands with the feature
+    Given the operator runs outside any git working tree
+    When the operator passes more than one --src root
+    Then crap4rs exits with an actionable error naming the unresolvable toplevel
+    And it does NOT silently fall back to a basename strip
+
+  # ── scorecard action surfaces ──────────────────────────────────────
+
+  @unwired
+  Scenario: comment-preamble prepends caller markdown to the sticky comment
+    # tracked: crap-rs#336 — action-integration scenarios wire at the CI layer, not the cli harness
+    Given the scorecard action is invoked with a non-empty `comment-preamble`
+    When the action composes the sticky comment
+    Then the preamble markdown appears above the rendered scorecard body
+    And an empty `comment-preamble` produces a byte-identical comment to today
+
+  @unwired
+  Scenario: Production and examples scorecards post distinct, non-colliding comments
+    # tracked: crap-rs#336 — action-integration scenarios wire at the CI layer, not the cli harness
+    Given the production scorecard uses `comment-header: crap-scorecard-production`
+    And the examples scorecard uses `comment-header: crap-scorecard-quickstart-smoke`
+    When both run on the same pull request
+    Then two separate sticky comments are posted
+    And each carries its own preamble labeling production vs teaching sample

--- a/crates/crap4rs/tests/multi_root_integration.rs
+++ b/crates/crap4rs/tests/multi_root_integration.rs
@@ -260,6 +260,47 @@ fn multi_root_no_coverage_bleed_on_shared_relative_path() {
     );
 }
 
+/// CI emits git-toplevel-RELATIVE `SF:` paths (`crates/crap-core/src/...`),
+/// NOT the absolute paths local `cargo llvm-cov` produces. The α'
+/// "both sides share the git-toplevel base natively" claim is what makes
+/// the production scorecard green in CI — exercise it explicitly so a
+/// `normalize_path` regression that breaks relative-SF anchoring can't
+/// slip past the absolute-SF fixtures above.
+#[test]
+fn multi_root_joins_relative_sf_paths_no_bleed() {
+    let tmp = scaffold_two_roots();
+    let top = tmp.path().canonicalize().unwrap();
+    let a = top.join("crate-a/src");
+    let b = top.join("crate-b/src");
+
+    // Toplevel-RELATIVE SF keys, mirroring CI's workspace lcov shape.
+    let lcov = "SF:crate-a/src/adapters/mod.rs\nDA:1,1\nend_of_record\n\
+                SF:crate-b/src/adapters/mod.rs\nDA:1,0\nend_of_record\n\
+                SF:crate-a/src/lib.rs\nDA:1,1\nend_of_record\n\
+                SF:crate-b/src/lib.rs\nDA:1,1\nend_of_record\n";
+    let lcov_path = top.join("rel.info");
+    std::fs::write(&lcov_path, lcov).unwrap();
+
+    let base = repo_relative_base(&top, &[a.clone(), b.clone()]);
+    let cx = SynComplexityAdapter::new();
+    let cov = LcovParser::new(top.clone());
+    let opts = multi_root_options(vec![a, b], lcov_path, base);
+
+    let result = analyze(&opts, &cx, &cov).unwrap().result;
+    let cov_of = |key: &str| {
+        result
+            .functions
+            .iter()
+            .find(|v| v.scored.identity.file_path == key)
+            .unwrap_or_else(|| panic!("function not found: {key}"))
+            .scored
+            .coverage_percent
+    };
+    // Relative-SF join lands on the right toplevel-relative key, no bleed.
+    assert_eq!(cov_of("crate-a/src/adapters/mod.rs"), 100.0);
+    assert_eq!(cov_of("crate-b/src/adapters/mod.rs"), 0.0);
+}
+
 #[test]
 fn single_root_yields_src_relative_identity() {
     // Back-compat: a single root via the Vec API + SrcRelative base

--- a/crates/crap4rs/tests/multi_root_integration.rs
+++ b/crates/crap4rs/tests/multi_root_integration.rs
@@ -1,0 +1,297 @@
+//! Integration tests for multi-root `--src` analysis (crap-rs#336).
+//!
+//! Exercises the α' dual-regime identity base end-to-end with the real
+//! syn complexity adapter + real LCOV parser:
+//!
+//! - **Union**: `analyze([A, B])` discovers every function under both
+//!   roots; order-independent; overlapping roots dedup.
+//! - **Single-root back-compat**: one root yields src-relative identity
+//!   (`lib.rs`), byte-identical to the pre-multi-root path.
+//! - **Multi-root identity**: git-toplevel-relative keys
+//!   (`crate-a/src/lib.rs`) so same-named files in different roots stay
+//!   distinct.
+//! - **No coverage bleed**: same relative path in two roots joins to its
+//!   own coverage, never the sibling's.
+//!
+//! The BDD contract these mirror: `tests/features/multi_root_src.feature`.
+
+use crap4rs::adapters::complexity::SynComplexityAdapter;
+use crap4rs::adapters::coverage::LcovParser;
+use crap4rs::core::identity::IdentityBase;
+use crap4rs::core::{AnalyzeOptions, analyze};
+use crap4rs::domain::threshold::ThresholdConfig;
+use crap4rs::domain::types::ComplexityMetric;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Lay out a throwaway git repo with two crate-like roots that share a
+/// crate-internal relative path (`adapters/mod.rs`) plus distinct files.
+/// Returns the repo root (git toplevel).
+fn scaffold_two_roots() -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+
+    // crate-a/src/{lib.rs, adapters/mod.rs}
+    let a_src = root.join("crate-a").join("src");
+    std::fs::create_dir_all(a_src.join("adapters")).unwrap();
+    std::fs::write(
+        a_src.join("lib.rs"),
+        "pub fn a_only(x: i32) -> i32 { if x > 0 { x } else { -x } }\n",
+    )
+    .unwrap();
+    std::fs::write(
+        a_src.join("adapters").join("mod.rs"),
+        "pub fn shared_a() -> u8 { 1 }\n",
+    )
+    .unwrap();
+
+    // crate-b/src/{lib.rs, adapters/mod.rs}
+    let b_src = root.join("crate-b").join("src");
+    std::fs::create_dir_all(b_src.join("adapters")).unwrap();
+    std::fs::write(
+        b_src.join("lib.rs"),
+        "pub fn b_only(y: i32) -> i32 { y * 2 }\n",
+    )
+    .unwrap();
+    std::fs::write(
+        b_src.join("adapters").join("mod.rs"),
+        "pub fn shared_b() -> u8 { 2 }\n",
+    )
+    .unwrap();
+
+    // git init so git_toplevel resolves to `root`.
+    git(root, &["init", "-q"]);
+    git(root, &["config", "user.email", "t@t.t"]);
+    git(root, &["config", "user.name", "t"]);
+
+    tmp
+}
+
+fn git(dir: &Path, args: &[&str]) {
+    let ok = Command::new("git")
+        .current_dir(dir)
+        .args(args)
+        .status()
+        .unwrap()
+        .success();
+    assert!(ok, "git {args:?} failed");
+}
+
+/// Build the RepoRelative identity base for two roots under `toplevel`.
+fn repo_relative_base(toplevel: &Path, roots: &[PathBuf]) -> IdentityBase {
+    let canonical_top = toplevel.canonicalize().unwrap();
+    let root_prefixes = roots
+        .iter()
+        .map(|r| {
+            let prefix = r
+                .strip_prefix(&canonical_top)
+                .unwrap()
+                .to_string_lossy()
+                .replace('\\', "/");
+            (r.clone(), prefix)
+        })
+        .collect();
+    IdentityBase::RepoRelative {
+        toplevel: canonical_top,
+        root_prefixes,
+    }
+}
+
+/// LCOV covering both roots' files, keyed git-toplevel-relative, with
+/// DIFFERENT hit counts on the two `adapters/mod.rs` so a bleed is
+/// detectable. crate-a's shared fn is fully covered; crate-b's is not.
+fn shared_lcov(toplevel: &Path) -> String {
+    let mut s = String::new();
+    // crate-a/src/adapters/mod.rs — covered (hits=1)
+    s.push_str(&format!(
+        "SF:{}\n",
+        toplevel.join("crate-a/src/adapters/mod.rs").display()
+    ));
+    s.push_str("DA:1,1\nend_of_record\n");
+    // crate-b/src/adapters/mod.rs — uncovered (hits=0)
+    s.push_str(&format!(
+        "SF:{}\n",
+        toplevel.join("crate-b/src/adapters/mod.rs").display()
+    ));
+    s.push_str("DA:1,0\nend_of_record\n");
+    // lib.rs files — both covered
+    s.push_str(&format!(
+        "SF:{}\n",
+        toplevel.join("crate-a/src/lib.rs").display()
+    ));
+    s.push_str("DA:1,1\nend_of_record\n");
+    s.push_str(&format!(
+        "SF:{}\n",
+        toplevel.join("crate-b/src/lib.rs").display()
+    ));
+    s.push_str("DA:1,1\nend_of_record\n");
+    s
+}
+
+fn multi_root_options(
+    roots: Vec<PathBuf>,
+    coverage: PathBuf,
+    base: IdentityBase,
+) -> AnalyzeOptions {
+    AnalyzeOptions {
+        src: roots,
+        coverage,
+        identity_base: base,
+        threshold_config: ThresholdConfig {
+            global: 100.0,
+            ..ThresholdConfig::default()
+        },
+        metric: ComplexityMetric::Cognitive,
+        exclude: Vec::new(),
+        respect_gitignore: false,
+        extensions: vec!["rs".to_string()],
+        ..AnalyzeOptions::default()
+    }
+}
+
+#[test]
+fn multi_root_unions_functions_with_toplevel_keys() {
+    let tmp = scaffold_two_roots();
+    let top = tmp.path().canonicalize().unwrap();
+    let a = top.join("crate-a/src");
+    let b = top.join("crate-b/src");
+
+    let lcov = shared_lcov(&top);
+    let lcov_path = top.join("lcov.info");
+    std::fs::write(&lcov_path, &lcov).unwrap();
+
+    let base = repo_relative_base(&top, &[a.clone(), b.clone()]);
+    // Coverage parser anchored on the toplevel (the multi-root base).
+    let cx = SynComplexityAdapter::new();
+    let cov = LcovParser::new(top.clone());
+    let opts = multi_root_options(vec![a, b], lcov_path, base);
+
+    let result = analyze(&opts, &cx, &cov).unwrap().result;
+
+    let keys: Vec<&str> = result
+        .functions
+        .iter()
+        .map(|v| v.scored.identity.file_path.as_str())
+        .collect();
+
+    // Every root's functions present, keyed git-toplevel-relative.
+    assert!(keys.contains(&"crate-a/src/lib.rs"), "keys: {keys:?}");
+    assert!(keys.contains(&"crate-b/src/lib.rs"), "keys: {keys:?}");
+    assert!(
+        keys.contains(&"crate-a/src/adapters/mod.rs"),
+        "keys: {keys:?}"
+    );
+    assert!(
+        keys.contains(&"crate-b/src/adapters/mod.rs"),
+        "keys: {keys:?}"
+    );
+    // 4 functions across both roots.
+    assert_eq!(result.functions.len(), 4, "keys: {keys:?}");
+}
+
+#[test]
+fn multi_root_union_is_order_independent() {
+    let tmp = scaffold_two_roots();
+    let top = tmp.path().canonicalize().unwrap();
+    let a = top.join("crate-a/src");
+    let b = top.join("crate-b/src");
+    let lcov_path = top.join("lcov.info");
+    std::fs::write(&lcov_path, shared_lcov(&top)).unwrap();
+
+    let run = |roots: Vec<PathBuf>| {
+        let base = repo_relative_base(&top, &roots);
+        let cx = SynComplexityAdapter::new();
+        let cov = LcovParser::new(top.clone());
+        let opts = multi_root_options(roots, lcov_path.clone(), base);
+        let mut keys: Vec<String> = analyze(&opts, &cx, &cov)
+            .unwrap()
+            .result
+            .functions
+            .iter()
+            .map(|v| v.scored.identity.file_path.clone())
+            .collect();
+        keys.sort();
+        keys
+    };
+
+    let ab = run(vec![a.clone(), b.clone()]);
+    let ba = run(vec![b, a]);
+    assert_eq!(ab, ba, "union must be order-independent");
+}
+
+#[test]
+fn multi_root_no_coverage_bleed_on_shared_relative_path() {
+    let tmp = scaffold_two_roots();
+    let top = tmp.path().canonicalize().unwrap();
+    let a = top.join("crate-a/src");
+    let b = top.join("crate-b/src");
+    let lcov_path = top.join("lcov.info");
+    std::fs::write(&lcov_path, shared_lcov(&top)).unwrap();
+
+    let base = repo_relative_base(&top, &[a.clone(), b.clone()]);
+    let cx = SynComplexityAdapter::new();
+    let cov = LcovParser::new(top.clone());
+    let opts = multi_root_options(vec![a, b], lcov_path, base);
+
+    let result = analyze(&opts, &cx, &cov).unwrap().result;
+
+    // crate-a/src/adapters/mod.rs is covered (DA:1,1 → 100%);
+    // crate-b/src/adapters/mod.rs is uncovered (DA:1,0 → 0%).
+    // A bleed would attribute a's coverage to b or vice versa.
+    let cov_of = |key: &str| {
+        result
+            .functions
+            .iter()
+            .find(|v| v.scored.identity.file_path == key)
+            .unwrap_or_else(|| panic!("function not found: {key}"))
+            .scored
+            .coverage_percent
+    };
+
+    assert_eq!(
+        cov_of("crate-a/src/adapters/mod.rs"),
+        100.0,
+        "crate-a shared file must keep its own (full) coverage"
+    );
+    assert_eq!(
+        cov_of("crate-b/src/adapters/mod.rs"),
+        0.0,
+        "crate-b shared file must keep its own (zero) coverage — no bleed"
+    );
+}
+
+#[test]
+fn single_root_yields_src_relative_identity() {
+    // Back-compat: a single root via the Vec API + SrcRelative base
+    // produces src-relative keys (`lib.rs`), exactly as before
+    // multi-root existed.
+    let tmp = scaffold_two_roots();
+    let top = tmp.path().canonicalize().unwrap();
+    let a = top.join("crate-a/src");
+
+    // src-relative lcov, anchored on the single root.
+    let lcov = "SF:lib.rs\nDA:1,1\nend_of_record\n\
+                SF:adapters/mod.rs\nDA:1,1\nend_of_record\n";
+    let lcov_path = top.join("single.info");
+    std::fs::write(&lcov_path, lcov).unwrap();
+
+    let base = IdentityBase::SrcRelative(a.clone());
+    let cx = SynComplexityAdapter::new();
+    let cov = LcovParser::new(a.clone());
+    let opts = multi_root_options(vec![a], lcov_path, base);
+
+    let result = analyze(&opts, &cx, &cov).unwrap().result;
+    let keys: Vec<&str> = result
+        .functions
+        .iter()
+        .map(|v| v.scored.identity.file_path.as_str())
+        .collect();
+
+    assert!(keys.contains(&"lib.rs"), "keys: {keys:?}");
+    assert!(keys.contains(&"adapters/mod.rs"), "keys: {keys:?}");
+    // NOT git-toplevel-relative in single-root mode.
+    assert!(
+        !keys.iter().any(|k| k.starts_with("crate-a/")),
+        "single-root must be src-relative, got: {keys:?}"
+    );
+}

--- a/crates/crap4ts/src/lib.rs
+++ b/crates/crap4ts/src/lib.rs
@@ -20,6 +20,7 @@ use std::path::Path;
 
 use serde::Serialize;
 
+use crap_core::core::identity::IdentityBase;
 use crap_core::core::{AnalyzeOptions, analyze};
 use crap_core::domain::threshold::{ThresholdConfig, ThresholdPreset};
 use crap_core::domain::types::{AnalysisDiagnostics, AnalysisResult, ComplexityMetric};
@@ -132,7 +133,12 @@ pub fn analyze_to_json(
     let global_threshold = threshold.unwrap_or_else(|| ThresholdPreset::Default.threshold(metric));
 
     let options = AnalyzeOptions {
-        src: src.clone(),
+        // Single-root TypeScript analysis: src-relative identity,
+        // byte-identical to before multi-root (crap-rs#336). The base
+        // holds the canonicalized `src` so the strip matches both the
+        // discovery root and `IstanbulCoverage::new(src)`'s anchor.
+        identity_base: IdentityBase::SrcRelative(src.clone()),
+        src: vec![src.clone()],
         coverage,
         threshold_config: ThresholdConfig {
             global: global_threshold,


### PR DESCRIPTION
Closes #336

**Relabel:** #336 was filed `type:polish` (separate the two scorecard comments); it grew to `type:feature` on the call to also ship a multi-root `--src` capability so the production scorecard covers all three prod crates in one card.

## α' — base-gated identity

`--src` is now repeatable. A run's `FunctionIdentity::file_path` (and coverage-SF normalization) relativizes to one `IdentityBase` decided from the root count:

- **single root → src-relative** (byte-identical to before)
- **multiple roots → git-toplevel-relative**, so crates sharing internal names like `adapters/mod.rs` stay globally unique and never bleed coverage across crates.

One base, two consumers (identity + coverage), resolved once in a fallible step. An unresolvable git toplevel under multi-root is a hard error, never a silent basename strip.

## Single-root output is byte-identical

The wire-envelope canaries and every reporter snapshot pass unchanged — **zero snapshot/fixture files in this diff**. That is the regression net for the dual-regime contract: a base leak into the single-root path would change either `file_path` or the coverage join key → CRAP drift → snapshot diff.

## Production scorecard restored — purely additive

#295 created a production scorecard over `crap-core/src`; #314 repointed that slot to `crap-examples`. The new gating `scorecard-production` job restores it across the full prod crate set (`crap-core` + `crap4rs` + `crap4ts`, `gate-on-analysis`, 0 above-15, running this PR's own binary). **No existing gate is removed** — it's the repo's first CRAP-threshold gate on production source. The examples scorecard gets a `comment-preamble` labeling it a teaching sample; distinct `comment-header`s so the two stickies never collide.

## API / behavior changes

- Public API: `AnalyzeOptions.src` becomes `Vec<PathBuf>` + new `identity_base` field (0.x break, inherent to the feature).
- Scorecard action: new `comment-preamble` input + `sticky-message` output; `src:`/`src-ts:` accept newline-separated multi-root.
- BDD contract: `crates/crap4rs/tests/features/multi_root_src.feature` (behavior covered by proptests + `multi_root_integration.rs`; cucumber wiring tracked to the #169 umbrella).

Architecture decision recorded in ADR `adr-multi-root-identity-base` (ops). Multi-root config `src = [...]` + `[output].title/subtitle` follow in #334 (blocked-by this PR; the `len()==1 ⇒ src-relative` constraint is noted there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-root source analysis support via repeatable `--src` arguments, unioning results into a single report with git-toplevel-relative file paths for disambiguation.
  * Added `comment-preamble` input and `sticky-message` output to the scorecard action for composing custom PR comment headers and exposing final comment bodies.

* **Documentation**
  * Updated README and contributor guides to document multi-root source behavior, identity keying semantics, and the two-scorecard (production + examples) workflow with distinct sticky comments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/breezy-bays-labs/crap-rs/pull/344?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->