### PR TITLE
feat(adapters): #283 — nested-mod qualified function names in the walker

### DIFF
--- a/crates/crap-core/tests/snapshots/wire_envelope_crap4rs__envelope.snap
+++ b/crates/crap-core/tests/snapshots/wire_envelope_crap4rs__envelope.snap
@@ -3859,10 +3859,10 @@ expression: pretty
           "contributors": [
             {
               "column": 72,
-              "end_line": 198,
+              "end_line": 199,
               "increment": 1,
               "kind": "try",
-              "line": 198,
+              "line": 199,
               "nesting_depth": 0
             }
           ],
@@ -3876,7 +3876,7 @@ expression: pretty
             "qualified_name": "LcovParser::parse",
             "span": {
               "end_column": 5,
-              "end_line": 200,
+              "end_line": 201,
               "start_column": 5,
               "start_line": 167
             }
@@ -3892,58 +3892,58 @@ expression: pretty
           "contributors": [
             {
               "column": 73,
-              "end_line": 215,
+              "end_line": 218,
               "increment": 1,
               "kind": "try",
-              "line": 215,
-              "nesting_depth": 0
-            },
-            {
-              "column": 9,
-              "end_line": 232,
-              "increment": 1,
-              "kind": "for-loop",
               "line": 218,
               "nesting_depth": 0
             },
             {
-              "column": 68,
-              "end_line": 219,
+              "column": 9,
+              "end_line": 235,
               "increment": 1,
-              "kind": "try",
-              "line": 219,
-              "nesting_depth": 1
+              "kind": "for-loop",
+              "line": 221,
+              "nesting_depth": 0
             },
             {
-              "column": 13,
-              "end_line": 223,
-              "increment": 2,
-              "kind": "if-branch",
-              "line": 220,
-              "nesting_depth": 1
-            },
-            {
-              "column": 17,
+              "column": 68,
               "end_line": 222,
               "increment": 1,
-              "kind": "continue",
+              "kind": "try",
               "line": 222,
-              "nesting_depth": 2
+              "nesting_depth": 1
             },
             {
               "column": 13,
-              "end_line": 231,
+              "end_line": 226,
               "increment": 2,
               "kind": "if-branch",
-              "line": 224,
+              "line": 223,
               "nesting_depth": 1
             },
             {
               "column": 17,
               "end_line": 225,
               "increment": 1,
-              "kind": "logical-operator",
+              "kind": "continue",
               "line": 225,
+              "nesting_depth": 2
+            },
+            {
+              "column": 13,
+              "end_line": 234,
+              "increment": 2,
+              "kind": "if-branch",
+              "line": 227,
+              "nesting_depth": 1
+            },
+            {
+              "column": 17,
+              "end_line": 228,
+              "increment": 1,
+              "kind": "logical-operator",
+              "line": 228,
               "nesting_depth": 1
             }
           ],
@@ -3957,9 +3957,9 @@ expression: pretty
             "qualified_name": "LcovParser::validate",
             "span": {
               "end_column": 5,
-              "end_line": 234,
+              "end_line": 237,
               "start_column": 5,
-              "start_line": 202
+              "start_line": 203
             }
           }
         },
@@ -3973,26 +3973,26 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 241,
+              "end_line": 244,
               "increment": 1,
               "kind": "if-branch",
-              "line": 238,
+              "line": 241,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 246,
+              "end_line": 249,
               "increment": 1,
               "kind": "if-branch",
-              "line": 243,
+              "line": 246,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 250,
+              "end_line": 253,
               "increment": 1,
               "kind": "if-branch",
-              "line": 248,
+              "line": 251,
               "nesting_depth": 0
             }
           ],
@@ -4006,9 +4006,9 @@ expression: pretty
             "qualified_name": "handle_parse_line",
             "span": {
               "end_column": 1,
-              "end_line": 251,
+              "end_line": 254,
               "start_column": 1,
-              "start_line": 237
+              "start_line": 240
             }
           }
         },
@@ -4022,14 +4022,14 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 263,
+              "end_line": 266,
               "increment": 1,
               "kind": "if-branch",
-              "line": 256,
+              "line": 259,
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 85.71428571428571,
+          "coverage_percent": 87.5,
           "crap": {
             "risk_level": "low",
             "value": 2.01
@@ -4039,9 +4039,9 @@ expression: pretty
             "qualified_name": "start_source_file",
             "span": {
               "end_column": 1,
-              "end_line": 264,
+              "end_line": 267,
               "start_column": 1,
-              "start_line": 253
+              "start_line": 256
             }
           }
         },
@@ -4055,18 +4055,18 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 269,
+              "end_line": 272,
               "increment": 1,
               "kind": "if-branch",
-              "line": 267,
+              "line": 270,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 274,
+              "end_line": 277,
               "increment": 1,
               "kind": "match",
-              "line": 271,
+              "line": 274,
               "nesting_depth": 0
             }
           ],
@@ -4080,9 +4080,9 @@ expression: pretty
             "qualified_name": "record_da",
             "span": {
               "end_column": 1,
-              "end_line": 275,
+              "end_line": 278,
               "start_column": 1,
-              "start_line": 266
+              "start_line": 269
             }
           }
         },
@@ -4096,18 +4096,18 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 280,
+              "end_line": 283,
               "increment": 1,
               "kind": "if-branch",
-              "line": 278,
+              "line": 281,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 287,
+              "end_line": 290,
               "increment": 1,
               "kind": "match",
-              "line": 282,
+              "line": 285,
               "nesting_depth": 0
             }
           ],
@@ -4121,9 +4121,9 @@ expression: pretty
             "qualified_name": "record_brda",
             "span": {
               "end_column": 1,
-              "end_line": 288,
+              "end_line": 291,
               "start_column": 1,
-              "start_line": 277
+              "start_line": 280
             }
           }
         },
@@ -4145,9 +4145,9 @@ expression: pretty
             "qualified_name": "push_malformed_record",
             "span": {
               "end_column": 1,
-              "end_line": 297,
+              "end_line": 300,
               "start_column": 1,
-              "start_line": 290
+              "start_line": 293
             }
           }
         },
@@ -4161,22 +4161,6 @@ expression: pretty
           "contributors": [
             {
               "column": 56,
-              "end_line": 302,
-              "increment": 1,
-              "kind": "try",
-              "line": 302,
-              "nesting_depth": 0
-            },
-            {
-              "column": 52,
-              "end_line": 304,
-              "increment": 1,
-              "kind": "try",
-              "line": 304,
-              "nesting_depth": 0
-            },
-            {
-              "column": 58,
               "end_line": 305,
               "increment": 1,
               "kind": "try",
@@ -4184,19 +4168,35 @@ expression: pretty
               "nesting_depth": 0
             },
             {
-              "column": 5,
+              "column": 52,
+              "end_line": 307,
+              "increment": 1,
+              "kind": "try",
+              "line": 307,
+              "nesting_depth": 0
+            },
+            {
+              "column": 58,
               "end_line": 308,
               "increment": 1,
+              "kind": "try",
+              "line": 308,
+              "nesting_depth": 0
+            },
+            {
+              "column": 5,
+              "end_line": 311,
+              "increment": 1,
               "kind": "if-branch",
-              "line": 306,
+              "line": 309,
               "nesting_depth": 0
             },
             {
               "column": 53,
-              "end_line": 309,
+              "end_line": 312,
               "increment": 1,
               "kind": "try",
-              "line": 309,
+              "line": 312,
               "nesting_depth": 0
             }
           ],
@@ -4210,9 +4210,9 @@ expression: pretty
             "qualified_name": "parse_da",
             "span": {
               "end_column": 1,
-              "end_line": 311,
+              "end_line": 314,
               "start_column": 1,
-              "start_line": 299
+              "start_line": 302
             }
           }
         },
@@ -4226,30 +4226,6 @@ expression: pretty
           "contributors": [
             {
               "column": 42,
-              "end_line": 318,
-              "increment": 1,
-              "kind": "try",
-              "line": 318,
-              "nesting_depth": 0
-            },
-            {
-              "column": 43,
-              "end_line": 319,
-              "increment": 1,
-              "kind": "try",
-              "line": 319,
-              "nesting_depth": 0
-            },
-            {
-              "column": 44,
-              "end_line": 320,
-              "increment": 1,
-              "kind": "try",
-              "line": 320,
-              "nesting_depth": 0
-            },
-            {
-              "column": 43,
               "end_line": 321,
               "increment": 1,
               "kind": "try",
@@ -4257,7 +4233,15 @@ expression: pretty
               "nesting_depth": 0
             },
             {
-              "column": 58,
+              "column": 43,
+              "end_line": 322,
+              "increment": 1,
+              "kind": "try",
+              "line": 322,
+              "nesting_depth": 0
+            },
+            {
+              "column": 44,
               "end_line": 323,
               "increment": 1,
               "kind": "try",
@@ -4265,43 +4249,59 @@ expression: pretty
               "nesting_depth": 0
             },
             {
-              "column": 5,
-              "end_line": 326,
+              "column": 43,
+              "end_line": 324,
               "increment": 1,
-              "kind": "if-branch",
+              "kind": "try",
               "line": 324,
               "nesting_depth": 0
             },
             {
-              "column": 55,
-              "end_line": 327,
+              "column": 58,
+              "end_line": 326,
               "increment": 1,
               "kind": "try",
+              "line": 326,
+              "nesting_depth": 0
+            },
+            {
+              "column": 5,
+              "end_line": 329,
+              "increment": 1,
+              "kind": "if-branch",
               "line": 327,
               "nesting_depth": 0
             },
             {
-              "column": 57,
-              "end_line": 328,
+              "column": 55,
+              "end_line": 330,
               "increment": 1,
               "kind": "try",
-              "line": 328,
+              "line": 330,
+              "nesting_depth": 0
+            },
+            {
+              "column": 57,
+              "end_line": 331,
+              "increment": 1,
+              "kind": "try",
+              "line": 331,
               "nesting_depth": 0
             },
             {
               "column": 17,
-              "end_line": 333,
+              "end_line": 336,
               "increment": 1,
               "kind": "if-branch",
-              "line": 329,
+              "line": 332,
               "nesting_depth": 0
             },
             {
               "column": 54,
-              "end_line": 332,
+              "end_line": 335,
               "increment": 1,
               "kind": "try",
-              "line": 332,
+              "line": 335,
               "nesting_depth": 1
             }
           ],
@@ -4315,9 +4315,9 @@ expression: pretty
             "qualified_name": "parse_brda",
             "span": {
               "end_column": 1,
-              "end_line": 336,
+              "end_line": 339,
               "start_column": 1,
-              "start_line": 313
+              "start_line": 316
             }
           }
         },
@@ -4331,10 +4331,10 @@ expression: pretty
           "contributors": [
             {
               "column": 52,
-              "end_line": 342,
+              "end_line": 345,
               "increment": 1,
               "kind": "let-else",
-              "line": 339,
+              "line": 342,
               "nesting_depth": 0
             }
           ],
@@ -4348,9 +4348,9 @@ expression: pretty
             "qualified_name": "flush_block",
             "span": {
               "end_column": 1,
-              "end_line": 347,
+              "end_line": 350,
               "start_column": 1,
-              "start_line": 338
+              "start_line": 341
             }
           }
         },
@@ -4364,18 +4364,18 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 356,
+              "end_line": 359,
               "increment": 1,
               "kind": "if-branch",
-              "line": 354,
+              "line": 357,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 361,
+              "end_line": 364,
               "increment": 1,
               "kind": "for-loop",
-              "line": 359,
+              "line": 362,
               "nesting_depth": 0
             }
           ],
@@ -4389,9 +4389,9 @@ expression: pretty
             "qualified_name": "merge_line_block",
             "span": {
               "end_column": 1,
-              "end_line": 362,
+              "end_line": 365,
               "start_column": 1,
-              "start_line": 349
+              "start_line": 352
             }
           }
         },
@@ -4405,18 +4405,18 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 371,
+              "end_line": 374,
               "increment": 1,
               "kind": "if-branch",
-              "line": 369,
+              "line": 372,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 376,
+              "end_line": 379,
               "increment": 1,
               "kind": "for-loop",
-              "line": 374,
+              "line": 377,
               "nesting_depth": 0
             }
           ],
@@ -4430,9 +4430,9 @@ expression: pretty
             "qualified_name": "merge_branch_block",
             "span": {
               "end_column": 1,
-              "end_line": 377,
+              "end_line": 380,
               "start_column": 1,
-              "start_line": 364
+              "start_line": 367
             }
           }
         },
@@ -4454,9 +4454,9 @@ expression: pretty
             "qualified_name": "merge_hits",
             "span": {
               "end_column": 1,
-              "end_line": 384,
+              "end_line": 387,
               "start_column": 1,
-              "start_line": 379
+              "start_line": 382
             }
           }
         },
@@ -4478,9 +4478,9 @@ expression: pretty
             "qualified_name": "merge_branch_value",
             "span": {
               "end_column": 1,
-              "end_line": 395,
+              "end_line": 398,
               "start_column": 1,
-              "start_line": 386
+              "start_line": 389
             }
           }
         },
@@ -4494,10 +4494,10 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 403,
+              "end_line": 406,
               "increment": 1,
               "kind": "match",
-              "line": 398,
+              "line": 401,
               "nesting_depth": 0
             }
           ],
@@ -4511,9 +4511,9 @@ expression: pretty
             "qualified_name": "merge_taken",
             "span": {
               "end_column": 1,
-              "end_line": 404,
+              "end_line": 407,
               "start_column": 1,
-              "start_line": 397
+              "start_line": 400
             }
           }
         },
@@ -4535,9 +4535,9 @@ expression: pretty
             "qualified_name": "clear_current_block",
             "span": {
               "end_column": 1,
-              "end_line": 409,
+              "end_line": 412,
               "start_column": 1,
-              "start_line": 406
+              "start_line": 409
             }
           }
         },
@@ -4559,9 +4559,9 @@ expression: pretty
             "qualified_name": "build_parse_output",
             "span": {
               "end_column": 1,
-              "end_line": 437,
+              "end_line": 440,
               "start_column": 1,
-              "start_line": 411
+              "start_line": 414
             }
           }
         },
@@ -4583,9 +4583,9 @@ expression: pretty
             "qualified_name": "to_line_coverage",
             "span": {
               "end_column": 1,
-              "end_line": 444,
+              "end_line": 447,
               "start_column": 1,
-              "start_line": 439
+              "start_line": 442
             }
           }
         },
@@ -4607,9 +4607,9 @@ expression: pretty
             "qualified_name": "tests::parser",
             "span": {
               "end_column": 5,
-              "end_line": 453,
+              "end_line": 456,
               "start_column": 5,
-              "start_line": 451
+              "start_line": 454
             }
           }
         },
@@ -4631,9 +4631,9 @@ expression: pretty
             "qualified_name": "tests::parse",
             "span": {
               "end_column": 5,
-              "end_line": 457,
+              "end_line": 460,
               "start_column": 5,
-              "start_line": 455
+              "start_line": 458
             }
           }
         },
@@ -4655,9 +4655,9 @@ expression: pretty
             "qualified_name": "tests::empty_input_returns_empty_output",
             "span": {
               "end_column": 5,
-              "end_line": 464,
+              "end_line": 467,
               "start_column": 5,
-              "start_line": 459
+              "start_line": 462
             }
           }
         },
@@ -4679,9 +4679,9 @@ expression: pretty
             "qualified_name": "tests::validate_str",
             "span": {
               "end_column": 5,
-              "end_line": 478,
+              "end_line": 481,
               "start_column": 5,
-              "start_line": 468
+              "start_line": 471
             }
           }
         },
@@ -4703,9 +4703,9 @@ expression: pretty
             "qualified_name": "tests::validate_empty_input_rejected",
             "span": {
               "end_column": 5,
-              "end_line": 483,
+              "end_line": 486,
               "start_column": 5,
-              "start_line": 480
+              "start_line": 483
             }
           }
         },
@@ -4727,9 +4727,9 @@ expression: pretty
             "qualified_name": "tests::validate_no_da_lines_rejected",
             "span": {
               "end_column": 5,
-              "end_line": 488,
+              "end_line": 491,
               "start_column": 5,
-              "start_line": 485
+              "start_line": 488
             }
           }
         },
@@ -4751,9 +4751,9 @@ expression: pretty
             "qualified_name": "tests::validate_da_outside_sf_block_rejected",
             "span": {
               "end_column": 5,
-              "end_line": 493,
+              "end_line": 496,
               "start_column": 5,
-              "start_line": 490
+              "start_line": 493
             }
           }
         },
@@ -4775,9 +4775,9 @@ expression: pretty
             "qualified_name": "tests::validate_malformed_da_rejected",
             "span": {
               "end_column": 5,
-              "end_line": 498,
+              "end_line": 501,
               "start_column": 5,
-              "start_line": 495
+              "start_line": 498
             }
           }
         },
@@ -4799,9 +4799,9 @@ expression: pretty
             "qualified_name": "tests::validate_single_da_inside_sf_block_passes",
             "span": {
               "end_column": 5,
-              "end_line": 503,
+              "end_line": 506,
               "start_column": 5,
-              "start_line": 500
+              "start_line": 503
             }
           }
         },
@@ -4823,9 +4823,9 @@ expression: pretty
             "qualified_name": "tests::validate_first_da_in_second_block_passes",
             "span": {
               "end_column": 5,
-              "end_line": 513,
+              "end_line": 516,
               "start_column": 5,
-              "start_line": 505
+              "start_line": 508
             }
           }
         },
@@ -4847,9 +4847,9 @@ expression: pretty
             "qualified_name": "tests::validate_missing_path_returns_open_error",
             "span": {
               "end_column": 5,
-              "end_line": 525,
+              "end_line": 528,
               "start_column": 5,
-              "start_line": 515
+              "start_line": 518
             }
           }
         },
@@ -4871,9 +4871,9 @@ expression: pretty
             "qualified_name": "tests::single_file_single_da",
             "span": {
               "end_column": 5,
-              "end_line": 535,
+              "end_line": 538,
               "start_column": 5,
-              "start_line": 527
+              "start_line": 530
             }
           }
         },
@@ -4895,9 +4895,9 @@ expression: pretty
             "qualified_name": "tests::multiple_da_lines",
             "span": {
               "end_column": 5,
-              "end_line": 545,
+              "end_line": 548,
               "start_column": 5,
-              "start_line": 537
+              "start_line": 540
             }
           }
         },
@@ -4919,9 +4919,9 @@ expression: pretty
             "qualified_name": "tests::multiple_source_files",
             "span": {
               "end_column": 5,
-              "end_line": 554,
+              "end_line": 557,
               "start_column": 5,
-              "start_line": 547
+              "start_line": 550
             }
           }
         },
@@ -4943,9 +4943,9 @@ expression: pretty
             "qualified_name": "tests::hit_count_preservation",
             "span": {
               "end_column": 5,
-              "end_line": 562,
+              "end_line": 565,
               "start_column": 5,
-              "start_line": 556
+              "start_line": 559
             }
           }
         },
@@ -4967,9 +4967,9 @@ expression: pretty
             "qualified_name": "tests::path_normalization_strips_prefix",
             "span": {
               "end_column": 5,
-              "end_line": 568,
+              "end_line": 571,
               "start_column": 5,
-              "start_line": 564
+              "start_line": 567
             }
           }
         },
@@ -4991,9 +4991,9 @@ expression: pretty
             "qualified_name": "tests::non_matching_path_passes_through",
             "span": {
               "end_column": 5,
-              "end_line": 574,
+              "end_line": 577,
               "start_column": 5,
-              "start_line": 570
+              "start_line": 573
             }
           }
         },
@@ -5015,9 +5015,9 @@ expression: pretty
             "qualified_name": "tests::backslash_normalized_to_forward_slash",
             "span": {
               "end_column": 5,
-              "end_line": 581,
+              "end_line": 584,
               "start_column": 5,
-              "start_line": 576
+              "start_line": 579
             }
           }
         },
@@ -5039,9 +5039,9 @@ expression: pretty
             "qualified_name": "tests::path_boundary_not_confused_by_prefix_substring",
             "span": {
               "end_column": 5,
-              "end_line": 587,
+              "end_line": 590,
               "start_column": 5,
-              "start_line": 583
+              "start_line": 586
             }
           }
         },
@@ -5063,9 +5063,9 @@ expression: pretty
             "qualified_name": "tests::parentdir_sf_path_does_not_take_fast_path_is_file_probe",
             "span": {
               "end_column": 5,
-              "end_line": 622,
+              "end_line": 625,
               "start_column": 5,
-              "start_line": 589
+              "start_line": 592
             }
           }
         },
@@ -5087,9 +5087,9 @@ expression: pretty
             "qualified_name": "tests::repeated_sf_blocks_merge_coverage",
             "span": {
               "end_column": 5,
-              "end_line": 636,
+              "end_line": 639,
               "start_column": 5,
-              "start_line": 624
+              "start_line": 627
             }
           }
         },
@@ -5111,9 +5111,9 @@ expression: pretty
             "qualified_name": "tests::duplicate_da_lines_sum_hits",
             "span": {
               "end_column": 5,
-              "end_line": 645,
+              "end_line": 648,
               "start_column": 5,
-              "start_line": 638
+              "start_line": 641
             }
           }
         },
@@ -5135,9 +5135,9 @@ expression: pretty
             "qualified_name": "tests::duplicate_da_multiple_lines_sum_correctly",
             "span": {
               "end_column": 5,
-              "end_line": 657,
+              "end_line": 660,
               "start_column": 5,
-              "start_line": 647
+              "start_line": 650
             }
           }
         },
@@ -5151,10 +5151,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 673,
+              "end_line": 676,
               "increment": 1,
               "kind": "match",
-              "line": 664,
+              "line": 667,
               "nesting_depth": 0
             }
           ],
@@ -5168,9 +5168,9 @@ expression: pretty
             "qualified_name": "tests::malformed_da_produces_diagnostic",
             "span": {
               "end_column": 5,
-              "end_line": 674,
+              "end_line": 677,
               "start_column": 5,
-              "start_line": 659
+              "start_line": 662
             }
           }
         },
@@ -5192,9 +5192,9 @@ expression: pretty
             "qualified_name": "tests::malformed_da_does_not_stop_parsing",
             "span": {
               "end_column": 5,
-              "end_line": 682,
+              "end_line": 685,
               "start_column": 5,
-              "start_line": 676
+              "start_line": 679
             }
           }
         },
@@ -5216,9 +5216,9 @@ expression: pretty
             "qualified_name": "tests::da_missing_hit_count_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 692,
+              "end_line": 695,
               "start_column": 5,
-              "start_line": 684
+              "start_line": 687
             }
           }
         },
@@ -5240,9 +5240,9 @@ expression: pretty
             "qualified_name": "tests::da_negative_hit_count_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 702,
+              "end_line": 705,
               "start_column": 5,
-              "start_line": 694
+              "start_line": 697
             }
           }
         },
@@ -5256,10 +5256,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 717,
+              "end_line": 720,
               "increment": 1,
               "kind": "match",
-              "line": 708,
+              "line": 711,
               "nesting_depth": 0
             }
           ],
@@ -5273,9 +5273,9 @@ expression: pretty
             "qualified_name": "tests::da_line_zero_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 718,
+              "end_line": 721,
               "start_column": 5,
-              "start_line": 704
+              "start_line": 707
             }
           }
         },
@@ -5297,9 +5297,9 @@ expression: pretty
             "qualified_name": "tests::end_of_record_is_ignored",
             "span": {
               "end_column": 5,
-              "end_line": 729,
+              "end_line": 732,
               "start_column": 5,
-              "start_line": 720
+              "start_line": 723
             }
           }
         },
@@ -5321,9 +5321,9 @@ expression: pretty
             "qualified_name": "tests::unterminated_final_block_emits_data",
             "span": {
               "end_column": 5,
-              "end_line": 736,
+              "end_line": 739,
               "start_column": 5,
-              "start_line": 731
+              "start_line": 734
             }
           }
         },
@@ -5345,9 +5345,9 @@ expression: pretty
             "qualified_name": "tests::empty_sf_path_emits_diagnostic",
             "span": {
               "end_column": 5,
-              "end_line": 747,
+              "end_line": 750,
               "start_column": 5,
-              "start_line": 738
+              "start_line": 741
             }
           }
         },
@@ -5369,9 +5369,9 @@ expression: pretty
             "qualified_name": "tests::da_with_checksum_field_is_accepted",
             "span": {
               "end_column": 5,
-              "end_line": 756,
+              "end_line": 759,
               "start_column": 5,
-              "start_line": 749
+              "start_line": 752
             }
           }
         },
@@ -5393,9 +5393,9 @@ expression: pretty
             "qualified_name": "tests::non_coverage_records_are_ignored",
             "span": {
               "end_column": 5,
-              "end_line": 770,
+              "end_line": 773,
               "start_column": 5,
-              "start_line": 758
+              "start_line": 761
             }
           }
         },
@@ -5417,9 +5417,9 @@ expression: pretty
             "qualified_name": "tests::brda_and_da_records_parsed",
             "span": {
               "end_column": 5,
-              "end_line": 782,
+              "end_line": 785,
               "start_column": 5,
-              "start_line": 774
+              "start_line": 777
             }
           }
         },
@@ -5441,9 +5441,9 @@ expression: pretty
             "qualified_name": "tests::brda_dash_maps_to_none",
             "span": {
               "end_column": 5,
-              "end_line": 789,
+              "end_line": 792,
               "start_column": 5,
-              "start_line": 784
+              "start_line": 787
             }
           }
         },
@@ -5465,9 +5465,9 @@ expression: pretty
             "qualified_name": "tests::brda_numeric_maps_to_some",
             "span": {
               "end_column": 5,
-              "end_line": 796,
+              "end_line": 799,
               "start_column": 5,
-              "start_line": 791
+              "start_line": 794
             }
           }
         },
@@ -5489,9 +5489,9 @@ expression: pretty
             "qualified_name": "tests::brda_zero_maps_to_some_zero",
             "span": {
               "end_column": 5,
-              "end_line": 803,
+              "end_line": 806,
               "start_column": 5,
-              "start_line": 798
+              "start_line": 801
             }
           }
         },
@@ -5513,9 +5513,9 @@ expression: pretty
             "qualified_name": "tests::duplicate_brda_sum_taken",
             "span": {
               "end_column": 5,
-              "end_line": 813,
+              "end_line": 816,
               "start_column": 5,
-              "start_line": 805
+              "start_line": 808
             }
           }
         },
@@ -5537,9 +5537,9 @@ expression: pretty
             "qualified_name": "tests::brda_dash_and_numeric_merge",
             "span": {
               "end_column": 5,
-              "end_line": 821,
+              "end_line": 824,
               "start_column": 5,
-              "start_line": 815
+              "start_line": 818
             }
           }
         },
@@ -5553,10 +5553,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 836,
+              "end_line": 839,
               "increment": 1,
               "kind": "match",
-              "line": 827,
+              "line": 830,
               "nesting_depth": 0
             }
           ],
@@ -5570,9 +5570,9 @@ expression: pretty
             "qualified_name": "tests::malformed_brda_produces_diagnostic",
             "span": {
               "end_column": 5,
-              "end_line": 837,
+              "end_line": 840,
               "start_column": 5,
-              "start_line": 823
+              "start_line": 826
             }
           }
         },
@@ -5594,9 +5594,9 @@ expression: pretty
             "qualified_name": "tests::brda_missing_fields_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 848,
+              "end_line": 851,
               "start_column": 5,
-              "start_line": 839
+              "start_line": 842
             }
           }
         },
@@ -5618,9 +5618,9 @@ expression: pretty
             "qualified_name": "tests::brda_missing_taken_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 859,
+              "end_line": 862,
               "start_column": 5,
-              "start_line": 850
+              "start_line": 853
             }
           }
         },
@@ -5634,10 +5634,10 @@ expression: pretty
           "contributors": [
             {
               "column": 13,
-              "end_line": 878,
+              "end_line": 881,
               "increment": 1,
               "kind": "for-loop",
-              "line": 876,
+              "line": 879,
               "nesting_depth": 0
             }
           ],
@@ -5651,9 +5651,9 @@ expression: pretty
             "qualified_name": "tests::repeated_sf_blocks_merge_branch_coverage",
             "span": {
               "end_column": 5,
-              "end_line": 888,
+              "end_line": 891,
               "start_column": 5,
-              "start_line": 861
+              "start_line": 864
             }
           }
         },
@@ -5675,9 +5675,9 @@ expression: pretty
             "qualified_name": "tests::brda_line_zero_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 898,
+              "end_line": 901,
               "start_column": 5,
-              "start_line": 890
+              "start_line": 893
             }
           }
         },
@@ -5699,9 +5699,9 @@ expression: pretty
             "qualified_name": "tests::no_brda_produces_none_branches",
             "span": {
               "end_column": 5,
-              "end_line": 904,
+              "end_line": 907,
               "start_column": 5,
-              "start_line": 900
+              "start_line": 903
             }
           }
         },
@@ -5723,9 +5723,9 @@ expression: pretty
             "qualified_name": "proptests::arb_da_line",
             "span": {
               "end_column": 5,
-              "end_line": 914,
+              "end_line": 917,
               "start_column": 5,
-              "start_line": 912
+              "start_line": 915
             }
           }
         },
@@ -5739,10 +5739,10 @@ expression: pretty
           "contributors": [
             {
               "column": 13,
-              "end_line": 922,
+              "end_line": 925,
               "increment": 2,
               "kind": "for-loop",
-              "line": 919,
+              "line": 922,
               "nesting_depth": 1
             }
           ],
@@ -5756,9 +5756,9 @@ expression: pretty
             "qualified_name": "proptests::arb_lcov_block",
             "span": {
               "end_column": 5,
-              "end_line": 926,
+              "end_line": 929,
               "start_column": 5,
-              "start_line": 916
+              "start_line": 919
             }
           }
         },
@@ -5780,9 +5780,9 @@ expression: pretty
             "qualified_name": "proptests::arb_lcov_input",
             "span": {
               "end_column": 5,
-              "end_line": 930,
+              "end_line": 933,
               "start_column": 5,
-              "start_line": 928
+              "start_line": 931
             }
           }
         },
@@ -5969,7 +5969,7 @@ expression: pretty
     "passed": false,
     "summary": {
       "average_complexity": 1.5492957746478873,
-      "average_coverage": 95.20976251582802,
+      "average_coverage": 95.21814615097222,
       "average_crap": 1.610093896713615,
       "distribution": {
         "acceptable": 2,
@@ -5994,9 +5994,9 @@ expression: pretty
         "qualified_name": "parse_brda",
         "span": {
           "end_column": 1,
-          "end_line": 336,
+          "end_line": 339,
           "start_column": 1,
-          "start_line": 313
+          "start_line": 316
         }
       }
     }
@@ -6017,30 +6017,6 @@ expression: pretty
           "contributors": [
             {
               "column": 42,
-              "end_line": 318,
-              "increment": 1,
-              "kind": "try",
-              "line": 318,
-              "nesting_depth": 0
-            },
-            {
-              "column": 43,
-              "end_line": 319,
-              "increment": 1,
-              "kind": "try",
-              "line": 319,
-              "nesting_depth": 0
-            },
-            {
-              "column": 44,
-              "end_line": 320,
-              "increment": 1,
-              "kind": "try",
-              "line": 320,
-              "nesting_depth": 0
-            },
-            {
-              "column": 43,
               "end_line": 321,
               "increment": 1,
               "kind": "try",
@@ -6048,7 +6024,15 @@ expression: pretty
               "nesting_depth": 0
             },
             {
-              "column": 58,
+              "column": 43,
+              "end_line": 322,
+              "increment": 1,
+              "kind": "try",
+              "line": 322,
+              "nesting_depth": 0
+            },
+            {
+              "column": 44,
               "end_line": 323,
               "increment": 1,
               "kind": "try",
@@ -6056,43 +6040,59 @@ expression: pretty
               "nesting_depth": 0
             },
             {
-              "column": 5,
-              "end_line": 326,
+              "column": 43,
+              "end_line": 324,
               "increment": 1,
-              "kind": "if-branch",
+              "kind": "try",
               "line": 324,
               "nesting_depth": 0
             },
             {
-              "column": 55,
-              "end_line": 327,
+              "column": 58,
+              "end_line": 326,
               "increment": 1,
               "kind": "try",
+              "line": 326,
+              "nesting_depth": 0
+            },
+            {
+              "column": 5,
+              "end_line": 329,
+              "increment": 1,
+              "kind": "if-branch",
               "line": 327,
               "nesting_depth": 0
             },
             {
-              "column": 57,
-              "end_line": 328,
+              "column": 55,
+              "end_line": 330,
               "increment": 1,
               "kind": "try",
-              "line": 328,
+              "line": 330,
+              "nesting_depth": 0
+            },
+            {
+              "column": 57,
+              "end_line": 331,
+              "increment": 1,
+              "kind": "try",
+              "line": 331,
               "nesting_depth": 0
             },
             {
               "column": 17,
-              "end_line": 333,
+              "end_line": 336,
               "increment": 1,
               "kind": "if-branch",
-              "line": 329,
+              "line": 332,
               "nesting_depth": 0
             },
             {
               "column": 54,
-              "end_line": 332,
+              "end_line": 335,
               "increment": 1,
               "kind": "try",
-              "line": 332,
+              "line": 335,
               "nesting_depth": 1
             }
           ],
@@ -6106,9 +6106,9 @@ expression: pretty
             "qualified_name": "parse_brda",
             "span": {
               "end_column": 1,
-              "end_line": 336,
+              "end_line": 339,
               "start_column": 1,
-              "start_line": 313
+              "start_line": 316
             }
           }
         },
@@ -6122,58 +6122,58 @@ expression: pretty
           "contributors": [
             {
               "column": 73,
-              "end_line": 215,
+              "end_line": 218,
               "increment": 1,
               "kind": "try",
-              "line": 215,
-              "nesting_depth": 0
-            },
-            {
-              "column": 9,
-              "end_line": 232,
-              "increment": 1,
-              "kind": "for-loop",
               "line": 218,
               "nesting_depth": 0
             },
             {
-              "column": 68,
-              "end_line": 219,
+              "column": 9,
+              "end_line": 235,
               "increment": 1,
-              "kind": "try",
-              "line": 219,
-              "nesting_depth": 1
+              "kind": "for-loop",
+              "line": 221,
+              "nesting_depth": 0
             },
             {
-              "column": 13,
-              "end_line": 223,
-              "increment": 2,
-              "kind": "if-branch",
-              "line": 220,
-              "nesting_depth": 1
-            },
-            {
-              "column": 17,
+              "column": 68,
               "end_line": 222,
               "increment": 1,
-              "kind": "continue",
+              "kind": "try",
               "line": 222,
-              "nesting_depth": 2
+              "nesting_depth": 1
             },
             {
               "column": 13,
-              "end_line": 231,
+              "end_line": 226,
               "increment": 2,
               "kind": "if-branch",
-              "line": 224,
+              "line": 223,
               "nesting_depth": 1
             },
             {
               "column": 17,
               "end_line": 225,
               "increment": 1,
-              "kind": "logical-operator",
+              "kind": "continue",
               "line": 225,
+              "nesting_depth": 2
+            },
+            {
+              "column": 13,
+              "end_line": 234,
+              "increment": 2,
+              "kind": "if-branch",
+              "line": 227,
+              "nesting_depth": 1
+            },
+            {
+              "column": 17,
+              "end_line": 228,
+              "increment": 1,
+              "kind": "logical-operator",
+              "line": 228,
               "nesting_depth": 1
             }
           ],
@@ -6187,9 +6187,9 @@ expression: pretty
             "qualified_name": "LcovParser::validate",
             "span": {
               "end_column": 5,
-              "end_line": 234,
+              "end_line": 237,
               "start_column": 5,
-              "start_line": 202
+              "start_line": 203
             }
           }
         },
@@ -6423,22 +6423,6 @@ expression: pretty
           "contributors": [
             {
               "column": 56,
-              "end_line": 302,
-              "increment": 1,
-              "kind": "try",
-              "line": 302,
-              "nesting_depth": 0
-            },
-            {
-              "column": 52,
-              "end_line": 304,
-              "increment": 1,
-              "kind": "try",
-              "line": 304,
-              "nesting_depth": 0
-            },
-            {
-              "column": 58,
               "end_line": 305,
               "increment": 1,
               "kind": "try",
@@ -6446,19 +6430,35 @@ expression: pretty
               "nesting_depth": 0
             },
             {
-              "column": 5,
+              "column": 52,
+              "end_line": 307,
+              "increment": 1,
+              "kind": "try",
+              "line": 307,
+              "nesting_depth": 0
+            },
+            {
+              "column": 58,
               "end_line": 308,
               "increment": 1,
+              "kind": "try",
+              "line": 308,
+              "nesting_depth": 0
+            },
+            {
+              "column": 5,
+              "end_line": 311,
+              "increment": 1,
               "kind": "if-branch",
-              "line": 306,
+              "line": 309,
               "nesting_depth": 0
             },
             {
               "column": 53,
-              "end_line": 309,
+              "end_line": 312,
               "increment": 1,
               "kind": "try",
-              "line": 309,
+              "line": 312,
               "nesting_depth": 0
             }
           ],
@@ -6472,9 +6472,9 @@ expression: pretty
             "qualified_name": "parse_da",
             "span": {
               "end_column": 1,
-              "end_line": 311,
+              "end_line": 314,
               "start_column": 1,
-              "start_line": 299
+              "start_line": 302
             }
           }
         },
@@ -6734,26 +6734,26 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 241,
+              "end_line": 244,
               "increment": 1,
               "kind": "if-branch",
-              "line": 238,
+              "line": 241,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 246,
+              "end_line": 249,
               "increment": 1,
               "kind": "if-branch",
-              "line": 243,
+              "line": 246,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 250,
+              "end_line": 253,
               "increment": 1,
               "kind": "if-branch",
-              "line": 248,
+              "line": 251,
               "nesting_depth": 0
             }
           ],
@@ -6767,9 +6767,9 @@ expression: pretty
             "qualified_name": "handle_parse_line",
             "span": {
               "end_column": 1,
-              "end_line": 251,
+              "end_line": 254,
               "start_column": 1,
-              "start_line": 237
+              "start_line": 240
             }
           }
         },
@@ -6980,18 +6980,18 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 269,
+              "end_line": 272,
               "increment": 1,
               "kind": "if-branch",
-              "line": 267,
+              "line": 270,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 274,
+              "end_line": 277,
               "increment": 1,
               "kind": "match",
-              "line": 271,
+              "line": 274,
               "nesting_depth": 0
             }
           ],
@@ -7005,9 +7005,9 @@ expression: pretty
             "qualified_name": "record_da",
             "span": {
               "end_column": 1,
-              "end_line": 275,
+              "end_line": 278,
               "start_column": 1,
-              "start_line": 266
+              "start_line": 269
             }
           }
         },
@@ -7021,18 +7021,18 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 280,
+              "end_line": 283,
               "increment": 1,
               "kind": "if-branch",
-              "line": 278,
+              "line": 281,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 287,
+              "end_line": 290,
               "increment": 1,
               "kind": "match",
-              "line": 282,
+              "line": 285,
               "nesting_depth": 0
             }
           ],
@@ -7046,9 +7046,9 @@ expression: pretty
             "qualified_name": "record_brda",
             "span": {
               "end_column": 1,
-              "end_line": 288,
+              "end_line": 291,
               "start_column": 1,
-              "start_line": 277
+              "start_line": 280
             }
           }
         },
@@ -7062,18 +7062,18 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 356,
+              "end_line": 359,
               "increment": 1,
               "kind": "if-branch",
-              "line": 354,
+              "line": 357,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 361,
+              "end_line": 364,
               "increment": 1,
               "kind": "for-loop",
-              "line": 359,
+              "line": 362,
               "nesting_depth": 0
             }
           ],
@@ -7087,9 +7087,9 @@ expression: pretty
             "qualified_name": "merge_line_block",
             "span": {
               "end_column": 1,
-              "end_line": 362,
+              "end_line": 365,
               "start_column": 1,
-              "start_line": 349
+              "start_line": 352
             }
           }
         },
@@ -7103,18 +7103,18 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 371,
+              "end_line": 374,
               "increment": 1,
               "kind": "if-branch",
-              "line": 369,
+              "line": 372,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 376,
+              "end_line": 379,
               "increment": 1,
               "kind": "for-loop",
-              "line": 374,
+              "line": 377,
               "nesting_depth": 0
             }
           ],
@@ -7128,9 +7128,9 @@ expression: pretty
             "qualified_name": "merge_branch_block",
             "span": {
               "end_column": 1,
-              "end_line": 377,
+              "end_line": 380,
               "start_column": 1,
-              "start_line": 364
+              "start_line": 367
             }
           }
         },
@@ -7144,10 +7144,10 @@ expression: pretty
           "contributors": [
             {
               "column": 13,
-              "end_line": 922,
+              "end_line": 925,
               "increment": 2,
               "kind": "for-loop",
-              "line": 919,
+              "line": 922,
               "nesting_depth": 1
             }
           ],
@@ -7161,9 +7161,9 @@ expression: pretty
             "qualified_name": "proptests::arb_lcov_block",
             "span": {
               "end_column": 5,
-              "end_line": 926,
+              "end_line": 929,
               "start_column": 5,
-              "start_line": 916
+              "start_line": 919
             }
           }
         },
@@ -7309,14 +7309,14 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 263,
+              "end_line": 266,
               "increment": 1,
               "kind": "if-branch",
-              "line": 256,
+              "line": 259,
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 85.71428571428571,
+          "coverage_percent": 87.5,
           "crap": {
             "risk_level": "low",
             "value": 2.01
@@ -7326,9 +7326,9 @@ expression: pretty
             "qualified_name": "start_source_file",
             "span": {
               "end_column": 1,
-              "end_line": 264,
+              "end_line": 267,
               "start_column": 1,
-              "start_line": 253
+              "start_line": 256
             }
           }
         },
@@ -7903,10 +7903,10 @@ expression: pretty
           "contributors": [
             {
               "column": 72,
-              "end_line": 198,
+              "end_line": 199,
               "increment": 1,
               "kind": "try",
-              "line": 198,
+              "line": 199,
               "nesting_depth": 0
             }
           ],
@@ -7920,7 +7920,7 @@ expression: pretty
             "qualified_name": "LcovParser::parse",
             "span": {
               "end_column": 5,
-              "end_line": 200,
+              "end_line": 201,
               "start_column": 5,
               "start_line": 167
             }
@@ -7936,10 +7936,10 @@ expression: pretty
           "contributors": [
             {
               "column": 52,
-              "end_line": 342,
+              "end_line": 345,
               "increment": 1,
               "kind": "let-else",
-              "line": 339,
+              "line": 342,
               "nesting_depth": 0
             }
           ],
@@ -7953,9 +7953,9 @@ expression: pretty
             "qualified_name": "flush_block",
             "span": {
               "end_column": 1,
-              "end_line": 347,
+              "end_line": 350,
               "start_column": 1,
-              "start_line": 338
+              "start_line": 341
             }
           }
         },
@@ -7969,10 +7969,10 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 403,
+              "end_line": 406,
               "increment": 1,
               "kind": "match",
-              "line": 398,
+              "line": 401,
               "nesting_depth": 0
             }
           ],
@@ -7986,9 +7986,9 @@ expression: pretty
             "qualified_name": "merge_taken",
             "span": {
               "end_column": 1,
-              "end_line": 404,
+              "end_line": 407,
               "start_column": 1,
-              "start_line": 397
+              "start_line": 400
             }
           }
         },
@@ -8002,10 +8002,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 673,
+              "end_line": 676,
               "increment": 1,
               "kind": "match",
-              "line": 664,
+              "line": 667,
               "nesting_depth": 0
             }
           ],
@@ -8019,9 +8019,9 @@ expression: pretty
             "qualified_name": "tests::malformed_da_produces_diagnostic",
             "span": {
               "end_column": 5,
-              "end_line": 674,
+              "end_line": 677,
               "start_column": 5,
-              "start_line": 659
+              "start_line": 662
             }
           }
         },
@@ -8035,10 +8035,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 717,
+              "end_line": 720,
               "increment": 1,
               "kind": "match",
-              "line": 708,
+              "line": 711,
               "nesting_depth": 0
             }
           ],
@@ -8052,9 +8052,9 @@ expression: pretty
             "qualified_name": "tests::da_line_zero_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 718,
+              "end_line": 721,
               "start_column": 5,
-              "start_line": 704
+              "start_line": 707
             }
           }
         },
@@ -8068,10 +8068,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 836,
+              "end_line": 839,
               "increment": 1,
               "kind": "match",
-              "line": 827,
+              "line": 830,
               "nesting_depth": 0
             }
           ],
@@ -8085,9 +8085,9 @@ expression: pretty
             "qualified_name": "tests::malformed_brda_produces_diagnostic",
             "span": {
               "end_column": 5,
-              "end_line": 837,
+              "end_line": 840,
               "start_column": 5,
-              "start_line": 823
+              "start_line": 826
             }
           }
         },
@@ -8101,10 +8101,10 @@ expression: pretty
           "contributors": [
             {
               "column": 13,
-              "end_line": 878,
+              "end_line": 881,
               "increment": 1,
               "kind": "for-loop",
-              "line": 876,
+              "line": 879,
               "nesting_depth": 0
             }
           ],
@@ -8118,9 +8118,9 @@ expression: pretty
             "qualified_name": "tests::repeated_sf_blocks_merge_branch_coverage",
             "span": {
               "end_column": 5,
-              "end_line": 888,
+              "end_line": 891,
               "start_column": 5,
-              "start_line": 861
+              "start_line": 864
             }
           }
         },
@@ -10782,9 +10782,9 @@ expression: pretty
             "qualified_name": "push_malformed_record",
             "span": {
               "end_column": 1,
-              "end_line": 297,
+              "end_line": 300,
               "start_column": 1,
-              "start_line": 290
+              "start_line": 293
             }
           }
         },
@@ -10806,9 +10806,9 @@ expression: pretty
             "qualified_name": "merge_hits",
             "span": {
               "end_column": 1,
-              "end_line": 384,
+              "end_line": 387,
               "start_column": 1,
-              "start_line": 379
+              "start_line": 382
             }
           }
         },
@@ -10830,9 +10830,9 @@ expression: pretty
             "qualified_name": "merge_branch_value",
             "span": {
               "end_column": 1,
-              "end_line": 395,
+              "end_line": 398,
               "start_column": 1,
-              "start_line": 386
+              "start_line": 389
             }
           }
         },
@@ -10854,9 +10854,9 @@ expression: pretty
             "qualified_name": "clear_current_block",
             "span": {
               "end_column": 1,
-              "end_line": 409,
+              "end_line": 412,
               "start_column": 1,
-              "start_line": 406
+              "start_line": 409
             }
           }
         },
@@ -10878,9 +10878,9 @@ expression: pretty
             "qualified_name": "build_parse_output",
             "span": {
               "end_column": 1,
-              "end_line": 437,
+              "end_line": 440,
               "start_column": 1,
-              "start_line": 411
+              "start_line": 414
             }
           }
         },
@@ -10902,9 +10902,9 @@ expression: pretty
             "qualified_name": "to_line_coverage",
             "span": {
               "end_column": 1,
-              "end_line": 444,
+              "end_line": 447,
               "start_column": 1,
-              "start_line": 439
+              "start_line": 442
             }
           }
         },
@@ -10926,9 +10926,9 @@ expression: pretty
             "qualified_name": "tests::parser",
             "span": {
               "end_column": 5,
-              "end_line": 453,
+              "end_line": 456,
               "start_column": 5,
-              "start_line": 451
+              "start_line": 454
             }
           }
         },
@@ -10950,9 +10950,9 @@ expression: pretty
             "qualified_name": "tests::parse",
             "span": {
               "end_column": 5,
-              "end_line": 457,
+              "end_line": 460,
               "start_column": 5,
-              "start_line": 455
+              "start_line": 458
             }
           }
         },
@@ -10974,9 +10974,9 @@ expression: pretty
             "qualified_name": "tests::empty_input_returns_empty_output",
             "span": {
               "end_column": 5,
-              "end_line": 464,
+              "end_line": 467,
               "start_column": 5,
-              "start_line": 459
+              "start_line": 462
             }
           }
         },
@@ -10998,9 +10998,9 @@ expression: pretty
             "qualified_name": "tests::validate_str",
             "span": {
               "end_column": 5,
-              "end_line": 478,
+              "end_line": 481,
               "start_column": 5,
-              "start_line": 468
+              "start_line": 471
             }
           }
         },
@@ -11022,9 +11022,9 @@ expression: pretty
             "qualified_name": "tests::validate_empty_input_rejected",
             "span": {
               "end_column": 5,
-              "end_line": 483,
+              "end_line": 486,
               "start_column": 5,
-              "start_line": 480
+              "start_line": 483
             }
           }
         },
@@ -11046,9 +11046,9 @@ expression: pretty
             "qualified_name": "tests::validate_no_da_lines_rejected",
             "span": {
               "end_column": 5,
-              "end_line": 488,
+              "end_line": 491,
               "start_column": 5,
-              "start_line": 485
+              "start_line": 488
             }
           }
         },
@@ -11070,9 +11070,9 @@ expression: pretty
             "qualified_name": "tests::validate_da_outside_sf_block_rejected",
             "span": {
               "end_column": 5,
-              "end_line": 493,
+              "end_line": 496,
               "start_column": 5,
-              "start_line": 490
+              "start_line": 493
             }
           }
         },
@@ -11094,9 +11094,9 @@ expression: pretty
             "qualified_name": "tests::validate_malformed_da_rejected",
             "span": {
               "end_column": 5,
-              "end_line": 498,
+              "end_line": 501,
               "start_column": 5,
-              "start_line": 495
+              "start_line": 498
             }
           }
         },
@@ -11118,9 +11118,9 @@ expression: pretty
             "qualified_name": "tests::validate_single_da_inside_sf_block_passes",
             "span": {
               "end_column": 5,
-              "end_line": 503,
+              "end_line": 506,
               "start_column": 5,
-              "start_line": 500
+              "start_line": 503
             }
           }
         },
@@ -11142,9 +11142,9 @@ expression: pretty
             "qualified_name": "tests::validate_first_da_in_second_block_passes",
             "span": {
               "end_column": 5,
-              "end_line": 513,
+              "end_line": 516,
               "start_column": 5,
-              "start_line": 505
+              "start_line": 508
             }
           }
         },
@@ -11166,9 +11166,9 @@ expression: pretty
             "qualified_name": "tests::validate_missing_path_returns_open_error",
             "span": {
               "end_column": 5,
-              "end_line": 525,
+              "end_line": 528,
               "start_column": 5,
-              "start_line": 515
+              "start_line": 518
             }
           }
         },
@@ -11190,9 +11190,9 @@ expression: pretty
             "qualified_name": "tests::single_file_single_da",
             "span": {
               "end_column": 5,
-              "end_line": 535,
+              "end_line": 538,
               "start_column": 5,
-              "start_line": 527
+              "start_line": 530
             }
           }
         },
@@ -11214,9 +11214,9 @@ expression: pretty
             "qualified_name": "tests::multiple_da_lines",
             "span": {
               "end_column": 5,
-              "end_line": 545,
+              "end_line": 548,
               "start_column": 5,
-              "start_line": 537
+              "start_line": 540
             }
           }
         },
@@ -11238,9 +11238,9 @@ expression: pretty
             "qualified_name": "tests::multiple_source_files",
             "span": {
               "end_column": 5,
-              "end_line": 554,
+              "end_line": 557,
               "start_column": 5,
-              "start_line": 547
+              "start_line": 550
             }
           }
         },
@@ -11262,9 +11262,9 @@ expression: pretty
             "qualified_name": "tests::hit_count_preservation",
             "span": {
               "end_column": 5,
-              "end_line": 562,
+              "end_line": 565,
               "start_column": 5,
-              "start_line": 556
+              "start_line": 559
             }
           }
         },
@@ -11286,9 +11286,9 @@ expression: pretty
             "qualified_name": "tests::path_normalization_strips_prefix",
             "span": {
               "end_column": 5,
-              "end_line": 568,
+              "end_line": 571,
               "start_column": 5,
-              "start_line": 564
+              "start_line": 567
             }
           }
         },
@@ -11310,9 +11310,9 @@ expression: pretty
             "qualified_name": "tests::non_matching_path_passes_through",
             "span": {
               "end_column": 5,
-              "end_line": 574,
+              "end_line": 577,
               "start_column": 5,
-              "start_line": 570
+              "start_line": 573
             }
           }
         },
@@ -11334,9 +11334,9 @@ expression: pretty
             "qualified_name": "tests::backslash_normalized_to_forward_slash",
             "span": {
               "end_column": 5,
-              "end_line": 581,
+              "end_line": 584,
               "start_column": 5,
-              "start_line": 576
+              "start_line": 579
             }
           }
         },
@@ -11358,9 +11358,9 @@ expression: pretty
             "qualified_name": "tests::path_boundary_not_confused_by_prefix_substring",
             "span": {
               "end_column": 5,
-              "end_line": 587,
+              "end_line": 590,
               "start_column": 5,
-              "start_line": 583
+              "start_line": 586
             }
           }
         },
@@ -11382,9 +11382,9 @@ expression: pretty
             "qualified_name": "tests::parentdir_sf_path_does_not_take_fast_path_is_file_probe",
             "span": {
               "end_column": 5,
-              "end_line": 622,
+              "end_line": 625,
               "start_column": 5,
-              "start_line": 589
+              "start_line": 592
             }
           }
         },
@@ -11406,9 +11406,9 @@ expression: pretty
             "qualified_name": "tests::repeated_sf_blocks_merge_coverage",
             "span": {
               "end_column": 5,
-              "end_line": 636,
+              "end_line": 639,
               "start_column": 5,
-              "start_line": 624
+              "start_line": 627
             }
           }
         },
@@ -11430,9 +11430,9 @@ expression: pretty
             "qualified_name": "tests::duplicate_da_lines_sum_hits",
             "span": {
               "end_column": 5,
-              "end_line": 645,
+              "end_line": 648,
               "start_column": 5,
-              "start_line": 638
+              "start_line": 641
             }
           }
         },
@@ -11454,9 +11454,9 @@ expression: pretty
             "qualified_name": "tests::duplicate_da_multiple_lines_sum_correctly",
             "span": {
               "end_column": 5,
-              "end_line": 657,
+              "end_line": 660,
               "start_column": 5,
-              "start_line": 647
+              "start_line": 650
             }
           }
         },
@@ -11478,9 +11478,9 @@ expression: pretty
             "qualified_name": "tests::malformed_da_does_not_stop_parsing",
             "span": {
               "end_column": 5,
-              "end_line": 682,
+              "end_line": 685,
               "start_column": 5,
-              "start_line": 676
+              "start_line": 679
             }
           }
         },
@@ -11502,9 +11502,9 @@ expression: pretty
             "qualified_name": "tests::da_missing_hit_count_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 692,
+              "end_line": 695,
               "start_column": 5,
-              "start_line": 684
+              "start_line": 687
             }
           }
         },
@@ -11526,9 +11526,9 @@ expression: pretty
             "qualified_name": "tests::da_negative_hit_count_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 702,
+              "end_line": 705,
               "start_column": 5,
-              "start_line": 694
+              "start_line": 697
             }
           }
         },
@@ -11550,9 +11550,9 @@ expression: pretty
             "qualified_name": "tests::end_of_record_is_ignored",
             "span": {
               "end_column": 5,
-              "end_line": 729,
+              "end_line": 732,
               "start_column": 5,
-              "start_line": 720
+              "start_line": 723
             }
           }
         },
@@ -11574,9 +11574,9 @@ expression: pretty
             "qualified_name": "tests::unterminated_final_block_emits_data",
             "span": {
               "end_column": 5,
-              "end_line": 736,
+              "end_line": 739,
               "start_column": 5,
-              "start_line": 731
+              "start_line": 734
             }
           }
         },
@@ -11598,9 +11598,9 @@ expression: pretty
             "qualified_name": "tests::empty_sf_path_emits_diagnostic",
             "span": {
               "end_column": 5,
-              "end_line": 747,
+              "end_line": 750,
               "start_column": 5,
-              "start_line": 738
+              "start_line": 741
             }
           }
         },
@@ -11622,9 +11622,9 @@ expression: pretty
             "qualified_name": "tests::da_with_checksum_field_is_accepted",
             "span": {
               "end_column": 5,
-              "end_line": 756,
+              "end_line": 759,
               "start_column": 5,
-              "start_line": 749
+              "start_line": 752
             }
           }
         },
@@ -11646,9 +11646,9 @@ expression: pretty
             "qualified_name": "tests::non_coverage_records_are_ignored",
             "span": {
               "end_column": 5,
-              "end_line": 770,
+              "end_line": 773,
               "start_column": 5,
-              "start_line": 758
+              "start_line": 761
             }
           }
         },
@@ -11670,9 +11670,9 @@ expression: pretty
             "qualified_name": "tests::brda_and_da_records_parsed",
             "span": {
               "end_column": 5,
-              "end_line": 782,
+              "end_line": 785,
               "start_column": 5,
-              "start_line": 774
+              "start_line": 777
             }
           }
         },
@@ -11694,9 +11694,9 @@ expression: pretty
             "qualified_name": "tests::brda_dash_maps_to_none",
             "span": {
               "end_column": 5,
-              "end_line": 789,
+              "end_line": 792,
               "start_column": 5,
-              "start_line": 784
+              "start_line": 787
             }
           }
         },
@@ -11718,9 +11718,9 @@ expression: pretty
             "qualified_name": "tests::brda_numeric_maps_to_some",
             "span": {
               "end_column": 5,
-              "end_line": 796,
+              "end_line": 799,
               "start_column": 5,
-              "start_line": 791
+              "start_line": 794
             }
           }
         },
@@ -11742,9 +11742,9 @@ expression: pretty
             "qualified_name": "tests::brda_zero_maps_to_some_zero",
             "span": {
               "end_column": 5,
-              "end_line": 803,
+              "end_line": 806,
               "start_column": 5,
-              "start_line": 798
+              "start_line": 801
             }
           }
         },
@@ -11766,9 +11766,9 @@ expression: pretty
             "qualified_name": "tests::duplicate_brda_sum_taken",
             "span": {
               "end_column": 5,
-              "end_line": 813,
+              "end_line": 816,
               "start_column": 5,
-              "start_line": 805
+              "start_line": 808
             }
           }
         },
@@ -11790,9 +11790,9 @@ expression: pretty
             "qualified_name": "tests::brda_dash_and_numeric_merge",
             "span": {
               "end_column": 5,
-              "end_line": 821,
+              "end_line": 824,
               "start_column": 5,
-              "start_line": 815
+              "start_line": 818
             }
           }
         },
@@ -11814,9 +11814,9 @@ expression: pretty
             "qualified_name": "tests::brda_missing_fields_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 848,
+              "end_line": 851,
               "start_column": 5,
-              "start_line": 839
+              "start_line": 842
             }
           }
         },
@@ -11838,9 +11838,9 @@ expression: pretty
             "qualified_name": "tests::brda_missing_taken_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 859,
+              "end_line": 862,
               "start_column": 5,
-              "start_line": 850
+              "start_line": 853
             }
           }
         },
@@ -11862,9 +11862,9 @@ expression: pretty
             "qualified_name": "tests::brda_line_zero_is_malformed",
             "span": {
               "end_column": 5,
-              "end_line": 898,
+              "end_line": 901,
               "start_column": 5,
-              "start_line": 890
+              "start_line": 893
             }
           }
         },
@@ -11886,9 +11886,9 @@ expression: pretty
             "qualified_name": "tests::no_brda_produces_none_branches",
             "span": {
               "end_column": 5,
-              "end_line": 904,
+              "end_line": 907,
               "start_column": 5,
-              "start_line": 900
+              "start_line": 903
             }
           }
         },
@@ -11910,9 +11910,9 @@ expression: pretty
             "qualified_name": "proptests::arb_da_line",
             "span": {
               "end_column": 5,
-              "end_line": 914,
+              "end_line": 917,
               "start_column": 5,
-              "start_line": 912
+              "start_line": 915
             }
           }
         },
@@ -11934,9 +11934,9 @@ expression: pretty
             "qualified_name": "proptests::arb_lcov_input",
             "span": {
               "end_column": 5,
-              "end_line": 930,
+              "end_line": 933,
               "start_column": 5,
-              "start_line": 928
+              "start_line": 931
             }
           }
         },
@@ -11969,7 +11969,7 @@ expression: pretty
     ],
     "shown_summary": {
       "average_complexity": 1.5492957746478873,
-      "average_coverage": 95.20976251582802,
+      "average_coverage": 95.21814615097222,
       "average_crap": 1.610093896713615,
       "distribution": {
         "acceptable": 2,
@@ -11994,9 +11994,9 @@ expression: pretty
         "qualified_name": "parse_brda",
         "span": {
           "end_column": 1,
-          "end_line": 336,
+          "end_line": 339,
           "start_column": 1,
-          "start_line": 313
+          "start_line": 316
         }
       }
     },

--- a/crates/crap-core/tests/snapshots/wire_envelope_crap4rs__envelope.snap
+++ b/crates/crap-core/tests/snapshots/wire_envelope_crap4rs__envelope.snap
@@ -57,9 +57,42 @@ expression: pretty
             "qualified_name": "SynComplexityAdapter::extract",
             "span": {
               "end_column": 5,
-              "end_line": 45,
+              "end_line": 46,
               "start_column": 5,
               "start_line": 27
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 2,
+          "complexity_metric": "cognitive",
+          "contributors": [
+            {
+              "column": 9,
+              "end_line": 77,
+              "increment": 1,
+              "kind": "if-branch",
+              "line": 75,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "FunctionFinder::qualify",
+            "span": {
+              "end_column": 5,
+              "end_line": 80,
+              "start_column": 5,
+              "start_line": 65
             }
           }
         },
@@ -71,7 +104,31 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 100.0,
+          "coverage_percent": 90.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "FunctionFinder::visit_item_mod",
+            "span": {
+              "end_column": 5,
+              "end_line": 95,
+              "start_column": 5,
+              "start_line": 84
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 92.85714285714286,
           "crap": {
             "risk_level": "low",
             "value": 1.0
@@ -81,9 +138,9 @@ expression: pretty
             "qualified_name": "FunctionFinder::visit_item_fn",
             "span": {
               "end_column": 5,
-              "end_line": 76,
+              "end_line": 115,
               "start_column": 5,
-              "start_line": 58
+              "start_line": 97
             }
           }
         },
@@ -105,9 +162,33 @@ expression: pretty
             "qualified_name": "FunctionFinder::visit_item_impl",
             "span": {
               "end_column": 5,
-              "end_line": 83,
+              "end_line": 122,
               "start_column": 5,
-              "start_line": 78
+              "start_line": 117
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "FunctionFinder::visit_impl_item_fn",
+            "span": {
+              "end_column": 5,
+              "end_line": 139,
+              "start_column": 5,
+              "start_line": 124
             }
           }
         },
@@ -120,68 +201,27 @@ expression: pretty
           "complexity_metric": "cognitive",
           "contributors": [
             {
-              "column": 25,
-              "end_line": 90,
-              "increment": 1,
-              "kind": "match",
-              "line": 87,
-              "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 93.75,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "FunctionFinder::visit_impl_item_fn",
-            "span": {
-              "end_column": 5,
-              "end_line": 104,
-              "start_column": 5,
-              "start_line": 85
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 4,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
               "column": 9,
-              "end_line": 125,
+              "end_line": 156,
               "increment": 1,
               "kind": "if-branch",
-              "line": 108,
+              "line": 143,
               "nesting_depth": 0
-            },
-            {
-              "column": 29,
-              "end_line": 113,
-              "increment": 2,
-              "kind": "match",
-              "line": 110,
-              "nesting_depth": 1
             }
           ],
-          "coverage_percent": 94.73684210526316,
+          "coverage_percent": 84.61538461538461,
           "crap": {
             "risk_level": "low",
-            "value": 4.0
+            "value": 2.01
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
             "qualified_name": "FunctionFinder::visit_trait_item_fn",
             "span": {
               "end_column": 5,
-              "end_line": 128,
+              "end_line": 159,
               "start_column": 5,
-              "start_line": 106
+              "start_line": 141
             }
           }
         },
@@ -203,56 +243,8 @@ expression: pretty
             "qualified_name": "FunctionFinder::visit_item_trait",
             "span": {
               "end_column": 5,
-              "end_line": 135,
+              "end_line": 166,
               "start_column": 5,
-              "start_line": 130
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 85.71428571428571,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "add_contributor",
-            "span": {
-              "end_column": 1,
-              "end_line": 159,
-              "start_column": 1,
-              "start_line": 140
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 100.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "end_line_of",
-            "span": {
-              "end_column": 1,
-              "end_line": 167,
-              "start_column": 1,
               "start_line": 161
             }
           }
@@ -272,12 +264,60 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "span_of",
+            "qualified_name": "add_contributor",
             "span": {
               "end_column": 1,
               "end_line": 190,
               "start_column": 1,
-              "start_line": 169
+              "start_line": 171
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 50.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.13
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "end_line_of",
+            "span": {
+              "end_column": 1,
+              "end_line": 198,
+              "start_column": 1,
+              "start_line": 192
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 94.73684210526316,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "span_of",
+            "span": {
+              "end_column": 1,
+              "end_line": 221,
+              "start_column": 1,
+              "start_line": 200
             }
           }
         },
@@ -291,34 +331,34 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 198,
+              "end_line": 229,
               "increment": 1,
               "kind": "if-branch",
-              "line": 194,
+              "line": 225,
               "nesting_depth": 0
             },
             {
               "column": 9,
-              "end_line": 195,
+              "end_line": 226,
               "increment": 1,
               "kind": "logical-operator",
-              "line": 195,
+              "line": 226,
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 71.42857142857143,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 3.21
+            "value": 3.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
             "qualified_name": "extract_type_name",
             "span": {
               "end_column": 1,
-              "end_line": 201,
+              "end_line": 232,
               "start_column": 1,
-              "start_line": 192
+              "start_line": 223
             }
           }
         },
@@ -332,26 +372,173 @@ expression: pretty
           "contributors": [
             {
               "column": 15,
-              "end_line": 213,
+              "end_line": 244,
               "increment": 1,
               "kind": "match",
-              "line": 210,
+              "line": 241,
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 90.0,
+          "coverage_percent": 85.71428571428571,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 2.01
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
             "qualified_name": "count_complexity",
             "span": {
               "end_column": 1,
-              "end_line": 216,
+              "end_line": 247,
               "start_column": 1,
-              "start_line": 205
+              "start_line": 236
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 77.77777777777779,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.01
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "count_cognitive_block",
+            "span": {
+              "end_column": 1,
+              "end_line": 261,
+              "start_column": 1,
+              "start_line": 251
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 7,
+          "complexity_metric": "cognitive",
+          "contributors": [
+            {
+              "column": 5,
+              "end_line": 291,
+              "increment": 1,
+              "kind": "match",
+              "line": 268,
+              "nesting_depth": 0
+            },
+            {
+              "column": 13,
+              "end_line": 287,
+              "increment": 2,
+              "kind": "if-branch",
+              "line": 272,
+              "nesting_depth": 1
+            },
+            {
+              "column": 17,
+              "end_line": 286,
+              "increment": 3,
+              "kind": "if-branch",
+              "line": 274,
+              "nesting_depth": 2
+            }
+          ],
+          "coverage_percent": 73.68421052631578,
+          "crap": {
+            "risk_level": "low",
+            "value": 7.89
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "count_cognitive_stmt",
+            "span": {
+              "end_column": 1,
+              "end_line": 292,
+              "start_column": 1,
+              "start_line": 263
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 2,
+          "complexity_metric": "cognitive",
+          "contributors": [
+            {
+              "column": 5,
+              "end_line": 321,
+              "increment": 1,
+              "kind": "match",
+              "line": 299,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 34.78260869565217,
+          "crap": {
+            "risk_level": "low",
+            "value": 3.11
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "count_cognitive_expr",
+            "span": {
+              "end_column": 1,
+              "end_line": 322,
+              "start_column": 1,
+              "start_line": 294
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 4,
+          "complexity_metric": "cognitive",
+          "contributors": [
+            {
+              "column": 5,
+              "end_line": 344,
+              "increment": 1,
+              "kind": "for-loop",
+              "line": 339,
+              "nesting_depth": 0
+            },
+            {
+              "column": 9,
+              "end_line": 342,
+              "increment": 2,
+              "kind": "if-branch",
+              "line": 340,
+              "nesting_depth": 1
+            }
+          ],
+          "coverage_percent": 80.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 4.13
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "count_cognitive_match",
+            "span": {
+              "end_column": 1,
+              "end_line": 346,
+              "start_column": 1,
+              "start_line": 324
             }
           }
         },
@@ -370,159 +557,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "count_cognitive_block",
-            "span": {
-              "end_column": 1,
-              "end_line": 230,
-              "start_column": 1,
-              "start_line": 220
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 7,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 5,
-              "end_line": 260,
-              "increment": 1,
-              "kind": "match",
-              "line": 237,
-              "nesting_depth": 0
-            },
-            {
-              "column": 13,
-              "end_line": 256,
-              "increment": 2,
-              "kind": "if-branch",
-              "line": 241,
-              "nesting_depth": 1
-            },
-            {
-              "column": 17,
-              "end_line": 255,
-              "increment": 3,
-              "kind": "if-branch",
-              "line": 243,
-              "nesting_depth": 2
-            }
-          ],
-          "coverage_percent": 82.6086956521739,
-          "crap": {
-            "risk_level": "low",
-            "value": 7.26
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "count_cognitive_stmt",
-            "span": {
-              "end_column": 1,
-              "end_line": 261,
-              "start_column": 1,
-              "start_line": 232
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 2,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 5,
-              "end_line": 290,
-              "increment": 1,
-              "kind": "match",
-              "line": 268,
-              "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 72.22222222222221,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.09
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "count_cognitive_expr",
-            "span": {
-              "end_column": 1,
-              "end_line": 291,
-              "start_column": 1,
-              "start_line": 263
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 4,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 5,
-              "end_line": 313,
-              "increment": 1,
-              "kind": "for-loop",
-              "line": 308,
-              "nesting_depth": 0
-            },
-            {
-              "column": 9,
-              "end_line": 311,
-              "increment": 2,
-              "kind": "if-branch",
-              "line": 309,
-              "nesting_depth": 1
-            }
-          ],
-          "coverage_percent": 42.10526315789473,
-          "crap": {
-            "risk_level": "low",
-            "value": 7.1
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "count_cognitive_match",
-            "span": {
-              "end_column": 1,
-              "end_line": 315,
-              "start_column": 1,
-              "start_line": 293
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 36.36363636363637,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.26
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
             "qualified_name": "count_cognitive_while",
             "span": {
               "end_column": 1,
-              "end_line": 334,
+              "end_line": 365,
               "start_column": 1,
-              "start_line": 317
+              "start_line": 348
             }
           }
         },
@@ -544,9 +584,9 @@ expression: pretty
             "qualified_name": "count_cognitive_for_loop",
             "span": {
               "end_column": 1,
-              "end_line": 353,
+              "end_line": 384,
               "start_column": 1,
-              "start_line": 336
+              "start_line": 367
             }
           }
         },
@@ -568,57 +608,9 @@ expression: pretty
             "qualified_name": "count_cognitive_loop",
             "span": {
               "end_column": 1,
-              "end_line": 371,
+              "end_line": 402,
               "start_column": 1,
-              "start_line": 355
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 100.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "count_cognitive_binary",
-            "span": {
-              "end_column": 1,
-              "end_line": 385,
-              "start_column": 1,
-              "start_line": 377
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 100.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "count_cognitive_try",
-            "span": {
-              "end_column": 1,
-              "end_line": 401,
-              "start_column": 1,
-              "start_line": 387
+              "start_line": 386
             }
           }
         },
@@ -637,12 +629,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "count_cognitive_break",
+            "qualified_name": "count_cognitive_binary",
             "span": {
               "end_column": 1,
-              "end_line": 417,
+              "end_line": 416,
               "start_column": 1,
-              "start_line": 403
+              "start_line": 408
             }
           }
         },
@@ -661,45 +653,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "count_cognitive_continue",
+            "qualified_name": "count_cognitive_try",
             "span": {
               "end_column": 1,
-              "end_line": 433,
+              "end_line": 432,
               "start_column": 1,
-              "start_line": 419
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 2,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 5,
-              "end_line": 443,
-              "increment": 1,
-              "kind": "match",
-              "line": 440,
-              "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 100.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "count_cognitive_return",
-            "span": {
-              "end_column": 1,
-              "end_line": 444,
-              "start_column": 1,
-              "start_line": 435
+              "start_line": 418
             }
           }
         },
@@ -718,12 +677,36 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "count_cognitive_closure",
+            "qualified_name": "count_cognitive_break",
             "span": {
               "end_column": 1,
-              "end_line": 454,
+              "end_line": 448,
               "start_column": 1,
-              "start_line": 448
+              "start_line": 434
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 90.9090909090909,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "count_cognitive_continue",
+            "span": {
+              "end_column": 1,
+              "end_line": 464,
+              "start_column": 1,
+              "start_line": 450
             }
           }
         },
@@ -737,26 +720,83 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 464,
+              "end_line": 474,
               "increment": 1,
-              "kind": "for-loop",
-              "line": 462,
+              "kind": "match",
+              "line": 471,
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 85.71428571428571,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.01
+            "value": 2.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "count_cognitive_return",
+            "span": {
+              "end_column": 1,
+              "end_line": 475,
+              "start_column": 1,
+              "start_line": 466
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 16.666666666666664,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.58
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "count_cognitive_closure",
+            "span": {
+              "end_column": 1,
+              "end_line": 485,
+              "start_column": 1,
+              "start_line": 479
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 2,
+          "complexity_metric": "cognitive",
+          "contributors": [
+            {
+              "column": 5,
+              "end_line": 495,
+              "increment": 1,
+              "kind": "for-loop",
+              "line": 493,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 57.14285714285714,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.31
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
             "qualified_name": "count_cognitive_call",
             "span": {
               "end_column": 1,
-              "end_line": 466,
+              "end_line": 497,
               "start_column": 1,
-              "start_line": 456
+              "start_line": 487
             }
           }
         },
@@ -770,10 +810,10 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 476,
+              "end_line": 507,
               "increment": 1,
               "kind": "for-loop",
-              "line": 474,
+              "line": 505,
               "nesting_depth": 0
             }
           ],
@@ -787,9 +827,9 @@ expression: pretty
             "qualified_name": "count_cognitive_method_call",
             "span": {
               "end_column": 1,
-              "end_line": 478,
+              "end_line": 509,
               "start_column": 1,
-              "start_line": 468
+              "start_line": 499
             }
           }
         },
@@ -803,26 +843,26 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 488,
+              "end_line": 519,
               "increment": 1,
               "kind": "for-loop",
-              "line": 486,
+              "line": 517,
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 11.11111111111111,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 4.81
+            "value": 2.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
             "qualified_name": "count_cognitive_tuple",
             "span": {
               "end_column": 1,
-              "end_line": 490,
+              "end_line": 521,
               "start_column": 1,
-              "start_line": 480
+              "start_line": 511
             }
           }
         },
@@ -836,42 +876,42 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 542,
+              "end_line": 573,
               "increment": 1,
               "kind": "if-branch",
-              "line": 515,
+              "line": 546,
               "nesting_depth": 0
             },
             {
               "column": 9,
-              "end_line": 541,
+              "end_line": 572,
               "increment": 2,
               "kind": "match",
-              "line": 516,
+              "line": 547,
               "nesting_depth": 1
             },
             {
               "column": 17,
-              "end_line": 532,
+              "end_line": 563,
               "increment": 3,
               "kind": "if-branch",
-              "line": 530,
+              "line": 561,
               "nesting_depth": 2
             }
           ],
-          "coverage_percent": 82.75862068965517,
+          "coverage_percent": 86.66666666666667,
           "crap": {
             "risk_level": "low",
-            "value": 7.25
+            "value": 7.12
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
             "qualified_name": "count_cognitive_if",
             "span": {
               "end_column": 1,
-              "end_line": 545,
+              "end_line": 576,
               "start_column": 1,
-              "start_line": 492
+              "start_line": 523
             }
           }
         },
@@ -885,91 +925,91 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 576,
+              "end_line": 607,
               "increment": 1,
               "kind": "match",
-              "line": 552,
+              "line": 583,
               "nesting_depth": 0
             },
             {
               "column": 13,
-              "end_line": 568,
+              "end_line": 599,
               "increment": 2,
               "kind": "if-branch",
-              "line": 566,
+              "line": 597,
               "nesting_depth": 1
             }
           ],
-          "coverage_percent": 100.0,
+          "coverage_percent": 91.30434782608695,
           "crap": {
             "risk_level": "low",
-            "value": 4.0
+            "value": 4.01
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
             "qualified_name": "count_cognitive_else",
             "span": {
               "end_column": 1,
-              "end_line": 577,
+              "end_line": 608,
               "start_column": 1,
-              "start_line": 547
+              "start_line": 578
             }
           }
         },
         "threshold": 8.0
       },
       {
-        "exceeds": true,
+        "exceeds": false,
         "scored": {
           "complexity": 8,
           "complexity_metric": "cognitive",
           "contributors": [
             {
               "column": 5,
-              "end_line": 589,
+              "end_line": 620,
               "increment": 1,
               "kind": "if-branch",
-              "line": 587,
+              "line": 618,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 614,
+              "end_line": 645,
               "increment": 1,
               "kind": "for-loop",
-              "line": 594,
+              "line": 625,
               "nesting_depth": 0
             },
             {
               "column": 9,
-              "end_line": 613,
+              "end_line": 644,
               "increment": 2,
               "kind": "match",
-              "line": 595,
+              "line": 626,
               "nesting_depth": 1
             },
             {
               "column": 17,
-              "end_line": 607,
+              "end_line": 638,
               "increment": 3,
               "kind": "if-branch",
-              "line": 597,
+              "line": 628,
               "nesting_depth": 2
             }
           ],
-          "coverage_percent": 92.5925925925926,
+          "coverage_percent": 100.0,
           "crap": {
-            "risk_level": "acceptable",
-            "value": 8.03
+            "risk_level": "low",
+            "value": 8.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
             "qualified_name": "count_cognitive_binary_chain",
             "span": {
               "end_column": 1,
-              "end_line": 617,
+              "end_line": 648,
               "start_column": 1,
-              "start_line": 579
+              "start_line": 610
             }
           }
         },
@@ -983,10 +1023,10 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 634,
+              "end_line": 665,
               "increment": 1,
               "kind": "match",
-              "line": 628,
+              "line": 659,
               "nesting_depth": 0
             }
           ],
@@ -1000,9 +1040,9 @@ expression: pretty
             "qualified_name": "count_cognitive_binary_operands",
             "span": {
               "end_column": 1,
-              "end_line": 635,
+              "end_line": 666,
               "start_column": 1,
-              "start_line": 619
+              "start_line": 650
             }
           }
         },
@@ -1016,10 +1056,10 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 649,
+              "end_line": 680,
               "increment": 1,
               "kind": "match",
-              "line": 645,
+              "line": 676,
               "nesting_depth": 0
             }
           ],
@@ -1033,9 +1073,9 @@ expression: pretty
             "qualified_name": "classify_binop",
             "span": {
               "end_column": 1,
-              "end_line": 650,
+              "end_line": 681,
               "start_column": 1,
-              "start_line": 644
+              "start_line": 675
             }
           }
         },
@@ -1049,10 +1089,10 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 660,
+              "end_line": 691,
               "increment": 1,
               "kind": "match",
-              "line": 653,
+              "line": 684,
               "nesting_depth": 0
             }
           ],
@@ -1066,9 +1106,9 @@ expression: pretty
             "qualified_name": "binop_span",
             "span": {
               "end_column": 1,
-              "end_line": 661,
+              "end_line": 692,
               "start_column": 1,
-              "start_line": 652
+              "start_line": 683
             }
           }
         },
@@ -1090,9 +1130,9 @@ expression: pretty
             "qualified_name": "flatten_binary_ops",
             "span": {
               "end_column": 1,
-              "end_line": 671,
+              "end_line": 702,
               "start_column": 1,
-              "start_line": 663
+              "start_line": 694
             }
           }
         },
@@ -1106,10 +1146,10 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 678,
+              "end_line": 709,
               "increment": 1,
               "kind": "if-branch",
-              "line": 674,
+              "line": 705,
               "nesting_depth": 0
             }
           ],
@@ -1123,9 +1163,9 @@ expression: pretty
             "qualified_name": "flatten_binary_ops_inner",
             "span": {
               "end_column": 1,
-              "end_line": 679,
+              "end_line": 710,
               "start_column": 1,
-              "start_line": 673
+              "start_line": 704
             }
           }
         },
@@ -1147,9 +1187,9 @@ expression: pretty
             "qualified_name": "count_cyclomatic_block",
             "span": {
               "end_column": 1,
-              "end_line": 688,
+              "end_line": 719,
               "start_column": 1,
-              "start_line": 683
+              "start_line": 714
             }
           }
         },
@@ -1171,9 +1211,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::count_block",
             "span": {
               "end_column": 5,
-              "end_line": 705,
+              "end_line": 736,
               "start_column": 5,
-              "start_line": 697
+              "start_line": 728
             }
           }
         },
@@ -1195,9 +1235,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::bump",
             "span": {
               "end_column": 5,
-              "end_line": 717,
+              "end_line": 748,
               "start_column": 5,
-              "start_line": 707
+              "start_line": 738
             }
           }
         },
@@ -1219,9 +1259,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::with_nesting",
             "span": {
               "end_column": 5,
-              "end_line": 723,
+              "end_line": 754,
               "start_column": 5,
-              "start_line": 719
+              "start_line": 750
             }
           }
         },
@@ -1235,10 +1275,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 732,
+              "end_line": 763,
               "increment": 1,
               "kind": "match",
-              "line": 728,
+              "line": 759,
               "nesting_depth": 0
             }
           ],
@@ -1252,9 +1292,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::visit_stmt",
             "span": {
               "end_column": 5,
-              "end_line": 733,
+              "end_line": 764,
               "start_column": 5,
-              "start_line": 727
+              "start_line": 758
             }
           }
         },
@@ -1268,18 +1308,18 @@ expression: pretty
           "contributors": [
             {
               "column": 38,
-              "end_line": 738,
+              "end_line": 769,
               "increment": 1,
               "kind": "let-else",
-              "line": 736,
+              "line": 767,
               "nesting_depth": 0
             },
             {
               "column": 9,
-              "end_line": 749,
+              "end_line": 780,
               "increment": 1,
               "kind": "if-branch",
-              "line": 741,
+              "line": 772,
               "nesting_depth": 0
             }
           ],
@@ -1293,9 +1333,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::visit_local",
             "span": {
               "end_column": 5,
-              "end_line": 750,
+              "end_line": 781,
               "start_column": 5,
-              "start_line": 735
+              "start_line": 766
             }
           }
         },
@@ -1309,18 +1349,18 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 770,
+              "end_line": 801,
               "increment": 1,
               "kind": "if-branch",
-              "line": 761,
+              "line": 792,
               "nesting_depth": 0
             },
             {
               "column": 13,
-              "end_line": 769,
+              "end_line": 800,
               "increment": 2,
               "kind": "match",
-              "line": 762,
+              "line": 793,
               "nesting_depth": 1
             }
           ],
@@ -1334,9 +1374,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::visit_expr_if",
             "span": {
               "end_column": 5,
-              "end_line": 771,
+              "end_line": 802,
               "start_column": 5,
-              "start_line": 752
+              "start_line": 783
             }
           }
         },
@@ -1350,18 +1390,18 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 781,
+              "end_line": 812,
               "increment": 1,
               "kind": "for-loop",
-              "line": 774,
+              "line": 805,
               "nesting_depth": 0
             },
             {
               "column": 9,
-              "end_line": 786,
+              "end_line": 817,
               "increment": 1,
               "kind": "for-loop",
-              "line": 784,
+              "line": 815,
               "nesting_depth": 0
             }
           ],
@@ -1375,9 +1415,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::visit_expr_match",
             "span": {
               "end_column": 5,
-              "end_line": 787,
+              "end_line": 818,
               "start_column": 5,
-              "start_line": 773
+              "start_line": 804
             }
           }
         },
@@ -1391,10 +1431,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 792,
+              "end_line": 823,
               "increment": 1,
               "kind": "if-branch",
-              "line": 790,
+              "line": 821,
               "nesting_depth": 0
             }
           ],
@@ -1408,9 +1448,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::visit_arm",
             "span": {
               "end_column": 5,
-              "end_line": 794,
+              "end_line": 825,
               "start_column": 5,
-              "start_line": 789
+              "start_line": 820
             }
           }
         },
@@ -1432,9 +1472,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::visit_expr_while",
             "span": {
               "end_column": 5,
-              "end_line": 805,
+              "end_line": 836,
               "start_column": 5,
-              "start_line": 796
+              "start_line": 827
             }
           }
         },
@@ -1456,9 +1496,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::visit_expr_for_loop",
             "span": {
               "end_column": 5,
-              "end_line": 816,
+              "end_line": 847,
               "start_column": 5,
-              "start_line": 807
+              "start_line": 838
             }
           }
         },
@@ -1480,9 +1520,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::visit_expr_loop",
             "span": {
               "end_column": 5,
-              "end_line": 826,
+              "end_line": 857,
               "start_column": 5,
-              "start_line": 818
+              "start_line": 849
             }
           }
         },
@@ -1496,10 +1536,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 832,
+              "end_line": 863,
               "increment": 1,
               "kind": "if-branch",
-              "line": 829,
+              "line": 860,
               "nesting_depth": 0
             }
           ],
@@ -1511,87 +1551,6 @@ expression: pretty
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
             "qualified_name": "CyclomaticCounter::visit_expr_binary",
-            "span": {
-              "end_column": 5,
-              "end_line": 835,
-              "start_column": 5,
-              "start_line": 828
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 100.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "CyclomaticCounter::visit_expr_try",
-            "span": {
-              "end_column": 5,
-              "end_line": 845,
-              "start_column": 5,
-              "start_line": 837
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 2,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 9,
-              "end_line": 856,
-              "increment": 1,
-              "kind": "if-branch",
-              "line": 854,
-              "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 100.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "CyclomaticCounter::visit_expr_break",
-            "span": {
-              "end_column": 5,
-              "end_line": 857,
-              "start_column": 5,
-              "start_line": 847
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 100.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "CyclomaticCounter::visit_expr_continue",
             "span": {
               "end_column": 5,
               "end_line": 866,
@@ -1615,10 +1574,10 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "CyclomaticCounter::visit_expr_closure",
+            "qualified_name": "CyclomaticCounter::visit_expr_try",
             "span": {
               "end_column": 5,
-              "end_line": 873,
+              "end_line": 876,
               "start_column": 5,
               "start_line": 868
             }
@@ -1629,22 +1588,31 @@ expression: pretty
       {
         "exceeds": false,
         "scored": {
-          "complexity": 1,
+          "complexity": 2,
           "complexity_metric": "cognitive",
-          "contributors": [],
+          "contributors": [
+            {
+              "column": 9,
+              "end_line": 887,
+              "increment": 1,
+              "kind": "if-branch",
+              "line": 885,
+              "nesting_depth": 0
+            }
+          ],
           "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 1.0
+            "value": 2.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "adapter",
+            "qualified_name": "CyclomaticCounter::visit_expr_break",
             "span": {
               "end_column": 5,
-              "end_line": 884,
+              "end_line": 888,
               "start_column": 5,
-              "start_line": 882
+              "start_line": 878
             }
           }
         },
@@ -1663,36 +1631,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "load_fixture",
-            "span": {
-              "end_column": 5,
-              "end_line": 890,
-              "start_column": 5,
-              "start_line": 886
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 100.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "extract_fixture",
+            "qualified_name": "CyclomaticCounter::visit_expr_continue",
             "span": {
               "end_column": 5,
               "end_line": 897,
               "start_column": 5,
-              "start_line": 892
+              "start_line": 890
             }
           }
         },
@@ -1711,10 +1655,10 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "find_fn",
+            "qualified_name": "CyclomaticCounter::visit_expr_closure",
             "span": {
               "end_column": 5,
-              "end_line": 910,
+              "end_line": 904,
               "start_column": 5,
               "start_line": 899
             }
@@ -1735,12 +1679,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "baseline_complexity_is_one_cognitive",
+            "qualified_name": "test_helpers::adapter",
             "span": {
               "end_column": 5,
-              "end_line": 926,
+              "end_line": 915,
               "start_column": 5,
-              "start_line": 921
+              "start_line": 913
             }
           }
         },
@@ -1759,12 +1703,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "baseline_complexity_is_one_cyclomatic",
+            "qualified_name": "test_helpers::load_fixture",
             "span": {
               "end_column": 5,
-              "end_line": 933,
+              "end_line": 921,
               "start_column": 5,
-              "start_line": 928
+              "start_line": 917
             }
           }
         },
@@ -1783,12 +1727,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "top_level_fn_identity",
+            "qualified_name": "test_helpers::extract_fixture",
             "span": {
               "end_column": 5,
-              "end_line": 944,
+              "end_line": 928,
               "start_column": 5,
-              "start_line": 937
+              "start_line": 923
             }
           }
         },
@@ -1807,12 +1751,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "impl_method_qualified_name",
+            "qualified_name": "test_helpers::find_fn",
             "span": {
               "end_column": 5,
-              "end_line": 952,
+              "end_line": 941,
               "start_column": 5,
-              "start_line": 946
+              "start_line": 930
             }
           }
         },
@@ -1831,12 +1775,60 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "span_accuracy",
+            "qualified_name": "tests::baseline_complexity_is_one_cognitive",
+            "span": {
+              "end_column": 5,
+              "end_line": 957,
+              "start_column": 5,
+              "start_line": 952
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "tests::baseline_complexity_is_one_cyclomatic",
+            "span": {
+              "end_column": 5,
+              "end_line": 964,
+              "start_column": 5,
+              "start_line": 959
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "tests::top_level_fn_identity",
             "span": {
               "end_column": 5,
               "end_line": 975,
               "start_column": 5,
-              "start_line": 954
+              "start_line": 968
             }
           }
         },
@@ -1855,10 +1847,10 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "span_carries_one_based_columns",
+            "qualified_name": "tests::impl_method_qualified_name",
             "span": {
               "end_column": 5,
-              "end_line": 996,
+              "end_line": 983,
               "start_column": 5,
               "start_line": 977
             }
@@ -1879,12 +1871,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "columns_are_exact_one_based_offsets_unindented",
+            "qualified_name": "tests::top_level_fn_in_nested_mods_fixture_is_unqualified",
             "span": {
               "end_column": 5,
-              "end_line": 1026,
+              "end_line": 993,
               "start_column": 5,
-              "start_line": 998
+              "start_line": 987
             }
           }
         },
@@ -1903,12 +1895,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "columns_are_exact_one_based_offsets_indented",
+            "qualified_name": "tests::one_level_mod_qualified_name",
             "span": {
               "end_column": 5,
-              "end_line": 1051,
+              "end_line": 999,
               "start_column": 5,
-              "start_line": 1028
+              "start_line": 995
             }
           }
         },
@@ -1927,12 +1919,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "multiple_fns_returns_all",
+            "qualified_name": "tests::multi_level_mod_qualified_name",
             "span": {
               "end_column": 5,
-              "end_line": 1057,
+              "end_line": 1005,
               "start_column": 5,
-              "start_line": 1053
+              "start_line": 1001
             }
           }
         },
@@ -1951,12 +1943,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "async_fn_detected",
+            "qualified_name": "tests::impl_method_inside_mod_prepends_mod_path",
             "span": {
               "end_column": 5,
-              "end_line": 1065,
+              "end_line": 1014,
               "start_column": 5,
-              "start_line": 1059
+              "start_line": 1007
             }
           }
         },
@@ -1975,12 +1967,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "if_else_cognitive",
+            "qualified_name": "tests::nested_fn_inside_mod_is_mod_scoped_not_fn_scoped",
             "span": {
               "end_column": 5,
-              "end_line": 1075,
+              "end_line": 1029,
               "start_column": 5,
-              "start_line": 1069
+              "start_line": 1016
             }
           }
         },
@@ -1999,12 +1991,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "nested_if_cognitive_penalty",
+            "qualified_name": "tests::mod_qualification_does_not_disturb_complexity",
             "span": {
               "end_column": 5,
-              "end_line": 1083,
+              "end_line": 1041,
               "start_column": 5,
-              "start_line": 1077
+              "start_line": 1031
             }
           }
         },
@@ -2023,12 +2015,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "else_is_not_counted_cognitive",
+            "qualified_name": "tests::span_accuracy",
             "span": {
               "end_column": 5,
-              "end_line": 1092,
+              "end_line": 1064,
               "start_column": 5,
-              "start_line": 1085
+              "start_line": 1043
             }
           }
         },
@@ -2047,12 +2039,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "match_flat_cognitive",
+            "qualified_name": "tests::span_carries_one_based_columns",
             "span": {
               "end_column": 5,
-              "end_line": 1100,
+              "end_line": 1085,
               "start_column": 5,
-              "start_line": 1094
+              "start_line": 1066
             }
           }
         },
@@ -2071,12 +2063,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "if_else_cyclomatic",
+            "qualified_name": "tests::columns_are_exact_one_based_offsets_unindented",
             "span": {
               "end_column": 5,
-              "end_line": 1110,
+              "end_line": 1115,
               "start_column": 5,
-              "start_line": 1104
+              "start_line": 1087
             }
           }
         },
@@ -2095,12 +2087,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "nested_if_cyclomatic",
+            "qualified_name": "tests::columns_are_exact_one_based_offsets_indented",
             "span": {
               "end_column": 5,
-              "end_line": 1118,
+              "end_line": 1140,
               "start_column": 5,
-              "start_line": 1112
+              "start_line": 1117
             }
           }
         },
@@ -2119,12 +2111,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "match_arms_cyclomatic",
+            "qualified_name": "tests::multiple_fns_returns_all",
             "span": {
               "end_column": 5,
-              "end_line": 1126,
+              "end_line": 1146,
               "start_column": 5,
-              "start_line": 1120
+              "start_line": 1142
             }
           }
         },
@@ -2143,12 +2135,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "cognitive_gte_cyclomatic_for_nested",
+            "qualified_name": "tests::async_fn_detected",
             "span": {
               "end_column": 5,
-              "end_line": 1139,
+              "end_line": 1154,
               "start_column": 5,
-              "start_line": 1128
+              "start_line": 1148
             }
           }
         },
@@ -2167,12 +2159,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "bool_same_sequence_cognitive",
+            "qualified_name": "tests::if_else_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1149,
+              "end_line": 1164,
               "start_column": 5,
-              "start_line": 1143
+              "start_line": 1158
             }
           }
         },
@@ -2191,12 +2183,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "bool_same_sequence_cyclomatic",
+            "qualified_name": "tests::nested_if_cognitive_penalty",
             "span": {
               "end_column": 5,
-              "end_line": 1157,
+              "end_line": 1172,
               "start_column": 5,
-              "start_line": 1151
+              "start_line": 1166
             }
           }
         },
@@ -2215,60 +2207,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "bool_operator_switch_cognitive",
-            "span": {
-              "end_column": 5,
-              "end_line": 1165,
-              "start_column": 5,
-              "start_line": 1159
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 100.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "bool_operator_switch_cyclomatic",
-            "span": {
-              "end_column": 5,
-              "end_line": 1173,
-              "start_column": 5,
-              "start_line": 1167
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 100.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "bool_in_condition_cognitive",
+            "qualified_name": "tests::else_is_not_counted_cognitive",
             "span": {
               "end_column": 5,
               "end_line": 1181,
               "start_column": 5,
-              "start_line": 1175
+              "start_line": 1174
             }
           }
         },
@@ -2287,7 +2231,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "long_or_chain_cognitive",
+            "qualified_name": "tests::match_flat_cognitive",
             "span": {
               "end_column": 5,
               "end_line": 1189,
@@ -2311,12 +2255,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "alternating_operators_cognitive",
+            "qualified_name": "tests::if_else_cyclomatic",
             "span": {
               "end_column": 5,
-              "end_line": 1197,
+              "end_line": 1199,
               "start_column": 5,
-              "start_line": 1191
+              "start_line": 1193
             }
           }
         },
@@ -2335,10 +2279,10 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "closure_in_parent_cognitive",
+            "qualified_name": "tests::nested_if_cyclomatic",
             "span": {
               "end_column": 5,
-              "end_line": 1210,
+              "end_line": 1207,
               "start_column": 5,
               "start_line": 1201
             }
@@ -2359,12 +2303,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "try_operator_cognitive",
+            "qualified_name": "tests::match_arms_cyclomatic",
             "span": {
               "end_column": 5,
-              "end_line": 1220,
+              "end_line": 1215,
               "start_column": 5,
-              "start_line": 1214
+              "start_line": 1209
             }
           }
         },
@@ -2383,12 +2327,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "try_operator_cyclomatic",
+            "qualified_name": "tests::cognitive_gte_cyclomatic_for_nested",
             "span": {
               "end_column": 5,
               "end_line": 1228,
               "start_column": 5,
-              "start_line": 1222
+              "start_line": 1217
             }
           }
         },
@@ -2407,7 +2351,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "loop_with_break_cognitive",
+            "qualified_name": "tests::bool_same_sequence_cognitive",
             "span": {
               "end_column": 5,
               "end_line": 1238,
@@ -2431,7 +2375,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "loop_with_break_cyclomatic",
+            "qualified_name": "tests::bool_same_sequence_cyclomatic",
             "span": {
               "end_column": 5,
               "end_line": 1246,
@@ -2455,12 +2399,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "let_else_cognitive",
+            "qualified_name": "tests::bool_operator_switch_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1256,
+              "end_line": 1254,
               "start_column": 5,
-              "start_line": 1250
+              "start_line": 1248
             }
           }
         },
@@ -2479,12 +2423,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "let_else_cyclomatic",
+            "qualified_name": "tests::bool_operator_switch_cyclomatic",
             "span": {
               "end_column": 5,
-              "end_line": 1264,
+              "end_line": 1262,
               "start_column": 5,
-              "start_line": 1258
+              "start_line": 1256
             }
           }
         },
@@ -2503,12 +2447,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "chained_try_cognitive",
+            "qualified_name": "tests::bool_in_condition_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1274,
+              "end_line": 1270,
               "start_column": 5,
-              "start_line": 1268
+              "start_line": 1264
             }
           }
         },
@@ -2527,12 +2471,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "chained_try_cyclomatic",
+            "qualified_name": "tests::long_or_chain_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1282,
+              "end_line": 1278,
               "start_column": 5,
-              "start_line": 1276
+              "start_line": 1272
             }
           }
         },
@@ -2551,12 +2495,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "for_iterator_try_cognitive",
+            "qualified_name": "tests::alternating_operators_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1290,
+              "end_line": 1286,
               "start_column": 5,
-              "start_line": 1284
+              "start_line": 1280
             }
           }
         },
@@ -2575,12 +2519,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "for_iterator_try_cyclomatic",
+            "qualified_name": "tests::closure_in_parent_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1298,
+              "end_line": 1299,
               "start_column": 5,
-              "start_line": 1292
+              "start_line": 1290
             }
           }
         },
@@ -2599,12 +2543,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "match_scrutinee_try_cognitive",
+            "qualified_name": "tests::try_operator_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1306,
+              "end_line": 1309,
               "start_column": 5,
-              "start_line": 1300
+              "start_line": 1303
             }
           }
         },
@@ -2623,12 +2567,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "trait_default_method_found",
+            "qualified_name": "tests::try_operator_cyclomatic",
             "span": {
               "end_column": 5,
-              "end_line": 1316,
+              "end_line": 1317,
               "start_column": 5,
-              "start_line": 1310
+              "start_line": 1311
             }
           }
         },
@@ -2647,12 +2591,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "trait_method_without_default_not_found",
+            "qualified_name": "tests::loop_with_break_cognitive",
             "span": {
               "end_column": 5,
               "end_line": 1327,
               "start_column": 5,
-              "start_line": 1318
+              "start_line": 1321
             }
           }
         },
@@ -2661,37 +2605,20 @@ expression: pretty
       {
         "exceeds": false,
         "scored": {
-          "complexity": 3,
+          "complexity": 1,
           "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 9,
-              "end_line": 1362,
-              "increment": 1,
-              "kind": "for-loop",
-              "line": 1356,
-              "nesting_depth": 0
-            },
-            {
-              "column": 9,
-              "end_line": 1369,
-              "increment": 1,
-              "kind": "for-loop",
-              "line": 1363,
-              "nesting_depth": 0
-            }
-          ],
+          "contributors": [],
           "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 3.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "trait_default_and_concrete_override_have_disjoint_spans",
+            "qualified_name": "tests::loop_with_break_cyclomatic",
             "span": {
               "end_column": 5,
-              "end_line": 1370,
+              "end_line": 1335,
               "start_column": 5,
               "start_line": 1329
             }
@@ -2712,12 +2639,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "impl_method_no_branch",
+            "qualified_name": "tests::let_else_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1379,
+              "end_line": 1345,
               "start_column": 5,
-              "start_line": 1374
+              "start_line": 1339
             }
           }
         },
@@ -2736,7 +2663,103 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "impl_method_with_branch",
+            "qualified_name": "tests::let_else_cyclomatic",
+            "span": {
+              "end_column": 5,
+              "end_line": 1353,
+              "start_column": 5,
+              "start_line": 1347
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "tests::chained_try_cognitive",
+            "span": {
+              "end_column": 5,
+              "end_line": 1363,
+              "start_column": 5,
+              "start_line": 1357
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "tests::chained_try_cyclomatic",
+            "span": {
+              "end_column": 5,
+              "end_line": 1371,
+              "start_column": 5,
+              "start_line": 1365
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "tests::for_iterator_try_cognitive",
+            "span": {
+              "end_column": 5,
+              "end_line": 1379,
+              "start_column": 5,
+              "start_line": 1373
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "tests::for_iterator_try_cyclomatic",
             "span": {
               "end_column": 5,
               "end_line": 1387,
@@ -2750,31 +2773,22 @@ expression: pretty
       {
         "exceeds": false,
         "scored": {
-          "complexity": 2,
+          "complexity": 1,
           "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 9,
-              "end_line": 1398,
-              "increment": 1,
-              "kind": "match",
-              "line": 1395,
-              "nesting_depth": 0
-            }
-          ],
+          "contributors": [],
           "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "invalid_source_returns_error",
+            "qualified_name": "tests::match_scrutinee_try_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1399,
+              "end_line": 1395,
               "start_column": 5,
-              "start_line": 1391
+              "start_line": 1389
             }
           }
         },
@@ -2793,12 +2807,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "contributors_for",
+            "qualified_name": "tests::trait_default_method_found",
             "span": {
               "end_column": 5,
-              "end_line": 1416,
+              "end_line": 1405,
               "start_column": 5,
-              "start_line": 1409
+              "start_line": 1399
             }
           }
         },
@@ -2807,29 +2821,61 @@ expression: pretty
       {
         "exceeds": false,
         "scored": {
-          "complexity": 2,
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "tests::trait_method_without_default_not_found",
+            "span": {
+              "end_column": 5,
+              "end_line": 1416,
+              "start_column": 5,
+              "start_line": 1407
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 3,
           "complexity_metric": "cognitive",
           "contributors": [
             {
               "column": 9,
-              "end_line": 1428,
+              "end_line": 1451,
               "increment": 1,
               "kind": "for-loop",
-              "line": 1420,
+              "line": 1445,
+              "nesting_depth": 0
+            },
+            {
+              "column": 9,
+              "end_line": 1458,
+              "increment": 1,
+              "kind": "for-loop",
+              "line": 1452,
               "nesting_depth": 0
             }
           ],
           "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 3.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "base_fn_empty_contributors",
+            "qualified_name": "tests::trait_default_and_concrete_override_have_disjoint_spans",
             "span": {
               "end_column": 5,
-              "end_line": 1429,
+              "end_line": 1459,
               "start_column": 5,
               "start_line": 1418
             }
@@ -2850,12 +2896,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "if_branch_contributor_cognitive",
+            "qualified_name": "tests::impl_method_no_branch",
             "span": {
               "end_column": 5,
-              "end_line": 1438,
+              "end_line": 1468,
               "start_column": 5,
-              "start_line": 1431
+              "start_line": 1463
             }
           }
         },
@@ -2874,36 +2920,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "nested_if_nesting_increment",
+            "qualified_name": "tests::impl_method_with_branch",
             "span": {
               "end_column": 5,
-              "end_line": 1450,
+              "end_line": 1476,
               "start_column": 5,
-              "start_line": 1440
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 100.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "match_contributor_cognitive",
-            "span": {
-              "end_column": 5,
-              "end_line": 1459,
-              "start_column": 5,
-              "start_line": 1452
+              "start_line": 1470
             }
           }
         },
@@ -2917,10 +2939,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 1474,
+              "end_line": 1487,
               "increment": 1,
-              "kind": "for-loop",
-              "line": 1472,
+              "kind": "match",
+              "line": 1484,
               "nesting_depth": 0
             }
           ],
@@ -2931,12 +2953,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "match_arm_contributor_cyclomatic",
+            "qualified_name": "tests::invalid_source_returns_error",
             "span": {
               "end_column": 5,
-              "end_line": 1475,
+              "end_line": 1488,
               "start_column": 5,
-              "start_line": 1461
+              "start_line": 1480
             }
           }
         },
@@ -2955,12 +2977,45 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "try_contributor_cognitive",
+            "qualified_name": "contributor_tests::contributors_for",
             "span": {
               "end_column": 5,
-              "end_line": 1483,
+              "end_line": 1505,
               "start_column": 5,
-              "start_line": 1477
+              "start_line": 1498
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 2,
+          "complexity_metric": "cognitive",
+          "contributors": [
+            {
+              "column": 9,
+              "end_line": 1517,
+              "increment": 1,
+              "kind": "for-loop",
+              "line": 1509,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "contributor_tests::base_fn_empty_contributors",
+            "span": {
+              "end_column": 5,
+              "end_line": 1518,
+              "start_column": 5,
+              "start_line": 1507
             }
           }
         },
@@ -2979,12 +3034,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "try_contributor_cyclomatic",
+            "qualified_name": "contributor_tests::if_branch_contributor_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1491,
+              "end_line": 1527,
               "start_column": 5,
-              "start_line": 1485
+              "start_line": 1520
             }
           }
         },
@@ -3003,132 +3058,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "let_else_contributor_cognitive",
-            "span": {
-              "end_column": 5,
-              "end_line": 1499,
-              "start_column": 5,
-              "start_line": 1493
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 100.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "let_else_contributor_cyclomatic",
-            "span": {
-              "end_column": 5,
-              "end_line": 1507,
-              "start_column": 5,
-              "start_line": 1501
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 100.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "loop_contributor_cognitive",
-            "span": {
-              "end_column": 5,
-              "end_line": 1515,
-              "start_column": 5,
-              "start_line": 1509
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 100.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "for_loop_contributor_cognitive",
-            "span": {
-              "end_column": 5,
-              "end_line": 1523,
-              "start_column": 5,
-              "start_line": 1517
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 100.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "for_loop_contributor_cyclomatic",
-            "span": {
-              "end_column": 5,
-              "end_line": 1531,
-              "start_column": 5,
-              "start_line": 1525
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 100.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "while_loop_contributor_cognitive",
+            "qualified_name": "contributor_tests::nested_if_nesting_increment",
             "span": {
               "end_column": 5,
               "end_line": 1539,
               "start_column": 5,
-              "start_line": 1533
+              "start_line": 1529
             }
           }
         },
@@ -3147,10 +3082,10 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "while_loop_contributor_cyclomatic",
+            "qualified_name": "contributor_tests::match_contributor_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1547,
+              "end_line": 1548,
               "start_column": 5,
               "start_line": 1541
             }
@@ -3161,46 +3096,31 @@ expression: pretty
       {
         "exceeds": false,
         "scored": {
-          "complexity": 1,
+          "complexity": 2,
           "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 100.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "logical_operator_same_chain_cognitive",
-            "span": {
-              "end_column": 5,
+          "contributors": [
+            {
+              "column": 9,
               "end_line": 1563,
-              "start_column": 5,
-              "start_line": 1549
+              "increment": 1,
+              "kind": "for-loop",
+              "line": 1561,
+              "nesting_depth": 0
             }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
+          ],
           "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 1.0
+            "value": 2.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "logical_operator_switch_cognitive",
+            "qualified_name": "contributor_tests::match_arm_contributor_cyclomatic",
             "span": {
               "end_column": 5,
-              "end_line": 1578,
+              "end_line": 1564,
               "start_column": 5,
-              "start_line": 1565
+              "start_line": 1550
             }
           }
         },
@@ -3219,12 +3139,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "break_contributor",
+            "qualified_name": "contributor_tests::try_contributor_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1591,
+              "end_line": 1572,
               "start_column": 5,
-              "start_line": 1580
+              "start_line": 1566
             }
           }
         },
@@ -3243,12 +3163,84 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "continue_contributor",
+            "qualified_name": "contributor_tests::try_contributor_cyclomatic",
+            "span": {
+              "end_column": 5,
+              "end_line": 1580,
+              "start_column": 5,
+              "start_line": 1574
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "contributor_tests::let_else_contributor_cognitive",
+            "span": {
+              "end_column": 5,
+              "end_line": 1588,
+              "start_column": 5,
+              "start_line": 1582
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "contributor_tests::let_else_contributor_cyclomatic",
+            "span": {
+              "end_column": 5,
+              "end_line": 1596,
+              "start_column": 5,
+              "start_line": 1590
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "contributor_tests::loop_contributor_cognitive",
             "span": {
               "end_column": 5,
               "end_line": 1604,
               "start_column": 5,
-              "start_line": 1593
+              "start_line": 1598
             }
           }
         },
@@ -3267,10 +3259,10 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "unsafe_block_produces_no_unsafe_contributor",
+            "qualified_name": "contributor_tests::for_loop_contributor_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1632,
+              "end_line": 1612,
               "start_column": 5,
               "start_line": 1606
             }
@@ -3291,12 +3283,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "closure_no_contributor",
+            "qualified_name": "contributor_tests::for_loop_contributor_cyclomatic",
             "span": {
               "end_column": 5,
-              "end_line": 1644,
+              "end_line": 1620,
               "start_column": 5,
-              "start_line": 1634
+              "start_line": 1614
             }
           }
         },
@@ -3315,12 +3307,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "nested_if_records_construct_end_line_and_nesting_depth_cognitive",
+            "qualified_name": "contributor_tests::while_loop_contributor_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1677,
+              "end_line": 1628,
               "start_column": 5,
-              "start_line": 1648
+              "start_line": 1622
             }
           }
         },
@@ -3339,12 +3331,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "try_records_token_span_for_atomic_contributor",
+            "qualified_name": "contributor_tests::while_loop_contributor_cyclomatic",
             "span": {
               "end_column": 5,
-              "end_line": 1691,
+              "end_line": 1636,
               "start_column": 5,
-              "start_line": 1679
+              "start_line": 1630
             }
           }
         },
@@ -3363,12 +3355,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "for_with_continue_threads_nesting_depth_cognitive",
+            "qualified_name": "contributor_tests::logical_operator_same_chain_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1713,
+              "end_line": 1652,
               "start_column": 5,
-              "start_line": 1693
+              "start_line": 1638
             }
           }
         },
@@ -3387,12 +3379,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "nested_if_records_nesting_depth_cyclomatic",
+            "qualified_name": "contributor_tests::logical_operator_switch_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1732,
+              "end_line": 1667,
               "start_column": 5,
-              "start_line": 1715
+              "start_line": 1654
             }
           }
         },
@@ -3411,12 +3403,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "for_with_continue_records_nesting_depth_cyclomatic",
+            "qualified_name": "contributor_tests::break_contributor",
             "span": {
               "end_column": 5,
-              "end_line": 1752,
+              "end_line": 1680,
               "start_column": 5,
-              "start_line": 1734
+              "start_line": 1669
             }
           }
         },
@@ -3435,12 +3427,204 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "match_records_end_line_covering_arms_cognitive",
+            "qualified_name": "contributor_tests::continue_contributor",
             "span": {
               "end_column": 5,
-              "end_line": 1771,
+              "end_line": 1693,
               "start_column": 5,
-              "start_line": 1754
+              "start_line": 1682
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "contributor_tests::unsafe_block_produces_no_unsafe_contributor",
+            "span": {
+              "end_column": 5,
+              "end_line": 1721,
+              "start_column": 5,
+              "start_line": 1695
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "contributor_tests::closure_no_contributor",
+            "span": {
+              "end_column": 5,
+              "end_line": 1733,
+              "start_column": 5,
+              "start_line": 1723
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "contributor_tests::nested_if_records_construct_end_line_and_nesting_depth_cognitive",
+            "span": {
+              "end_column": 5,
+              "end_line": 1766,
+              "start_column": 5,
+              "start_line": 1737
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "contributor_tests::try_records_token_span_for_atomic_contributor",
+            "span": {
+              "end_column": 5,
+              "end_line": 1780,
+              "start_column": 5,
+              "start_line": 1768
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "contributor_tests::for_with_continue_threads_nesting_depth_cognitive",
+            "span": {
+              "end_column": 5,
+              "end_line": 1802,
+              "start_column": 5,
+              "start_line": 1782
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "contributor_tests::nested_if_records_nesting_depth_cyclomatic",
+            "span": {
+              "end_column": 5,
+              "end_line": 1821,
+              "start_column": 5,
+              "start_line": 1804
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "contributor_tests::for_with_continue_records_nesting_depth_cyclomatic",
+            "span": {
+              "end_column": 5,
+              "end_line": 1841,
+              "start_column": 5,
+              "start_line": 1823
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "contributor_tests::match_records_end_line_covering_arms_cognitive",
+            "span": {
+              "end_column": 5,
+              "end_line": 1860,
+              "start_column": 5,
+              "start_line": 1843
             }
           }
         },
@@ -3454,10 +3638,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 1791,
+              "end_line": 1880,
               "increment": 1,
               "kind": "for-loop",
-              "line": 1782,
+              "line": 1871,
               "nesting_depth": 0
             }
           ],
@@ -3468,12 +3652,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "contributors_sorted_by_line",
+            "qualified_name": "contributor_tests::contributors_sorted_by_line",
             "span": {
               "end_column": 5,
-              "end_line": 1792,
+              "end_line": 1881,
               "start_column": 5,
-              "start_line": 1773
+              "start_line": 1862
             }
           }
         },
@@ -4403,7 +4587,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "parser",
+            "qualified_name": "tests::parser",
             "span": {
               "end_column": 5,
               "end_line": 453,
@@ -4427,7 +4611,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "parse",
+            "qualified_name": "tests::parse",
             "span": {
               "end_column": 5,
               "end_line": 457,
@@ -4451,7 +4635,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "empty_input_returns_empty_output",
+            "qualified_name": "tests::empty_input_returns_empty_output",
             "span": {
               "end_column": 5,
               "end_line": 464,
@@ -4475,7 +4659,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "validate_str",
+            "qualified_name": "tests::validate_str",
             "span": {
               "end_column": 5,
               "end_line": 478,
@@ -4499,7 +4683,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "validate_empty_input_rejected",
+            "qualified_name": "tests::validate_empty_input_rejected",
             "span": {
               "end_column": 5,
               "end_line": 483,
@@ -4523,7 +4707,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "validate_no_da_lines_rejected",
+            "qualified_name": "tests::validate_no_da_lines_rejected",
             "span": {
               "end_column": 5,
               "end_line": 488,
@@ -4547,7 +4731,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "validate_da_outside_sf_block_rejected",
+            "qualified_name": "tests::validate_da_outside_sf_block_rejected",
             "span": {
               "end_column": 5,
               "end_line": 493,
@@ -4571,7 +4755,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "validate_malformed_da_rejected",
+            "qualified_name": "tests::validate_malformed_da_rejected",
             "span": {
               "end_column": 5,
               "end_line": 498,
@@ -4595,7 +4779,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "validate_single_da_inside_sf_block_passes",
+            "qualified_name": "tests::validate_single_da_inside_sf_block_passes",
             "span": {
               "end_column": 5,
               "end_line": 503,
@@ -4619,7 +4803,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "validate_first_da_in_second_block_passes",
+            "qualified_name": "tests::validate_first_da_in_second_block_passes",
             "span": {
               "end_column": 5,
               "end_line": 513,
@@ -4643,7 +4827,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "validate_missing_path_returns_open_error",
+            "qualified_name": "tests::validate_missing_path_returns_open_error",
             "span": {
               "end_column": 5,
               "end_line": 525,
@@ -4667,7 +4851,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "single_file_single_da",
+            "qualified_name": "tests::single_file_single_da",
             "span": {
               "end_column": 5,
               "end_line": 535,
@@ -4691,7 +4875,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "multiple_da_lines",
+            "qualified_name": "tests::multiple_da_lines",
             "span": {
               "end_column": 5,
               "end_line": 545,
@@ -4715,7 +4899,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "multiple_source_files",
+            "qualified_name": "tests::multiple_source_files",
             "span": {
               "end_column": 5,
               "end_line": 554,
@@ -4739,7 +4923,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "hit_count_preservation",
+            "qualified_name": "tests::hit_count_preservation",
             "span": {
               "end_column": 5,
               "end_line": 562,
@@ -4763,7 +4947,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "path_normalization_strips_prefix",
+            "qualified_name": "tests::path_normalization_strips_prefix",
             "span": {
               "end_column": 5,
               "end_line": 568,
@@ -4787,7 +4971,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "non_matching_path_passes_through",
+            "qualified_name": "tests::non_matching_path_passes_through",
             "span": {
               "end_column": 5,
               "end_line": 574,
@@ -4811,7 +4995,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "backslash_normalized_to_forward_slash",
+            "qualified_name": "tests::backslash_normalized_to_forward_slash",
             "span": {
               "end_column": 5,
               "end_line": 581,
@@ -4835,7 +5019,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "path_boundary_not_confused_by_prefix_substring",
+            "qualified_name": "tests::path_boundary_not_confused_by_prefix_substring",
             "span": {
               "end_column": 5,
               "end_line": 587,
@@ -4859,7 +5043,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "parentdir_sf_path_does_not_take_fast_path_is_file_probe",
+            "qualified_name": "tests::parentdir_sf_path_does_not_take_fast_path_is_file_probe",
             "span": {
               "end_column": 5,
               "end_line": 622,
@@ -4883,7 +5067,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "repeated_sf_blocks_merge_coverage",
+            "qualified_name": "tests::repeated_sf_blocks_merge_coverage",
             "span": {
               "end_column": 5,
               "end_line": 636,
@@ -4907,7 +5091,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "duplicate_da_lines_sum_hits",
+            "qualified_name": "tests::duplicate_da_lines_sum_hits",
             "span": {
               "end_column": 5,
               "end_line": 645,
@@ -4931,7 +5115,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "duplicate_da_multiple_lines_sum_correctly",
+            "qualified_name": "tests::duplicate_da_multiple_lines_sum_correctly",
             "span": {
               "end_column": 5,
               "end_line": 657,
@@ -4964,7 +5148,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "malformed_da_produces_diagnostic",
+            "qualified_name": "tests::malformed_da_produces_diagnostic",
             "span": {
               "end_column": 5,
               "end_line": 674,
@@ -4988,7 +5172,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "malformed_da_does_not_stop_parsing",
+            "qualified_name": "tests::malformed_da_does_not_stop_parsing",
             "span": {
               "end_column": 5,
               "end_line": 682,
@@ -5012,7 +5196,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "da_missing_hit_count_is_malformed",
+            "qualified_name": "tests::da_missing_hit_count_is_malformed",
             "span": {
               "end_column": 5,
               "end_line": 692,
@@ -5036,7 +5220,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "da_negative_hit_count_is_malformed",
+            "qualified_name": "tests::da_negative_hit_count_is_malformed",
             "span": {
               "end_column": 5,
               "end_line": 702,
@@ -5069,7 +5253,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "da_line_zero_is_malformed",
+            "qualified_name": "tests::da_line_zero_is_malformed",
             "span": {
               "end_column": 5,
               "end_line": 718,
@@ -5093,7 +5277,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "end_of_record_is_ignored",
+            "qualified_name": "tests::end_of_record_is_ignored",
             "span": {
               "end_column": 5,
               "end_line": 729,
@@ -5117,7 +5301,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "unterminated_final_block_emits_data",
+            "qualified_name": "tests::unterminated_final_block_emits_data",
             "span": {
               "end_column": 5,
               "end_line": 736,
@@ -5141,7 +5325,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "empty_sf_path_emits_diagnostic",
+            "qualified_name": "tests::empty_sf_path_emits_diagnostic",
             "span": {
               "end_column": 5,
               "end_line": 747,
@@ -5165,7 +5349,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "da_with_checksum_field_is_accepted",
+            "qualified_name": "tests::da_with_checksum_field_is_accepted",
             "span": {
               "end_column": 5,
               "end_line": 756,
@@ -5189,7 +5373,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "non_coverage_records_are_ignored",
+            "qualified_name": "tests::non_coverage_records_are_ignored",
             "span": {
               "end_column": 5,
               "end_line": 770,
@@ -5213,7 +5397,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "brda_and_da_records_parsed",
+            "qualified_name": "tests::brda_and_da_records_parsed",
             "span": {
               "end_column": 5,
               "end_line": 782,
@@ -5237,7 +5421,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "brda_dash_maps_to_none",
+            "qualified_name": "tests::brda_dash_maps_to_none",
             "span": {
               "end_column": 5,
               "end_line": 789,
@@ -5261,7 +5445,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "brda_numeric_maps_to_some",
+            "qualified_name": "tests::brda_numeric_maps_to_some",
             "span": {
               "end_column": 5,
               "end_line": 796,
@@ -5285,7 +5469,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "brda_zero_maps_to_some_zero",
+            "qualified_name": "tests::brda_zero_maps_to_some_zero",
             "span": {
               "end_column": 5,
               "end_line": 803,
@@ -5309,7 +5493,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "duplicate_brda_sum_taken",
+            "qualified_name": "tests::duplicate_brda_sum_taken",
             "span": {
               "end_column": 5,
               "end_line": 813,
@@ -5333,7 +5517,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "brda_dash_and_numeric_merge",
+            "qualified_name": "tests::brda_dash_and_numeric_merge",
             "span": {
               "end_column": 5,
               "end_line": 821,
@@ -5366,7 +5550,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "malformed_brda_produces_diagnostic",
+            "qualified_name": "tests::malformed_brda_produces_diagnostic",
             "span": {
               "end_column": 5,
               "end_line": 837,
@@ -5390,7 +5574,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "brda_missing_fields_is_malformed",
+            "qualified_name": "tests::brda_missing_fields_is_malformed",
             "span": {
               "end_column": 5,
               "end_line": 848,
@@ -5414,7 +5598,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "brda_missing_taken_is_malformed",
+            "qualified_name": "tests::brda_missing_taken_is_malformed",
             "span": {
               "end_column": 5,
               "end_line": 859,
@@ -5447,7 +5631,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "repeated_sf_blocks_merge_branch_coverage",
+            "qualified_name": "tests::repeated_sf_blocks_merge_branch_coverage",
             "span": {
               "end_column": 5,
               "end_line": 888,
@@ -5471,7 +5655,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "brda_line_zero_is_malformed",
+            "qualified_name": "tests::brda_line_zero_is_malformed",
             "span": {
               "end_column": 5,
               "end_line": 898,
@@ -5495,7 +5679,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "no_brda_produces_none_branches",
+            "qualified_name": "tests::no_brda_produces_none_branches",
             "span": {
               "end_column": 5,
               "end_line": 904,
@@ -5519,7 +5703,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "arb_da_line",
+            "qualified_name": "proptests::arb_da_line",
             "span": {
               "end_column": 5,
               "end_line": 914,
@@ -5552,7 +5736,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "arb_lcov_block",
+            "qualified_name": "proptests::arb_lcov_block",
             "span": {
               "end_column": 5,
               "end_line": 926,
@@ -5576,7 +5760,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "arb_lcov_input",
+            "qualified_name": "proptests::arb_lcov_input",
             "span": {
               "end_column": 5,
               "end_line": 930,
@@ -5600,7 +5784,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/mod.rs",
-            "qualified_name": "load",
+            "qualified_name": "baseline::load",
             "span": {
               "end_column": 5,
               "end_line": 55,
@@ -5624,7 +5808,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/mod.rs",
-            "qualified_name": "format_json",
+            "qualified_name": "reporters::format_json",
             "span": {
               "end_column": 5,
               "end_line": 85,
@@ -5705,7 +5889,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "parse_diagnostic.rs",
-            "qualified_name": "parse_diagnostic_display_malformed_record",
+            "qualified_name": "tests::parse_diagnostic_display_malformed_record",
             "span": {
               "end_column": 5,
               "end_line": 63,
@@ -5729,7 +5913,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "parse_diagnostic.rs",
-            "qualified_name": "parse_diagnostic_display_empty_source_file",
+            "qualified_name": "tests::parse_diagnostic_display_empty_source_file",
             "span": {
               "end_column": 5,
               "end_line": 69,
@@ -5753,7 +5937,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "parse_diagnostic.rs",
-            "qualified_name": "parse_diagnostic_serde_round_trip",
+            "qualified_name": "tests::parse_diagnostic_serde_round_trip",
             "span": {
               "end_column": 5,
               "end_line": 80,
@@ -5767,16 +5951,16 @@ expression: pretty
     ],
     "passed": false,
     "summary": {
-      "average_complexity": 1.5658536585365854,
-      "average_coverage": 94.8358552536385,
-      "average_crap": 1.6449268292682926,
+      "average_complexity": 1.5352112676056338,
+      "average_coverage": 94.86902385796895,
+      "average_crap": 1.5938967136150233,
       "distribution": {
-        "acceptable": 3,
+        "acceptable": 2,
         "high": 0,
-        "low": 202,
+        "low": 211,
         "moderate": 0
       },
-      "exceeding_threshold": 3,
+      "exceeding_threshold": 2,
       "max_complexity": 11,
       "max_crap": {
         "risk_level": "acceptable",
@@ -5787,7 +5971,7 @@ expression: pretty
       "median_crap": 1.0,
       "min_coverage": 0.0,
       "total_files": 5,
-      "total_functions": 205,
+      "total_functions": 213,
       "worst_function": {
         "file_path": "adapters/coverage/mod.rs",
         "qualified_name": "parse_brda",
@@ -5805,7 +5989,7 @@ expression: pretty
   "timestamp": "[STRIPPED:timestamp]",
   "tool_version": "[STRIPPED:tool_version]",
   "view": {
-    "eligible_count": 205,
+    "eligible_count": 213,
     "grouped": null,
     "shown": [
       {
@@ -5995,57 +6179,57 @@ expression: pretty
         "threshold": 8.0
       },
       {
-        "exceeds": true,
+        "exceeds": false,
         "scored": {
           "complexity": 8,
           "complexity_metric": "cognitive",
           "contributors": [
             {
               "column": 5,
-              "end_line": 589,
+              "end_line": 620,
               "increment": 1,
               "kind": "if-branch",
-              "line": 587,
+              "line": 618,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 614,
+              "end_line": 645,
               "increment": 1,
               "kind": "for-loop",
-              "line": 594,
+              "line": 625,
               "nesting_depth": 0
             },
             {
               "column": 9,
-              "end_line": 613,
+              "end_line": 644,
               "increment": 2,
               "kind": "match",
-              "line": 595,
+              "line": 626,
               "nesting_depth": 1
             },
             {
               "column": 17,
-              "end_line": 607,
+              "end_line": 638,
               "increment": 3,
               "kind": "if-branch",
-              "line": 597,
+              "line": 628,
               "nesting_depth": 2
             }
           ],
-          "coverage_percent": 92.5925925925926,
+          "coverage_percent": 100.0,
           "crap": {
-            "risk_level": "acceptable",
-            "value": 8.03
+            "risk_level": "low",
+            "value": 8.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
             "qualified_name": "count_cognitive_binary_chain",
             "span": {
               "end_column": 1,
-              "end_line": 617,
+              "end_line": 648,
               "start_column": 1,
-              "start_line": 579
+              "start_line": 610
             }
           }
         },
@@ -6124,42 +6308,42 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 260,
+              "end_line": 291,
               "increment": 1,
               "kind": "match",
-              "line": 237,
+              "line": 268,
               "nesting_depth": 0
             },
             {
               "column": 13,
-              "end_line": 256,
+              "end_line": 287,
               "increment": 2,
               "kind": "if-branch",
-              "line": 241,
+              "line": 272,
               "nesting_depth": 1
             },
             {
               "column": 17,
-              "end_line": 255,
+              "end_line": 286,
               "increment": 3,
               "kind": "if-branch",
-              "line": 243,
+              "line": 274,
               "nesting_depth": 2
             }
           ],
-          "coverage_percent": 82.6086956521739,
+          "coverage_percent": 73.68421052631578,
           "crap": {
             "risk_level": "low",
-            "value": 7.26
+            "value": 7.89
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
             "qualified_name": "count_cognitive_stmt",
             "span": {
               "end_column": 1,
-              "end_line": 261,
+              "end_line": 292,
               "start_column": 1,
-              "start_line": 232
+              "start_line": 263
             }
           }
         },
@@ -6173,83 +6357,42 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 542,
+              "end_line": 573,
               "increment": 1,
               "kind": "if-branch",
-              "line": 515,
+              "line": 546,
               "nesting_depth": 0
             },
             {
               "column": 9,
-              "end_line": 541,
+              "end_line": 572,
               "increment": 2,
               "kind": "match",
-              "line": 516,
+              "line": 547,
               "nesting_depth": 1
             },
             {
               "column": 17,
-              "end_line": 532,
+              "end_line": 563,
               "increment": 3,
               "kind": "if-branch",
-              "line": 530,
+              "line": 561,
               "nesting_depth": 2
             }
           ],
-          "coverage_percent": 82.75862068965517,
+          "coverage_percent": 86.66666666666667,
           "crap": {
             "risk_level": "low",
-            "value": 7.25
+            "value": 7.12
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
             "qualified_name": "count_cognitive_if",
             "span": {
               "end_column": 1,
-              "end_line": 545,
+              "end_line": 576,
               "start_column": 1,
-              "start_line": 492
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 4,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 5,
-              "end_line": 313,
-              "increment": 1,
-              "kind": "for-loop",
-              "line": 308,
-              "nesting_depth": 0
-            },
-            {
-              "column": 9,
-              "end_line": 311,
-              "increment": 2,
-              "kind": "if-branch",
-              "line": 309,
-              "nesting_depth": 1
-            }
-          ],
-          "coverage_percent": 42.10526315789473,
-          "crap": {
-            "risk_level": "low",
-            "value": 7.1
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "count_cognitive_match",
-            "span": {
-              "end_column": 1,
-              "end_line": 315,
-              "start_column": 1,
-              "start_line": 293
+              "start_line": 523
             }
           }
         },
@@ -6356,72 +6499,39 @@ expression: pretty
       {
         "exceeds": false,
         "scored": {
-          "complexity": 2,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 5,
-              "end_line": 488,
-              "increment": 1,
-              "kind": "for-loop",
-              "line": 486,
-              "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 11.11111111111111,
-          "crap": {
-            "risk_level": "low",
-            "value": 4.81
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "count_cognitive_tuple",
-            "span": {
-              "end_column": 1,
-              "end_line": 490,
-              "start_column": 1,
-              "start_line": 480
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
           "complexity": 4,
           "complexity_metric": "cognitive",
           "contributors": [
             {
-              "column": 9,
-              "end_line": 125,
+              "column": 5,
+              "end_line": 344,
               "increment": 1,
-              "kind": "if-branch",
-              "line": 108,
+              "kind": "for-loop",
+              "line": 339,
               "nesting_depth": 0
             },
             {
-              "column": 29,
-              "end_line": 113,
+              "column": 9,
+              "end_line": 342,
               "increment": 2,
-              "kind": "match",
-              "line": 110,
+              "kind": "if-branch",
+              "line": 340,
               "nesting_depth": 1
             }
           ],
-          "coverage_percent": 94.73684210526316,
+          "coverage_percent": 80.0,
           "crap": {
             "risk_level": "low",
-            "value": 4.0
+            "value": 4.13
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "FunctionFinder::visit_trait_item_fn",
+            "qualified_name": "count_cognitive_match",
             "span": {
-              "end_column": 5,
-              "end_line": 128,
-              "start_column": 5,
-              "start_line": 106
+              "end_column": 1,
+              "end_line": 346,
+              "start_column": 1,
+              "start_line": 324
             }
           }
         },
@@ -6435,34 +6545,34 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 576,
+              "end_line": 607,
               "increment": 1,
               "kind": "match",
-              "line": 552,
+              "line": 583,
               "nesting_depth": 0
             },
             {
               "column": 13,
-              "end_line": 568,
+              "end_line": 599,
               "increment": 2,
               "kind": "if-branch",
-              "line": 566,
+              "line": 597,
               "nesting_depth": 1
             }
           ],
-          "coverage_percent": 100.0,
+          "coverage_percent": 91.30434782608695,
           "crap": {
             "risk_level": "low",
-            "value": 4.0
+            "value": 4.01
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
             "qualified_name": "count_cognitive_else",
             "span": {
               "end_column": 1,
-              "end_line": 577,
+              "end_line": 608,
               "start_column": 1,
-              "start_line": 547
+              "start_line": 578
             }
           }
         },
@@ -6476,18 +6586,18 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 770,
+              "end_line": 801,
               "increment": 1,
               "kind": "if-branch",
-              "line": 761,
+              "line": 792,
               "nesting_depth": 0
             },
             {
               "column": 13,
-              "end_line": 769,
+              "end_line": 800,
               "increment": 2,
               "kind": "match",
-              "line": 762,
+              "line": 793,
               "nesting_depth": 1
             }
           ],
@@ -6501,9 +6611,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::visit_expr_if",
             "span": {
               "end_column": 5,
-              "end_line": 771,
+              "end_line": 802,
               "start_column": 5,
-              "start_line": 752
+              "start_line": 783
             }
           }
         },
@@ -6610,39 +6720,72 @@ expression: pretty
       {
         "exceeds": false,
         "scored": {
+          "complexity": 2,
+          "complexity_metric": "cognitive",
+          "contributors": [
+            {
+              "column": 5,
+              "end_line": 321,
+              "increment": 1,
+              "kind": "match",
+              "line": 299,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 34.78260869565217,
+          "crap": {
+            "risk_level": "low",
+            "value": 3.11
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "count_cognitive_expr",
+            "span": {
+              "end_column": 1,
+              "end_line": 322,
+              "start_column": 1,
+              "start_line": 294
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
           "complexity": 3,
           "complexity_metric": "cognitive",
           "contributors": [
             {
               "column": 5,
-              "end_line": 198,
+              "end_line": 229,
               "increment": 1,
               "kind": "if-branch",
-              "line": 194,
+              "line": 225,
               "nesting_depth": 0
             },
             {
               "column": 9,
-              "end_line": 195,
+              "end_line": 226,
               "increment": 1,
               "kind": "logical-operator",
-              "line": 195,
+              "line": 226,
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 71.42857142857143,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 3.21
+            "value": 3.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
             "qualified_name": "extract_type_name",
             "span": {
               "end_column": 1,
-              "end_line": 201,
+              "end_line": 232,
               "start_column": 1,
-              "start_line": 192
+              "start_line": 223
             }
           }
         },
@@ -6656,18 +6799,18 @@ expression: pretty
           "contributors": [
             {
               "column": 38,
-              "end_line": 738,
+              "end_line": 769,
               "increment": 1,
               "kind": "let-else",
-              "line": 736,
+              "line": 767,
               "nesting_depth": 0
             },
             {
               "column": 9,
-              "end_line": 749,
+              "end_line": 780,
               "increment": 1,
               "kind": "if-branch",
-              "line": 741,
+              "line": 772,
               "nesting_depth": 0
             }
           ],
@@ -6681,9 +6824,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::visit_local",
             "span": {
               "end_column": 5,
-              "end_line": 750,
+              "end_line": 781,
               "start_column": 5,
-              "start_line": 735
+              "start_line": 766
             }
           }
         },
@@ -6697,18 +6840,18 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 781,
+              "end_line": 812,
               "increment": 1,
               "kind": "for-loop",
-              "line": 774,
+              "line": 805,
               "nesting_depth": 0
             },
             {
               "column": 9,
-              "end_line": 786,
+              "end_line": 817,
               "increment": 1,
               "kind": "for-loop",
-              "line": 784,
+              "line": 815,
               "nesting_depth": 0
             }
           ],
@@ -6722,9 +6865,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::visit_expr_match",
             "span": {
               "end_column": 5,
-              "end_line": 787,
+              "end_line": 818,
               "start_column": 5,
-              "start_line": 773
+              "start_line": 804
             }
           }
         },
@@ -6738,18 +6881,18 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 1362,
+              "end_line": 1451,
               "increment": 1,
               "kind": "for-loop",
-              "line": 1356,
+              "line": 1445,
               "nesting_depth": 0
             },
             {
               "column": 9,
-              "end_line": 1369,
+              "end_line": 1458,
               "increment": 1,
               "kind": "for-loop",
-              "line": 1363,
+              "line": 1452,
               "nesting_depth": 0
             }
           ],
@@ -6760,12 +6903,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "trait_default_and_concrete_override_have_disjoint_spans",
+            "qualified_name": "tests::trait_default_and_concrete_override_have_disjoint_spans",
             "span": {
               "end_column": 5,
-              "end_line": 1370,
+              "end_line": 1459,
               "start_column": 5,
-              "start_line": 1329
+              "start_line": 1418
             }
           }
         },
@@ -6957,7 +7100,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "arb_lcov_block",
+            "qualified_name": "proptests::arb_lcov_block",
             "span": {
               "end_column": 5,
               "end_line": 926,
@@ -6976,26 +7119,26 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 290,
+              "end_line": 495,
               "increment": 1,
-              "kind": "match",
-              "line": 268,
+              "kind": "for-loop",
+              "line": 493,
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 72.22222222222221,
+          "coverage_percent": 57.14285714285714,
           "crap": {
             "risk_level": "low",
-            "value": 2.09
+            "value": 2.31
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "count_cognitive_expr",
+            "qualified_name": "count_cognitive_call",
             "span": {
               "end_column": 1,
-              "end_line": 291,
+              "end_line": 497,
               "start_column": 1,
-              "start_line": 263
+              "start_line": 487
             }
           }
         },
@@ -7008,11 +7151,44 @@ expression: pretty
           "complexity_metric": "cognitive",
           "contributors": [
             {
-              "column": 5,
-              "end_line": 464,
+              "column": 9,
+              "end_line": 156,
               "increment": 1,
-              "kind": "for-loop",
-              "line": 462,
+              "kind": "if-branch",
+              "line": 143,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 84.61538461538461,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.01
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "FunctionFinder::visit_trait_item_fn",
+            "span": {
+              "end_column": 5,
+              "end_line": 159,
+              "start_column": 5,
+              "start_line": 141
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 2,
+          "complexity_metric": "cognitive",
+          "contributors": [
+            {
+              "column": 15,
+              "end_line": 244,
+              "increment": 1,
+              "kind": "match",
+              "line": 241,
               "nesting_depth": 0
             }
           ],
@@ -7023,12 +7199,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "count_cognitive_call",
+            "qualified_name": "count_complexity",
             "span": {
               "end_column": 1,
-              "end_line": 466,
+              "end_line": 247,
               "start_column": 1,
-              "start_line": 456
+              "start_line": 236
             }
           }
         },
@@ -7092,7 +7268,7 @@ expression: pretty
             "qualified_name": "SynComplexityAdapter::extract",
             "span": {
               "end_column": 5,
-              "end_line": 45,
+              "end_line": 46,
               "start_column": 5,
               "start_line": 27
             }
@@ -7107,60 +7283,27 @@ expression: pretty
           "complexity_metric": "cognitive",
           "contributors": [
             {
-              "column": 25,
-              "end_line": 90,
+              "column": 9,
+              "end_line": 77,
               "increment": 1,
-              "kind": "match",
-              "line": 87,
+              "kind": "if-branch",
+              "line": 75,
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 93.75,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
             "value": 2.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "FunctionFinder::visit_impl_item_fn",
+            "qualified_name": "FunctionFinder::qualify",
             "span": {
               "end_column": 5,
-              "end_line": 104,
+              "end_line": 80,
               "start_column": 5,
-              "start_line": 85
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 2,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 15,
-              "end_line": 213,
-              "increment": 1,
-              "kind": "match",
-              "line": 210,
-              "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 90.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "count_complexity",
-            "span": {
-              "end_column": 1,
-              "end_line": 216,
-              "start_column": 1,
-              "start_line": 205
+              "start_line": 65
             }
           }
         },
@@ -7174,10 +7317,10 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 443,
+              "end_line": 474,
               "increment": 1,
               "kind": "match",
-              "line": 440,
+              "line": 471,
               "nesting_depth": 0
             }
           ],
@@ -7191,9 +7334,9 @@ expression: pretty
             "qualified_name": "count_cognitive_return",
             "span": {
               "end_column": 1,
-              "end_line": 444,
+              "end_line": 475,
               "start_column": 1,
-              "start_line": 435
+              "start_line": 466
             }
           }
         },
@@ -7207,10 +7350,10 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 476,
+              "end_line": 507,
               "increment": 1,
               "kind": "for-loop",
-              "line": 474,
+              "line": 505,
               "nesting_depth": 0
             }
           ],
@@ -7224,9 +7367,9 @@ expression: pretty
             "qualified_name": "count_cognitive_method_call",
             "span": {
               "end_column": 1,
-              "end_line": 478,
+              "end_line": 509,
               "start_column": 1,
-              "start_line": 468
+              "start_line": 499
             }
           }
         },
@@ -7240,10 +7383,43 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 634,
+              "end_line": 519,
+              "increment": 1,
+              "kind": "for-loop",
+              "line": 517,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "count_cognitive_tuple",
+            "span": {
+              "end_column": 1,
+              "end_line": 521,
+              "start_column": 1,
+              "start_line": 511
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 2,
+          "complexity_metric": "cognitive",
+          "contributors": [
+            {
+              "column": 5,
+              "end_line": 665,
               "increment": 1,
               "kind": "match",
-              "line": 628,
+              "line": 659,
               "nesting_depth": 0
             }
           ],
@@ -7257,9 +7433,9 @@ expression: pretty
             "qualified_name": "count_cognitive_binary_operands",
             "span": {
               "end_column": 1,
-              "end_line": 635,
+              "end_line": 666,
               "start_column": 1,
-              "start_line": 619
+              "start_line": 650
             }
           }
         },
@@ -7273,10 +7449,10 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 649,
+              "end_line": 680,
               "increment": 1,
               "kind": "match",
-              "line": 645,
+              "line": 676,
               "nesting_depth": 0
             }
           ],
@@ -7290,9 +7466,9 @@ expression: pretty
             "qualified_name": "classify_binop",
             "span": {
               "end_column": 1,
-              "end_line": 650,
+              "end_line": 681,
               "start_column": 1,
-              "start_line": 644
+              "start_line": 675
             }
           }
         },
@@ -7306,10 +7482,10 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 660,
+              "end_line": 691,
               "increment": 1,
               "kind": "match",
-              "line": 653,
+              "line": 684,
               "nesting_depth": 0
             }
           ],
@@ -7323,9 +7499,9 @@ expression: pretty
             "qualified_name": "binop_span",
             "span": {
               "end_column": 1,
-              "end_line": 661,
+              "end_line": 692,
               "start_column": 1,
-              "start_line": 652
+              "start_line": 683
             }
           }
         },
@@ -7339,10 +7515,10 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 678,
+              "end_line": 709,
               "increment": 1,
               "kind": "if-branch",
-              "line": 674,
+              "line": 705,
               "nesting_depth": 0
             }
           ],
@@ -7356,9 +7532,9 @@ expression: pretty
             "qualified_name": "flatten_binary_ops_inner",
             "span": {
               "end_column": 1,
-              "end_line": 679,
+              "end_line": 710,
               "start_column": 1,
-              "start_line": 673
+              "start_line": 704
             }
           }
         },
@@ -7372,10 +7548,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 732,
+              "end_line": 763,
               "increment": 1,
               "kind": "match",
-              "line": 728,
+              "line": 759,
               "nesting_depth": 0
             }
           ],
@@ -7389,9 +7565,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::visit_stmt",
             "span": {
               "end_column": 5,
-              "end_line": 733,
+              "end_line": 764,
               "start_column": 5,
-              "start_line": 727
+              "start_line": 758
             }
           }
         },
@@ -7405,10 +7581,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 792,
+              "end_line": 823,
               "increment": 1,
               "kind": "if-branch",
-              "line": 790,
+              "line": 821,
               "nesting_depth": 0
             }
           ],
@@ -7422,9 +7598,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::visit_arm",
             "span": {
               "end_column": 5,
-              "end_line": 794,
+              "end_line": 825,
               "start_column": 5,
-              "start_line": 789
+              "start_line": 820
             }
           }
         },
@@ -7438,10 +7614,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 832,
+              "end_line": 863,
               "increment": 1,
               "kind": "if-branch",
-              "line": 829,
+              "line": 860,
               "nesting_depth": 0
             }
           ],
@@ -7455,9 +7631,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::visit_expr_binary",
             "span": {
               "end_column": 5,
-              "end_line": 835,
+              "end_line": 866,
               "start_column": 5,
-              "start_line": 828
+              "start_line": 859
             }
           }
         },
@@ -7471,10 +7647,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 856,
+              "end_line": 887,
               "increment": 1,
               "kind": "if-branch",
-              "line": 854,
+              "line": 885,
               "nesting_depth": 0
             }
           ],
@@ -7488,9 +7664,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::visit_expr_break",
             "span": {
               "end_column": 5,
-              "end_line": 857,
+              "end_line": 888,
               "start_column": 5,
-              "start_line": 847
+              "start_line": 878
             }
           }
         },
@@ -7504,10 +7680,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 1398,
+              "end_line": 1487,
               "increment": 1,
               "kind": "match",
-              "line": 1395,
+              "line": 1484,
               "nesting_depth": 0
             }
           ],
@@ -7518,12 +7694,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "invalid_source_returns_error",
+            "qualified_name": "tests::invalid_source_returns_error",
             "span": {
               "end_column": 5,
-              "end_line": 1399,
+              "end_line": 1488,
               "start_column": 5,
-              "start_line": 1391
+              "start_line": 1480
             }
           }
         },
@@ -7537,10 +7713,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 1428,
+              "end_line": 1517,
               "increment": 1,
               "kind": "for-loop",
-              "line": 1420,
+              "line": 1509,
               "nesting_depth": 0
             }
           ],
@@ -7551,12 +7727,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "base_fn_empty_contributors",
+            "qualified_name": "contributor_tests::base_fn_empty_contributors",
             "span": {
               "end_column": 5,
-              "end_line": 1429,
+              "end_line": 1518,
               "start_column": 5,
-              "start_line": 1418
+              "start_line": 1507
             }
           }
         },
@@ -7570,10 +7746,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 1474,
+              "end_line": 1563,
               "increment": 1,
               "kind": "for-loop",
-              "line": 1472,
+              "line": 1561,
               "nesting_depth": 0
             }
           ],
@@ -7584,12 +7760,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "match_arm_contributor_cyclomatic",
+            "qualified_name": "contributor_tests::match_arm_contributor_cyclomatic",
             "span": {
               "end_column": 5,
-              "end_line": 1475,
+              "end_line": 1564,
               "start_column": 5,
-              "start_line": 1461
+              "start_line": 1550
             }
           }
         },
@@ -7603,10 +7779,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 1791,
+              "end_line": 1880,
               "increment": 1,
               "kind": "for-loop",
-              "line": 1782,
+              "line": 1871,
               "nesting_depth": 0
             }
           ],
@@ -7617,12 +7793,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "contributors_sorted_by_line",
+            "qualified_name": "contributor_tests::contributors_sorted_by_line",
             "span": {
               "end_column": 5,
-              "end_line": 1792,
+              "end_line": 1881,
               "start_column": 5,
-              "start_line": 1773
+              "start_line": 1862
             }
           }
         },
@@ -7782,7 +7958,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "malformed_da_produces_diagnostic",
+            "qualified_name": "tests::malformed_da_produces_diagnostic",
             "span": {
               "end_column": 5,
               "end_line": 674,
@@ -7815,7 +7991,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "da_line_zero_is_malformed",
+            "qualified_name": "tests::da_line_zero_is_malformed",
             "span": {
               "end_column": 5,
               "end_line": 718,
@@ -7848,7 +8024,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "malformed_brda_produces_diagnostic",
+            "qualified_name": "tests::malformed_brda_produces_diagnostic",
             "span": {
               "end_column": 5,
               "end_line": 837,
@@ -7881,7 +8057,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "repeated_sf_blocks_merge_branch_coverage",
+            "qualified_name": "tests::repeated_sf_blocks_merge_branch_coverage",
             "span": {
               "end_column": 5,
               "end_line": 888,
@@ -7905,7 +8081,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/mod.rs",
-            "qualified_name": "load",
+            "qualified_name": "baseline::load",
             "span": {
               "end_column": 5,
               "end_line": 55,
@@ -7929,7 +8105,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/mod.rs",
-            "qualified_name": "format_json",
+            "qualified_name": "reporters::format_json",
             "span": {
               "end_column": 5,
               "end_line": 85,
@@ -7953,7 +8129,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "parse_diagnostic.rs",
-            "qualified_name": "parse_diagnostic_display_malformed_record",
+            "qualified_name": "tests::parse_diagnostic_display_malformed_record",
             "span": {
               "end_column": 5,
               "end_line": 63,
@@ -7977,7 +8153,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "parse_diagnostic.rs",
-            "qualified_name": "parse_diagnostic_display_empty_source_file",
+            "qualified_name": "tests::parse_diagnostic_display_empty_source_file",
             "span": {
               "end_column": 5,
               "end_line": 69,
@@ -8001,7 +8177,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "parse_diagnostic.rs",
-            "qualified_name": "parse_diagnostic_serde_round_trip",
+            "qualified_name": "tests::parse_diagnostic_serde_round_trip",
             "span": {
               "end_column": 5,
               "end_line": 80,
@@ -8018,19 +8194,19 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 36.36363636363637,
+          "coverage_percent": 16.666666666666664,
           "crap": {
             "risk_level": "low",
-            "value": 1.26
+            "value": 1.58
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "count_cognitive_while",
+            "qualified_name": "count_cognitive_closure",
             "span": {
               "end_column": 1,
-              "end_line": 334,
+              "end_line": 485,
               "start_column": 1,
-              "start_line": 317
+              "start_line": 479
             }
           }
         },
@@ -8049,12 +8225,60 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "find_fn",
+            "qualified_name": "end_line_of",
+            "span": {
+              "end_column": 1,
+              "end_line": 198,
+              "start_column": 1,
+              "start_line": 192
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 50.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.13
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "CyclomaticCounter::visit_expr_closure",
             "span": {
               "end_column": 5,
-              "end_line": 910,
+              "end_line": 904,
               "start_column": 5,
               "start_line": 899
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 77.77777777777779,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.01
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "count_cognitive_block",
+            "span": {
+              "end_column": 1,
+              "end_line": 261,
+              "start_column": 1,
+              "start_line": 251
             }
           }
         },
@@ -8090,7 +8314,31 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 100.0,
+          "coverage_percent": 90.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "FunctionFinder::visit_item_mod",
+            "span": {
+              "end_column": 5,
+              "end_line": 95,
+              "start_column": 5,
+              "start_line": 84
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 92.85714285714286,
           "crap": {
             "risk_level": "low",
             "value": 1.0
@@ -8100,9 +8348,9 @@ expression: pretty
             "qualified_name": "FunctionFinder::visit_item_fn",
             "span": {
               "end_column": 5,
-              "end_line": 76,
+              "end_line": 115,
               "start_column": 5,
-              "start_line": 58
+              "start_line": 97
             }
           }
         },
@@ -8124,9 +8372,33 @@ expression: pretty
             "qualified_name": "FunctionFinder::visit_item_impl",
             "span": {
               "end_column": 5,
-              "end_line": 83,
+              "end_line": 122,
               "start_column": 5,
-              "start_line": 78
+              "start_line": 117
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "FunctionFinder::visit_impl_item_fn",
+            "span": {
+              "end_column": 5,
+              "end_line": 139,
+              "start_column": 5,
+              "start_line": 124
             }
           }
         },
@@ -8148,56 +8420,8 @@ expression: pretty
             "qualified_name": "FunctionFinder::visit_item_trait",
             "span": {
               "end_column": 5,
-              "end_line": 135,
+              "end_line": 166,
               "start_column": 5,
-              "start_line": 130
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 85.71428571428571,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "add_contributor",
-            "span": {
-              "end_column": 1,
-              "end_line": 159,
-              "start_column": 1,
-              "start_line": 140
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 100.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "end_line_of",
-            "span": {
-              "end_column": 1,
-              "end_line": 167,
-              "start_column": 1,
               "start_line": 161
             }
           }
@@ -8217,12 +8441,36 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "span_of",
+            "qualified_name": "add_contributor",
             "span": {
               "end_column": 1,
               "end_line": 190,
               "start_column": 1,
-              "start_line": 169
+              "start_line": 171
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 94.73684210526316,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "span_of",
+            "span": {
+              "end_column": 1,
+              "end_line": 221,
+              "start_column": 1,
+              "start_line": 200
             }
           }
         },
@@ -8241,12 +8489,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "count_cognitive_block",
+            "qualified_name": "count_cognitive_while",
             "span": {
               "end_column": 1,
-              "end_line": 230,
+              "end_line": 365,
               "start_column": 1,
-              "start_line": 220
+              "start_line": 348
             }
           }
         },
@@ -8268,9 +8516,9 @@ expression: pretty
             "qualified_name": "count_cognitive_for_loop",
             "span": {
               "end_column": 1,
-              "end_line": 353,
+              "end_line": 384,
               "start_column": 1,
-              "start_line": 336
+              "start_line": 367
             }
           }
         },
@@ -8292,57 +8540,9 @@ expression: pretty
             "qualified_name": "count_cognitive_loop",
             "span": {
               "end_column": 1,
-              "end_line": 371,
+              "end_line": 402,
               "start_column": 1,
-              "start_line": 355
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 100.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "count_cognitive_binary",
-            "span": {
-              "end_column": 1,
-              "end_line": 385,
-              "start_column": 1,
-              "start_line": 377
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 100.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "count_cognitive_try",
-            "span": {
-              "end_column": 1,
-              "end_line": 401,
-              "start_column": 1,
-              "start_line": 387
+              "start_line": 386
             }
           }
         },
@@ -8361,12 +8561,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "count_cognitive_break",
+            "qualified_name": "count_cognitive_binary",
             "span": {
               "end_column": 1,
-              "end_line": 417,
+              "end_line": 416,
               "start_column": 1,
-              "start_line": 403
+              "start_line": 408
             }
           }
         },
@@ -8385,12 +8585,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "count_cognitive_continue",
+            "qualified_name": "count_cognitive_try",
             "span": {
               "end_column": 1,
-              "end_line": 433,
+              "end_line": 432,
               "start_column": 1,
-              "start_line": 419
+              "start_line": 418
             }
           }
         },
@@ -8409,12 +8609,36 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "count_cognitive_closure",
+            "qualified_name": "count_cognitive_break",
             "span": {
               "end_column": 1,
-              "end_line": 454,
+              "end_line": 448,
               "start_column": 1,
-              "start_line": 448
+              "start_line": 434
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 90.9090909090909,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "count_cognitive_continue",
+            "span": {
+              "end_column": 1,
+              "end_line": 464,
+              "start_column": 1,
+              "start_line": 450
             }
           }
         },
@@ -8436,9 +8660,9 @@ expression: pretty
             "qualified_name": "flatten_binary_ops",
             "span": {
               "end_column": 1,
-              "end_line": 671,
+              "end_line": 702,
               "start_column": 1,
-              "start_line": 663
+              "start_line": 694
             }
           }
         },
@@ -8460,9 +8684,9 @@ expression: pretty
             "qualified_name": "count_cyclomatic_block",
             "span": {
               "end_column": 1,
-              "end_line": 688,
+              "end_line": 719,
               "start_column": 1,
-              "start_line": 683
+              "start_line": 714
             }
           }
         },
@@ -8484,9 +8708,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::count_block",
             "span": {
               "end_column": 5,
-              "end_line": 705,
+              "end_line": 736,
               "start_column": 5,
-              "start_line": 697
+              "start_line": 728
             }
           }
         },
@@ -8508,9 +8732,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::bump",
             "span": {
               "end_column": 5,
-              "end_line": 717,
+              "end_line": 748,
               "start_column": 5,
-              "start_line": 707
+              "start_line": 738
             }
           }
         },
@@ -8532,9 +8756,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::with_nesting",
             "span": {
               "end_column": 5,
-              "end_line": 723,
+              "end_line": 754,
               "start_column": 5,
-              "start_line": 719
+              "start_line": 750
             }
           }
         },
@@ -8556,9 +8780,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::visit_expr_while",
             "span": {
               "end_column": 5,
-              "end_line": 805,
+              "end_line": 836,
               "start_column": 5,
-              "start_line": 796
+              "start_line": 827
             }
           }
         },
@@ -8580,9 +8804,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::visit_expr_for_loop",
             "span": {
               "end_column": 5,
-              "end_line": 816,
+              "end_line": 847,
               "start_column": 5,
-              "start_line": 807
+              "start_line": 838
             }
           }
         },
@@ -8604,9 +8828,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::visit_expr_loop",
             "span": {
               "end_column": 5,
-              "end_line": 826,
+              "end_line": 857,
               "start_column": 5,
-              "start_line": 818
+              "start_line": 849
             }
           }
         },
@@ -8628,9 +8852,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::visit_expr_try",
             "span": {
               "end_column": 5,
-              "end_line": 845,
+              "end_line": 876,
               "start_column": 5,
-              "start_line": 837
+              "start_line": 868
             }
           }
         },
@@ -8652,105 +8876,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::visit_expr_continue",
             "span": {
               "end_column": 5,
-              "end_line": 866,
-              "start_column": 5,
-              "start_line": 859
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 100.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "CyclomaticCounter::visit_expr_closure",
-            "span": {
-              "end_column": 5,
-              "end_line": 873,
-              "start_column": 5,
-              "start_line": 868
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 100.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "adapter",
-            "span": {
-              "end_column": 5,
-              "end_line": 884,
-              "start_column": 5,
-              "start_line": 882
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 100.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "load_fixture",
-            "span": {
-              "end_column": 5,
-              "end_line": 890,
-              "start_column": 5,
-              "start_line": 886
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 100.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "extract_fixture",
-            "span": {
-              "end_column": 5,
               "end_line": 897,
               "start_column": 5,
-              "start_line": 892
+              "start_line": 890
             }
           }
         },
@@ -8769,12 +8897,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "baseline_complexity_is_one_cognitive",
+            "qualified_name": "test_helpers::adapter",
             "span": {
               "end_column": 5,
-              "end_line": 926,
+              "end_line": 915,
               "start_column": 5,
-              "start_line": 921
+              "start_line": 913
             }
           }
         },
@@ -8793,12 +8921,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "baseline_complexity_is_one_cyclomatic",
+            "qualified_name": "test_helpers::load_fixture",
             "span": {
               "end_column": 5,
-              "end_line": 933,
+              "end_line": 921,
               "start_column": 5,
-              "start_line": 928
+              "start_line": 917
             }
           }
         },
@@ -8817,12 +8945,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "top_level_fn_identity",
+            "qualified_name": "test_helpers::extract_fixture",
             "span": {
               "end_column": 5,
-              "end_line": 944,
+              "end_line": 928,
               "start_column": 5,
-              "start_line": 937
+              "start_line": 923
             }
           }
         },
@@ -8841,12 +8969,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "impl_method_qualified_name",
+            "qualified_name": "test_helpers::find_fn",
             "span": {
               "end_column": 5,
-              "end_line": 952,
+              "end_line": 941,
               "start_column": 5,
-              "start_line": 946
+              "start_line": 930
             }
           }
         },
@@ -8865,12 +8993,60 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "span_accuracy",
+            "qualified_name": "tests::baseline_complexity_is_one_cognitive",
+            "span": {
+              "end_column": 5,
+              "end_line": 957,
+              "start_column": 5,
+              "start_line": 952
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "tests::baseline_complexity_is_one_cyclomatic",
+            "span": {
+              "end_column": 5,
+              "end_line": 964,
+              "start_column": 5,
+              "start_line": 959
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "tests::top_level_fn_identity",
             "span": {
               "end_column": 5,
               "end_line": 975,
               "start_column": 5,
-              "start_line": 954
+              "start_line": 968
             }
           }
         },
@@ -8889,10 +9065,10 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "span_carries_one_based_columns",
+            "qualified_name": "tests::impl_method_qualified_name",
             "span": {
               "end_column": 5,
-              "end_line": 996,
+              "end_line": 983,
               "start_column": 5,
               "start_line": 977
             }
@@ -8913,12 +9089,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "columns_are_exact_one_based_offsets_unindented",
+            "qualified_name": "tests::top_level_fn_in_nested_mods_fixture_is_unqualified",
             "span": {
               "end_column": 5,
-              "end_line": 1026,
+              "end_line": 993,
               "start_column": 5,
-              "start_line": 998
+              "start_line": 987
             }
           }
         },
@@ -8937,12 +9113,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "columns_are_exact_one_based_offsets_indented",
+            "qualified_name": "tests::one_level_mod_qualified_name",
             "span": {
               "end_column": 5,
-              "end_line": 1051,
+              "end_line": 999,
               "start_column": 5,
-              "start_line": 1028
+              "start_line": 995
             }
           }
         },
@@ -8961,12 +9137,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "multiple_fns_returns_all",
+            "qualified_name": "tests::multi_level_mod_qualified_name",
             "span": {
               "end_column": 5,
-              "end_line": 1057,
+              "end_line": 1005,
               "start_column": 5,
-              "start_line": 1053
+              "start_line": 1001
             }
           }
         },
@@ -8985,12 +9161,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "async_fn_detected",
+            "qualified_name": "tests::impl_method_inside_mod_prepends_mod_path",
             "span": {
               "end_column": 5,
-              "end_line": 1065,
+              "end_line": 1014,
               "start_column": 5,
-              "start_line": 1059
+              "start_line": 1007
             }
           }
         },
@@ -9009,12 +9185,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "if_else_cognitive",
+            "qualified_name": "tests::nested_fn_inside_mod_is_mod_scoped_not_fn_scoped",
             "span": {
               "end_column": 5,
-              "end_line": 1075,
+              "end_line": 1029,
               "start_column": 5,
-              "start_line": 1069
+              "start_line": 1016
             }
           }
         },
@@ -9033,12 +9209,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "nested_if_cognitive_penalty",
+            "qualified_name": "tests::mod_qualification_does_not_disturb_complexity",
             "span": {
               "end_column": 5,
-              "end_line": 1083,
+              "end_line": 1041,
               "start_column": 5,
-              "start_line": 1077
+              "start_line": 1031
             }
           }
         },
@@ -9057,12 +9233,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "else_is_not_counted_cognitive",
+            "qualified_name": "tests::span_accuracy",
             "span": {
               "end_column": 5,
-              "end_line": 1092,
+              "end_line": 1064,
               "start_column": 5,
-              "start_line": 1085
+              "start_line": 1043
             }
           }
         },
@@ -9081,12 +9257,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "match_flat_cognitive",
+            "qualified_name": "tests::span_carries_one_based_columns",
             "span": {
               "end_column": 5,
-              "end_line": 1100,
+              "end_line": 1085,
               "start_column": 5,
-              "start_line": 1094
+              "start_line": 1066
             }
           }
         },
@@ -9105,12 +9281,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "if_else_cyclomatic",
+            "qualified_name": "tests::columns_are_exact_one_based_offsets_unindented",
             "span": {
               "end_column": 5,
-              "end_line": 1110,
+              "end_line": 1115,
               "start_column": 5,
-              "start_line": 1104
+              "start_line": 1087
             }
           }
         },
@@ -9129,12 +9305,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "nested_if_cyclomatic",
+            "qualified_name": "tests::columns_are_exact_one_based_offsets_indented",
             "span": {
               "end_column": 5,
-              "end_line": 1118,
+              "end_line": 1140,
               "start_column": 5,
-              "start_line": 1112
+              "start_line": 1117
             }
           }
         },
@@ -9153,12 +9329,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "match_arms_cyclomatic",
+            "qualified_name": "tests::multiple_fns_returns_all",
             "span": {
               "end_column": 5,
-              "end_line": 1126,
+              "end_line": 1146,
               "start_column": 5,
-              "start_line": 1120
+              "start_line": 1142
             }
           }
         },
@@ -9177,12 +9353,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "cognitive_gte_cyclomatic_for_nested",
+            "qualified_name": "tests::async_fn_detected",
             "span": {
               "end_column": 5,
-              "end_line": 1139,
+              "end_line": 1154,
               "start_column": 5,
-              "start_line": 1128
+              "start_line": 1148
             }
           }
         },
@@ -9201,12 +9377,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "bool_same_sequence_cognitive",
+            "qualified_name": "tests::if_else_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1149,
+              "end_line": 1164,
               "start_column": 5,
-              "start_line": 1143
+              "start_line": 1158
             }
           }
         },
@@ -9225,12 +9401,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "bool_same_sequence_cyclomatic",
+            "qualified_name": "tests::nested_if_cognitive_penalty",
             "span": {
               "end_column": 5,
-              "end_line": 1157,
+              "end_line": 1172,
               "start_column": 5,
-              "start_line": 1151
+              "start_line": 1166
             }
           }
         },
@@ -9249,60 +9425,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "bool_operator_switch_cognitive",
-            "span": {
-              "end_column": 5,
-              "end_line": 1165,
-              "start_column": 5,
-              "start_line": 1159
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 100.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "bool_operator_switch_cyclomatic",
-            "span": {
-              "end_column": 5,
-              "end_line": 1173,
-              "start_column": 5,
-              "start_line": 1167
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 100.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "bool_in_condition_cognitive",
+            "qualified_name": "tests::else_is_not_counted_cognitive",
             "span": {
               "end_column": 5,
               "end_line": 1181,
               "start_column": 5,
-              "start_line": 1175
+              "start_line": 1174
             }
           }
         },
@@ -9321,7 +9449,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "long_or_chain_cognitive",
+            "qualified_name": "tests::match_flat_cognitive",
             "span": {
               "end_column": 5,
               "end_line": 1189,
@@ -9345,12 +9473,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "alternating_operators_cognitive",
+            "qualified_name": "tests::if_else_cyclomatic",
             "span": {
               "end_column": 5,
-              "end_line": 1197,
+              "end_line": 1199,
               "start_column": 5,
-              "start_line": 1191
+              "start_line": 1193
             }
           }
         },
@@ -9369,10 +9497,10 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "closure_in_parent_cognitive",
+            "qualified_name": "tests::nested_if_cyclomatic",
             "span": {
               "end_column": 5,
-              "end_line": 1210,
+              "end_line": 1207,
               "start_column": 5,
               "start_line": 1201
             }
@@ -9393,12 +9521,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "try_operator_cognitive",
+            "qualified_name": "tests::match_arms_cyclomatic",
             "span": {
               "end_column": 5,
-              "end_line": 1220,
+              "end_line": 1215,
               "start_column": 5,
-              "start_line": 1214
+              "start_line": 1209
             }
           }
         },
@@ -9417,12 +9545,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "try_operator_cyclomatic",
+            "qualified_name": "tests::cognitive_gte_cyclomatic_for_nested",
             "span": {
               "end_column": 5,
               "end_line": 1228,
               "start_column": 5,
-              "start_line": 1222
+              "start_line": 1217
             }
           }
         },
@@ -9441,7 +9569,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "loop_with_break_cognitive",
+            "qualified_name": "tests::bool_same_sequence_cognitive",
             "span": {
               "end_column": 5,
               "end_line": 1238,
@@ -9465,7 +9593,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "loop_with_break_cyclomatic",
+            "qualified_name": "tests::bool_same_sequence_cyclomatic",
             "span": {
               "end_column": 5,
               "end_line": 1246,
@@ -9489,12 +9617,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "let_else_cognitive",
+            "qualified_name": "tests::bool_operator_switch_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1256,
+              "end_line": 1254,
               "start_column": 5,
-              "start_line": 1250
+              "start_line": 1248
             }
           }
         },
@@ -9513,12 +9641,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "let_else_cyclomatic",
+            "qualified_name": "tests::bool_operator_switch_cyclomatic",
             "span": {
               "end_column": 5,
-              "end_line": 1264,
+              "end_line": 1262,
               "start_column": 5,
-              "start_line": 1258
+              "start_line": 1256
             }
           }
         },
@@ -9537,12 +9665,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "chained_try_cognitive",
+            "qualified_name": "tests::bool_in_condition_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1274,
+              "end_line": 1270,
               "start_column": 5,
-              "start_line": 1268
+              "start_line": 1264
             }
           }
         },
@@ -9561,12 +9689,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "chained_try_cyclomatic",
+            "qualified_name": "tests::long_or_chain_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1282,
+              "end_line": 1278,
               "start_column": 5,
-              "start_line": 1276
+              "start_line": 1272
             }
           }
         },
@@ -9585,12 +9713,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "for_iterator_try_cognitive",
+            "qualified_name": "tests::alternating_operators_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1290,
+              "end_line": 1286,
               "start_column": 5,
-              "start_line": 1284
+              "start_line": 1280
             }
           }
         },
@@ -9609,12 +9737,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "for_iterator_try_cyclomatic",
+            "qualified_name": "tests::closure_in_parent_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1298,
+              "end_line": 1299,
               "start_column": 5,
-              "start_line": 1292
+              "start_line": 1290
             }
           }
         },
@@ -9633,12 +9761,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "match_scrutinee_try_cognitive",
+            "qualified_name": "tests::try_operator_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1306,
+              "end_line": 1309,
               "start_column": 5,
-              "start_line": 1300
+              "start_line": 1303
             }
           }
         },
@@ -9657,12 +9785,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "trait_default_method_found",
+            "qualified_name": "tests::try_operator_cyclomatic",
             "span": {
               "end_column": 5,
-              "end_line": 1316,
+              "end_line": 1317,
               "start_column": 5,
-              "start_line": 1310
+              "start_line": 1311
             }
           }
         },
@@ -9681,12 +9809,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "trait_method_without_default_not_found",
+            "qualified_name": "tests::loop_with_break_cognitive",
             "span": {
               "end_column": 5,
               "end_line": 1327,
               "start_column": 5,
-              "start_line": 1318
+              "start_line": 1321
             }
           }
         },
@@ -9705,12 +9833,132 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "impl_method_no_branch",
+            "qualified_name": "tests::loop_with_break_cyclomatic",
+            "span": {
+              "end_column": 5,
+              "end_line": 1335,
+              "start_column": 5,
+              "start_line": 1329
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "tests::let_else_cognitive",
+            "span": {
+              "end_column": 5,
+              "end_line": 1345,
+              "start_column": 5,
+              "start_line": 1339
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "tests::let_else_cyclomatic",
+            "span": {
+              "end_column": 5,
+              "end_line": 1353,
+              "start_column": 5,
+              "start_line": 1347
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "tests::chained_try_cognitive",
+            "span": {
+              "end_column": 5,
+              "end_line": 1363,
+              "start_column": 5,
+              "start_line": 1357
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "tests::chained_try_cyclomatic",
+            "span": {
+              "end_column": 5,
+              "end_line": 1371,
+              "start_column": 5,
+              "start_line": 1365
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "tests::for_iterator_try_cognitive",
             "span": {
               "end_column": 5,
               "end_line": 1379,
               "start_column": 5,
-              "start_line": 1374
+              "start_line": 1373
             }
           }
         },
@@ -9729,7 +9977,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "impl_method_with_branch",
+            "qualified_name": "tests::for_iterator_try_cyclomatic",
             "span": {
               "end_column": 5,
               "end_line": 1387,
@@ -9753,12 +10001,60 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "contributors_for",
+            "qualified_name": "tests::match_scrutinee_try_cognitive",
+            "span": {
+              "end_column": 5,
+              "end_line": 1395,
+              "start_column": 5,
+              "start_line": 1389
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "tests::trait_default_method_found",
+            "span": {
+              "end_column": 5,
+              "end_line": 1405,
+              "start_column": 5,
+              "start_line": 1399
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "tests::trait_method_without_default_not_found",
             "span": {
               "end_column": 5,
               "end_line": 1416,
               "start_column": 5,
-              "start_line": 1409
+              "start_line": 1407
             }
           }
         },
@@ -9777,12 +10073,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "if_branch_contributor_cognitive",
+            "qualified_name": "tests::impl_method_no_branch",
             "span": {
               "end_column": 5,
-              "end_line": 1438,
+              "end_line": 1468,
               "start_column": 5,
-              "start_line": 1431
+              "start_line": 1463
             }
           }
         },
@@ -9801,12 +10097,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "nested_if_nesting_increment",
+            "qualified_name": "tests::impl_method_with_branch",
             "span": {
               "end_column": 5,
-              "end_line": 1450,
+              "end_line": 1476,
               "start_column": 5,
-              "start_line": 1440
+              "start_line": 1470
             }
           }
         },
@@ -9825,12 +10121,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "match_contributor_cognitive",
+            "qualified_name": "contributor_tests::contributors_for",
             "span": {
               "end_column": 5,
-              "end_line": 1459,
+              "end_line": 1505,
               "start_column": 5,
-              "start_line": 1452
+              "start_line": 1498
             }
           }
         },
@@ -9849,12 +10145,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "try_contributor_cognitive",
+            "qualified_name": "contributor_tests::if_branch_contributor_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1483,
+              "end_line": 1527,
               "start_column": 5,
-              "start_line": 1477
+              "start_line": 1520
             }
           }
         },
@@ -9873,156 +10169,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "try_contributor_cyclomatic",
-            "span": {
-              "end_column": 5,
-              "end_line": 1491,
-              "start_column": 5,
-              "start_line": 1485
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 100.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "let_else_contributor_cognitive",
-            "span": {
-              "end_column": 5,
-              "end_line": 1499,
-              "start_column": 5,
-              "start_line": 1493
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 100.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "let_else_contributor_cyclomatic",
-            "span": {
-              "end_column": 5,
-              "end_line": 1507,
-              "start_column": 5,
-              "start_line": 1501
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 100.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "loop_contributor_cognitive",
-            "span": {
-              "end_column": 5,
-              "end_line": 1515,
-              "start_column": 5,
-              "start_line": 1509
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 100.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "for_loop_contributor_cognitive",
-            "span": {
-              "end_column": 5,
-              "end_line": 1523,
-              "start_column": 5,
-              "start_line": 1517
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 100.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "for_loop_contributor_cyclomatic",
-            "span": {
-              "end_column": 5,
-              "end_line": 1531,
-              "start_column": 5,
-              "start_line": 1525
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 100.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "while_loop_contributor_cognitive",
+            "qualified_name": "contributor_tests::nested_if_nesting_increment",
             "span": {
               "end_column": 5,
               "end_line": 1539,
               "start_column": 5,
-              "start_line": 1533
+              "start_line": 1529
             }
           }
         },
@@ -10041,10 +10193,10 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "while_loop_contributor_cyclomatic",
+            "qualified_name": "contributor_tests::match_contributor_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1547,
+              "end_line": 1548,
               "start_column": 5,
               "start_line": 1541
             }
@@ -10065,12 +10217,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "logical_operator_same_chain_cognitive",
+            "qualified_name": "contributor_tests::try_contributor_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1563,
+              "end_line": 1572,
               "start_column": 5,
-              "start_line": 1549
+              "start_line": 1566
             }
           }
         },
@@ -10089,12 +10241,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "logical_operator_switch_cognitive",
+            "qualified_name": "contributor_tests::try_contributor_cyclomatic",
             "span": {
               "end_column": 5,
-              "end_line": 1578,
+              "end_line": 1580,
               "start_column": 5,
-              "start_line": 1565
+              "start_line": 1574
             }
           }
         },
@@ -10113,12 +10265,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "break_contributor",
+            "qualified_name": "contributor_tests::let_else_contributor_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1591,
+              "end_line": 1588,
               "start_column": 5,
-              "start_line": 1580
+              "start_line": 1582
             }
           }
         },
@@ -10137,12 +10289,36 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "continue_contributor",
+            "qualified_name": "contributor_tests::let_else_contributor_cyclomatic",
+            "span": {
+              "end_column": 5,
+              "end_line": 1596,
+              "start_column": 5,
+              "start_line": 1590
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "contributor_tests::loop_contributor_cognitive",
             "span": {
               "end_column": 5,
               "end_line": 1604,
               "start_column": 5,
-              "start_line": 1593
+              "start_line": 1598
             }
           }
         },
@@ -10161,10 +10337,10 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "unsafe_block_produces_no_unsafe_contributor",
+            "qualified_name": "contributor_tests::for_loop_contributor_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1632,
+              "end_line": 1612,
               "start_column": 5,
               "start_line": 1606
             }
@@ -10185,12 +10361,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "closure_no_contributor",
+            "qualified_name": "contributor_tests::for_loop_contributor_cyclomatic",
             "span": {
               "end_column": 5,
-              "end_line": 1644,
+              "end_line": 1620,
               "start_column": 5,
-              "start_line": 1634
+              "start_line": 1614
             }
           }
         },
@@ -10209,12 +10385,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "nested_if_records_construct_end_line_and_nesting_depth_cognitive",
+            "qualified_name": "contributor_tests::while_loop_contributor_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1677,
+              "end_line": 1628,
               "start_column": 5,
-              "start_line": 1648
+              "start_line": 1622
             }
           }
         },
@@ -10233,12 +10409,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "try_records_token_span_for_atomic_contributor",
+            "qualified_name": "contributor_tests::while_loop_contributor_cyclomatic",
             "span": {
               "end_column": 5,
-              "end_line": 1691,
+              "end_line": 1636,
               "start_column": 5,
-              "start_line": 1679
+              "start_line": 1630
             }
           }
         },
@@ -10257,12 +10433,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "for_with_continue_threads_nesting_depth_cognitive",
+            "qualified_name": "contributor_tests::logical_operator_same_chain_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1713,
+              "end_line": 1652,
               "start_column": 5,
-              "start_line": 1693
+              "start_line": 1638
             }
           }
         },
@@ -10281,12 +10457,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "nested_if_records_nesting_depth_cyclomatic",
+            "qualified_name": "contributor_tests::logical_operator_switch_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1732,
+              "end_line": 1667,
               "start_column": 5,
-              "start_line": 1715
+              "start_line": 1654
             }
           }
         },
@@ -10305,12 +10481,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "for_with_continue_records_nesting_depth_cyclomatic",
+            "qualified_name": "contributor_tests::break_contributor",
             "span": {
               "end_column": 5,
-              "end_line": 1752,
+              "end_line": 1680,
               "start_column": 5,
-              "start_line": 1734
+              "start_line": 1669
             }
           }
         },
@@ -10329,12 +10505,204 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "match_records_end_line_covering_arms_cognitive",
+            "qualified_name": "contributor_tests::continue_contributor",
             "span": {
               "end_column": 5,
-              "end_line": 1771,
+              "end_line": 1693,
               "start_column": 5,
-              "start_line": 1754
+              "start_line": 1682
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "contributor_tests::unsafe_block_produces_no_unsafe_contributor",
+            "span": {
+              "end_column": 5,
+              "end_line": 1721,
+              "start_column": 5,
+              "start_line": 1695
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "contributor_tests::closure_no_contributor",
+            "span": {
+              "end_column": 5,
+              "end_line": 1733,
+              "start_column": 5,
+              "start_line": 1723
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "contributor_tests::nested_if_records_construct_end_line_and_nesting_depth_cognitive",
+            "span": {
+              "end_column": 5,
+              "end_line": 1766,
+              "start_column": 5,
+              "start_line": 1737
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "contributor_tests::try_records_token_span_for_atomic_contributor",
+            "span": {
+              "end_column": 5,
+              "end_line": 1780,
+              "start_column": 5,
+              "start_line": 1768
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "contributor_tests::for_with_continue_threads_nesting_depth_cognitive",
+            "span": {
+              "end_column": 5,
+              "end_line": 1802,
+              "start_column": 5,
+              "start_line": 1782
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "contributor_tests::nested_if_records_nesting_depth_cyclomatic",
+            "span": {
+              "end_column": 5,
+              "end_line": 1821,
+              "start_column": 5,
+              "start_line": 1804
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "contributor_tests::for_with_continue_records_nesting_depth_cyclomatic",
+            "span": {
+              "end_column": 5,
+              "end_line": 1841,
+              "start_column": 5,
+              "start_line": 1823
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "contributor_tests::match_records_end_line_covering_arms_cognitive",
+            "span": {
+              "end_column": 5,
+              "end_line": 1860,
+              "start_column": 5,
+              "start_line": 1843
             }
           }
         },
@@ -10521,7 +10889,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "parser",
+            "qualified_name": "tests::parser",
             "span": {
               "end_column": 5,
               "end_line": 453,
@@ -10545,7 +10913,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "parse",
+            "qualified_name": "tests::parse",
             "span": {
               "end_column": 5,
               "end_line": 457,
@@ -10569,7 +10937,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "empty_input_returns_empty_output",
+            "qualified_name": "tests::empty_input_returns_empty_output",
             "span": {
               "end_column": 5,
               "end_line": 464,
@@ -10593,7 +10961,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "validate_str",
+            "qualified_name": "tests::validate_str",
             "span": {
               "end_column": 5,
               "end_line": 478,
@@ -10617,7 +10985,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "validate_empty_input_rejected",
+            "qualified_name": "tests::validate_empty_input_rejected",
             "span": {
               "end_column": 5,
               "end_line": 483,
@@ -10641,7 +11009,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "validate_no_da_lines_rejected",
+            "qualified_name": "tests::validate_no_da_lines_rejected",
             "span": {
               "end_column": 5,
               "end_line": 488,
@@ -10665,7 +11033,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "validate_da_outside_sf_block_rejected",
+            "qualified_name": "tests::validate_da_outside_sf_block_rejected",
             "span": {
               "end_column": 5,
               "end_line": 493,
@@ -10689,7 +11057,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "validate_malformed_da_rejected",
+            "qualified_name": "tests::validate_malformed_da_rejected",
             "span": {
               "end_column": 5,
               "end_line": 498,
@@ -10713,7 +11081,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "validate_single_da_inside_sf_block_passes",
+            "qualified_name": "tests::validate_single_da_inside_sf_block_passes",
             "span": {
               "end_column": 5,
               "end_line": 503,
@@ -10737,7 +11105,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "validate_first_da_in_second_block_passes",
+            "qualified_name": "tests::validate_first_da_in_second_block_passes",
             "span": {
               "end_column": 5,
               "end_line": 513,
@@ -10761,7 +11129,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "validate_missing_path_returns_open_error",
+            "qualified_name": "tests::validate_missing_path_returns_open_error",
             "span": {
               "end_column": 5,
               "end_line": 525,
@@ -10785,7 +11153,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "single_file_single_da",
+            "qualified_name": "tests::single_file_single_da",
             "span": {
               "end_column": 5,
               "end_line": 535,
@@ -10809,7 +11177,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "multiple_da_lines",
+            "qualified_name": "tests::multiple_da_lines",
             "span": {
               "end_column": 5,
               "end_line": 545,
@@ -10833,7 +11201,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "multiple_source_files",
+            "qualified_name": "tests::multiple_source_files",
             "span": {
               "end_column": 5,
               "end_line": 554,
@@ -10857,7 +11225,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "hit_count_preservation",
+            "qualified_name": "tests::hit_count_preservation",
             "span": {
               "end_column": 5,
               "end_line": 562,
@@ -10881,7 +11249,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "path_normalization_strips_prefix",
+            "qualified_name": "tests::path_normalization_strips_prefix",
             "span": {
               "end_column": 5,
               "end_line": 568,
@@ -10905,7 +11273,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "non_matching_path_passes_through",
+            "qualified_name": "tests::non_matching_path_passes_through",
             "span": {
               "end_column": 5,
               "end_line": 574,
@@ -10929,7 +11297,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "backslash_normalized_to_forward_slash",
+            "qualified_name": "tests::backslash_normalized_to_forward_slash",
             "span": {
               "end_column": 5,
               "end_line": 581,
@@ -10953,7 +11321,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "path_boundary_not_confused_by_prefix_substring",
+            "qualified_name": "tests::path_boundary_not_confused_by_prefix_substring",
             "span": {
               "end_column": 5,
               "end_line": 587,
@@ -10977,7 +11345,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "parentdir_sf_path_does_not_take_fast_path_is_file_probe",
+            "qualified_name": "tests::parentdir_sf_path_does_not_take_fast_path_is_file_probe",
             "span": {
               "end_column": 5,
               "end_line": 622,
@@ -11001,7 +11369,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "repeated_sf_blocks_merge_coverage",
+            "qualified_name": "tests::repeated_sf_blocks_merge_coverage",
             "span": {
               "end_column": 5,
               "end_line": 636,
@@ -11025,7 +11393,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "duplicate_da_lines_sum_hits",
+            "qualified_name": "tests::duplicate_da_lines_sum_hits",
             "span": {
               "end_column": 5,
               "end_line": 645,
@@ -11049,7 +11417,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "duplicate_da_multiple_lines_sum_correctly",
+            "qualified_name": "tests::duplicate_da_multiple_lines_sum_correctly",
             "span": {
               "end_column": 5,
               "end_line": 657,
@@ -11073,7 +11441,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "malformed_da_does_not_stop_parsing",
+            "qualified_name": "tests::malformed_da_does_not_stop_parsing",
             "span": {
               "end_column": 5,
               "end_line": 682,
@@ -11097,7 +11465,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "da_missing_hit_count_is_malformed",
+            "qualified_name": "tests::da_missing_hit_count_is_malformed",
             "span": {
               "end_column": 5,
               "end_line": 692,
@@ -11121,7 +11489,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "da_negative_hit_count_is_malformed",
+            "qualified_name": "tests::da_negative_hit_count_is_malformed",
             "span": {
               "end_column": 5,
               "end_line": 702,
@@ -11145,7 +11513,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "end_of_record_is_ignored",
+            "qualified_name": "tests::end_of_record_is_ignored",
             "span": {
               "end_column": 5,
               "end_line": 729,
@@ -11169,7 +11537,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "unterminated_final_block_emits_data",
+            "qualified_name": "tests::unterminated_final_block_emits_data",
             "span": {
               "end_column": 5,
               "end_line": 736,
@@ -11193,7 +11561,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "empty_sf_path_emits_diagnostic",
+            "qualified_name": "tests::empty_sf_path_emits_diagnostic",
             "span": {
               "end_column": 5,
               "end_line": 747,
@@ -11217,7 +11585,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "da_with_checksum_field_is_accepted",
+            "qualified_name": "tests::da_with_checksum_field_is_accepted",
             "span": {
               "end_column": 5,
               "end_line": 756,
@@ -11241,7 +11609,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "non_coverage_records_are_ignored",
+            "qualified_name": "tests::non_coverage_records_are_ignored",
             "span": {
               "end_column": 5,
               "end_line": 770,
@@ -11265,7 +11633,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "brda_and_da_records_parsed",
+            "qualified_name": "tests::brda_and_da_records_parsed",
             "span": {
               "end_column": 5,
               "end_line": 782,
@@ -11289,7 +11657,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "brda_dash_maps_to_none",
+            "qualified_name": "tests::brda_dash_maps_to_none",
             "span": {
               "end_column": 5,
               "end_line": 789,
@@ -11313,7 +11681,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "brda_numeric_maps_to_some",
+            "qualified_name": "tests::brda_numeric_maps_to_some",
             "span": {
               "end_column": 5,
               "end_line": 796,
@@ -11337,7 +11705,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "brda_zero_maps_to_some_zero",
+            "qualified_name": "tests::brda_zero_maps_to_some_zero",
             "span": {
               "end_column": 5,
               "end_line": 803,
@@ -11361,7 +11729,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "duplicate_brda_sum_taken",
+            "qualified_name": "tests::duplicate_brda_sum_taken",
             "span": {
               "end_column": 5,
               "end_line": 813,
@@ -11385,7 +11753,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "brda_dash_and_numeric_merge",
+            "qualified_name": "tests::brda_dash_and_numeric_merge",
             "span": {
               "end_column": 5,
               "end_line": 821,
@@ -11409,7 +11777,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "brda_missing_fields_is_malformed",
+            "qualified_name": "tests::brda_missing_fields_is_malformed",
             "span": {
               "end_column": 5,
               "end_line": 848,
@@ -11433,7 +11801,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "brda_missing_taken_is_malformed",
+            "qualified_name": "tests::brda_missing_taken_is_malformed",
             "span": {
               "end_column": 5,
               "end_line": 859,
@@ -11457,7 +11825,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "brda_line_zero_is_malformed",
+            "qualified_name": "tests::brda_line_zero_is_malformed",
             "span": {
               "end_column": 5,
               "end_line": 898,
@@ -11481,7 +11849,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "no_brda_produces_none_branches",
+            "qualified_name": "tests::no_brda_produces_none_branches",
             "span": {
               "end_column": 5,
               "end_line": 904,
@@ -11505,7 +11873,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "arb_da_line",
+            "qualified_name": "proptests::arb_da_line",
             "span": {
               "end_column": 5,
               "end_line": 914,
@@ -11529,7 +11897,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/coverage/mod.rs",
-            "qualified_name": "arb_lcov_input",
+            "qualified_name": "proptests::arb_lcov_input",
             "span": {
               "end_column": 5,
               "end_line": 930,
@@ -11566,16 +11934,16 @@ expression: pretty
       }
     ],
     "shown_summary": {
-      "average_complexity": 1.5658536585365854,
-      "average_coverage": 94.8358552536385,
-      "average_crap": 1.6449268292682926,
+      "average_complexity": 1.5352112676056338,
+      "average_coverage": 94.86902385796895,
+      "average_crap": 1.5938967136150233,
       "distribution": {
-        "acceptable": 3,
+        "acceptable": 2,
         "high": 0,
-        "low": 202,
+        "low": 211,
         "moderate": 0
       },
-      "exceeding_threshold": 3,
+      "exceeding_threshold": 2,
       "max_complexity": 11,
       "max_crap": {
         "risk_level": "acceptable",
@@ -11586,7 +11954,7 @@ expression: pretty
       "median_crap": 1.0,
       "min_coverage": 0.0,
       "total_files": 5,
-      "total_functions": 205,
+      "total_functions": 213,
       "worst_function": {
         "file_path": "adapters/coverage/mod.rs",
         "qualified_name": "parse_brda",

--- a/crates/crap-core/tests/snapshots/wire_envelope_crap4rs__envelope.snap
+++ b/crates/crap-core/tests/snapshots/wire_envelope_crap4rs__envelope.snap
@@ -68,29 +68,37 @@ expression: pretty
       {
         "exceeds": false,
         "scored": {
-          "complexity": 2,
+          "complexity": 4,
           "complexity_metric": "cognitive",
           "contributors": [
             {
               "column": 9,
-              "end_line": 77,
+              "end_line": 90,
               "increment": 1,
-              "kind": "if-branch",
-              "line": 75,
+              "kind": "match",
+              "line": 79,
               "nesting_depth": 0
+            },
+            {
+              "column": 17,
+              "end_line": 86,
+              "increment": 2,
+              "kind": "if-branch",
+              "line": 84,
+              "nesting_depth": 1
             }
           ],
-          "coverage_percent": 100.0,
+          "coverage_percent": 94.73684210526316,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 4.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
             "qualified_name": "FunctionFinder::qualify",
             "span": {
               "end_column": 5,
-              "end_line": 80,
+              "end_line": 91,
               "start_column": 5,
               "start_line": 65
             }
@@ -101,22 +109,31 @@ expression: pretty
       {
         "exceeds": false,
         "scored": {
-          "complexity": 1,
+          "complexity": 2,
           "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 90.0,
+          "contributors": [
+            {
+              "column": 9,
+              "end_line": 112,
+              "increment": 1,
+              "kind": "if-branch",
+              "line": 106,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 93.33333333333331,
           "crap": {
             "risk_level": "low",
-            "value": 1.0
+            "value": 2.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
             "qualified_name": "FunctionFinder::visit_item_mod",
             "span": {
               "end_column": 5,
-              "end_line": 95,
+              "end_line": 113,
               "start_column": 5,
-              "start_line": 84
+              "start_line": 95
             }
           }
         },
@@ -128,7 +145,7 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 92.85714285714286,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
             "value": 1.0
@@ -138,9 +155,9 @@ expression: pretty
             "qualified_name": "FunctionFinder::visit_item_fn",
             "span": {
               "end_column": 5,
-              "end_line": 115,
+              "end_line": 133,
               "start_column": 5,
-              "start_line": 97
+              "start_line": 115
             }
           }
         },
@@ -162,9 +179,9 @@ expression: pretty
             "qualified_name": "FunctionFinder::visit_item_impl",
             "span": {
               "end_column": 5,
-              "end_line": 122,
+              "end_line": 140,
               "start_column": 5,
-              "start_line": 117
+              "start_line": 135
             }
           }
         },
@@ -176,7 +193,7 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 100.0,
+          "coverage_percent": 83.33333333333334,
           "crap": {
             "risk_level": "low",
             "value": 1.0
@@ -186,9 +203,9 @@ expression: pretty
             "qualified_name": "FunctionFinder::visit_impl_item_fn",
             "span": {
               "end_column": 5,
-              "end_line": 139,
+              "end_line": 157,
               "start_column": 5,
-              "start_line": 124
+              "start_line": 142
             }
           }
         },
@@ -202,26 +219,26 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 156,
+              "end_line": 174,
               "increment": 1,
               "kind": "if-branch",
-              "line": 143,
+              "line": 161,
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 84.61538461538461,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.01
+            "value": 2.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
             "qualified_name": "FunctionFinder::visit_trait_item_fn",
             "span": {
               "end_column": 5,
-              "end_line": 159,
+              "end_line": 177,
               "start_column": 5,
-              "start_line": 141
+              "start_line": 159
             }
           }
         },
@@ -243,9 +260,33 @@ expression: pretty
             "qualified_name": "FunctionFinder::visit_item_trait",
             "span": {
               "end_column": 5,
-              "end_line": 166,
+              "end_line": 184,
               "start_column": 5,
-              "start_line": 161
+              "start_line": 179
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 82.35294117647058,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.01
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "add_contributor",
+            "span": {
+              "end_column": 1,
+              "end_line": 208,
+              "start_column": 1,
+              "start_line": 189
             }
           }
         },
@@ -264,36 +305,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "add_contributor",
-            "span": {
-              "end_column": 1,
-              "end_line": 190,
-              "start_column": 1,
-              "start_line": 171
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 50.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.13
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
             "qualified_name": "end_line_of",
             "span": {
               "end_column": 1,
-              "end_line": 198,
+              "end_line": 216,
               "start_column": 1,
-              "start_line": 192
+              "start_line": 210
             }
           }
         },
@@ -305,7 +322,7 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 94.73684210526316,
+          "coverage_percent": 88.88888888888889,
           "crap": {
             "risk_level": "low",
             "value": 1.0
@@ -315,9 +332,9 @@ expression: pretty
             "qualified_name": "span_of",
             "span": {
               "end_column": 1,
-              "end_line": 221,
+              "end_line": 239,
               "start_column": 1,
-              "start_line": 200
+              "start_line": 218
             }
           }
         },
@@ -331,18 +348,18 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 229,
+              "end_line": 247,
               "increment": 1,
               "kind": "if-branch",
-              "line": 225,
+              "line": 243,
               "nesting_depth": 0
             },
             {
               "column": 9,
-              "end_line": 226,
+              "end_line": 244,
               "increment": 1,
               "kind": "logical-operator",
-              "line": 226,
+              "line": 244,
               "nesting_depth": 0
             }
           ],
@@ -356,9 +373,9 @@ expression: pretty
             "qualified_name": "extract_type_name",
             "span": {
               "end_column": 1,
-              "end_line": 232,
+              "end_line": 250,
               "start_column": 1,
-              "start_line": 223
+              "start_line": 241
             }
           }
         },
@@ -372,26 +389,26 @@ expression: pretty
           "contributors": [
             {
               "column": 15,
-              "end_line": 244,
+              "end_line": 262,
               "increment": 1,
               "kind": "match",
-              "line": 241,
+              "line": 259,
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 85.71428571428571,
+          "coverage_percent": 45.45454545454545,
           "crap": {
             "risk_level": "low",
-            "value": 2.01
+            "value": 2.65
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
             "qualified_name": "count_complexity",
             "span": {
               "end_column": 1,
-              "end_line": 247,
+              "end_line": 265,
               "start_column": 1,
-              "start_line": 236
+              "start_line": 254
             }
           }
         },
@@ -403,19 +420,19 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 77.77777777777779,
+          "coverage_percent": 83.33333333333334,
           "crap": {
             "risk_level": "low",
-            "value": 1.01
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
             "qualified_name": "count_cognitive_block",
             "span": {
               "end_column": 1,
-              "end_line": 261,
+              "end_line": 279,
               "start_column": 1,
-              "start_line": 251
+              "start_line": 269
             }
           }
         },
@@ -429,42 +446,42 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 291,
+              "end_line": 309,
               "increment": 1,
               "kind": "match",
-              "line": 268,
+              "line": 286,
               "nesting_depth": 0
             },
             {
               "column": 13,
-              "end_line": 287,
+              "end_line": 305,
               "increment": 2,
               "kind": "if-branch",
-              "line": 272,
+              "line": 290,
               "nesting_depth": 1
             },
             {
               "column": 17,
-              "end_line": 286,
+              "end_line": 304,
               "increment": 3,
               "kind": "if-branch",
-              "line": 274,
+              "line": 292,
               "nesting_depth": 2
             }
           ],
-          "coverage_percent": 73.68421052631578,
+          "coverage_percent": 72.72727272727273,
           "crap": {
             "risk_level": "low",
-            "value": 7.89
+            "value": 7.99
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
             "qualified_name": "count_cognitive_stmt",
             "span": {
               "end_column": 1,
-              "end_line": 292,
+              "end_line": 310,
               "start_column": 1,
-              "start_line": 263
+              "start_line": 281
             }
           }
         },
@@ -478,26 +495,26 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 321,
+              "end_line": 339,
               "increment": 1,
               "kind": "match",
-              "line": 299,
+              "line": 317,
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 34.78260869565217,
+          "coverage_percent": 40.0,
           "crap": {
             "risk_level": "low",
-            "value": 3.11
+            "value": 2.86
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
             "qualified_name": "count_cognitive_expr",
             "span": {
               "end_column": 1,
-              "end_line": 322,
+              "end_line": 340,
               "start_column": 1,
-              "start_line": 294
+              "start_line": 312
             }
           }
         },
@@ -511,34 +528,34 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 344,
+              "end_line": 362,
               "increment": 1,
               "kind": "for-loop",
-              "line": 339,
+              "line": 357,
               "nesting_depth": 0
             },
             {
               "column": 9,
-              "end_line": 342,
+              "end_line": 360,
               "increment": 2,
               "kind": "if-branch",
-              "line": 340,
+              "line": 358,
               "nesting_depth": 1
             }
           ],
-          "coverage_percent": 80.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 4.13
+            "value": 4.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
             "qualified_name": "count_cognitive_match",
             "span": {
               "end_column": 1,
-              "end_line": 346,
+              "end_line": 364,
               "start_column": 1,
-              "start_line": 324
+              "start_line": 342
             }
           }
         },
@@ -560,9 +577,9 @@ expression: pretty
             "qualified_name": "count_cognitive_while",
             "span": {
               "end_column": 1,
-              "end_line": 365,
+              "end_line": 383,
               "start_column": 1,
-              "start_line": 348
+              "start_line": 366
             }
           }
         },
@@ -584,9 +601,9 @@ expression: pretty
             "qualified_name": "count_cognitive_for_loop",
             "span": {
               "end_column": 1,
-              "end_line": 384,
+              "end_line": 402,
               "start_column": 1,
-              "start_line": 367
+              "start_line": 385
             }
           }
         },
@@ -598,7 +615,7 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 100.0,
+          "coverage_percent": 85.71428571428571,
           "crap": {
             "risk_level": "low",
             "value": 1.0
@@ -608,9 +625,9 @@ expression: pretty
             "qualified_name": "count_cognitive_loop",
             "span": {
               "end_column": 1,
-              "end_line": 402,
+              "end_line": 420,
               "start_column": 1,
-              "start_line": 386
+              "start_line": 404
             }
           }
         },
@@ -622,7 +639,7 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 83.33333333333334,
+          "coverage_percent": 85.71428571428571,
           "crap": {
             "risk_level": "low",
             "value": 1.0
@@ -632,9 +649,9 @@ expression: pretty
             "qualified_name": "count_cognitive_binary",
             "span": {
               "end_column": 1,
-              "end_line": 416,
+              "end_line": 434,
               "start_column": 1,
-              "start_line": 408
+              "start_line": 426
             }
           }
         },
@@ -646,7 +663,7 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 92.3076923076923,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
             "value": 1.0
@@ -656,9 +673,9 @@ expression: pretty
             "qualified_name": "count_cognitive_try",
             "span": {
               "end_column": 1,
-              "end_line": 432,
+              "end_line": 450,
               "start_column": 1,
-              "start_line": 418
+              "start_line": 436
             }
           }
         },
@@ -670,7 +687,7 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 100.0,
+          "coverage_percent": 90.0,
           "crap": {
             "risk_level": "low",
             "value": 1.0
@@ -680,9 +697,9 @@ expression: pretty
             "qualified_name": "count_cognitive_break",
             "span": {
               "end_column": 1,
-              "end_line": 448,
+              "end_line": 466,
               "start_column": 1,
-              "start_line": 434
+              "start_line": 452
             }
           }
         },
@@ -694,7 +711,7 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 90.9090909090909,
+          "coverage_percent": 84.61538461538461,
           "crap": {
             "risk_level": "low",
             "value": 1.0
@@ -704,9 +721,9 @@ expression: pretty
             "qualified_name": "count_cognitive_continue",
             "span": {
               "end_column": 1,
-              "end_line": 464,
+              "end_line": 482,
               "start_column": 1,
-              "start_line": 450
+              "start_line": 468
             }
           }
         },
@@ -720,26 +737,26 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 474,
+              "end_line": 492,
               "increment": 1,
               "kind": "match",
-              "line": 471,
+              "line": 489,
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 100.0,
+          "coverage_percent": 33.33333333333333,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 3.19
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
             "qualified_name": "count_cognitive_return",
             "span": {
               "end_column": 1,
-              "end_line": 475,
+              "end_line": 493,
               "start_column": 1,
-              "start_line": 466
+              "start_line": 484
             }
           }
         },
@@ -751,19 +768,19 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 16.666666666666664,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 1.58
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
             "qualified_name": "count_cognitive_closure",
             "span": {
               "end_column": 1,
-              "end_line": 485,
+              "end_line": 503,
               "start_column": 1,
-              "start_line": 479
+              "start_line": 497
             }
           }
         },
@@ -777,43 +794,10 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 495,
+              "end_line": 513,
               "increment": 1,
               "kind": "for-loop",
-              "line": 493,
-              "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 57.14285714285714,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.31
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "count_cognitive_call",
-            "span": {
-              "end_column": 1,
-              "end_line": 497,
-              "start_column": 1,
-              "start_line": 487
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 2,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 5,
-              "end_line": 507,
-              "increment": 1,
-              "kind": "for-loop",
-              "line": 505,
+              "line": 511,
               "nesting_depth": 0
             }
           ],
@@ -824,12 +808,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "count_cognitive_method_call",
+            "qualified_name": "count_cognitive_call",
             "span": {
               "end_column": 1,
-              "end_line": 509,
+              "end_line": 515,
               "start_column": 1,
-              "start_line": 499
+              "start_line": 505
             }
           }
         },
@@ -843,10 +827,43 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 519,
+              "end_line": 525,
               "increment": 1,
               "kind": "for-loop",
-              "line": 517,
+              "line": 523,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 66.66666666666666,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.15
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "count_cognitive_method_call",
+            "span": {
+              "end_column": 1,
+              "end_line": 527,
+              "start_column": 1,
+              "start_line": 517
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 2,
+          "complexity_metric": "cognitive",
+          "contributors": [
+            {
+              "column": 5,
+              "end_line": 537,
+              "increment": 1,
+              "kind": "for-loop",
+              "line": 535,
               "nesting_depth": 0
             }
           ],
@@ -860,9 +877,9 @@ expression: pretty
             "qualified_name": "count_cognitive_tuple",
             "span": {
               "end_column": 1,
-              "end_line": 521,
+              "end_line": 539,
               "start_column": 1,
-              "start_line": 511
+              "start_line": 529
             }
           }
         },
@@ -876,42 +893,42 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 573,
+              "end_line": 591,
               "increment": 1,
               "kind": "if-branch",
-              "line": 546,
+              "line": 564,
               "nesting_depth": 0
             },
             {
               "column": 9,
-              "end_line": 572,
+              "end_line": 590,
               "increment": 2,
               "kind": "match",
-              "line": 547,
+              "line": 565,
               "nesting_depth": 1
             },
             {
               "column": 17,
-              "end_line": 563,
+              "end_line": 581,
               "increment": 3,
               "kind": "if-branch",
-              "line": 561,
+              "line": 579,
               "nesting_depth": 2
             }
           ],
-          "coverage_percent": 86.66666666666667,
+          "coverage_percent": 94.87179487179486,
           "crap": {
             "risk_level": "low",
-            "value": 7.12
+            "value": 7.01
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
             "qualified_name": "count_cognitive_if",
             "span": {
               "end_column": 1,
-              "end_line": 576,
+              "end_line": 594,
               "start_column": 1,
-              "start_line": 523
+              "start_line": 541
             }
           }
         },
@@ -925,34 +942,34 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 607,
+              "end_line": 625,
               "increment": 1,
               "kind": "match",
-              "line": 583,
+              "line": 601,
               "nesting_depth": 0
             },
             {
               "column": 13,
-              "end_line": 599,
+              "end_line": 617,
               "increment": 2,
               "kind": "if-branch",
-              "line": 597,
+              "line": 615,
               "nesting_depth": 1
             }
           ],
-          "coverage_percent": 91.30434782608695,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 4.01
+            "value": 4.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
             "qualified_name": "count_cognitive_else",
             "span": {
               "end_column": 1,
-              "end_line": 608,
+              "end_line": 626,
               "start_column": 1,
-              "start_line": 578
+              "start_line": 596
             }
           }
         },
@@ -966,34 +983,34 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 620,
+              "end_line": 638,
               "increment": 1,
               "kind": "if-branch",
-              "line": 618,
+              "line": 636,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 645,
+              "end_line": 663,
               "increment": 1,
               "kind": "for-loop",
-              "line": 625,
+              "line": 643,
               "nesting_depth": 0
             },
             {
               "column": 9,
-              "end_line": 644,
+              "end_line": 662,
               "increment": 2,
               "kind": "match",
-              "line": 626,
+              "line": 644,
               "nesting_depth": 1
             },
             {
               "column": 17,
-              "end_line": 638,
+              "end_line": 656,
               "increment": 3,
               "kind": "if-branch",
-              "line": 628,
+              "line": 646,
               "nesting_depth": 2
             }
           ],
@@ -1007,9 +1024,9 @@ expression: pretty
             "qualified_name": "count_cognitive_binary_chain",
             "span": {
               "end_column": 1,
-              "end_line": 648,
+              "end_line": 666,
               "start_column": 1,
-              "start_line": 610
+              "start_line": 628
             }
           }
         },
@@ -1023,10 +1040,10 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 665,
+              "end_line": 683,
               "increment": 1,
               "kind": "match",
-              "line": 659,
+              "line": 677,
               "nesting_depth": 0
             }
           ],
@@ -1040,9 +1057,9 @@ expression: pretty
             "qualified_name": "count_cognitive_binary_operands",
             "span": {
               "end_column": 1,
-              "end_line": 666,
+              "end_line": 684,
               "start_column": 1,
-              "start_line": 650
+              "start_line": 668
             }
           }
         },
@@ -1056,10 +1073,10 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 680,
+              "end_line": 698,
               "increment": 1,
               "kind": "match",
-              "line": 676,
+              "line": 694,
               "nesting_depth": 0
             }
           ],
@@ -1073,9 +1090,9 @@ expression: pretty
             "qualified_name": "classify_binop",
             "span": {
               "end_column": 1,
-              "end_line": 681,
+              "end_line": 699,
               "start_column": 1,
-              "start_line": 675
+              "start_line": 693
             }
           }
         },
@@ -1089,10 +1106,10 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 691,
+              "end_line": 709,
               "increment": 1,
               "kind": "match",
-              "line": 684,
+              "line": 702,
               "nesting_depth": 0
             }
           ],
@@ -1106,9 +1123,9 @@ expression: pretty
             "qualified_name": "binop_span",
             "span": {
               "end_column": 1,
-              "end_line": 692,
+              "end_line": 710,
               "start_column": 1,
-              "start_line": 683
+              "start_line": 701
             }
           }
         },
@@ -1130,9 +1147,9 @@ expression: pretty
             "qualified_name": "flatten_binary_ops",
             "span": {
               "end_column": 1,
-              "end_line": 702,
+              "end_line": 720,
               "start_column": 1,
-              "start_line": 694
+              "start_line": 712
             }
           }
         },
@@ -1146,10 +1163,10 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 709,
+              "end_line": 727,
               "increment": 1,
               "kind": "if-branch",
-              "line": 705,
+              "line": 723,
               "nesting_depth": 0
             }
           ],
@@ -1163,9 +1180,9 @@ expression: pretty
             "qualified_name": "flatten_binary_ops_inner",
             "span": {
               "end_column": 1,
-              "end_line": 710,
+              "end_line": 728,
               "start_column": 1,
-              "start_line": 704
+              "start_line": 722
             }
           }
         },
@@ -1187,9 +1204,9 @@ expression: pretty
             "qualified_name": "count_cyclomatic_block",
             "span": {
               "end_column": 1,
-              "end_line": 719,
+              "end_line": 737,
               "start_column": 1,
-              "start_line": 714
+              "start_line": 732
             }
           }
         },
@@ -1211,9 +1228,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::count_block",
             "span": {
               "end_column": 5,
-              "end_line": 736,
+              "end_line": 754,
               "start_column": 5,
-              "start_line": 728
+              "start_line": 746
             }
           }
         },
@@ -1235,9 +1252,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::bump",
             "span": {
               "end_column": 5,
-              "end_line": 748,
+              "end_line": 766,
               "start_column": 5,
-              "start_line": 738
+              "start_line": 756
             }
           }
         },
@@ -1259,9 +1276,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::with_nesting",
             "span": {
               "end_column": 5,
-              "end_line": 754,
+              "end_line": 772,
               "start_column": 5,
-              "start_line": 750
+              "start_line": 768
             }
           }
         },
@@ -1275,10 +1292,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 763,
+              "end_line": 781,
               "increment": 1,
               "kind": "match",
-              "line": 759,
+              "line": 777,
               "nesting_depth": 0
             }
           ],
@@ -1292,9 +1309,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::visit_stmt",
             "span": {
               "end_column": 5,
-              "end_line": 764,
+              "end_line": 782,
               "start_column": 5,
-              "start_line": 758
+              "start_line": 776
             }
           }
         },
@@ -1308,18 +1325,18 @@ expression: pretty
           "contributors": [
             {
               "column": 38,
-              "end_line": 769,
+              "end_line": 787,
               "increment": 1,
               "kind": "let-else",
-              "line": 767,
+              "line": 785,
               "nesting_depth": 0
             },
             {
               "column": 9,
-              "end_line": 780,
+              "end_line": 798,
               "increment": 1,
               "kind": "if-branch",
-              "line": 772,
+              "line": 790,
               "nesting_depth": 0
             }
           ],
@@ -1333,9 +1350,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::visit_local",
             "span": {
               "end_column": 5,
-              "end_line": 781,
+              "end_line": 799,
               "start_column": 5,
-              "start_line": 766
+              "start_line": 784
             }
           }
         },
@@ -1349,18 +1366,18 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 801,
+              "end_line": 819,
               "increment": 1,
               "kind": "if-branch",
-              "line": 792,
+              "line": 810,
               "nesting_depth": 0
             },
             {
               "column": 13,
-              "end_line": 800,
+              "end_line": 818,
               "increment": 2,
               "kind": "match",
-              "line": 793,
+              "line": 811,
               "nesting_depth": 1
             }
           ],
@@ -1374,9 +1391,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::visit_expr_if",
             "span": {
               "end_column": 5,
-              "end_line": 802,
+              "end_line": 820,
               "start_column": 5,
-              "start_line": 783
+              "start_line": 801
             }
           }
         },
@@ -1390,18 +1407,18 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 812,
+              "end_line": 830,
               "increment": 1,
               "kind": "for-loop",
-              "line": 805,
+              "line": 823,
               "nesting_depth": 0
             },
             {
               "column": 9,
-              "end_line": 817,
+              "end_line": 835,
               "increment": 1,
               "kind": "for-loop",
-              "line": 815,
+              "line": 833,
               "nesting_depth": 0
             }
           ],
@@ -1415,9 +1432,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::visit_expr_match",
             "span": {
               "end_column": 5,
-              "end_line": 818,
+              "end_line": 836,
               "start_column": 5,
-              "start_line": 804
+              "start_line": 822
             }
           }
         },
@@ -1431,10 +1448,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 823,
+              "end_line": 841,
               "increment": 1,
               "kind": "if-branch",
-              "line": 821,
+              "line": 839,
               "nesting_depth": 0
             }
           ],
@@ -1448,9 +1465,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::visit_arm",
             "span": {
               "end_column": 5,
-              "end_line": 825,
+              "end_line": 843,
               "start_column": 5,
-              "start_line": 820
+              "start_line": 838
             }
           }
         },
@@ -1472,9 +1489,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::visit_expr_while",
             "span": {
               "end_column": 5,
-              "end_line": 836,
+              "end_line": 854,
               "start_column": 5,
-              "start_line": 827
+              "start_line": 845
             }
           }
         },
@@ -1496,9 +1513,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::visit_expr_for_loop",
             "span": {
               "end_column": 5,
-              "end_line": 847,
+              "end_line": 865,
               "start_column": 5,
-              "start_line": 838
+              "start_line": 856
             }
           }
         },
@@ -1520,9 +1537,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::visit_expr_loop",
             "span": {
               "end_column": 5,
-              "end_line": 857,
+              "end_line": 875,
               "start_column": 5,
-              "start_line": 849
+              "start_line": 867
             }
           }
         },
@@ -1536,10 +1553,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 863,
+              "end_line": 881,
               "increment": 1,
               "kind": "if-branch",
-              "line": 860,
+              "line": 878,
               "nesting_depth": 0
             }
           ],
@@ -1553,9 +1570,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::visit_expr_binary",
             "span": {
               "end_column": 5,
-              "end_line": 866,
+              "end_line": 884,
               "start_column": 5,
-              "start_line": 859
+              "start_line": 877
             }
           }
         },
@@ -1577,9 +1594,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::visit_expr_try",
             "span": {
               "end_column": 5,
-              "end_line": 876,
+              "end_line": 894,
               "start_column": 5,
-              "start_line": 868
+              "start_line": 886
             }
           }
         },
@@ -1593,26 +1610,26 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 887,
+              "end_line": 905,
               "increment": 1,
               "kind": "if-branch",
-              "line": 885,
+              "line": 903,
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 100.0,
+          "coverage_percent": 80.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.0
+            "value": 2.03
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
             "qualified_name": "CyclomaticCounter::visit_expr_break",
             "span": {
               "end_column": 5,
-              "end_line": 888,
+              "end_line": 906,
               "start_column": 5,
-              "start_line": 878
+              "start_line": 896
             }
           }
         },
@@ -1634,9 +1651,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::visit_expr_continue",
             "span": {
               "end_column": 5,
-              "end_line": 897,
+              "end_line": 915,
               "start_column": 5,
-              "start_line": 890
+              "start_line": 908
             }
           }
         },
@@ -1648,19 +1665,19 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 50.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 1.13
+            "value": 1.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
             "qualified_name": "CyclomaticCounter::visit_expr_closure",
             "span": {
               "end_column": 5,
-              "end_line": 904,
+              "end_line": 922,
               "start_column": 5,
-              "start_line": 899
+              "start_line": 917
             }
           }
         },
@@ -1682,9 +1699,9 @@ expression: pretty
             "qualified_name": "test_helpers::adapter",
             "span": {
               "end_column": 5,
-              "end_line": 915,
+              "end_line": 933,
               "start_column": 5,
-              "start_line": 913
+              "start_line": 931
             }
           }
         },
@@ -1706,9 +1723,9 @@ expression: pretty
             "qualified_name": "test_helpers::load_fixture",
             "span": {
               "end_column": 5,
-              "end_line": 921,
+              "end_line": 939,
               "start_column": 5,
-              "start_line": 917
+              "start_line": 935
             }
           }
         },
@@ -1730,9 +1747,9 @@ expression: pretty
             "qualified_name": "test_helpers::extract_fixture",
             "span": {
               "end_column": 5,
-              "end_line": 928,
+              "end_line": 946,
               "start_column": 5,
-              "start_line": 923
+              "start_line": 941
             }
           }
         },
@@ -1754,9 +1771,9 @@ expression: pretty
             "qualified_name": "test_helpers::find_fn",
             "span": {
               "end_column": 5,
-              "end_line": 941,
+              "end_line": 959,
               "start_column": 5,
-              "start_line": 930
+              "start_line": 948
             }
           }
         },
@@ -1778,9 +1795,9 @@ expression: pretty
             "qualified_name": "tests::baseline_complexity_is_one_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 957,
+              "end_line": 975,
               "start_column": 5,
-              "start_line": 952
+              "start_line": 970
             }
           }
         },
@@ -1802,9 +1819,9 @@ expression: pretty
             "qualified_name": "tests::baseline_complexity_is_one_cyclomatic",
             "span": {
               "end_column": 5,
-              "end_line": 964,
+              "end_line": 982,
               "start_column": 5,
-              "start_line": 959
+              "start_line": 977
             }
           }
         },
@@ -1826,9 +1843,9 @@ expression: pretty
             "qualified_name": "tests::top_level_fn_identity",
             "span": {
               "end_column": 5,
-              "end_line": 975,
+              "end_line": 993,
               "start_column": 5,
-              "start_line": 968
+              "start_line": 986
             }
           }
         },
@@ -1850,9 +1867,9 @@ expression: pretty
             "qualified_name": "tests::impl_method_qualified_name",
             "span": {
               "end_column": 5,
-              "end_line": 983,
+              "end_line": 1001,
               "start_column": 5,
-              "start_line": 977
+              "start_line": 995
             }
           }
         },
@@ -1874,9 +1891,9 @@ expression: pretty
             "qualified_name": "tests::top_level_fn_in_nested_mods_fixture_is_unqualified",
             "span": {
               "end_column": 5,
-              "end_line": 993,
+              "end_line": 1011,
               "start_column": 5,
-              "start_line": 987
+              "start_line": 1005
             }
           }
         },
@@ -1898,9 +1915,9 @@ expression: pretty
             "qualified_name": "tests::one_level_mod_qualified_name",
             "span": {
               "end_column": 5,
-              "end_line": 999,
+              "end_line": 1017,
               "start_column": 5,
-              "start_line": 995
+              "start_line": 1013
             }
           }
         },
@@ -1922,9 +1939,9 @@ expression: pretty
             "qualified_name": "tests::multi_level_mod_qualified_name",
             "span": {
               "end_column": 5,
-              "end_line": 1005,
+              "end_line": 1023,
               "start_column": 5,
-              "start_line": 1001
+              "start_line": 1019
             }
           }
         },
@@ -1946,9 +1963,9 @@ expression: pretty
             "qualified_name": "tests::impl_method_inside_mod_prepends_mod_path",
             "span": {
               "end_column": 5,
-              "end_line": 1014,
+              "end_line": 1032,
               "start_column": 5,
-              "start_line": 1007
+              "start_line": 1025
             }
           }
         },
@@ -1970,9 +1987,9 @@ expression: pretty
             "qualified_name": "tests::nested_fn_inside_mod_is_mod_scoped_not_fn_scoped",
             "span": {
               "end_column": 5,
-              "end_line": 1029,
+              "end_line": 1047,
               "start_column": 5,
-              "start_line": 1016
+              "start_line": 1034
             }
           }
         },
@@ -1994,9 +2011,9 @@ expression: pretty
             "qualified_name": "tests::mod_qualification_does_not_disturb_complexity",
             "span": {
               "end_column": 5,
-              "end_line": 1041,
+              "end_line": 1059,
               "start_column": 5,
-              "start_line": 1031
+              "start_line": 1049
             }
           }
         },
@@ -2018,9 +2035,9 @@ expression: pretty
             "qualified_name": "tests::span_accuracy",
             "span": {
               "end_column": 5,
-              "end_line": 1064,
+              "end_line": 1082,
               "start_column": 5,
-              "start_line": 1043
+              "start_line": 1061
             }
           }
         },
@@ -2042,9 +2059,9 @@ expression: pretty
             "qualified_name": "tests::span_carries_one_based_columns",
             "span": {
               "end_column": 5,
-              "end_line": 1085,
+              "end_line": 1103,
               "start_column": 5,
-              "start_line": 1066
+              "start_line": 1084
             }
           }
         },
@@ -2066,9 +2083,9 @@ expression: pretty
             "qualified_name": "tests::columns_are_exact_one_based_offsets_unindented",
             "span": {
               "end_column": 5,
-              "end_line": 1115,
+              "end_line": 1133,
               "start_column": 5,
-              "start_line": 1087
+              "start_line": 1105
             }
           }
         },
@@ -2090,9 +2107,9 @@ expression: pretty
             "qualified_name": "tests::columns_are_exact_one_based_offsets_indented",
             "span": {
               "end_column": 5,
-              "end_line": 1140,
+              "end_line": 1158,
               "start_column": 5,
-              "start_line": 1117
+              "start_line": 1135
             }
           }
         },
@@ -2114,9 +2131,9 @@ expression: pretty
             "qualified_name": "tests::multiple_fns_returns_all",
             "span": {
               "end_column": 5,
-              "end_line": 1146,
+              "end_line": 1164,
               "start_column": 5,
-              "start_line": 1142
+              "start_line": 1160
             }
           }
         },
@@ -2136,54 +2153,6 @@ expression: pretty
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
             "qualified_name": "tests::async_fn_detected",
-            "span": {
-              "end_column": 5,
-              "end_line": 1154,
-              "start_column": 5,
-              "start_line": 1148
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 100.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "tests::if_else_cognitive",
-            "span": {
-              "end_column": 5,
-              "end_line": 1164,
-              "start_column": 5,
-              "start_line": 1158
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 100.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "tests::nested_if_cognitive_penalty",
             "span": {
               "end_column": 5,
               "end_line": 1172,
@@ -2207,12 +2176,60 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "tests::if_else_cognitive",
+            "span": {
+              "end_column": 5,
+              "end_line": 1182,
+              "start_column": 5,
+              "start_line": 1176
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "tests::nested_if_cognitive_penalty",
+            "span": {
+              "end_column": 5,
+              "end_line": 1190,
+              "start_column": 5,
+              "start_line": 1184
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
             "qualified_name": "tests::else_is_not_counted_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1181,
+              "end_line": 1199,
               "start_column": 5,
-              "start_line": 1174
+              "start_line": 1192
             }
           }
         },
@@ -2232,54 +2249,6 @@ expression: pretty
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
             "qualified_name": "tests::match_flat_cognitive",
-            "span": {
-              "end_column": 5,
-              "end_line": 1189,
-              "start_column": 5,
-              "start_line": 1183
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 100.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "tests::if_else_cyclomatic",
-            "span": {
-              "end_column": 5,
-              "end_line": 1199,
-              "start_column": 5,
-              "start_line": 1193
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 100.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "tests::nested_if_cyclomatic",
             "span": {
               "end_column": 5,
               "end_line": 1207,
@@ -2303,12 +2272,60 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "tests::if_else_cyclomatic",
+            "span": {
+              "end_column": 5,
+              "end_line": 1217,
+              "start_column": 5,
+              "start_line": 1211
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "tests::nested_if_cyclomatic",
+            "span": {
+              "end_column": 5,
+              "end_line": 1225,
+              "start_column": 5,
+              "start_line": 1219
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
             "qualified_name": "tests::match_arms_cyclomatic",
             "span": {
               "end_column": 5,
-              "end_line": 1215,
+              "end_line": 1233,
               "start_column": 5,
-              "start_line": 1209
+              "start_line": 1227
             }
           }
         },
@@ -2330,9 +2347,9 @@ expression: pretty
             "qualified_name": "tests::cognitive_gte_cyclomatic_for_nested",
             "span": {
               "end_column": 5,
-              "end_line": 1228,
+              "end_line": 1246,
               "start_column": 5,
-              "start_line": 1217
+              "start_line": 1235
             }
           }
         },
@@ -2354,9 +2371,9 @@ expression: pretty
             "qualified_name": "tests::bool_same_sequence_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1238,
+              "end_line": 1256,
               "start_column": 5,
-              "start_line": 1232
+              "start_line": 1250
             }
           }
         },
@@ -2378,9 +2395,9 @@ expression: pretty
             "qualified_name": "tests::bool_same_sequence_cyclomatic",
             "span": {
               "end_column": 5,
-              "end_line": 1246,
+              "end_line": 1264,
               "start_column": 5,
-              "start_line": 1240
+              "start_line": 1258
             }
           }
         },
@@ -2402,9 +2419,9 @@ expression: pretty
             "qualified_name": "tests::bool_operator_switch_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1254,
+              "end_line": 1272,
               "start_column": 5,
-              "start_line": 1248
+              "start_line": 1266
             }
           }
         },
@@ -2426,9 +2443,9 @@ expression: pretty
             "qualified_name": "tests::bool_operator_switch_cyclomatic",
             "span": {
               "end_column": 5,
-              "end_line": 1262,
+              "end_line": 1280,
               "start_column": 5,
-              "start_line": 1256
+              "start_line": 1274
             }
           }
         },
@@ -2450,9 +2467,9 @@ expression: pretty
             "qualified_name": "tests::bool_in_condition_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1270,
+              "end_line": 1288,
               "start_column": 5,
-              "start_line": 1264
+              "start_line": 1282
             }
           }
         },
@@ -2474,9 +2491,9 @@ expression: pretty
             "qualified_name": "tests::long_or_chain_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1278,
+              "end_line": 1296,
               "start_column": 5,
-              "start_line": 1272
+              "start_line": 1290
             }
           }
         },
@@ -2498,9 +2515,9 @@ expression: pretty
             "qualified_name": "tests::alternating_operators_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1286,
+              "end_line": 1304,
               "start_column": 5,
-              "start_line": 1280
+              "start_line": 1298
             }
           }
         },
@@ -2522,9 +2539,9 @@ expression: pretty
             "qualified_name": "tests::closure_in_parent_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1299,
+              "end_line": 1317,
               "start_column": 5,
-              "start_line": 1290
+              "start_line": 1308
             }
           }
         },
@@ -2544,54 +2561,6 @@ expression: pretty
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
             "qualified_name": "tests::try_operator_cognitive",
-            "span": {
-              "end_column": 5,
-              "end_line": 1309,
-              "start_column": 5,
-              "start_line": 1303
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 100.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "tests::try_operator_cyclomatic",
-            "span": {
-              "end_column": 5,
-              "end_line": 1317,
-              "start_column": 5,
-              "start_line": 1311
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 100.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "tests::loop_with_break_cognitive",
             "span": {
               "end_column": 5,
               "end_line": 1327,
@@ -2615,7 +2584,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "tests::loop_with_break_cyclomatic",
+            "qualified_name": "tests::try_operator_cyclomatic",
             "span": {
               "end_column": 5,
               "end_line": 1335,
@@ -2639,7 +2608,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "tests::let_else_cognitive",
+            "qualified_name": "tests::loop_with_break_cognitive",
             "span": {
               "end_column": 5,
               "end_line": 1345,
@@ -2663,7 +2632,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "tests::let_else_cyclomatic",
+            "qualified_name": "tests::loop_with_break_cyclomatic",
             "span": {
               "end_column": 5,
               "end_line": 1353,
@@ -2687,7 +2656,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "tests::chained_try_cognitive",
+            "qualified_name": "tests::let_else_cognitive",
             "span": {
               "end_column": 5,
               "end_line": 1363,
@@ -2711,7 +2680,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "tests::chained_try_cyclomatic",
+            "qualified_name": "tests::let_else_cyclomatic",
             "span": {
               "end_column": 5,
               "end_line": 1371,
@@ -2735,12 +2704,60 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "tests::chained_try_cognitive",
+            "span": {
+              "end_column": 5,
+              "end_line": 1381,
+              "start_column": 5,
+              "start_line": 1375
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "tests::chained_try_cyclomatic",
+            "span": {
+              "end_column": 5,
+              "end_line": 1389,
+              "start_column": 5,
+              "start_line": 1383
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
             "qualified_name": "tests::for_iterator_try_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1379,
+              "end_line": 1397,
               "start_column": 5,
-              "start_line": 1373
+              "start_line": 1391
             }
           }
         },
@@ -2760,54 +2777,6 @@ expression: pretty
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
             "qualified_name": "tests::for_iterator_try_cyclomatic",
-            "span": {
-              "end_column": 5,
-              "end_line": 1387,
-              "start_column": 5,
-              "start_line": 1381
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 100.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "tests::match_scrutinee_try_cognitive",
-            "span": {
-              "end_column": 5,
-              "end_line": 1395,
-              "start_column": 5,
-              "start_line": 1389
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 100.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "tests::trait_default_method_found",
             "span": {
               "end_column": 5,
               "end_line": 1405,
@@ -2831,12 +2800,60 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "tests::match_scrutinee_try_cognitive",
+            "span": {
+              "end_column": 5,
+              "end_line": 1413,
+              "start_column": 5,
+              "start_line": 1407
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "tests::trait_default_method_found",
+            "span": {
+              "end_column": 5,
+              "end_line": 1423,
+              "start_column": 5,
+              "start_line": 1417
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
             "qualified_name": "tests::trait_method_without_default_not_found",
             "span": {
               "end_column": 5,
-              "end_line": 1416,
+              "end_line": 1434,
               "start_column": 5,
-              "start_line": 1407
+              "start_line": 1425
             }
           }
         },
@@ -2850,18 +2867,18 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 1451,
+              "end_line": 1469,
               "increment": 1,
               "kind": "for-loop",
-              "line": 1445,
+              "line": 1463,
               "nesting_depth": 0
             },
             {
               "column": 9,
-              "end_line": 1458,
+              "end_line": 1476,
               "increment": 1,
               "kind": "for-loop",
-              "line": 1452,
+              "line": 1470,
               "nesting_depth": 0
             }
           ],
@@ -2875,9 +2892,9 @@ expression: pretty
             "qualified_name": "tests::trait_default_and_concrete_override_have_disjoint_spans",
             "span": {
               "end_column": 5,
-              "end_line": 1459,
+              "end_line": 1477,
               "start_column": 5,
-              "start_line": 1418
+              "start_line": 1436
             }
           }
         },
@@ -2899,9 +2916,9 @@ expression: pretty
             "qualified_name": "tests::impl_method_no_branch",
             "span": {
               "end_column": 5,
-              "end_line": 1468,
+              "end_line": 1486,
               "start_column": 5,
-              "start_line": 1463
+              "start_line": 1481
             }
           }
         },
@@ -2923,9 +2940,9 @@ expression: pretty
             "qualified_name": "tests::impl_method_with_branch",
             "span": {
               "end_column": 5,
-              "end_line": 1476,
+              "end_line": 1494,
               "start_column": 5,
-              "start_line": 1470
+              "start_line": 1488
             }
           }
         },
@@ -2939,10 +2956,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 1487,
+              "end_line": 1505,
               "increment": 1,
               "kind": "match",
-              "line": 1484,
+              "line": 1502,
               "nesting_depth": 0
             }
           ],
@@ -2956,9 +2973,9 @@ expression: pretty
             "qualified_name": "tests::invalid_source_returns_error",
             "span": {
               "end_column": 5,
-              "end_line": 1488,
+              "end_line": 1506,
               "start_column": 5,
-              "start_line": 1480
+              "start_line": 1498
             }
           }
         },
@@ -2980,9 +2997,9 @@ expression: pretty
             "qualified_name": "contributor_tests::contributors_for",
             "span": {
               "end_column": 5,
-              "end_line": 1505,
+              "end_line": 1523,
               "start_column": 5,
-              "start_line": 1498
+              "start_line": 1516
             }
           }
         },
@@ -2996,10 +3013,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 1517,
+              "end_line": 1535,
               "increment": 1,
               "kind": "for-loop",
-              "line": 1509,
+              "line": 1527,
               "nesting_depth": 0
             }
           ],
@@ -3013,9 +3030,9 @@ expression: pretty
             "qualified_name": "contributor_tests::base_fn_empty_contributors",
             "span": {
               "end_column": 5,
-              "end_line": 1518,
+              "end_line": 1536,
               "start_column": 5,
-              "start_line": 1507
+              "start_line": 1525
             }
           }
         },
@@ -3037,9 +3054,9 @@ expression: pretty
             "qualified_name": "contributor_tests::if_branch_contributor_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1527,
+              "end_line": 1545,
               "start_column": 5,
-              "start_line": 1520
+              "start_line": 1538
             }
           }
         },
@@ -3061,9 +3078,9 @@ expression: pretty
             "qualified_name": "contributor_tests::nested_if_nesting_increment",
             "span": {
               "end_column": 5,
-              "end_line": 1539,
+              "end_line": 1557,
               "start_column": 5,
-              "start_line": 1529
+              "start_line": 1547
             }
           }
         },
@@ -3085,9 +3102,9 @@ expression: pretty
             "qualified_name": "contributor_tests::match_contributor_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1548,
+              "end_line": 1566,
               "start_column": 5,
-              "start_line": 1541
+              "start_line": 1559
             }
           }
         },
@@ -3101,10 +3118,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 1563,
+              "end_line": 1581,
               "increment": 1,
               "kind": "for-loop",
-              "line": 1561,
+              "line": 1579,
               "nesting_depth": 0
             }
           ],
@@ -3118,9 +3135,9 @@ expression: pretty
             "qualified_name": "contributor_tests::match_arm_contributor_cyclomatic",
             "span": {
               "end_column": 5,
-              "end_line": 1564,
+              "end_line": 1582,
               "start_column": 5,
-              "start_line": 1550
+              "start_line": 1568
             }
           }
         },
@@ -3142,9 +3159,9 @@ expression: pretty
             "qualified_name": "contributor_tests::try_contributor_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1572,
+              "end_line": 1590,
               "start_column": 5,
-              "start_line": 1566
+              "start_line": 1584
             }
           }
         },
@@ -3166,9 +3183,9 @@ expression: pretty
             "qualified_name": "contributor_tests::try_contributor_cyclomatic",
             "span": {
               "end_column": 5,
-              "end_line": 1580,
+              "end_line": 1598,
               "start_column": 5,
-              "start_line": 1574
+              "start_line": 1592
             }
           }
         },
@@ -3190,9 +3207,9 @@ expression: pretty
             "qualified_name": "contributor_tests::let_else_contributor_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1588,
+              "end_line": 1606,
               "start_column": 5,
-              "start_line": 1582
+              "start_line": 1600
             }
           }
         },
@@ -3214,9 +3231,9 @@ expression: pretty
             "qualified_name": "contributor_tests::let_else_contributor_cyclomatic",
             "span": {
               "end_column": 5,
-              "end_line": 1596,
+              "end_line": 1614,
               "start_column": 5,
-              "start_line": 1590
+              "start_line": 1608
             }
           }
         },
@@ -3238,9 +3255,9 @@ expression: pretty
             "qualified_name": "contributor_tests::loop_contributor_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1604,
+              "end_line": 1622,
               "start_column": 5,
-              "start_line": 1598
+              "start_line": 1616
             }
           }
         },
@@ -3262,9 +3279,9 @@ expression: pretty
             "qualified_name": "contributor_tests::for_loop_contributor_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1612,
+              "end_line": 1630,
               "start_column": 5,
-              "start_line": 1606
+              "start_line": 1624
             }
           }
         },
@@ -3286,9 +3303,9 @@ expression: pretty
             "qualified_name": "contributor_tests::for_loop_contributor_cyclomatic",
             "span": {
               "end_column": 5,
-              "end_line": 1620,
+              "end_line": 1638,
               "start_column": 5,
-              "start_line": 1614
+              "start_line": 1632
             }
           }
         },
@@ -3310,9 +3327,9 @@ expression: pretty
             "qualified_name": "contributor_tests::while_loop_contributor_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1628,
+              "end_line": 1646,
               "start_column": 5,
-              "start_line": 1622
+              "start_line": 1640
             }
           }
         },
@@ -3334,9 +3351,9 @@ expression: pretty
             "qualified_name": "contributor_tests::while_loop_contributor_cyclomatic",
             "span": {
               "end_column": 5,
-              "end_line": 1636,
+              "end_line": 1654,
               "start_column": 5,
-              "start_line": 1630
+              "start_line": 1648
             }
           }
         },
@@ -3358,9 +3375,9 @@ expression: pretty
             "qualified_name": "contributor_tests::logical_operator_same_chain_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1652,
+              "end_line": 1670,
               "start_column": 5,
-              "start_line": 1638
+              "start_line": 1656
             }
           }
         },
@@ -3382,9 +3399,9 @@ expression: pretty
             "qualified_name": "contributor_tests::logical_operator_switch_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1667,
+              "end_line": 1685,
               "start_column": 5,
-              "start_line": 1654
+              "start_line": 1672
             }
           }
         },
@@ -3406,9 +3423,9 @@ expression: pretty
             "qualified_name": "contributor_tests::break_contributor",
             "span": {
               "end_column": 5,
-              "end_line": 1680,
+              "end_line": 1698,
               "start_column": 5,
-              "start_line": 1669
+              "start_line": 1687
             }
           }
         },
@@ -3430,9 +3447,9 @@ expression: pretty
             "qualified_name": "contributor_tests::continue_contributor",
             "span": {
               "end_column": 5,
-              "end_line": 1693,
+              "end_line": 1711,
               "start_column": 5,
-              "start_line": 1682
+              "start_line": 1700
             }
           }
         },
@@ -3454,9 +3471,9 @@ expression: pretty
             "qualified_name": "contributor_tests::unsafe_block_produces_no_unsafe_contributor",
             "span": {
               "end_column": 5,
-              "end_line": 1721,
+              "end_line": 1739,
               "start_column": 5,
-              "start_line": 1695
+              "start_line": 1713
             }
           }
         },
@@ -3478,9 +3495,9 @@ expression: pretty
             "qualified_name": "contributor_tests::closure_no_contributor",
             "span": {
               "end_column": 5,
-              "end_line": 1733,
+              "end_line": 1751,
               "start_column": 5,
-              "start_line": 1723
+              "start_line": 1741
             }
           }
         },
@@ -3502,9 +3519,9 @@ expression: pretty
             "qualified_name": "contributor_tests::nested_if_records_construct_end_line_and_nesting_depth_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1766,
+              "end_line": 1784,
               "start_column": 5,
-              "start_line": 1737
+              "start_line": 1755
             }
           }
         },
@@ -3526,9 +3543,9 @@ expression: pretty
             "qualified_name": "contributor_tests::try_records_token_span_for_atomic_contributor",
             "span": {
               "end_column": 5,
-              "end_line": 1780,
+              "end_line": 1798,
               "start_column": 5,
-              "start_line": 1768
+              "start_line": 1786
             }
           }
         },
@@ -3550,9 +3567,9 @@ expression: pretty
             "qualified_name": "contributor_tests::for_with_continue_threads_nesting_depth_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1802,
+              "end_line": 1820,
               "start_column": 5,
-              "start_line": 1782
+              "start_line": 1800
             }
           }
         },
@@ -3574,9 +3591,9 @@ expression: pretty
             "qualified_name": "contributor_tests::nested_if_records_nesting_depth_cyclomatic",
             "span": {
               "end_column": 5,
-              "end_line": 1821,
+              "end_line": 1839,
               "start_column": 5,
-              "start_line": 1804
+              "start_line": 1822
             }
           }
         },
@@ -3598,9 +3615,9 @@ expression: pretty
             "qualified_name": "contributor_tests::for_with_continue_records_nesting_depth_cyclomatic",
             "span": {
               "end_column": 5,
-              "end_line": 1841,
+              "end_line": 1859,
               "start_column": 5,
-              "start_line": 1823
+              "start_line": 1841
             }
           }
         },
@@ -3622,9 +3639,9 @@ expression: pretty
             "qualified_name": "contributor_tests::match_records_end_line_covering_arms_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1860,
+              "end_line": 1878,
               "start_column": 5,
-              "start_line": 1843
+              "start_line": 1861
             }
           }
         },
@@ -3638,10 +3655,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 1880,
+              "end_line": 1898,
               "increment": 1,
               "kind": "for-loop",
-              "line": 1871,
+              "line": 1889,
               "nesting_depth": 0
             }
           ],
@@ -3655,9 +3672,9 @@ expression: pretty
             "qualified_name": "contributor_tests::contributors_sorted_by_line",
             "span": {
               "end_column": 5,
-              "end_line": 1881,
+              "end_line": 1899,
               "start_column": 5,
-              "start_line": 1862
+              "start_line": 1880
             }
           }
         },
@@ -5951,9 +5968,9 @@ expression: pretty
     ],
     "passed": false,
     "summary": {
-      "average_complexity": 1.5352112676056338,
-      "average_coverage": 94.86902385796895,
-      "average_crap": 1.5938967136150233,
+      "average_complexity": 1.5492957746478873,
+      "average_coverage": 95.20976251582802,
+      "average_crap": 1.610093896713615,
       "distribution": {
         "acceptable": 2,
         "high": 0,
@@ -6186,34 +6203,34 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 620,
+              "end_line": 638,
               "increment": 1,
               "kind": "if-branch",
-              "line": 618,
+              "line": 636,
               "nesting_depth": 0
             },
             {
               "column": 5,
-              "end_line": 645,
+              "end_line": 663,
               "increment": 1,
               "kind": "for-loop",
-              "line": 625,
+              "line": 643,
               "nesting_depth": 0
             },
             {
               "column": 9,
-              "end_line": 644,
+              "end_line": 662,
               "increment": 2,
               "kind": "match",
-              "line": 626,
+              "line": 644,
               "nesting_depth": 1
             },
             {
               "column": 17,
-              "end_line": 638,
+              "end_line": 656,
               "increment": 3,
               "kind": "if-branch",
-              "line": 628,
+              "line": 646,
               "nesting_depth": 2
             }
           ],
@@ -6227,9 +6244,9 @@ expression: pretty
             "qualified_name": "count_cognitive_binary_chain",
             "span": {
               "end_column": 1,
-              "end_line": 648,
+              "end_line": 666,
               "start_column": 1,
-              "start_line": 610
+              "start_line": 628
             }
           }
         },
@@ -6308,42 +6325,42 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 291,
+              "end_line": 309,
               "increment": 1,
               "kind": "match",
-              "line": 268,
+              "line": 286,
               "nesting_depth": 0
             },
             {
               "column": 13,
-              "end_line": 287,
+              "end_line": 305,
               "increment": 2,
               "kind": "if-branch",
-              "line": 272,
+              "line": 290,
               "nesting_depth": 1
             },
             {
               "column": 17,
-              "end_line": 286,
+              "end_line": 304,
               "increment": 3,
               "kind": "if-branch",
-              "line": 274,
+              "line": 292,
               "nesting_depth": 2
             }
           ],
-          "coverage_percent": 73.68421052631578,
+          "coverage_percent": 72.72727272727273,
           "crap": {
             "risk_level": "low",
-            "value": 7.89
+            "value": 7.99
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
             "qualified_name": "count_cognitive_stmt",
             "span": {
               "end_column": 1,
-              "end_line": 292,
+              "end_line": 310,
               "start_column": 1,
-              "start_line": 263
+              "start_line": 281
             }
           }
         },
@@ -6357,42 +6374,42 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 573,
+              "end_line": 591,
               "increment": 1,
               "kind": "if-branch",
-              "line": 546,
+              "line": 564,
               "nesting_depth": 0
             },
             {
               "column": 9,
-              "end_line": 572,
+              "end_line": 590,
               "increment": 2,
               "kind": "match",
-              "line": 547,
+              "line": 565,
               "nesting_depth": 1
             },
             {
               "column": 17,
-              "end_line": 563,
+              "end_line": 581,
               "increment": 3,
               "kind": "if-branch",
-              "line": 561,
+              "line": 579,
               "nesting_depth": 2
             }
           ],
-          "coverage_percent": 86.66666666666667,
+          "coverage_percent": 94.87179487179486,
           "crap": {
             "risk_level": "low",
-            "value": 7.12
+            "value": 7.01
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
             "qualified_name": "count_cognitive_if",
             "span": {
               "end_column": 1,
-              "end_line": 576,
+              "end_line": 594,
               "start_column": 1,
-              "start_line": 523
+              "start_line": 541
             }
           }
         },
@@ -6503,35 +6520,76 @@ expression: pretty
           "complexity_metric": "cognitive",
           "contributors": [
             {
+              "column": 9,
+              "end_line": 90,
+              "increment": 1,
+              "kind": "match",
+              "line": 79,
+              "nesting_depth": 0
+            },
+            {
+              "column": 17,
+              "end_line": 86,
+              "increment": 2,
+              "kind": "if-branch",
+              "line": 84,
+              "nesting_depth": 1
+            }
+          ],
+          "coverage_percent": 94.73684210526316,
+          "crap": {
+            "risk_level": "low",
+            "value": 4.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "FunctionFinder::qualify",
+            "span": {
+              "end_column": 5,
+              "end_line": 91,
+              "start_column": 5,
+              "start_line": 65
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 4,
+          "complexity_metric": "cognitive",
+          "contributors": [
+            {
               "column": 5,
-              "end_line": 344,
+              "end_line": 362,
               "increment": 1,
               "kind": "for-loop",
-              "line": 339,
+              "line": 357,
               "nesting_depth": 0
             },
             {
               "column": 9,
-              "end_line": 342,
+              "end_line": 360,
               "increment": 2,
               "kind": "if-branch",
-              "line": 340,
+              "line": 358,
               "nesting_depth": 1
             }
           ],
-          "coverage_percent": 80.0,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 4.13
+            "value": 4.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
             "qualified_name": "count_cognitive_match",
             "span": {
               "end_column": 1,
-              "end_line": 346,
+              "end_line": 364,
               "start_column": 1,
-              "start_line": 324
+              "start_line": 342
             }
           }
         },
@@ -6545,34 +6603,34 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 607,
+              "end_line": 625,
               "increment": 1,
               "kind": "match",
-              "line": 583,
+              "line": 601,
               "nesting_depth": 0
             },
             {
               "column": 13,
-              "end_line": 599,
+              "end_line": 617,
               "increment": 2,
               "kind": "if-branch",
-              "line": 597,
+              "line": 615,
               "nesting_depth": 1
             }
           ],
-          "coverage_percent": 91.30434782608695,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
-            "value": 4.01
+            "value": 4.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
             "qualified_name": "count_cognitive_else",
             "span": {
               "end_column": 1,
-              "end_line": 608,
+              "end_line": 626,
               "start_column": 1,
-              "start_line": 578
+              "start_line": 596
             }
           }
         },
@@ -6586,18 +6644,18 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 801,
+              "end_line": 819,
               "increment": 1,
               "kind": "if-branch",
-              "line": 792,
+              "line": 810,
               "nesting_depth": 0
             },
             {
               "column": 13,
-              "end_line": 800,
+              "end_line": 818,
               "increment": 2,
               "kind": "match",
-              "line": 793,
+              "line": 811,
               "nesting_depth": 1
             }
           ],
@@ -6611,9 +6669,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::visit_expr_if",
             "span": {
               "end_column": 5,
-              "end_line": 802,
+              "end_line": 820,
               "start_column": 5,
-              "start_line": 783
+              "start_line": 801
             }
           }
         },
@@ -6725,26 +6783,26 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 321,
+              "end_line": 492,
               "increment": 1,
               "kind": "match",
-              "line": 299,
+              "line": 489,
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 34.78260869565217,
+          "coverage_percent": 33.33333333333333,
           "crap": {
             "risk_level": "low",
-            "value": 3.11
+            "value": 3.19
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "count_cognitive_expr",
+            "qualified_name": "count_cognitive_return",
             "span": {
               "end_column": 1,
-              "end_line": 322,
+              "end_line": 493,
               "start_column": 1,
-              "start_line": 294
+              "start_line": 484
             }
           }
         },
@@ -6758,18 +6816,18 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 229,
+              "end_line": 247,
               "increment": 1,
               "kind": "if-branch",
-              "line": 225,
+              "line": 243,
               "nesting_depth": 0
             },
             {
               "column": 9,
-              "end_line": 226,
+              "end_line": 244,
               "increment": 1,
               "kind": "logical-operator",
-              "line": 226,
+              "line": 244,
               "nesting_depth": 0
             }
           ],
@@ -6783,9 +6841,9 @@ expression: pretty
             "qualified_name": "extract_type_name",
             "span": {
               "end_column": 1,
-              "end_line": 232,
+              "end_line": 250,
               "start_column": 1,
-              "start_line": 223
+              "start_line": 241
             }
           }
         },
@@ -6799,18 +6857,18 @@ expression: pretty
           "contributors": [
             {
               "column": 38,
-              "end_line": 769,
+              "end_line": 787,
               "increment": 1,
               "kind": "let-else",
-              "line": 767,
+              "line": 785,
               "nesting_depth": 0
             },
             {
               "column": 9,
-              "end_line": 780,
+              "end_line": 798,
               "increment": 1,
               "kind": "if-branch",
-              "line": 772,
+              "line": 790,
               "nesting_depth": 0
             }
           ],
@@ -6824,9 +6882,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::visit_local",
             "span": {
               "end_column": 5,
-              "end_line": 781,
+              "end_line": 799,
               "start_column": 5,
-              "start_line": 766
+              "start_line": 784
             }
           }
         },
@@ -6840,18 +6898,18 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 812,
+              "end_line": 830,
               "increment": 1,
               "kind": "for-loop",
-              "line": 805,
+              "line": 823,
               "nesting_depth": 0
             },
             {
               "column": 9,
-              "end_line": 817,
+              "end_line": 835,
               "increment": 1,
               "kind": "for-loop",
-              "line": 815,
+              "line": 833,
               "nesting_depth": 0
             }
           ],
@@ -6865,9 +6923,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::visit_expr_match",
             "span": {
               "end_column": 5,
-              "end_line": 818,
+              "end_line": 836,
               "start_column": 5,
-              "start_line": 804
+              "start_line": 822
             }
           }
         },
@@ -6881,18 +6939,18 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 1451,
+              "end_line": 1469,
               "increment": 1,
               "kind": "for-loop",
-              "line": 1445,
+              "line": 1463,
               "nesting_depth": 0
             },
             {
               "column": 9,
-              "end_line": 1458,
+              "end_line": 1476,
               "increment": 1,
               "kind": "for-loop",
-              "line": 1452,
+              "line": 1470,
               "nesting_depth": 0
             }
           ],
@@ -6906,9 +6964,9 @@ expression: pretty
             "qualified_name": "tests::trait_default_and_concrete_override_have_disjoint_spans",
             "span": {
               "end_column": 5,
-              "end_line": 1459,
+              "end_line": 1477,
               "start_column": 5,
-              "start_line": 1418
+              "start_line": 1436
             }
           }
         },
@@ -7119,59 +7177,26 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 495,
+              "end_line": 339,
               "increment": 1,
-              "kind": "for-loop",
-              "line": 493,
+              "kind": "match",
+              "line": 317,
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 57.14285714285714,
+          "coverage_percent": 40.0,
           "crap": {
             "risk_level": "low",
-            "value": 2.31
+            "value": 2.86
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "count_cognitive_call",
+            "qualified_name": "count_cognitive_expr",
             "span": {
               "end_column": 1,
-              "end_line": 497,
+              "end_line": 340,
               "start_column": 1,
-              "start_line": 487
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 2,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 9,
-              "end_line": 156,
-              "increment": 1,
-              "kind": "if-branch",
-              "line": 143,
-              "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 84.61538461538461,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.01
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "FunctionFinder::visit_trait_item_fn",
-            "span": {
-              "end_column": 5,
-              "end_line": 159,
-              "start_column": 5,
-              "start_line": 141
+              "start_line": 312
             }
           }
         },
@@ -7185,26 +7210,92 @@ expression: pretty
           "contributors": [
             {
               "column": 15,
-              "end_line": 244,
+              "end_line": 262,
               "increment": 1,
               "kind": "match",
-              "line": 241,
+              "line": 259,
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 85.71428571428571,
+          "coverage_percent": 45.45454545454545,
           "crap": {
             "risk_level": "low",
-            "value": 2.01
+            "value": 2.65
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
             "qualified_name": "count_complexity",
             "span": {
               "end_column": 1,
-              "end_line": 247,
+              "end_line": 265,
               "start_column": 1,
-              "start_line": 236
+              "start_line": 254
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 2,
+          "complexity_metric": "cognitive",
+          "contributors": [
+            {
+              "column": 5,
+              "end_line": 525,
+              "increment": 1,
+              "kind": "for-loop",
+              "line": 523,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 66.66666666666666,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.15
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "count_cognitive_method_call",
+            "span": {
+              "end_column": 1,
+              "end_line": 527,
+              "start_column": 1,
+              "start_line": 517
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 2,
+          "complexity_metric": "cognitive",
+          "contributors": [
+            {
+              "column": 9,
+              "end_line": 905,
+              "increment": 1,
+              "kind": "if-branch",
+              "line": 903,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 80.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.03
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "CyclomaticCounter::visit_expr_break",
+            "span": {
+              "end_column": 5,
+              "end_line": 906,
+              "start_column": 5,
+              "start_line": 896
             }
           }
         },
@@ -7284,26 +7375,26 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 77,
+              "end_line": 112,
               "increment": 1,
               "kind": "if-branch",
-              "line": 75,
+              "line": 106,
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 100.0,
+          "coverage_percent": 93.33333333333331,
           "crap": {
             "risk_level": "low",
             "value": 2.0
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "FunctionFinder::qualify",
+            "qualified_name": "FunctionFinder::visit_item_mod",
             "span": {
               "end_column": 5,
-              "end_line": 80,
+              "end_line": 113,
               "start_column": 5,
-              "start_line": 65
+              "start_line": 95
             }
           }
         },
@@ -7316,11 +7407,11 @@ expression: pretty
           "complexity_metric": "cognitive",
           "contributors": [
             {
-              "column": 5,
-              "end_line": 474,
+              "column": 9,
+              "end_line": 174,
               "increment": 1,
-              "kind": "match",
-              "line": 471,
+              "kind": "if-branch",
+              "line": 161,
               "nesting_depth": 0
             }
           ],
@@ -7331,12 +7422,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "count_cognitive_return",
+            "qualified_name": "FunctionFinder::visit_trait_item_fn",
             "span": {
-              "end_column": 1,
-              "end_line": 475,
-              "start_column": 1,
-              "start_line": 466
+              "end_column": 5,
+              "end_line": 177,
+              "start_column": 5,
+              "start_line": 159
             }
           }
         },
@@ -7350,10 +7441,10 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 507,
+              "end_line": 513,
               "increment": 1,
               "kind": "for-loop",
-              "line": 505,
+              "line": 511,
               "nesting_depth": 0
             }
           ],
@@ -7364,12 +7455,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "count_cognitive_method_call",
+            "qualified_name": "count_cognitive_call",
             "span": {
               "end_column": 1,
-              "end_line": 509,
+              "end_line": 515,
               "start_column": 1,
-              "start_line": 499
+              "start_line": 505
             }
           }
         },
@@ -7383,10 +7474,10 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 519,
+              "end_line": 537,
               "increment": 1,
               "kind": "for-loop",
-              "line": 517,
+              "line": 535,
               "nesting_depth": 0
             }
           ],
@@ -7400,9 +7491,9 @@ expression: pretty
             "qualified_name": "count_cognitive_tuple",
             "span": {
               "end_column": 1,
-              "end_line": 521,
+              "end_line": 539,
               "start_column": 1,
-              "start_line": 511
+              "start_line": 529
             }
           }
         },
@@ -7416,10 +7507,10 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 665,
+              "end_line": 683,
               "increment": 1,
               "kind": "match",
-              "line": 659,
+              "line": 677,
               "nesting_depth": 0
             }
           ],
@@ -7433,9 +7524,9 @@ expression: pretty
             "qualified_name": "count_cognitive_binary_operands",
             "span": {
               "end_column": 1,
-              "end_line": 666,
+              "end_line": 684,
               "start_column": 1,
-              "start_line": 650
+              "start_line": 668
             }
           }
         },
@@ -7449,10 +7540,10 @@ expression: pretty
           "contributors": [
             {
               "column": 5,
-              "end_line": 680,
+              "end_line": 698,
               "increment": 1,
               "kind": "match",
-              "line": 676,
+              "line": 694,
               "nesting_depth": 0
             }
           ],
@@ -7466,42 +7557,9 @@ expression: pretty
             "qualified_name": "classify_binop",
             "span": {
               "end_column": 1,
-              "end_line": 681,
+              "end_line": 699,
               "start_column": 1,
-              "start_line": 675
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 2,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 5,
-              "end_line": 691,
-              "increment": 1,
-              "kind": "match",
-              "line": 684,
-              "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 100.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "binop_span",
-            "span": {
-              "end_column": 1,
-              "end_line": 692,
-              "start_column": 1,
-              "start_line": 683
+              "start_line": 693
             }
           }
         },
@@ -7517,8 +7575,41 @@ expression: pretty
               "column": 5,
               "end_line": 709,
               "increment": 1,
+              "kind": "match",
+              "line": 702,
+              "nesting_depth": 0
+            }
+          ],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 2.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "binop_span",
+            "span": {
+              "end_column": 1,
+              "end_line": 710,
+              "start_column": 1,
+              "start_line": 701
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 2,
+          "complexity_metric": "cognitive",
+          "contributors": [
+            {
+              "column": 5,
+              "end_line": 727,
+              "increment": 1,
               "kind": "if-branch",
-              "line": 705,
+              "line": 723,
               "nesting_depth": 0
             }
           ],
@@ -7532,9 +7623,9 @@ expression: pretty
             "qualified_name": "flatten_binary_ops_inner",
             "span": {
               "end_column": 1,
-              "end_line": 710,
+              "end_line": 728,
               "start_column": 1,
-              "start_line": 704
+              "start_line": 722
             }
           }
         },
@@ -7548,10 +7639,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 763,
+              "end_line": 781,
               "increment": 1,
               "kind": "match",
-              "line": 759,
+              "line": 777,
               "nesting_depth": 0
             }
           ],
@@ -7565,9 +7656,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::visit_stmt",
             "span": {
               "end_column": 5,
-              "end_line": 764,
+              "end_line": 782,
               "start_column": 5,
-              "start_line": 758
+              "start_line": 776
             }
           }
         },
@@ -7581,10 +7672,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 823,
+              "end_line": 841,
               "increment": 1,
               "kind": "if-branch",
-              "line": 821,
+              "line": 839,
               "nesting_depth": 0
             }
           ],
@@ -7598,9 +7689,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::visit_arm",
             "span": {
               "end_column": 5,
-              "end_line": 825,
+              "end_line": 843,
               "start_column": 5,
-              "start_line": 820
+              "start_line": 838
             }
           }
         },
@@ -7614,10 +7705,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 863,
+              "end_line": 881,
               "increment": 1,
               "kind": "if-branch",
-              "line": 860,
+              "line": 878,
               "nesting_depth": 0
             }
           ],
@@ -7631,9 +7722,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::visit_expr_binary",
             "span": {
               "end_column": 5,
-              "end_line": 866,
+              "end_line": 884,
               "start_column": 5,
-              "start_line": 859
+              "start_line": 877
             }
           }
         },
@@ -7647,43 +7738,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 887,
-              "increment": 1,
-              "kind": "if-branch",
-              "line": 885,
-              "nesting_depth": 0
-            }
-          ],
-          "coverage_percent": 100.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 2.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "CyclomaticCounter::visit_expr_break",
-            "span": {
-              "end_column": 5,
-              "end_line": 888,
-              "start_column": 5,
-              "start_line": 878
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 2,
-          "complexity_metric": "cognitive",
-          "contributors": [
-            {
-              "column": 9,
-              "end_line": 1487,
+              "end_line": 1505,
               "increment": 1,
               "kind": "match",
-              "line": 1484,
+              "line": 1502,
               "nesting_depth": 0
             }
           ],
@@ -7697,9 +7755,9 @@ expression: pretty
             "qualified_name": "tests::invalid_source_returns_error",
             "span": {
               "end_column": 5,
-              "end_line": 1488,
+              "end_line": 1506,
               "start_column": 5,
-              "start_line": 1480
+              "start_line": 1498
             }
           }
         },
@@ -7713,10 +7771,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 1517,
+              "end_line": 1535,
               "increment": 1,
               "kind": "for-loop",
-              "line": 1509,
+              "line": 1527,
               "nesting_depth": 0
             }
           ],
@@ -7730,9 +7788,9 @@ expression: pretty
             "qualified_name": "contributor_tests::base_fn_empty_contributors",
             "span": {
               "end_column": 5,
-              "end_line": 1518,
+              "end_line": 1536,
               "start_column": 5,
-              "start_line": 1507
+              "start_line": 1525
             }
           }
         },
@@ -7746,10 +7804,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 1563,
+              "end_line": 1581,
               "increment": 1,
               "kind": "for-loop",
-              "line": 1561,
+              "line": 1579,
               "nesting_depth": 0
             }
           ],
@@ -7763,9 +7821,9 @@ expression: pretty
             "qualified_name": "contributor_tests::match_arm_contributor_cyclomatic",
             "span": {
               "end_column": 5,
-              "end_line": 1564,
+              "end_line": 1582,
               "start_column": 5,
-              "start_line": 1550
+              "start_line": 1568
             }
           }
         },
@@ -7779,10 +7837,10 @@ expression: pretty
           "contributors": [
             {
               "column": 9,
-              "end_line": 1880,
+              "end_line": 1898,
               "increment": 1,
               "kind": "for-loop",
-              "line": 1871,
+              "line": 1889,
               "nesting_depth": 0
             }
           ],
@@ -7796,9 +7854,9 @@ expression: pretty
             "qualified_name": "contributor_tests::contributors_sorted_by_line",
             "span": {
               "end_column": 5,
-              "end_line": 1881,
+              "end_line": 1899,
               "start_column": 5,
-              "start_line": 1862
+              "start_line": 1880
             }
           }
         },
@@ -8194,91 +8252,19 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 16.666666666666664,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.58
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "count_cognitive_closure",
-            "span": {
-              "end_column": 1,
-              "end_line": 485,
-              "start_column": 1,
-              "start_line": 479
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 50.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.13
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "end_line_of",
-            "span": {
-              "end_column": 1,
-              "end_line": 198,
-              "start_column": 1,
-              "start_line": 192
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 50.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.13
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "CyclomaticCounter::visit_expr_closure",
-            "span": {
-              "end_column": 5,
-              "end_line": 904,
-              "start_column": 5,
-              "start_line": 899
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 77.77777777777779,
+          "coverage_percent": 82.35294117647058,
           "crap": {
             "risk_level": "low",
             "value": 1.01
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "count_cognitive_block",
+            "qualified_name": "add_contributor",
             "span": {
               "end_column": 1,
-              "end_line": 261,
+              "end_line": 208,
               "start_column": 1,
-              "start_line": 251
+              "start_line": 189
             }
           }
         },
@@ -8314,31 +8300,7 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 90.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "FunctionFinder::visit_item_mod",
-            "span": {
-              "end_column": 5,
-              "end_line": 95,
-              "start_column": 5,
-              "start_line": 84
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 92.85714285714286,
+          "coverage_percent": 100.0,
           "crap": {
             "risk_level": "low",
             "value": 1.0
@@ -8348,9 +8310,9 @@ expression: pretty
             "qualified_name": "FunctionFinder::visit_item_fn",
             "span": {
               "end_column": 5,
-              "end_line": 115,
+              "end_line": 133,
               "start_column": 5,
-              "start_line": 97
+              "start_line": 115
             }
           }
         },
@@ -8372,9 +8334,9 @@ expression: pretty
             "qualified_name": "FunctionFinder::visit_item_impl",
             "span": {
               "end_column": 5,
-              "end_line": 122,
+              "end_line": 140,
               "start_column": 5,
-              "start_line": 117
+              "start_line": 135
             }
           }
         },
@@ -8386,7 +8348,7 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 100.0,
+          "coverage_percent": 83.33333333333334,
           "crap": {
             "risk_level": "low",
             "value": 1.0
@@ -8396,9 +8358,9 @@ expression: pretty
             "qualified_name": "FunctionFinder::visit_impl_item_fn",
             "span": {
               "end_column": 5,
-              "end_line": 139,
+              "end_line": 157,
               "start_column": 5,
-              "start_line": 124
+              "start_line": 142
             }
           }
         },
@@ -8420,9 +8382,9 @@ expression: pretty
             "qualified_name": "FunctionFinder::visit_item_trait",
             "span": {
               "end_column": 5,
-              "end_line": 166,
+              "end_line": 184,
               "start_column": 5,
-              "start_line": 161
+              "start_line": 179
             }
           }
         },
@@ -8441,12 +8403,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "add_contributor",
+            "qualified_name": "end_line_of",
             "span": {
               "end_column": 1,
-              "end_line": 190,
+              "end_line": 216,
               "start_column": 1,
-              "start_line": 171
+              "start_line": 210
             }
           }
         },
@@ -8458,7 +8420,7 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 94.73684210526316,
+          "coverage_percent": 88.88888888888889,
           "crap": {
             "risk_level": "low",
             "value": 1.0
@@ -8468,9 +8430,33 @@ expression: pretty
             "qualified_name": "span_of",
             "span": {
               "end_column": 1,
-              "end_line": 221,
+              "end_line": 239,
               "start_column": 1,
-              "start_line": 200
+              "start_line": 218
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 83.33333333333334,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "count_cognitive_block",
+            "span": {
+              "end_column": 1,
+              "end_line": 279,
+              "start_column": 1,
+              "start_line": 269
             }
           }
         },
@@ -8492,9 +8478,9 @@ expression: pretty
             "qualified_name": "count_cognitive_while",
             "span": {
               "end_column": 1,
-              "end_line": 365,
+              "end_line": 383,
               "start_column": 1,
-              "start_line": 348
+              "start_line": 366
             }
           }
         },
@@ -8516,9 +8502,9 @@ expression: pretty
             "qualified_name": "count_cognitive_for_loop",
             "span": {
               "end_column": 1,
-              "end_line": 384,
+              "end_line": 402,
               "start_column": 1,
-              "start_line": 367
+              "start_line": 385
             }
           }
         },
@@ -8530,7 +8516,7 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 100.0,
+          "coverage_percent": 85.71428571428571,
           "crap": {
             "risk_level": "low",
             "value": 1.0
@@ -8540,9 +8526,9 @@ expression: pretty
             "qualified_name": "count_cognitive_loop",
             "span": {
               "end_column": 1,
-              "end_line": 402,
+              "end_line": 420,
               "start_column": 1,
-              "start_line": 386
+              "start_line": 404
             }
           }
         },
@@ -8554,7 +8540,7 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 83.33333333333334,
+          "coverage_percent": 85.71428571428571,
           "crap": {
             "risk_level": "low",
             "value": 1.0
@@ -8564,33 +8550,9 @@ expression: pretty
             "qualified_name": "count_cognitive_binary",
             "span": {
               "end_column": 1,
-              "end_line": 416,
+              "end_line": 434,
               "start_column": 1,
-              "start_line": 408
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 92.3076923076923,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "count_cognitive_try",
-            "span": {
-              "end_column": 1,
-              "end_line": 432,
-              "start_column": 1,
-              "start_line": 418
+              "start_line": 426
             }
           }
         },
@@ -8609,12 +8571,12 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "count_cognitive_break",
+            "qualified_name": "count_cognitive_try",
             "span": {
               "end_column": 1,
-              "end_line": 448,
+              "end_line": 450,
               "start_column": 1,
-              "start_line": 434
+              "start_line": 436
             }
           }
         },
@@ -8626,7 +8588,31 @@ expression: pretty
           "complexity": 1,
           "complexity_metric": "cognitive",
           "contributors": [],
-          "coverage_percent": 90.9090909090909,
+          "coverage_percent": 90.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "count_cognitive_break",
+            "span": {
+              "end_column": 1,
+              "end_line": 466,
+              "start_column": 1,
+              "start_line": 452
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 84.61538461538461,
           "crap": {
             "risk_level": "low",
             "value": 1.0
@@ -8636,9 +8622,33 @@ expression: pretty
             "qualified_name": "count_cognitive_continue",
             "span": {
               "end_column": 1,
-              "end_line": 464,
+              "end_line": 482,
               "start_column": 1,
-              "start_line": 450
+              "start_line": 468
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "count_cognitive_closure",
+            "span": {
+              "end_column": 1,
+              "end_line": 503,
+              "start_column": 1,
+              "start_line": 497
             }
           }
         },
@@ -8660,9 +8670,9 @@ expression: pretty
             "qualified_name": "flatten_binary_ops",
             "span": {
               "end_column": 1,
-              "end_line": 702,
+              "end_line": 720,
               "start_column": 1,
-              "start_line": 694
+              "start_line": 712
             }
           }
         },
@@ -8684,9 +8694,9 @@ expression: pretty
             "qualified_name": "count_cyclomatic_block",
             "span": {
               "end_column": 1,
-              "end_line": 719,
+              "end_line": 737,
               "start_column": 1,
-              "start_line": 714
+              "start_line": 732
             }
           }
         },
@@ -8708,9 +8718,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::count_block",
             "span": {
               "end_column": 5,
-              "end_line": 736,
+              "end_line": 754,
               "start_column": 5,
-              "start_line": 728
+              "start_line": 746
             }
           }
         },
@@ -8732,9 +8742,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::bump",
             "span": {
               "end_column": 5,
-              "end_line": 748,
+              "end_line": 766,
               "start_column": 5,
-              "start_line": 738
+              "start_line": 756
             }
           }
         },
@@ -8756,9 +8766,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::with_nesting",
             "span": {
               "end_column": 5,
-              "end_line": 754,
+              "end_line": 772,
               "start_column": 5,
-              "start_line": 750
+              "start_line": 768
             }
           }
         },
@@ -8780,9 +8790,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::visit_expr_while",
             "span": {
               "end_column": 5,
-              "end_line": 836,
+              "end_line": 854,
               "start_column": 5,
-              "start_line": 827
+              "start_line": 845
             }
           }
         },
@@ -8804,9 +8814,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::visit_expr_for_loop",
             "span": {
               "end_column": 5,
-              "end_line": 847,
+              "end_line": 865,
               "start_column": 5,
-              "start_line": 838
+              "start_line": 856
             }
           }
         },
@@ -8828,9 +8838,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::visit_expr_loop",
             "span": {
               "end_column": 5,
-              "end_line": 857,
+              "end_line": 875,
               "start_column": 5,
-              "start_line": 849
+              "start_line": 867
             }
           }
         },
@@ -8852,9 +8862,9 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::visit_expr_try",
             "span": {
               "end_column": 5,
-              "end_line": 876,
+              "end_line": 894,
               "start_column": 5,
-              "start_line": 868
+              "start_line": 886
             }
           }
         },
@@ -8876,9 +8886,33 @@ expression: pretty
             "qualified_name": "CyclomaticCounter::visit_expr_continue",
             "span": {
               "end_column": 5,
-              "end_line": 897,
+              "end_line": 915,
               "start_column": 5,
-              "start_line": 890
+              "start_line": 908
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "CyclomaticCounter::visit_expr_closure",
+            "span": {
+              "end_column": 5,
+              "end_line": 922,
+              "start_column": 5,
+              "start_line": 917
             }
           }
         },
@@ -8900,9 +8934,9 @@ expression: pretty
             "qualified_name": "test_helpers::adapter",
             "span": {
               "end_column": 5,
-              "end_line": 915,
+              "end_line": 933,
               "start_column": 5,
-              "start_line": 913
+              "start_line": 931
             }
           }
         },
@@ -8924,9 +8958,9 @@ expression: pretty
             "qualified_name": "test_helpers::load_fixture",
             "span": {
               "end_column": 5,
-              "end_line": 921,
+              "end_line": 939,
               "start_column": 5,
-              "start_line": 917
+              "start_line": 935
             }
           }
         },
@@ -8948,9 +8982,9 @@ expression: pretty
             "qualified_name": "test_helpers::extract_fixture",
             "span": {
               "end_column": 5,
-              "end_line": 928,
+              "end_line": 946,
               "start_column": 5,
-              "start_line": 923
+              "start_line": 941
             }
           }
         },
@@ -8972,9 +9006,9 @@ expression: pretty
             "qualified_name": "test_helpers::find_fn",
             "span": {
               "end_column": 5,
-              "end_line": 941,
+              "end_line": 959,
               "start_column": 5,
-              "start_line": 930
+              "start_line": 948
             }
           }
         },
@@ -8996,9 +9030,9 @@ expression: pretty
             "qualified_name": "tests::baseline_complexity_is_one_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 957,
+              "end_line": 975,
               "start_column": 5,
-              "start_line": 952
+              "start_line": 970
             }
           }
         },
@@ -9020,9 +9054,9 @@ expression: pretty
             "qualified_name": "tests::baseline_complexity_is_one_cyclomatic",
             "span": {
               "end_column": 5,
-              "end_line": 964,
+              "end_line": 982,
               "start_column": 5,
-              "start_line": 959
+              "start_line": 977
             }
           }
         },
@@ -9044,9 +9078,9 @@ expression: pretty
             "qualified_name": "tests::top_level_fn_identity",
             "span": {
               "end_column": 5,
-              "end_line": 975,
+              "end_line": 993,
               "start_column": 5,
-              "start_line": 968
+              "start_line": 986
             }
           }
         },
@@ -9068,9 +9102,9 @@ expression: pretty
             "qualified_name": "tests::impl_method_qualified_name",
             "span": {
               "end_column": 5,
-              "end_line": 983,
+              "end_line": 1001,
               "start_column": 5,
-              "start_line": 977
+              "start_line": 995
             }
           }
         },
@@ -9092,9 +9126,9 @@ expression: pretty
             "qualified_name": "tests::top_level_fn_in_nested_mods_fixture_is_unqualified",
             "span": {
               "end_column": 5,
-              "end_line": 993,
+              "end_line": 1011,
               "start_column": 5,
-              "start_line": 987
+              "start_line": 1005
             }
           }
         },
@@ -9116,9 +9150,9 @@ expression: pretty
             "qualified_name": "tests::one_level_mod_qualified_name",
             "span": {
               "end_column": 5,
-              "end_line": 999,
+              "end_line": 1017,
               "start_column": 5,
-              "start_line": 995
+              "start_line": 1013
             }
           }
         },
@@ -9140,9 +9174,9 @@ expression: pretty
             "qualified_name": "tests::multi_level_mod_qualified_name",
             "span": {
               "end_column": 5,
-              "end_line": 1005,
+              "end_line": 1023,
               "start_column": 5,
-              "start_line": 1001
+              "start_line": 1019
             }
           }
         },
@@ -9164,9 +9198,9 @@ expression: pretty
             "qualified_name": "tests::impl_method_inside_mod_prepends_mod_path",
             "span": {
               "end_column": 5,
-              "end_line": 1014,
+              "end_line": 1032,
               "start_column": 5,
-              "start_line": 1007
+              "start_line": 1025
             }
           }
         },
@@ -9188,9 +9222,9 @@ expression: pretty
             "qualified_name": "tests::nested_fn_inside_mod_is_mod_scoped_not_fn_scoped",
             "span": {
               "end_column": 5,
-              "end_line": 1029,
+              "end_line": 1047,
               "start_column": 5,
-              "start_line": 1016
+              "start_line": 1034
             }
           }
         },
@@ -9212,9 +9246,9 @@ expression: pretty
             "qualified_name": "tests::mod_qualification_does_not_disturb_complexity",
             "span": {
               "end_column": 5,
-              "end_line": 1041,
+              "end_line": 1059,
               "start_column": 5,
-              "start_line": 1031
+              "start_line": 1049
             }
           }
         },
@@ -9236,9 +9270,9 @@ expression: pretty
             "qualified_name": "tests::span_accuracy",
             "span": {
               "end_column": 5,
-              "end_line": 1064,
+              "end_line": 1082,
               "start_column": 5,
-              "start_line": 1043
+              "start_line": 1061
             }
           }
         },
@@ -9260,9 +9294,9 @@ expression: pretty
             "qualified_name": "tests::span_carries_one_based_columns",
             "span": {
               "end_column": 5,
-              "end_line": 1085,
+              "end_line": 1103,
               "start_column": 5,
-              "start_line": 1066
+              "start_line": 1084
             }
           }
         },
@@ -9284,9 +9318,9 @@ expression: pretty
             "qualified_name": "tests::columns_are_exact_one_based_offsets_unindented",
             "span": {
               "end_column": 5,
-              "end_line": 1115,
+              "end_line": 1133,
               "start_column": 5,
-              "start_line": 1087
+              "start_line": 1105
             }
           }
         },
@@ -9308,9 +9342,9 @@ expression: pretty
             "qualified_name": "tests::columns_are_exact_one_based_offsets_indented",
             "span": {
               "end_column": 5,
-              "end_line": 1140,
+              "end_line": 1158,
               "start_column": 5,
-              "start_line": 1117
+              "start_line": 1135
             }
           }
         },
@@ -9332,9 +9366,9 @@ expression: pretty
             "qualified_name": "tests::multiple_fns_returns_all",
             "span": {
               "end_column": 5,
-              "end_line": 1146,
+              "end_line": 1164,
               "start_column": 5,
-              "start_line": 1142
+              "start_line": 1160
             }
           }
         },
@@ -9354,54 +9388,6 @@ expression: pretty
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
             "qualified_name": "tests::async_fn_detected",
-            "span": {
-              "end_column": 5,
-              "end_line": 1154,
-              "start_column": 5,
-              "start_line": 1148
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 100.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "tests::if_else_cognitive",
-            "span": {
-              "end_column": 5,
-              "end_line": 1164,
-              "start_column": 5,
-              "start_line": 1158
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 100.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "tests::nested_if_cognitive_penalty",
             "span": {
               "end_column": 5,
               "end_line": 1172,
@@ -9425,12 +9411,60 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "tests::if_else_cognitive",
+            "span": {
+              "end_column": 5,
+              "end_line": 1182,
+              "start_column": 5,
+              "start_line": 1176
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "tests::nested_if_cognitive_penalty",
+            "span": {
+              "end_column": 5,
+              "end_line": 1190,
+              "start_column": 5,
+              "start_line": 1184
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
             "qualified_name": "tests::else_is_not_counted_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1181,
+              "end_line": 1199,
               "start_column": 5,
-              "start_line": 1174
+              "start_line": 1192
             }
           }
         },
@@ -9450,54 +9484,6 @@ expression: pretty
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
             "qualified_name": "tests::match_flat_cognitive",
-            "span": {
-              "end_column": 5,
-              "end_line": 1189,
-              "start_column": 5,
-              "start_line": 1183
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 100.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "tests::if_else_cyclomatic",
-            "span": {
-              "end_column": 5,
-              "end_line": 1199,
-              "start_column": 5,
-              "start_line": 1193
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 100.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "tests::nested_if_cyclomatic",
             "span": {
               "end_column": 5,
               "end_line": 1207,
@@ -9521,12 +9507,60 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "tests::if_else_cyclomatic",
+            "span": {
+              "end_column": 5,
+              "end_line": 1217,
+              "start_column": 5,
+              "start_line": 1211
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "tests::nested_if_cyclomatic",
+            "span": {
+              "end_column": 5,
+              "end_line": 1225,
+              "start_column": 5,
+              "start_line": 1219
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
             "qualified_name": "tests::match_arms_cyclomatic",
             "span": {
               "end_column": 5,
-              "end_line": 1215,
+              "end_line": 1233,
               "start_column": 5,
-              "start_line": 1209
+              "start_line": 1227
             }
           }
         },
@@ -9548,9 +9582,9 @@ expression: pretty
             "qualified_name": "tests::cognitive_gte_cyclomatic_for_nested",
             "span": {
               "end_column": 5,
-              "end_line": 1228,
+              "end_line": 1246,
               "start_column": 5,
-              "start_line": 1217
+              "start_line": 1235
             }
           }
         },
@@ -9572,9 +9606,9 @@ expression: pretty
             "qualified_name": "tests::bool_same_sequence_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1238,
+              "end_line": 1256,
               "start_column": 5,
-              "start_line": 1232
+              "start_line": 1250
             }
           }
         },
@@ -9596,9 +9630,9 @@ expression: pretty
             "qualified_name": "tests::bool_same_sequence_cyclomatic",
             "span": {
               "end_column": 5,
-              "end_line": 1246,
+              "end_line": 1264,
               "start_column": 5,
-              "start_line": 1240
+              "start_line": 1258
             }
           }
         },
@@ -9620,9 +9654,9 @@ expression: pretty
             "qualified_name": "tests::bool_operator_switch_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1254,
+              "end_line": 1272,
               "start_column": 5,
-              "start_line": 1248
+              "start_line": 1266
             }
           }
         },
@@ -9644,9 +9678,9 @@ expression: pretty
             "qualified_name": "tests::bool_operator_switch_cyclomatic",
             "span": {
               "end_column": 5,
-              "end_line": 1262,
+              "end_line": 1280,
               "start_column": 5,
-              "start_line": 1256
+              "start_line": 1274
             }
           }
         },
@@ -9668,9 +9702,9 @@ expression: pretty
             "qualified_name": "tests::bool_in_condition_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1270,
+              "end_line": 1288,
               "start_column": 5,
-              "start_line": 1264
+              "start_line": 1282
             }
           }
         },
@@ -9692,9 +9726,9 @@ expression: pretty
             "qualified_name": "tests::long_or_chain_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1278,
+              "end_line": 1296,
               "start_column": 5,
-              "start_line": 1272
+              "start_line": 1290
             }
           }
         },
@@ -9716,9 +9750,9 @@ expression: pretty
             "qualified_name": "tests::alternating_operators_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1286,
+              "end_line": 1304,
               "start_column": 5,
-              "start_line": 1280
+              "start_line": 1298
             }
           }
         },
@@ -9740,9 +9774,9 @@ expression: pretty
             "qualified_name": "tests::closure_in_parent_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1299,
+              "end_line": 1317,
               "start_column": 5,
-              "start_line": 1290
+              "start_line": 1308
             }
           }
         },
@@ -9762,54 +9796,6 @@ expression: pretty
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
             "qualified_name": "tests::try_operator_cognitive",
-            "span": {
-              "end_column": 5,
-              "end_line": 1309,
-              "start_column": 5,
-              "start_line": 1303
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 100.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "tests::try_operator_cyclomatic",
-            "span": {
-              "end_column": 5,
-              "end_line": 1317,
-              "start_column": 5,
-              "start_line": 1311
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 100.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "tests::loop_with_break_cognitive",
             "span": {
               "end_column": 5,
               "end_line": 1327,
@@ -9833,7 +9819,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "tests::loop_with_break_cyclomatic",
+            "qualified_name": "tests::try_operator_cyclomatic",
             "span": {
               "end_column": 5,
               "end_line": 1335,
@@ -9857,7 +9843,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "tests::let_else_cognitive",
+            "qualified_name": "tests::loop_with_break_cognitive",
             "span": {
               "end_column": 5,
               "end_line": 1345,
@@ -9881,7 +9867,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "tests::let_else_cyclomatic",
+            "qualified_name": "tests::loop_with_break_cyclomatic",
             "span": {
               "end_column": 5,
               "end_line": 1353,
@@ -9905,7 +9891,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "tests::chained_try_cognitive",
+            "qualified_name": "tests::let_else_cognitive",
             "span": {
               "end_column": 5,
               "end_line": 1363,
@@ -9929,7 +9915,7 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "tests::chained_try_cyclomatic",
+            "qualified_name": "tests::let_else_cyclomatic",
             "span": {
               "end_column": 5,
               "end_line": 1371,
@@ -9953,12 +9939,60 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "tests::chained_try_cognitive",
+            "span": {
+              "end_column": 5,
+              "end_line": 1381,
+              "start_column": 5,
+              "start_line": 1375
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "tests::chained_try_cyclomatic",
+            "span": {
+              "end_column": 5,
+              "end_line": 1389,
+              "start_column": 5,
+              "start_line": 1383
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
             "qualified_name": "tests::for_iterator_try_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1379,
+              "end_line": 1397,
               "start_column": 5,
-              "start_line": 1373
+              "start_line": 1391
             }
           }
         },
@@ -9978,54 +10012,6 @@ expression: pretty
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
             "qualified_name": "tests::for_iterator_try_cyclomatic",
-            "span": {
-              "end_column": 5,
-              "end_line": 1387,
-              "start_column": 5,
-              "start_line": 1381
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 100.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "tests::match_scrutinee_try_cognitive",
-            "span": {
-              "end_column": 5,
-              "end_line": 1395,
-              "start_column": 5,
-              "start_line": 1389
-            }
-          }
-        },
-        "threshold": 8.0
-      },
-      {
-        "exceeds": false,
-        "scored": {
-          "complexity": 1,
-          "complexity_metric": "cognitive",
-          "contributors": [],
-          "coverage_percent": 100.0,
-          "crap": {
-            "risk_level": "low",
-            "value": 1.0
-          },
-          "identity": {
-            "file_path": "adapters/complexity/mod.rs",
-            "qualified_name": "tests::trait_default_method_found",
             "span": {
               "end_column": 5,
               "end_line": 1405,
@@ -10049,12 +10035,60 @@ expression: pretty
           },
           "identity": {
             "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "tests::match_scrutinee_try_cognitive",
+            "span": {
+              "end_column": 5,
+              "end_line": 1413,
+              "start_column": 5,
+              "start_line": 1407
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
+            "qualified_name": "tests::trait_default_method_found",
+            "span": {
+              "end_column": 5,
+              "end_line": 1423,
+              "start_column": 5,
+              "start_line": 1417
+            }
+          }
+        },
+        "threshold": 8.0
+      },
+      {
+        "exceeds": false,
+        "scored": {
+          "complexity": 1,
+          "complexity_metric": "cognitive",
+          "contributors": [],
+          "coverage_percent": 100.0,
+          "crap": {
+            "risk_level": "low",
+            "value": 1.0
+          },
+          "identity": {
+            "file_path": "adapters/complexity/mod.rs",
             "qualified_name": "tests::trait_method_without_default_not_found",
             "span": {
               "end_column": 5,
-              "end_line": 1416,
+              "end_line": 1434,
               "start_column": 5,
-              "start_line": 1407
+              "start_line": 1425
             }
           }
         },
@@ -10076,9 +10110,9 @@ expression: pretty
             "qualified_name": "tests::impl_method_no_branch",
             "span": {
               "end_column": 5,
-              "end_line": 1468,
+              "end_line": 1486,
               "start_column": 5,
-              "start_line": 1463
+              "start_line": 1481
             }
           }
         },
@@ -10100,9 +10134,9 @@ expression: pretty
             "qualified_name": "tests::impl_method_with_branch",
             "span": {
               "end_column": 5,
-              "end_line": 1476,
+              "end_line": 1494,
               "start_column": 5,
-              "start_line": 1470
+              "start_line": 1488
             }
           }
         },
@@ -10124,9 +10158,9 @@ expression: pretty
             "qualified_name": "contributor_tests::contributors_for",
             "span": {
               "end_column": 5,
-              "end_line": 1505,
+              "end_line": 1523,
               "start_column": 5,
-              "start_line": 1498
+              "start_line": 1516
             }
           }
         },
@@ -10148,9 +10182,9 @@ expression: pretty
             "qualified_name": "contributor_tests::if_branch_contributor_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1527,
+              "end_line": 1545,
               "start_column": 5,
-              "start_line": 1520
+              "start_line": 1538
             }
           }
         },
@@ -10172,9 +10206,9 @@ expression: pretty
             "qualified_name": "contributor_tests::nested_if_nesting_increment",
             "span": {
               "end_column": 5,
-              "end_line": 1539,
+              "end_line": 1557,
               "start_column": 5,
-              "start_line": 1529
+              "start_line": 1547
             }
           }
         },
@@ -10196,9 +10230,9 @@ expression: pretty
             "qualified_name": "contributor_tests::match_contributor_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1548,
+              "end_line": 1566,
               "start_column": 5,
-              "start_line": 1541
+              "start_line": 1559
             }
           }
         },
@@ -10220,9 +10254,9 @@ expression: pretty
             "qualified_name": "contributor_tests::try_contributor_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1572,
+              "end_line": 1590,
               "start_column": 5,
-              "start_line": 1566
+              "start_line": 1584
             }
           }
         },
@@ -10244,9 +10278,9 @@ expression: pretty
             "qualified_name": "contributor_tests::try_contributor_cyclomatic",
             "span": {
               "end_column": 5,
-              "end_line": 1580,
+              "end_line": 1598,
               "start_column": 5,
-              "start_line": 1574
+              "start_line": 1592
             }
           }
         },
@@ -10268,9 +10302,9 @@ expression: pretty
             "qualified_name": "contributor_tests::let_else_contributor_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1588,
+              "end_line": 1606,
               "start_column": 5,
-              "start_line": 1582
+              "start_line": 1600
             }
           }
         },
@@ -10292,9 +10326,9 @@ expression: pretty
             "qualified_name": "contributor_tests::let_else_contributor_cyclomatic",
             "span": {
               "end_column": 5,
-              "end_line": 1596,
+              "end_line": 1614,
               "start_column": 5,
-              "start_line": 1590
+              "start_line": 1608
             }
           }
         },
@@ -10316,9 +10350,9 @@ expression: pretty
             "qualified_name": "contributor_tests::loop_contributor_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1604,
+              "end_line": 1622,
               "start_column": 5,
-              "start_line": 1598
+              "start_line": 1616
             }
           }
         },
@@ -10340,9 +10374,9 @@ expression: pretty
             "qualified_name": "contributor_tests::for_loop_contributor_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1612,
+              "end_line": 1630,
               "start_column": 5,
-              "start_line": 1606
+              "start_line": 1624
             }
           }
         },
@@ -10364,9 +10398,9 @@ expression: pretty
             "qualified_name": "contributor_tests::for_loop_contributor_cyclomatic",
             "span": {
               "end_column": 5,
-              "end_line": 1620,
+              "end_line": 1638,
               "start_column": 5,
-              "start_line": 1614
+              "start_line": 1632
             }
           }
         },
@@ -10388,9 +10422,9 @@ expression: pretty
             "qualified_name": "contributor_tests::while_loop_contributor_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1628,
+              "end_line": 1646,
               "start_column": 5,
-              "start_line": 1622
+              "start_line": 1640
             }
           }
         },
@@ -10412,9 +10446,9 @@ expression: pretty
             "qualified_name": "contributor_tests::while_loop_contributor_cyclomatic",
             "span": {
               "end_column": 5,
-              "end_line": 1636,
+              "end_line": 1654,
               "start_column": 5,
-              "start_line": 1630
+              "start_line": 1648
             }
           }
         },
@@ -10436,9 +10470,9 @@ expression: pretty
             "qualified_name": "contributor_tests::logical_operator_same_chain_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1652,
+              "end_line": 1670,
               "start_column": 5,
-              "start_line": 1638
+              "start_line": 1656
             }
           }
         },
@@ -10460,9 +10494,9 @@ expression: pretty
             "qualified_name": "contributor_tests::logical_operator_switch_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1667,
+              "end_line": 1685,
               "start_column": 5,
-              "start_line": 1654
+              "start_line": 1672
             }
           }
         },
@@ -10484,9 +10518,9 @@ expression: pretty
             "qualified_name": "contributor_tests::break_contributor",
             "span": {
               "end_column": 5,
-              "end_line": 1680,
+              "end_line": 1698,
               "start_column": 5,
-              "start_line": 1669
+              "start_line": 1687
             }
           }
         },
@@ -10508,9 +10542,9 @@ expression: pretty
             "qualified_name": "contributor_tests::continue_contributor",
             "span": {
               "end_column": 5,
-              "end_line": 1693,
+              "end_line": 1711,
               "start_column": 5,
-              "start_line": 1682
+              "start_line": 1700
             }
           }
         },
@@ -10532,9 +10566,9 @@ expression: pretty
             "qualified_name": "contributor_tests::unsafe_block_produces_no_unsafe_contributor",
             "span": {
               "end_column": 5,
-              "end_line": 1721,
+              "end_line": 1739,
               "start_column": 5,
-              "start_line": 1695
+              "start_line": 1713
             }
           }
         },
@@ -10556,9 +10590,9 @@ expression: pretty
             "qualified_name": "contributor_tests::closure_no_contributor",
             "span": {
               "end_column": 5,
-              "end_line": 1733,
+              "end_line": 1751,
               "start_column": 5,
-              "start_line": 1723
+              "start_line": 1741
             }
           }
         },
@@ -10580,9 +10614,9 @@ expression: pretty
             "qualified_name": "contributor_tests::nested_if_records_construct_end_line_and_nesting_depth_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1766,
+              "end_line": 1784,
               "start_column": 5,
-              "start_line": 1737
+              "start_line": 1755
             }
           }
         },
@@ -10604,9 +10638,9 @@ expression: pretty
             "qualified_name": "contributor_tests::try_records_token_span_for_atomic_contributor",
             "span": {
               "end_column": 5,
-              "end_line": 1780,
+              "end_line": 1798,
               "start_column": 5,
-              "start_line": 1768
+              "start_line": 1786
             }
           }
         },
@@ -10628,9 +10662,9 @@ expression: pretty
             "qualified_name": "contributor_tests::for_with_continue_threads_nesting_depth_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1802,
+              "end_line": 1820,
               "start_column": 5,
-              "start_line": 1782
+              "start_line": 1800
             }
           }
         },
@@ -10652,9 +10686,9 @@ expression: pretty
             "qualified_name": "contributor_tests::nested_if_records_nesting_depth_cyclomatic",
             "span": {
               "end_column": 5,
-              "end_line": 1821,
+              "end_line": 1839,
               "start_column": 5,
-              "start_line": 1804
+              "start_line": 1822
             }
           }
         },
@@ -10676,9 +10710,9 @@ expression: pretty
             "qualified_name": "contributor_tests::for_with_continue_records_nesting_depth_cyclomatic",
             "span": {
               "end_column": 5,
-              "end_line": 1841,
+              "end_line": 1859,
               "start_column": 5,
-              "start_line": 1823
+              "start_line": 1841
             }
           }
         },
@@ -10700,9 +10734,9 @@ expression: pretty
             "qualified_name": "contributor_tests::match_records_end_line_covering_arms_cognitive",
             "span": {
               "end_column": 5,
-              "end_line": 1860,
+              "end_line": 1878,
               "start_column": 5,
-              "start_line": 1843
+              "start_line": 1861
             }
           }
         },
@@ -11934,9 +11968,9 @@ expression: pretty
       }
     ],
     "shown_summary": {
-      "average_complexity": 1.5352112676056338,
-      "average_coverage": 94.86902385796895,
-      "average_crap": 1.5938967136150233,
+      "average_complexity": 1.5492957746478873,
+      "average_coverage": 95.20976251582802,
+      "average_crap": 1.610093896713615,
       "distribution": {
         "acceptable": 2,
         "high": 0,

--- a/crates/crap4rs/src/adapters/complexity/mod.rs
+++ b/crates/crap4rs/src/adapters/complexity/mod.rs
@@ -71,27 +71,45 @@ impl FunctionFinder {
     /// orthogonal (Rust forbids `mod` inside `impl`), so they never
     /// interleave — the path is always `<mods>::<Type?>::<name>`.
     fn qualify(&self, name: &str) -> String {
-        let mut segments: Vec<&str> = self.mod_path.iter().map(String::as_str).collect();
-        if let Some(ty) = &self.current_impl_type {
-            segments.push(ty);
+        // Fast paths for the two overwhelmingly common shapes avoid the
+        // Vec<&str> allocation that the general join needs:
+        //   - top-level free fn  → bare name
+        //   - top-level method   → `Type::name`
+        // The nested-mod cases (rare) fall through to the Vec+join.
+        match (self.mod_path.is_empty(), &self.current_impl_type) {
+            (true, None) => name.to_string(),
+            (true, Some(ty)) => format!("{ty}::{name}"),
+            _ => {
+                let mut segments: Vec<&str> = self.mod_path.iter().map(String::as_str).collect();
+                if let Some(ty) = &self.current_impl_type {
+                    segments.push(ty);
+                }
+                segments.push(name);
+                segments.join("::")
+            }
         }
-        segments.push(name);
-        segments.join("::")
     }
 }
 
 impl<'ast> Visit<'ast> for FunctionFinder {
     fn visit_item_mod(&mut self, node: &'ast syn::ItemMod) {
         // Track inline module nesting so functions inside `mod a { mod b
-        // { fn f } }` are qualified `a::b::f`. Modules declared as `mod
-        // foo;` (file-backed, `content == None`) have no inline body to
-        // walk, so the push/pop is a no-op for them. `#[cfg(test)]` and
-        // other attributed modules are NOT special-cased — the walker is
-        // a generic Rust analyzer and `tests::some_fn` is the genuinely
+        // { fn f } }` are qualified `a::b::f`. `#[cfg(test)]` and other
+        // attributed modules are NOT special-cased — the walker is a
+        // generic Rust analyzer and `tests::some_fn` is the genuinely
         // correct qualified name.
-        self.mod_path.push(node.ident.to_string());
-        syn::visit::visit_item_mod(self, node);
-        self.mod_path.pop();
+        //
+        // Modules declared as `mod foo;` (file-backed, `content == None`)
+        // have no inline body to walk, so pushing/popping the ident would
+        // be wasted allocation — skip the stack mutation entirely and
+        // just default-walk.
+        if node.content.is_some() {
+            self.mod_path.push(node.ident.to_string());
+            syn::visit::visit_item_mod(self, node);
+            self.mod_path.pop();
+        } else {
+            syn::visit::visit_item_mod(self, node);
+        }
     }
 
     fn visit_item_fn(&mut self, node: &'ast ItemFn) {

--- a/crates/crap4rs/src/adapters/complexity/mod.rs
+++ b/crates/crap4rs/src/adapters/complexity/mod.rs
@@ -36,6 +36,7 @@ impl ComplexityPort for SynComplexityAdapter {
         let mut finder = FunctionFinder {
             file_path: file_path.to_string(),
             metric,
+            mod_path: Vec::new(),
             current_impl_type: None,
             functions: Vec::new(),
         };
@@ -50,13 +51,51 @@ impl ComplexityPort for SynComplexityAdapter {
 struct FunctionFinder {
     file_path: String,
     metric: ComplexityMetric,
+    /// Stack of enclosing inline `mod` idents, outermost first. A
+    /// function discovered while this stack is `["outer", "inner"]`
+    /// is qualified `outer::inner::<name>`. The walker runs per file,
+    /// so only *inline* module nesting is visible — the file's own
+    /// position in the crate module tree is not reconstructed.
+    mod_path: Vec<String>,
     current_impl_type: Option<String>,
     functions: Vec<FunctionComplexity>,
 }
 
+impl FunctionFinder {
+    /// Build a function's qualified name from the current `mod` path,
+    /// the optional enclosing impl/trait type, and the bare ident.
+    ///
+    /// The mod path is a pure prefix: a free fn becomes
+    /// `outer::inner::f`; a `Type::method` inside a mod becomes
+    /// `outer::Type::method`. `mod_path` and `current_impl_type` are
+    /// orthogonal (Rust forbids `mod` inside `impl`), so they never
+    /// interleave — the path is always `<mods>::<Type?>::<name>`.
+    fn qualify(&self, name: &str) -> String {
+        let mut segments: Vec<&str> = self.mod_path.iter().map(String::as_str).collect();
+        if let Some(ty) = &self.current_impl_type {
+            segments.push(ty);
+        }
+        segments.push(name);
+        segments.join("::")
+    }
+}
+
 impl<'ast> Visit<'ast> for FunctionFinder {
+    fn visit_item_mod(&mut self, node: &'ast syn::ItemMod) {
+        // Track inline module nesting so functions inside `mod a { mod b
+        // { fn f } }` are qualified `a::b::f`. Modules declared as `mod
+        // foo;` (file-backed, `content == None`) have no inline body to
+        // walk, so the push/pop is a no-op for them. `#[cfg(test)]` and
+        // other attributed modules are NOT special-cased — the walker is
+        // a generic Rust analyzer and `tests::some_fn` is the genuinely
+        // correct qualified name.
+        self.mod_path.push(node.ident.to_string());
+        syn::visit::visit_item_mod(self, node);
+        self.mod_path.pop();
+    }
+
     fn visit_item_fn(&mut self, node: &'ast ItemFn) {
-        let name = node.sig.ident.to_string();
+        let name = self.qualify(&node.sig.ident.to_string());
         let span = span_of(node);
         let mut contributors = Vec::new();
         let complexity = count_complexity(&node.block, self.metric, &mut contributors);
@@ -83,11 +122,7 @@ impl<'ast> Visit<'ast> for FunctionFinder {
     }
 
     fn visit_impl_item_fn(&mut self, node: &'ast syn::ImplItemFn) {
-        let method_name = node.sig.ident.to_string();
-        let qualified = match &self.current_impl_type {
-            Some(ty) => format!("{ty}::{method_name}"),
-            None => method_name,
-        };
+        let qualified = self.qualify(&node.sig.ident.to_string());
         let span = span_of(node);
         let mut contributors = Vec::new();
         let complexity = count_complexity(&node.block, self.metric, &mut contributors);
@@ -106,11 +141,7 @@ impl<'ast> Visit<'ast> for FunctionFinder {
     fn visit_trait_item_fn(&mut self, node: &'ast syn::TraitItemFn) {
         // Only record trait methods that have a default body
         if let Some(block) = &node.default {
-            let method_name = node.sig.ident.to_string();
-            let qualified = match &self.current_impl_type {
-                Some(ty) => format!("{ty}::{method_name}"),
-                None => method_name,
-            };
+            let qualified = self.qualify(&node.sig.ident.to_string());
             let span = span_of(node);
             let mut contributors = Vec::new();
             let complexity = count_complexity(block, self.metric, &mut contributors);
@@ -949,6 +980,64 @@ mod tests {
         let _new = find_fn(&fns, "Calculator::new");
         let _add = find_fn(&fns, "Calculator::add");
         let _div = find_fn(&fns, "Calculator::divide");
+    }
+
+    // ── Nested-mod qualified names (crap-rs#283) ───────────────────────
+
+    #[test]
+    fn top_level_fn_in_nested_mods_fixture_is_unqualified() {
+        // A free function at file root carries no mod prefix — its
+        // qualified name is just its ident.
+        let fns = extract_fixture("nested_mods.rs", ComplexityMetric::Cognitive);
+        let _top = find_fn(&fns, "top_level");
+    }
+
+    #[test]
+    fn one_level_mod_qualified_name() {
+        let fns = extract_fixture("nested_mods.rs", ComplexityMetric::Cognitive);
+        let _f = find_fn(&fns, "outer::in_outer");
+    }
+
+    #[test]
+    fn multi_level_mod_qualified_name() {
+        let fns = extract_fixture("nested_mods.rs", ComplexityMetric::Cognitive);
+        let _f = find_fn(&fns, "outer::inner::deep");
+    }
+
+    #[test]
+    fn impl_method_inside_mod_prepends_mod_path() {
+        // The Discovery answer: `Type::method` inside `mod outer` is
+        // `outer::Type::method` — the mod path is a pure prefix on top
+        // of the existing impl-type qualification.
+        let fns = extract_fixture("nested_mods.rs", ComplexityMetric::Cognitive);
+        let _m = find_fn(&fns, "outer::Widget::render");
+    }
+
+    #[test]
+    fn nested_fn_inside_mod_is_mod_scoped_not_fn_scoped() {
+        // The walker threads `mod` nesting only, never `fn` nesting. A
+        // `fn helper` declared inside `outer::with_nested` is emitted as
+        // `outer::helper`, NOT `outer::with_nested::helper`.
+        let fns = extract_fixture("nested_mods.rs", ComplexityMetric::Cognitive);
+        let _outer = find_fn(&fns, "outer::with_nested");
+        let _helper = find_fn(&fns, "outer::helper");
+        assert!(
+            fns.iter()
+                .all(|f| f.identity.qualified_name != "outer::with_nested::helper"),
+            "nested fn must not inherit the enclosing fn's name as a path segment"
+        );
+    }
+
+    #[test]
+    fn mod_qualification_does_not_disturb_complexity() {
+        // Threading the mod path is a display-only change — complexity
+        // for a fn inside a mod is computed exactly as if it were at
+        // file root.
+        let fns = extract_fixture("nested_mods.rs", ComplexityMetric::Cognitive);
+        let render = find_fn(&fns, "outer::Widget::render");
+        assert_eq!(render.complexity, 1, "render has no branching");
+        let deep = find_fn(&fns, "outer::inner::deep");
+        assert_eq!(deep.complexity, 1, "deep is an empty body");
     }
 
     #[test]
@@ -1927,6 +2016,44 @@ mod proptests {
             prop_assert_eq!(
                 cog.len(), cyc.len(),
                 "Metric should not change function count for {}", fixture
+            );
+        }
+
+        // crap-rs#283 AC: qualified_name length monotonically reflects
+        // nesting depth. Synthesize a source wrapping a single free fn
+        // in `depth` levels of nested mods (`m0::m1::...::f`) and assert
+        // the number of `::`-separated segments is exactly `depth + 1`
+        // — strictly increasing in `depth`.
+        #[test]
+        fn qualified_name_segment_count_tracks_mod_depth(
+            depth in 0u32..6,
+            metric in prop_oneof![
+                Just(ComplexityMetric::Cognitive),
+                Just(ComplexityMetric::Cyclomatic),
+            ],
+        ) {
+            // Build `mod m0 { mod m1 { ... fn f() {} ... } }`.
+            let mut source = String::from("fn f() {}");
+            for level in (0..depth).rev() {
+                source = format!("mod m{level} {{ {source} }}");
+            }
+
+            let fns = adapter().extract(&source, "synth.rs", metric).unwrap();
+            prop_assert_eq!(fns.len(), 1, "exactly one fn expected: {}", source);
+
+            let name = &fns[0].identity.qualified_name;
+            let segments = name.split("::").count();
+            prop_assert_eq!(
+                segments as u32,
+                depth + 1,
+                "fn at mod depth {} should have {} segments, got {:?}",
+                depth, depth + 1, name
+            );
+
+            // The bare ident is always the final segment.
+            prop_assert!(
+                name.ends_with('f'),
+                "qualified name {:?} must end with the fn ident", name
             );
         }
     }

--- a/crates/crap4rs/src/adapters/coverage/mod.rs
+++ b/crates/crap4rs/src/adapters/coverage/mod.rs
@@ -166,34 +166,35 @@ impl CoveragePort for LcovParser {
 
     /// Slurp the LCOV file at `path` and parse it.
     ///
-    /// **Slurp choice (vs streaming via `BufReader`)**: deliberate
-    /// tradeoff. The slurp holds the file in memory once as a `String`,
-    /// then iterates `&str::lines()` which yields borrowed `&str`
-    /// slices with **zero per-line allocations**. A streaming
-    /// `BufReader::lines()` rewrite would bound peak memory at one line
-    /// — but each yielded `Result<String>` allocates a fresh `String`
-    /// per line. On the LCOV files this adapter sees (workspace
-    /// coverage from `cargo-llvm-cov --lcov`), files are line-oriented
-    /// text without expansion and stay well under any concerning
-    /// memory ceiling; a 1 M-line file would buy ~50 MB of avoided
-    /// peak RSS at the cost of 1 M small heap allocations, a trade
-    /// that's net-negative on every workload we measure. The
-    /// single-pass block accumulator (`flush_block` and its state
-    /// machine in this module) was also designed around `&str`
-    /// borrowing — refactoring to `impl BufRead` would force the
-    /// accumulator to own each line.
+    /// **Slurp choice (vs streaming via `BufReader`)**: deliberate, but
+    /// only because the memory bound doesn't matter yet — not because
+    /// streaming would be costly or awkward. A streaming rewrite is
+    /// viable and clean: `read_line(&mut buf)` + `buf.clear()` reuses a
+    /// single buffer across all lines (zero per-line allocation), and
+    /// the single-pass block accumulator wouldn't change at all —
+    /// `ParseState` already owns everything it keeps (`BTreeMap`, owned
+    /// path `String`s, the diagnostic `Vec`); each line `&str` is
+    /// borrowed only within one `handle_parse_line` call, never held
+    /// across reads. So streaming *would* drop the file-size term from
+    /// peak RSS, bounding it at roughly the parse-tree size.
     ///
-    /// [`Self::validate`] is a separate story and streams via
-    /// `BufReader` because it short-circuits on the first match —
-    /// for an early-exit gate, the per-line allocation cost is
-    /// dominated by the I/O-skipped tail, so streaming is the right
-    /// call there.
+    /// The reason to keep slurp is simply that peak RSS is trivial at
+    /// realistic LCOV sizes. Benchmarking `cargo-llvm-cov --lcov` output
+    /// (workspace coverage — line-oriented text, no expansion): a 45 MB
+    /// / 5 M-line file parses at ~58 MB peak RSS (file size + ~13 MB
+    /// parse tree) sub-second; 90 MB / 10 M lines at ~106 MB. Real files
+    /// — including large monorepos — sit in the low tens of MB. Slurp's
+    /// extra peak RSS is the file-size term, which is negligible there.
+    /// The multi-GB-file trigger that would make the file-size term
+    /// worth eliminating has not fired; until it does, the streaming
+    /// refactor is tracked separately rather than built speculatively
+    /// (the abstraction would take `impl BufRead` so production streams
+    /// and tests slice strings via `.as_bytes()`).
     ///
-    /// If a future workload surfaces a multi-GB LCOV file, the
-    /// streaming refactor is tracked separately rather than blanket-
-    /// applied here — see follow-up issue for the abstraction (taking
-    /// `impl BufRead` so production streams and tests slice strings
-    /// via `.as_bytes()`).
+    /// [`Self::validate`] streams via `BufReader` for a different
+    /// reason: it short-circuits on the first match, so the per-line
+    /// cost is dominated by the I/O it skips, and slurping there would
+    /// double peak RSS against the `parse` read that follows.
     fn parse(&self, path: &Path) -> Result<ParseOutput<LcovParseDiagnostic>, CrapError> {
         let data = std::fs::read_to_string(path).map_err(CrapError::Io)?;
         Ok(self.parse_str(&data))
@@ -205,10 +206,12 @@ impl CoveragePort for LcovParser {
     /// shape that `parse` consumes; orphan `DA:` records outside an
     /// `SF:` block and malformed line/hit pairs are rejected.
     ///
-    /// Streams (rather than slurping) because LCOV files easily exceed
-    /// 100 MB on large workspaces and `parse` will read the file again
-    /// shortly after — doubling peak RSS would be a regression from the
-    /// pre-D5 single-pass preflight.
+    /// Streams (rather than slurping) because this gate short-circuits
+    /// on the first well-formed record — it almost never reads the whole
+    /// file — and `parse` will read the file again shortly after.
+    /// Slurping here would hold the full file in memory only to discard
+    /// it after the first match, and the early-exit means the per-line
+    /// allocation cost is dominated by the I/O the gate skips.
     fn validate(&self, path: &Path) -> Result<(), String> {
         use std::io::{BufRead, BufReader};
         let file = std::fs::File::open(path)

--- a/crates/crap4rs/tests/fixtures/nested_mods.rs
+++ b/crates/crap4rs/tests/fixtures/nested_mods.rs
@@ -1,0 +1,42 @@
+// Fixture: functions nested in `mod` blocks for qualified-name testing.
+// Used by the complexity walker tests (crap-rs#283).
+//
+// The walker prepends the inline `mod` path to each function's name:
+//   - top-level fn        → "top_level"
+//   - fn in one mod        → "outer::in_outer"
+//   - fn in nested mods    → "outer::inner::deep"
+//   - method in a mod      → "outer::Widget::render" (mod path + Type::method)
+//   - nested fn in a mod   → "outer::with_nested" (the inner `fn` is emitted
+//                            file-scoped under the mod, NOT mod::outer::inner)
+
+/// Top-level free function — qualified name is unchanged: "top_level".
+pub fn top_level() {}
+
+pub mod outer {
+    /// One level deep — qualified: "outer::in_outer".
+    pub fn in_outer() {}
+
+    pub mod inner {
+        /// Two levels deep — qualified: "outer::inner::deep".
+        pub fn deep() {}
+    }
+
+    pub struct Widget;
+
+    impl Widget {
+        /// Method inside a mod — qualified: "outer::Widget::render"
+        /// (mod path prepended to the impl-type qualification).
+        pub fn render(&self) -> u32 {
+            1
+        }
+    }
+
+    /// A free fn in a mod that itself contains a nested `fn` item.
+    /// The outer fn is "outer::with_nested"; the nested `helper` is
+    /// emitted as "outer::helper" (mod-scoped, NOT fn-scoped) because
+    /// the walker only threads `mod` nesting, not `fn` nesting.
+    pub fn with_nested() {
+        fn helper() {}
+        helper();
+    }
+}


### PR DESCRIPTION
## Summary

The syn complexity walker now threads the enclosing inline `mod` path into each function's emitted **qualified name**. A free function inside `mod a { mod b { fn f } }` is reported as `a::b::f`; top-level functions are unchanged (`f`). Existing `Type::method` qualification continues to work, and a `Type::method` inside `mod outer` is now `outer::Type::method`.

This PR also folds in two follow-ups (both touch `crap4rs/src`, so they ride this PR's existing canary regen at zero extra cost):
- **Two behavior-preserving perf fixes** to the walker (Gemini review on #354): minimal-allocation `qualify` (fast paths for the common top-level fn / top-level method shapes) and skipping the `mod_path` push/pop for file-backed `mod foo;` declarations.
- **#353 rustdoc correction** to the LCOV coverage adapter: drops two disproven streaming arguments (per-line-alloc + accumulator-ownership) and reconciles the `parse`/`validate` memory-ceiling framing.

Closes #283
Closes #353

## Scope: crap4rs only

The crap4ts (TypeScript) walker already qualifies functions through its `visit_namespace_*` path, so the nested-qualification gap was Rust-side only. The `domain/` and `ports/` layers stay language-agnostic — the mod-path construction is entirely walker-internal (`crates/crap4rs/src/adapters/complexity/mod.rs`).

## How the module path is threaded

- `FunctionFinder` gains a `mod_path: Vec<String>` stack and a `visit_item_mod` hook that pushes the module ident, default-walks the body, then pops. File-backed `mod foo;` declarations (no inline body) are a no-op.
- A single `qualify(name)` helper composes the name as `<mods>::<Type?>::<name>`. The mod path is a **pure prefix** on top of the existing impl/trait qualification. `mod_path` and `current_impl_type` are orthogonal (Rust forbids `mod` inside `impl`), so they never interleave.
- Only `mod` nesting is threaded, never `fn` nesting — a nested `fn` inside `outer::with_nested` is emitted `outer::helper`, matching the walker's existing file-scoped treatment of nested fn items.

**Qualified names are display-only.** Coverage matching joins on `(file_path, span line-range)` in `crap-core::domain::matching` — never on `qualified_name`. This change does not alter `FunctionIdentity`'s join behavior or any matching path.

## Tests (TDD)

- New fixture `crates/crap4rs/tests/fixtures/nested_mods.rs` plus unit tests covering: top-level (unchanged), one-level, multi-level nesting, `Type::method` inside a mod, and nested-fn mod-scoping.
- AC property test `qualified_name_segment_count_tracks_mod_depth`: synthesizes sources at mod depth `0..6` and asserts the `::`-segment count is exactly `depth + 1` (strictly monotonic in nesting depth).

## Snapshot / wire-envelope canary impact

The `wire_envelope_crap4rs` canary analyzes the live `crap4rs/src` tree against the frozen `crap4rs-self.lcov`, so it picks up the rename. **Regenerated deliberately via `cargo insta accept` (documented drift).** The new names are the intended qualified forms:

- Production shims in `adapters/mod.rs`: `load` → `baseline::load`, `format_json` → `reporters::format_json`.
- Every `#[cfg(test)] mod` test fn: `tests::*`, `contributor_tests::*`, `test_helpers::*`, `proptests::*`. `#[cfg(test)]` modules are **not** special-cased — the walker is a generic Rust analyzer and `tests::some_fn` is the genuinely-correct qualified name.

`total_functions` 205 → 213 (+8), fully accounted: the 2 new walker fns (`FunctionFinder::qualify`, `FunctionFinder::visit_item_mod`) plus the 6 new `#[test]` fns added in this PR. The 7th added fn lives inside a `proptest!{}` macro invocation, which `syn::parse_file` does not expand, so it stays invisible to the walker (same reason the existing proptests never appeared in the snapshot).

The frozen `crap4rs-self.lcov` **input** is intentionally **not** regenerated — it's a fixed-shape oracle (single commit since #133; its DA lines stop at ~901 against a 2060-line source, so most functions already resolve via the "no instrumentable lines → 100%" path). The canary locks envelope **shape**, not coverage accuracy. Only the derived snapshot is re-accepted.

**Coordination note:** two other concurrent crap-rs PRs (#348 config, #263 coverage) also touch `crap4rs/src` and regenerate this same snapshot. A rebase-regenerate against latest `main` may be needed at merge time; the canary must be green at merge.

## Gates (all green)

- `cargo fmt --check`
- `cargo +1.96.0 clippy --workspace --all-targets -- -D warnings` (CI toolchain)
- `cargo nextest run --workspace --all-targets` — 1282 passed
- `cargo +1.93 check --workspace --all-targets` (MSRV)
- `python3 scripts/bdd-tracked-lint.py`
- `python3 scripts/mutants-skip-lint.py`
- `wire_envelope_crap4rs` canary regenerated + accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

