### PR TITLE
docs(core): #356 — correct merge_exclude rustdoc on the forced-excludes guarantee

### DIFF
--- a/crates/crap-core/src/cli/mod.rs
+++ b/crates/crap-core/src/cli/mod.rs
@@ -1855,22 +1855,34 @@ fn merge_threshold(
     (config, global)
 }
 
-/// Build the effective exclude list applied to the source walker:
-/// `meta.forced_excludes` first (adapter-mandated, structural skips
-/// like `**/*.d.ts` for crap4ts — see `AdapterMeta::forced_excludes`),
-/// then CLI `--exclude` flags, then patterns from the user's config
-/// file. Duplicates are dropped so the override builder doesn't see
-/// the same pattern twice. Order matters because `ignore::overrides`
-/// is order-sensitive on shadowed patterns; forced excludes lead so a
-/// user can't accidentally re-include a structurally-skipped file.
+/// Build the effective exclude list applied to the source walker, as
+/// the union of four sources: `meta.forced_excludes` (adapter-mandated
+/// structural skips like `**/*.d.ts` for crap4ts — see
+/// `AdapterMeta::forced_excludes`), CLI `--exclude` flags, the running
+/// adapter's per-language `[language.<name>].exclude`, and the shared
+/// top-level config `exclude`. Duplicates are dropped so the override
+/// builder doesn't see the same pattern twice.
+///
+/// The order in which patterns are appended is NOT load-bearing for the
+/// forced-excludes guarantee. `core::discover_source_files` adds every
+/// pattern to `ignore::overrides::OverrideBuilder` as `!{pattern}`, and
+/// that builder inverts `!` so a `!`-prefixed glob is an *ignore* (a
+/// bare glob would be a whitelist). Because this list only ever yields
+/// `!`-form ignores — never a bare/whitelist glob — the result is an
+/// order-independent union of ignores: a later config exclude cannot
+/// re-include a forced-excluded file (re-inclusion needs a whitelist
+/// glob, which is never emitted here). So `**/*.d.ts` stays excluded
+/// regardless of what the user's config adds. Dedup order is preserved
+/// only for stable, reproducible output.
 fn merge_exclude(
     cli: &Cli,
     file_config: &Option<FileConfig>,
     lang: Option<&LangConfig>,
     meta: &AdapterMeta,
 ) -> Vec<String> {
-    // Append patterns not already seen, preserving order (the override
-    // builder is order-sensitive on shadowed patterns).
+    // Append patterns not already seen. Order is preserved only for
+    // stable output — the walker adds each as a `!`-ignore override, so
+    // the effective set is an order-independent union (see the fn doc).
     fn extend_deduped(
         patterns: &[String],
         exclude: &mut Vec<String>,


### PR DESCRIPTION
## Summary

Fast-follow for the post-merge Gemini review on #348 / PR #355. Both review findings are **false positives against main**; the only correction worth landing is the stale `merge_exclude` rustdoc. **Doc/comment only — zero logic change.**

## Findings + disposition

1. **(HIGH) exclude-merge precedence inverted — false positive (cosmetic).** `core::discover_source_files` (`walker.rs:39`) adds every exclude pattern to `ignore::overrides::OverrideBuilder` as `!{pattern}`. Per the [`ignore` docs](https://docs.rs/ignore/latest/ignore/overrides/struct.OverrideBuilder.html#method.add), `OverrideBuilder` **inverts** `!`: a `!`-prefixed glob is an *ignore*; a bare glob is a *whitelist*. The exclude path only ever emits `!`-form ignores (never a bare/whitelist glob), so the effective set is an **order-independent union of ignores** — a later config exclude cannot re-include a forced-excluded file (re-inclusion would need a whitelist glob, which is never produced). `**/*.d.ts` stays excluded regardless of append order. Live impact is doubly nil: crap4rs `forced_excludes` is empty, and config isn't production-wired until #346.
   - **Fix: doc-only.** The old rustdoc wrongly attributed the guarantee to append *order*. Corrected to name the real `!`-only-union mechanism and list all four sources (forced / CLI / per-language / shared). No reorder — reordering "for intent" would contradict the corrected doc (order is moot).

2. **(MEDIUM) top-level `raw.threshold` not validated — false positive.** `validate_raw_config` already validates it at `crates/crap-core/src/adapters/config.rs:452-456` (`if let Some(t) = raw.threshold && !is_valid_threshold(t) { bail!("...finite positive...") }`), exercised by `negative_threshold_rejected` / `zero_threshold_rejected` / `inf_threshold_rejected`. Gemini cited line 451 (the closing brace of the mutual-exclusion check) and didn't read the let-chain immediately below. **No code change** — adding it would be a duplicate `bail!`.

## Gates

All green: `cargo fmt --check`; `cargo +1.96.0 clippy --workspace --all-targets -- -D warnings` (CI toolchain 1.96, not local 1.95); `cargo nextest run --workspace --all-targets` (1300 passed); `cargo +1.93 check --workspace --all-targets` (MSRV). The crap4rs wire-envelope canary analyzes `../crap4rs/src` only — unaffected by this crap-core doc change, no re-accept.

Closes #356

🤖 Generated with [Claude Code](https://claude.com/claude-code)