### PR TITLE
test(crap-core): #317 — cross-adapter RiskLevel enum consistency canary

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -10,11 +10,17 @@
 # `assert_cmd::Command::cargo_bin(...)` finds `CARGO_BIN_EXE_<bin>`
 # unset and panics in the UNMUTATED baseline — which aborts the whole
 # run before a single mutant is tested (cargo-mutants exits 4,
-# "cargo test failed in an unmutated tree"). Three such tests exist:
+# "cargo test failed in an unmutated tree"). Such tests:
 #
 #   * `wire_envelope_crap4rs.rs` / `wire_envelope_crap4ts.rs` (test fn
 #     `envelope`) — exec the crap4rs / crap4ts bins to lock the JSON
 #     envelope shape. Unbuilt under `--package crap-core`.
+#   * `risk_level_cross_adapter.rs` (test fn `risk_level_envelope_parity`)
+#     — execs BOTH the crap4rs and crap4ts bins to pin cross-adapter
+#     `RiskLevel` consistency (canonical wire vocabulary + a shared
+#     `classify_risk` score→band oracle applied to both envelopes).
+#     Unbuilt under `--package crap-core`; the `envelope` substring in
+#     the fn name is covered by the `--skip envelope` token below.
 #   * `default_gate_threshold.rs` (test fns prefixed `default_gate_`) —
 #     exec an adapter bin to assert the no-explicit-`--threshold` gate
 #     resolves to the metric-calibrated cutoff. Unbuilt under
@@ -38,14 +44,18 @@
 #     view.rs gate targets), so keeping them in the gate would inflate
 #     per-mutant runtime without changing the mutant-killed set.
 #
-# All three are still fully exercised every PR by the `Test
+# All of these are still fully exercised every PR by the `Test
 # (linux-x86)` / `Test (macos-arm)` / `Test (macos-x86)` jobs, which
 # run `cargo nextest run --workspace --all-targets` and build every
 # bin first — so skipping them here loses zero mutant-killing power
-# (none of the three exercises the mutated files). The `--skip`
-# filters are libtest substring matches on the test-fn name; `envelope`,
-# `default_gate`, and `crap4rs_no_flag_default_cognitive_still_works`
-# are each collision-free workspace-wide. Scoped to mutants only.
+# (none of them exercises the mutated files). The `--skip`
+# filters are libtest substring matches on the test-fn name; the
+# `envelope` token covers both `wire_envelope_crap4{rs,ts}.rs`'s
+# `envelope` fn and `risk_level_cross_adapter.rs`'s
+# `risk_level_envelope_parity` fn (substring match — both names
+# contain `envelope`), while `default_gate` and
+# `crap4rs_no_flag_default_cognitive_still_works` match their own
+# fns. Scoped to mutants only.
 additional_cargo_test_args = [
     "--",
     "--skip",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -320,6 +320,43 @@ schema fragment
 "Documentation rots; CI doesn't" — same pattern as
 `scripts/bdd-tracked-lint.py` and `scripts/mutants-skip-lint.py`.
 
+### Cross-adapter `RiskLevel` consistency canary
+
+`crap4rs` and `crap4ts` both derive every function's `RiskLevel`
+from one shared `crap_core::domain::crap::classify_risk` (score →
+band) and serialize it through one shared serde derive on
+`crap_core::domain::types::RiskLevel`. Cross-adapter consistency
+therefore holds by construction — there is no per-language
+risk-classification step. This is the dimensional-consistency
+invariant ζ's Combined-view ranking depends on (risk-level desc,
+then CRAP/threshold ratio desc within band).
+
+Two axes are deliberately kept distinct here, since #317's prose
+conflates them: `RiskLevel` **bands** are score-based, fixed in
+`classify_risk` (≤8 Low / ≤15 Acceptable / ≤25 Moderate / else High),
+metric-agnostic, and independent of `--threshold`; the per-adapter
+**calibrated thresholds** (cognitive 15/25/40 ⇄ cyclomatic 8/16/30)
+drive the `--threshold` GATE (`exceeds` / scorecard-row `status`),
+which is the separate axis the scorecard-row + default-gate canaries
+own. The RiskLevel canary pins the band axis only.
+
+**Mechanical enforcement**:
+`crates/crap-core/tests/risk_level_cross_adapter.rs` (test fn
+`risk_level_envelope_parity`) runs both bins' `--format json`
+envelopes and asserts, for every function in either envelope, that
+the serialized `risk_level` is (a) one of the four canonical
+`RiskLevel::as_wire_str` values and (b) the band the shared
+`classify_risk` oracle re-derives from the wire `crap.value`. Because
+`risk_level` and `crap.value` are serialized independently, the
+oracle is a genuine round-trip check, not a tautology; running the
+same shared oracle against both adapters is what makes it a
+cross-adapter consistency proof. A future per-adapter
+risk-classification step or a serde rename on one path fails the
+canary loudly. The fn name carries the `envelope` substring so the
+existing `--skip envelope` token in `.cargo/mutants.toml` covers it
+(see the Mutation testing section). "Documentation rots; CI doesn't"
+— same pattern as the scorecard-row parity + wire-envelope canaries.
+
 ### crap4ts install constraint
 
 Until crap4ts publishes a working binary release to crates.io

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -526,6 +526,11 @@ The wire-envelope snapshot tests
 `wire_envelope_crap4ts.rs`, test name `envelope`) shell out to the
 `crap4rs` / `crap4ts` binaries, which a scoped `cargo mutants --package
 crap-core` (or `--package crap4ts`) doesn't necessarily build. The
+cross-adapter RiskLevel canary
+(`crates/crap-core/tests/risk_level_cross_adapter.rs`, test fn
+`risk_level_envelope_parity`) shells both bins too; its fn name carries
+the `envelope` substring deliberately so the same `--skip envelope`
+token covers it without a new token. The
 skip lives in the **repo-global** `.cargo/mutants.toml`, so
 cargo-mutants applies it to **every** invocation in this workspace —
 both the `view.rs` step and the walker step inherit it automatically;

--- a/crates/crap-core/tests/risk_level_cross_adapter.rs
+++ b/crates/crap-core/tests/risk_level_cross_adapter.rs
@@ -229,16 +229,15 @@ struct WireBand {
 fn collect_bands(value: &Value, path: &str, out: &mut Vec<WireBand>) {
     match value {
         Value::Object(map) => {
-            if let (Some(Value::Number(v)), Some(Value::String(rl))) =
-                (map.get("value"), map.get("risk_level"))
-            {
-                if let Some(v) = v.as_f64() {
-                    out.push(WireBand {
-                        location: path.to_string(),
-                        value: v,
-                        risk_level: rl.clone(),
-                    });
-                }
+            if let (Some(v), Some(Value::String(rl))) = (
+                map.get("value").and_then(Value::as_f64),
+                map.get("risk_level"),
+            ) {
+                out.push(WireBand {
+                    location: path.to_string(),
+                    value: v,
+                    risk_level: rl.clone(),
+                });
             }
             for (k, child) in map {
                 let child_path = if path.is_empty() {
@@ -279,6 +278,17 @@ fn assert_bands_consistent(bands: &[WireBand], adapter: &str) {
     );
     let canonical = canonical_wire_set();
     for band in bands {
+        assert!(
+            !band.location.is_empty(),
+            "{adapter}: a band carried an empty location breadcrumb — collect_bands path tracking regressed"
+        );
+        assert!(
+            band.value >= 1.0,
+            "{adapter}: CRAP value {} at {} is below the formula floor of 1.0 \
+             (crap(c, cov) >= 1.0 for all inputs) — a malformed wire value slipped through",
+            band.value,
+            band.location,
+        );
         assert!(
             canonical.contains(band.risk_level.as_str()),
             "{adapter}: risk_level {:?} at {} is not a canonical RiskLevel wire string \

--- a/crates/crap-core/tests/risk_level_cross_adapter.rs
+++ b/crates/crap-core/tests/risk_level_cross_adapter.rs
@@ -1,0 +1,352 @@
+//! Cross-adapter `RiskLevel` consistency canary (crap-rs#317).
+//!
+//! Both `crap4rs` and `crap4ts` derive every function's `RiskLevel`
+//! from one shared `crap_core::domain::crap::classify_risk` (score →
+//! band) and
+//! serialize it through one shared serde derive on
+//! `crap_core::domain::types::RiskLevel`. Cross-adapter consistency
+//! therefore holds *by construction today* — neither adapter has a
+//! per-language risk-classification step. This canary mechanically
+//! pins that property at the **wire level** so a future refactor
+//! cannot quietly diverge it — e.g. by introducing a per-adapter
+//! post-processing pass, renaming a serde variant on one path, or
+//! reordering the round-then-classify pipeline. Mirrors the
+//! "documentation rots; CI doesn't" discipline of
+//! `scorecard_row_parity.rs` and the `wire_envelope_crap4{rs,ts}.rs`
+//! envelope locks.
+//!
+//! ## What this canary pins
+//!
+//! * **Serialization vocabulary** — every `risk_level` string in
+//!   either adapter's `--format json` envelope is one of the four
+//!   canonical wire strings the shared `RiskLevel` enum emits
+//!   (`low`/`acceptable`/`moderate`/`high`). The enum IS the
+//!   "identical variant set across adapters" the issue asks for;
+//!   each adapter's observed values are asserted to be a subset of
+//!   that one canonical set, so neither adapter can mint a band the
+//!   other can't.
+//! * **Score → band oracle** — for every function in either
+//!   envelope, `wire.risk_level ==
+//!   classify_risk(wire.crap.value).as_wire_str()`. The adapter
+//!   serializes `risk_level` and `crap.value` *independently* into
+//!   the JSON, so re-deriving the band from the wire `value` and
+//!   comparing it to the wire `risk_level` is a genuine round-trip
+//!   check, not a tautology. Running it against the SAME shared
+//!   `classify_risk` for both adapters is what makes it a
+//!   *cross-adapter* consistency proof: one oracle, two adapters.
+//! * **Round-then-classify ordering** — `classify_risk` classifies
+//!   the rounded CRAP value; the oracle re-runs it on the wire
+//!   `value` (which is
+//!   already rounded), so a regression that classified the unrounded
+//!   score on one path would surface as an oracle mismatch on a
+//!   boundary function.
+//!
+//! ## Why this is NOT "mapped against per-adapter thresholds"
+//!
+//! Issue #317's prose says to map the High/Moderate/Acceptable/Low
+//! buckets "against their respective per-adapter thresholds
+//! (cognitive 15/25/40 ⇄ cyclomatic 8/16/30)". Reading the substrate
+//! shows those two things are distinct and must not be conflated:
+//!
+//! * **`RiskLevel` bands are score-based and shared.** `classify_risk`
+//!   keys off the raw CRAP *score* (≤8 Low, ≤15 Acceptable, ≤25
+//!   Moderate, else
+//!   High) and is metric-agnostic — identical for both adapters,
+//!   independent of any `--threshold`.
+//! * **The per-adapter calibrated numbers drive the `--threshold`
+//!   GATE**, not the risk band. They decide `exceeds` /
+//!   scorecard-row `status` (Green/Yellow/Red), which is a *separate*
+//!   axis already locked by `scorecard_row_parity.rs` +
+//!   `default_gate_threshold.rs`.
+//!
+//! So the honest invariant — the one ζ's Combined-view ranking
+//! actually depends on (risk-level desc, then CRAP/threshold ratio
+//! desc within band) — is "both adapters map score → band through
+//! one shared, consistent enum". That is what this canary pins. It
+//! deliberately does not re-assert the threshold-gate calibration;
+//! that lives in the scorecard-row / default-gate canaries.
+//!
+//! ## Fixture corpus note (TS side is all-Low)
+//!
+//! The Rust self-LCOV fixture spans two bands at `--threshold 8`
+//! (`low` + `acceptable`), so the oracle exercises a real band
+//! boundary on the Rust side. The crap4ts istanbul fixture corpus is
+//! entirely `low` (its functions are small, near-fully-covered). The
+//! oracle check is the spine and is meaningful on all-`low` data —
+//! it still re-derives and compares the band from the wire `value`
+//! for every TS function, and the canonical-set/subset assertion +
+//! the single shared `classify_risk` oracle carry the cross-adapter
+//! guarantee
+//! regardless of the TS spread. Constructing a synthetic high-CRAP
+//! TS fixture would add brittleness (hand-authored istanbul
+//! statement/branch maps) without strengthening the invariant this
+//! canary locks.
+//!
+//! ## Mutants gate interaction
+//!
+//! The test fn is named `risk_level_envelope_parity` — the
+//! `envelope` substring is covered by the existing `--skip envelope`
+//! token in `.cargo/mutants.toml`, so a scoped
+//! `cargo mutants --package crap-core` run (which does not build the
+//! crap4rs / crap4ts bins) skips it instead of panicking on
+//! `CARGO_BIN_EXE_*` unset in the unmutated baseline. See AGENTS.md
+//! "Mutation testing" → "Why `additional_cargo_test_args` …".
+
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+use assert_cmd::Command;
+use crap_core::domain::crap::classify_risk;
+use crap_core::domain::types::RiskLevel;
+use serde_json::Value;
+use tempfile::TempDir;
+
+const TS_FIXTURE_TEMPLATE: &str =
+    include_str!("../../crap4ts/tests/fixtures/istanbul-jest/coverage-final.json");
+
+/// The single canonical set of `risk_level` wire strings — the shared
+/// `RiskLevel` enum enumerated through its own `as_wire_str`. Both
+/// adapters' observed values must be a subset of this. Extending
+/// `RiskLevel` requires extending this array (and `as_wire_str`, which
+/// `as_wire_str_matches_serde.rs` cross-checks against serde).
+const CANONICAL_VARIANTS: &[RiskLevel] = &[
+    RiskLevel::Low,
+    RiskLevel::Acceptable,
+    RiskLevel::Moderate,
+    RiskLevel::High,
+];
+
+/// Build a canonicalized tempdir holding the W1.1 jest fixture sources
+/// plus a resolved `coverage-final.json`. Mirrors the helper in
+/// `scorecard_row_parity.rs` / `wire_envelope_crap4ts.rs` so the canary
+/// exercises a real Istanbul parse. The `TempDir` is returned so the
+/// directory stays alive for the lifetime of the test.
+fn build_ts_fixture() -> (TempDir, PathBuf) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let canonical = std::fs::canonicalize(tmp.path()).expect("canonicalize tempdir");
+
+    for (name, content) in [
+        (
+            "simple.ts",
+            include_str!("../../crap4ts/tests/fixtures/ts-fixtures/simple.ts"),
+        ),
+        (
+            "arrow.ts",
+            include_str!("../../crap4ts/tests/fixtures/ts-fixtures/arrow.ts"),
+        ),
+        (
+            "Button.tsx",
+            include_str!("../../crap4ts/tests/fixtures/ts-fixtures/Button.tsx"),
+        ),
+        (
+            "map.ts",
+            include_str!("../../crap4ts/tests/fixtures/ts-fixtures/map.ts"),
+        ),
+        (
+            "mixed.ts",
+            include_str!("../../crap4ts/tests/fixtures/ts-fixtures/mixed.ts"),
+        ),
+    ] {
+        std::fs::write(canonical.join(name), content).expect("write fixture");
+    }
+
+    let payload = TS_FIXTURE_TEMPLATE.replace(
+        "{SRC_ROOT}",
+        &canonical.to_string_lossy().replace('\\', "/"),
+    );
+    std::fs::write(canonical.join("coverage-final.json"), payload)
+        .expect("write coverage-final.json");
+
+    (tmp, canonical)
+}
+
+/// Invoke `crap4rs --format json` against its own self-LCOV fixture at
+/// `--threshold 8` (the strict cutoff that surfaces the over-threshold
+/// `acceptable`-band functions). Returns the parsed envelope.
+fn run_crap4rs_json() -> Value {
+    let output = Command::cargo_bin("crap4rs")
+        .expect("crap4rs binary discoverable in workspace")
+        .args([
+            "--coverage",
+            "../crap4rs/tests/fixtures/crap4rs-self.lcov",
+            "--src",
+            "../crap4rs/src",
+            "--threshold",
+            "8",
+            "--format",
+            "json",
+            "--no-fail",
+        ])
+        .output()
+        .expect("crap4rs binary executes");
+    assert!(
+        output.status.success(),
+        "crap4rs exited non-zero: stdout={}\nstderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    serde_json::from_slice(&output.stdout).expect("crap4rs --format json emits valid JSON")
+}
+
+/// Invoke `crap4ts --format json` against the temp Istanbul fixture.
+/// Returns the parsed envelope.
+fn run_crap4ts_json() -> Value {
+    let (_tmp, root) = build_ts_fixture();
+    let coverage = root.join("coverage-final.json");
+    let output = Command::cargo_bin("crap4ts")
+        .expect("crap4ts binary discoverable in workspace")
+        .arg("--coverage")
+        .arg(&coverage)
+        .arg("--src")
+        .arg(&root)
+        .args(["--threshold", "16", "--format", "json", "--no-fail"])
+        .output()
+        .expect("crap4ts binary executes");
+    assert!(
+        output.status.success(),
+        "crap4ts exited non-zero: stdout={}\nstderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    serde_json::from_slice(&output.stdout).expect("crap4ts --format json emits valid JSON")
+}
+
+/// One `(crap.value, risk_level)` pair lifted from a wire envelope,
+/// tagged with a human-readable location so a failure names the
+/// offending function.
+struct WireBand {
+    location: String,
+    value: f64,
+    risk_level: String,
+}
+
+/// Recursively collect every `{ "value": <f64>, "risk_level": <str> }`
+/// object reachable in the envelope. This catches `crap` objects on
+/// `result.functions[].scored.crap`, the `result.summary.max_crap`
+/// roll-up, and any future site that embeds a CRAP score — the canary
+/// should not be tied to one path through the envelope. `path` is the
+/// breadcrumb trail used in panic messages.
+fn collect_bands(value: &Value, path: &str, out: &mut Vec<WireBand>) {
+    match value {
+        Value::Object(map) => {
+            if let (Some(Value::Number(v)), Some(Value::String(rl))) =
+                (map.get("value"), map.get("risk_level"))
+            {
+                if let Some(v) = v.as_f64() {
+                    out.push(WireBand {
+                        location: path.to_string(),
+                        value: v,
+                        risk_level: rl.clone(),
+                    });
+                }
+            }
+            for (k, child) in map {
+                let child_path = if path.is_empty() {
+                    k.clone()
+                } else {
+                    format!("{path}.{k}")
+                };
+                collect_bands(child, &child_path, out);
+            }
+        }
+        Value::Array(items) => {
+            for (i, item) in items.iter().enumerate() {
+                collect_bands(item, &format!("{path}[{i}]"), out);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// The canonical wire-string set the shared `RiskLevel` enum emits.
+fn canonical_wire_set() -> BTreeSet<&'static str> {
+    CANONICAL_VARIANTS
+        .iter()
+        .map(RiskLevel::as_wire_str)
+        .collect()
+}
+
+/// Assert every band in `bands`:
+///   1. uses a wire string drawn from the canonical `RiskLevel` set
+///      (no adapter-minted variant), and
+///   2. matches the band the shared oracle `classify_risk` derives
+///      from the wire
+///      `value` (cross-adapter score→band consistency).
+fn assert_bands_consistent(bands: &[WireBand], adapter: &str) {
+    assert!(
+        !bands.is_empty(),
+        "{adapter}: envelope carried no CRAP bands — fixture or envelope shape changed"
+    );
+    let canonical = canonical_wire_set();
+    for band in bands {
+        assert!(
+            canonical.contains(band.risk_level.as_str()),
+            "{adapter}: risk_level {:?} at {} is not a canonical RiskLevel wire string \
+             (expected one of {canonical:?}) — an adapter minted a band the shared enum \
+             does not define",
+            band.risk_level,
+            band.location,
+        );
+        let oracle = classify_risk(band.value).as_wire_str();
+        assert_eq!(
+            band.risk_level, oracle,
+            "{adapter}: risk_level divergence at {} — wire value {} serialized band {:?} \
+             but the shared crap_core::domain::crap::classify_risk oracle classifies it as {:?}. \
+             A future per-adapter risk-classification step or a serde rename on one path \
+             would surface here.",
+            band.location, band.value, band.risk_level, oracle,
+        );
+    }
+}
+
+#[test]
+fn risk_level_envelope_parity() {
+    let rs = run_crap4rs_json();
+    let ts = run_crap4ts_json();
+
+    let mut rs_bands = Vec::new();
+    collect_bands(&rs, "rust", &mut rs_bands);
+    let mut ts_bands = Vec::new();
+    collect_bands(&ts, "typescript", &mut ts_bands);
+
+    // Per-adapter: canonical vocabulary + score→band oracle. The same
+    // shared `classify_risk` oracle is applied to both, which is what
+    // makes this a
+    // cross-adapter consistency proof rather than two independent checks.
+    assert_bands_consistent(&rs_bands, "crap4rs");
+    assert_bands_consistent(&ts_bands, "crap4ts");
+
+    // Sanity: the Rust self-LCOV fixture is expected to span more than
+    // one band at --threshold 8 (it has uncovered functions that round
+    // into `acceptable`). If this collapses to a single band, the
+    // fixture changed and the oracle no longer exercises a real band
+    // boundary — surface it loudly rather than silently weakening the
+    // canary.
+    let rs_observed: BTreeSet<&str> = rs_bands.iter().map(|b| b.risk_level.as_str()).collect();
+    assert!(
+        rs_observed.len() >= 2,
+        "crap4rs self-LCOV fixture collapsed to a single risk band {rs_observed:?} at \
+         --threshold 8 — the oracle no longer crosses a band boundary; refresh the fixture \
+         expectation so the canary keeps exercising a transition"
+    );
+
+    // Both adapters draw from one shared enum, so neither observed set
+    // can contain a variant outside the canonical set — already proven
+    // per-band above, but assert the set relationship explicitly so the
+    // "identical variant set across adapters" contract from #317 is
+    // legible in one place.
+    let canonical = canonical_wire_set();
+    for (adapter, observed) in [
+        ("crap4rs", &rs_observed),
+        (
+            "crap4ts",
+            &ts_bands.iter().map(|b| b.risk_level.as_str()).collect(),
+        ),
+    ] {
+        assert!(
+            observed.is_subset(&canonical),
+            "{adapter}: observed risk bands {observed:?} are not a subset of the canonical \
+             RiskLevel set {canonical:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds a wire-level canary, `crates/crap-core/tests/risk_level_cross_adapter.rs` (test fn `risk_level_envelope_parity`), that pins cross-adapter `RiskLevel` consistency between the crap4rs and crap4ts adapters. Both adapters derive every function's band from one shared `crap_core::domain::crap::classify_risk` (score → band) and serialize it through one shared serde derive on `crap_core::domain::types::RiskLevel`, so consistency holds by construction today — this canary makes a future divergence fail CI loudly. Same "documentation rots; CI doesn't" discipline as the existing scorecard-row and wire-envelope canaries.

## What the canary pins

For every function in BOTH adapters' `--format json` envelopes, it asserts:

1. **Serialization vocabulary** — the serialized `risk_level` is one of the four canonical `RiskLevel::as_wire_str` values (`low`/`acceptable`/`moderate`/`high`); each adapter's observed bands are a subset of that one canonical set, so neither adapter can mint a band the other can't. The shared enum IS the "identical variant set across adapters."
2. **Score → band oracle** — `wire.risk_level == classify_risk(wire.crap.value).as_wire_str()`. Because `risk_level` and `crap.value` are serialized independently into the JSON, re-deriving the band from the wire `value` is a genuine round-trip check, not a tautology. Running the SAME shared oracle against both adapters is what makes it a *cross-adapter* consistency proof — one oracle, two adapters.
3. **Round-then-classify ordering** — the oracle re-runs `classify_risk` on the already-rounded wire `value`, so a regression that classified the unrounded score on one path would surface as a boundary mismatch.

## Band axis vs. threshold-gate axis (honest reframe)

Issue #317's prose maps the buckets "against their respective per-adapter thresholds (cognitive 15/25/40 ⇄ cyclomatic 8/16/30)." Reading the substrate shows those are two distinct axes that must not be conflated:

- `RiskLevel` **bands** are score-based, fixed in `classify_risk` (≤8 Low / ≤15 Acceptable / ≤25 Moderate / else High), metric-agnostic, and independent of `--threshold`. **This canary pins the band axis.**
- The per-adapter **calibrated thresholds** drive the `--threshold` GATE (`exceeds` / scorecard-row `status`), which is a separate axis already locked by `scorecard_row_parity.rs` + `default_gate_threshold.rs`.

So the canary pins the honest invariant ζ's Combined-view ranking actually depends on (risk-level desc, then CRAP/threshold ratio desc within band): both adapters map score → band through one shared, consistent enum. It deliberately does not re-assert threshold-gate calibration.

## How it fails on divergence (TDD red, confirmed)

Injecting a wire/oracle divergence (flipping one collected band to `high`) made the canary fail with an actionable message naming the adapter, location, wire value, serialized band, and the oracle's correct band:

```
crap4rs: risk_level divergence at rust.result.functions[0].scored.crap — wire value 1
serialized band "high" but the shared crap_core::domain::crap::classify_risk oracle
classifies it as "low". A future per-adapter risk-classification step or a serde rename
on one path would surface here.
```

The injection was reverted; the canary passes on the current consistent state.

## Fixture corpus note

The crap4ts istanbul fixture corpus is entirely `low` (small, near-fully-covered functions), so the **TS-side cross-adapter consistency is guaranteed structurally** by the shared type + shared `classify_risk`, not fixture-demonstrated — the TS fixture exercises the `low` band only. The **Rust** self-LCOV side spans `low` + `acceptable` at `--threshold 8`, exercising a real low↔acceptable boundary. A synthetic high-CRAP TS fixture (hand-authored istanbul statement/branch maps) would add brittleness without strengthening the structural invariant this canary locks.

## Discipline docs (AC #3)

- `.cargo/mutants.toml`: documented the new test in the adapter-bin shelling skip list; the fn name carries the `envelope` substring so the existing `--skip envelope` token covers it (verified via `scripts/mutants-skip-lint.py`).
- `AGENTS.md`: added the canary to the wire-envelope canary discipline alongside the existing canaries, and to the mutants-skip rationale prose.

## Gates

`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo nextest run --workspace --all-targets` (1276 passed), `cargo +1.93 check --workspace --all-targets` (MSRV), `scripts/mutants-skip-lint.py`, `scripts/bdd-tracked-lint.py` — all pass. No adapter source touched; the wire-envelope snapshots stay byte-identical (no `.snap.new`).

Closes #317

🤖 Generated with [Claude Code](https://claude.com/claude-code)