### PR TITLE
feat(core): #352 — render [output] title/subtitle in table/markdown/html reporters

### DIFF
--- a/crates/crap-core/src/adapters/reporters/html.rs
+++ b/crates/crap-core/src/adapters/reporters/html.rs
@@ -1717,6 +1717,24 @@ mod tests {
     }
 
     #[test]
+    fn subtitle_without_title_keeps_default_html_heading() {
+        let result = make_multi_function_result();
+        let out = html_labeled(&make_view_default(&result), None, Some("nightly build"));
+        // A subtitle set without a title keeps the default `<tool>
+        // report` H1 (no title to replace it) and still renders the
+        // subtitle span beneath. Exercises the default-h1 + subtitle
+        // combination.
+        assert!(
+            out.contains(&format!("<h1>{TEST_TOOL_NAME} report</h1>")),
+            "expected the default tool H1 when only a subtitle is set",
+        );
+        assert!(
+            out.contains(r#"<span class="subtitle">nightly build</span>"#),
+            "expected the subtitle span even without a title",
+        );
+    }
+
+    #[test]
     fn html_title_subtitle_are_escaped() {
         let result = make_multi_function_result();
         let out = html_labeled(

--- a/crates/crap-core/src/adapters/reporters/html.rs
+++ b/crates/crap-core/src/adapters/reporters/html.rs
@@ -58,12 +58,24 @@ use std::collections::BTreeMap;
 /// click away and reachable directly via the `#delta` URL hash (the
 /// inline `<script>` hook honors `location.hash` for CI sticky-comment
 /// deep links).
+/// `report_title` and `subtitle` are the optional `[output] title` /
+/// `subtitle` config labels (crap-rs#352). When `report_title` is
+/// `Some`, the configured label replaces the `<h1>tool report</h1>`
+/// scorecard heading and is also folded into the `<title>` document
+/// element; when `subtitle` is `Some`, it renders on a line beneath the
+/// heading. Both default to `None`, in which case the header is
+/// byte-identical to the unlabeled default — no empty subtitle element
+/// is emitted. (Single-card path only — the multi-language unified
+/// renderer composes its own header and never threads these, per D20.)
+#[allow(clippy::too_many_arguments)]
 pub fn format_html(
     view: &AnalysisView<'_>,
     delta: Option<&DeltaView<'_>>,
     threshold: f64,
     meta: &AdapterMeta,
     effective_metric: ComplexityMetric,
+    report_title: Option<&str>,
+    subtitle: Option<&str>,
 ) -> String {
     // `AdapterMeta`'s `&'static str` fields originate from the adapter
     // binaries' compile-time literals. `format_html_inner` takes
@@ -79,9 +91,12 @@ pub fn format_html(
         meta.tool_version,
         meta.display_name,
         effective_metric,
+        report_title,
+        subtitle,
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn format_html_inner(
     view: &AnalysisView<'_>,
     delta: Option<&DeltaView<'_>>,
@@ -90,9 +105,17 @@ fn format_html_inner(
     tool_version: &str,
     display_name: &str,
     effective_metric: ComplexityMetric,
+    report_title: Option<&str>,
+    subtitle: Option<&str>,
 ) -> String {
     let summary = &view.full.summary;
-    let title = format!("{} v{} — CRAP score analysis", tool_name, tool_version);
+    // The `<title>` document element folds in the configured scorecard
+    // title when set (crap-rs#352); otherwise it keeps the unlabeled
+    // tool/version default verbatim (byte-identical absent path).
+    let title = match report_title {
+        Some(t) => format!("{} — {} v{}", t, tool_name, tool_version),
+        None => format!("{} v{} — CRAP score analysis", tool_name, tool_version),
+    };
 
     let metric_label = metric_label(effective_metric);
 
@@ -141,6 +164,8 @@ fn format_html_inner(
 
     let tmpl = HtmlReport {
         title,
+        report_title,
+        subtitle,
         tool_name,
         tool_version,
         adapter_display: display_name,
@@ -169,6 +194,13 @@ fn format_html_inner(
 #[template(path = "html_report.html")]
 struct HtmlReport<'a> {
     title: String,
+    /// Configured scorecard title (`[output] title`, crap-rs#352). When
+    /// `Some`, the template renders it as the `<h1>` heading in place of
+    /// the default `<tool> report` label. `None` keeps the default.
+    report_title: Option<&'a str>,
+    /// Configured scorecard subtitle (`[output] subtitle`), rendered as a
+    /// line beneath the heading. `None` emits no element.
+    subtitle: Option<&'a str>,
     tool_name: &'a str,
     tool_version: &'a str,
     adapter_display: &'a str,
@@ -703,6 +735,11 @@ pub fn format_html_multi(
         // `&'static str` projection — the rendered template only
         // needs the strings to live for the duration of the call,
         // which `&block.tool_name` etc. already guarantee.
+        // No `[output]` title/subtitle on the multi-language passthrough:
+        // the unified renderer composes its own header and the envelope
+        // carries no per-language scorecard label (crap-rs#352, D20). The
+        // `None, None` here keeps single-language passthrough output
+        // byte-identical to the unlabeled `format_html` default.
         return format_html_inner(
             &block.view,
             block.delta.as_ref(),
@@ -711,6 +748,8 @@ pub fn format_html_multi(
             &block.tool_version,
             &block.display_name,
             block.metric,
+            None,
+            None,
         );
     }
 
@@ -1599,7 +1638,15 @@ mod tests {
     }
 
     fn html(view: &AnalysisView<'_>) -> String {
-        format_html(view, None, 8.0, &test_meta(), ComplexityMetric::Cognitive)
+        format_html(
+            view,
+            None,
+            8.0,
+            &test_meta(),
+            ComplexityMetric::Cognitive,
+            None,
+            None,
+        )
     }
 
     fn html_with_delta(view: &AnalysisView<'_>, delta: &DeltaView<'_>) -> String {
@@ -1609,7 +1656,116 @@ mod tests {
             8.0,
             &test_meta(),
             ComplexityMetric::Cognitive,
+            None,
+            None,
         )
+    }
+
+    fn html_labeled(
+        view: &AnalysisView<'_>,
+        title: Option<&str>,
+        subtitle: Option<&str>,
+    ) -> String {
+        format_html(
+            view,
+            None,
+            8.0,
+            &test_meta(),
+            ComplexityMetric::Cognitive,
+            title,
+            subtitle,
+        )
+    }
+
+    // ── [output] title / subtitle labeling (crap-rs#352) ────────────────
+
+    #[test]
+    fn title_labels_the_html_heading() {
+        let result = make_multi_function_result();
+        let out = html_labeled(
+            &make_view_default(&result),
+            Some("Acme Coverage Report"),
+            None,
+        );
+        // The configured title replaces the default `<tool> report` H1
+        // and is folded into the document `<title>`.
+        assert!(
+            out.contains("<h1>Acme Coverage Report</h1>"),
+            "expected the configured title as the H1; got header region:\n{}",
+            &out[..out.len().min(2000)],
+        );
+        assert!(
+            out.contains("<title>Acme Coverage Report — "),
+            "expected the configured title folded into <title>",
+        );
+        // The default `<tool> report` H1 must no longer be present.
+        assert!(!out.contains(&format!("<h1>{TEST_TOOL_NAME} report</h1>")));
+    }
+
+    #[test]
+    fn subtitle_renders_in_html_header() {
+        let result = make_multi_function_result();
+        let out = html_labeled(
+            &make_view_default(&result),
+            Some("Acme Coverage Report"),
+            Some("nightly build"),
+        );
+        assert!(
+            out.contains(r#"<span class="subtitle">nightly build</span>"#),
+            "expected the subtitle span in the header",
+        );
+    }
+
+    #[test]
+    fn html_title_subtitle_are_escaped() {
+        let result = make_multi_function_result();
+        let out = html_labeled(
+            &make_view_default(&result),
+            Some("A & B <script>"),
+            Some("v1 > v0"),
+        );
+        // askama auto-escapes `.html` templates (numeric entities), so
+        // HTML metacharacters in a user-supplied title/subtitle must not
+        // inject raw markup.
+        assert!(
+            out.contains("A &#38; B &#60;script&#62;"),
+            "title must be HTML-escaped in the heading; got:\n{}",
+            &out[..out.len().min(2000)],
+        );
+        assert!(
+            out.contains("v1 &#62; v0"),
+            "subtitle must be HTML-escaped in the header",
+        );
+        // The raw `<script>` token from the title must never appear as
+        // injected markup. The template's own legitimate `<script>` tags
+        // are followed by attributes/newlines, never `>A`, so guarding on
+        // the title-derived `<script>A` reconstruction is precise.
+        assert!(
+            !out.contains("<script>A"),
+            "raw `<script>` from a title must never reach the document",
+        );
+    }
+
+    #[test]
+    fn absent_html_title_subtitle_is_byte_identical() {
+        let result = make_multi_function_result();
+        // Absent title/subtitle must be byte-identical to the unlabeled
+        // default — the template gates both arms so no empty element and
+        // no whitespace drift leaks into the no-config path.
+        let labeled = html_labeled(&make_view_default(&result), None, None);
+        let default = html(&make_view_default(&result));
+        assert_eq!(
+            labeled, default,
+            "absent title/subtitle must produce the unlabeled HTML verbatim",
+        );
+        assert!(
+            default.contains(&format!("<h1>{TEST_TOOL_NAME} report</h1>")),
+            "default header must keep the `<tool> report` H1",
+        );
+        assert!(
+            !default.contains(r#"class="subtitle""#),
+            "no subtitle element when none is configured",
+        );
     }
 
     #[test]
@@ -1799,6 +1955,8 @@ mod tests {
             8.0,
             &test_meta(),
             ComplexityMetric::Cognitive,
+            None,
+            None,
         );
         assert!(out.contains("footer-adapters"));
         assert!(
@@ -1821,6 +1979,8 @@ mod tests {
             10.0,
             &test_meta(),
             ComplexityMetric::Cyclomatic,
+            None,
+            None,
         );
         assert!(out.contains("cyclomatic complexity"));
         assert!(out.contains("10.00"));
@@ -2188,6 +2348,8 @@ mod tests {
             8.0,
             &test_meta(),
             ComplexityMetric::Cognitive,
+            None,
+            None,
         );
 
         let block = build_block(
@@ -3098,6 +3260,8 @@ mod tests {
             8.0,
             &test_meta(),
             ComplexityMetric::Cognitive,
+            None,
+            None,
         );
 
         let block = LanguageBlock {

--- a/crates/crap-core/src/adapters/reporters/markdown.rs
+++ b/crates/crap-core/src/adapters/reporters/markdown.rs
@@ -49,6 +49,14 @@ use askama::Template;
 /// for signature symmetry with `format_html`. `effective_metric` is
 /// the runtime-resolved metric (post-CLI/config merge); see
 /// `EffectiveInputs.metric`.
+///
+/// `title` and `subtitle` are the optional `[output] title` / `subtitle`
+/// config labels (crap-rs#352). When `title` is `Some`, it renders as a
+/// `## <title>` line above the tool/version H1; when `subtitle` is
+/// `Some`, it renders on the line beneath. Both default to `None`, in
+/// which case the output is byte-identical to the unlabeled default — no
+/// empty title/subtitle line is emitted (the template ws-strips the
+/// absent arms).
 #[allow(clippy::too_many_arguments)]
 pub fn format_markdown(
     view: &AnalysisView<'_>,
@@ -60,6 +68,8 @@ pub fn format_markdown(
     top_n: usize,
     meta: &AdapterMeta,
     _effective_metric: ComplexityMetric,
+    title: Option<&str>,
+    subtitle: Option<&str>,
 ) -> String {
     let body = if view.full.functions.is_empty() {
         MarkdownBody::Empty
@@ -80,6 +90,8 @@ pub fn format_markdown(
     let delta_block = delta.map(format_markdown_delta);
 
     let tmpl = MarkdownReport {
+        title,
+        subtitle,
         tool_name: meta.tool_name,
         tool_version: meta.tool_version,
         body,
@@ -107,6 +119,12 @@ pub fn format_markdown(
 #[derive(Template)]
 #[template(path = "markdown_report.txt", escape = "none")]
 struct MarkdownReport<'a> {
+    /// Configured scorecard title (`[output] title`), rendered as a
+    /// `## <title>` line above the tool/version H1. `None` emits nothing.
+    title: Option<&'a str>,
+    /// Configured scorecard subtitle (`[output] subtitle`), rendered
+    /// beneath the title. `None` emits nothing.
+    subtitle: Option<&'a str>,
     tool_name: &'a str,
     tool_version: &'a str,
     body: MarkdownBody,
@@ -533,7 +551,85 @@ mod tests {
             10,
             &test_meta(),
             ComplexityMetric::Cognitive,
+            None,
+            None,
         )
+    }
+
+    // ── [output] title / subtitle labeling (crap-rs#352) ────────────────
+
+    fn md_labeled(view: &AnalysisView<'_>, title: Option<&str>, subtitle: Option<&str>) -> String {
+        format_markdown(
+            view,
+            None,
+            8.0,
+            false,
+            false,
+            false,
+            10,
+            &test_meta(),
+            ComplexityMetric::Cognitive,
+            title,
+            subtitle,
+        )
+    }
+
+    #[test]
+    fn title_labels_the_markdown_header() {
+        let result = make_multi_function_result();
+        let out = md_labeled(
+            &make_view_default(&result),
+            Some("Acme Coverage Report"),
+            None,
+        );
+        // The configured title is the prominent headline — it takes the
+        // `#` H1, and the tool/version line demotes to `##` attribution
+        // (prominence consistent with the table + html reporters).
+        assert!(
+            out.starts_with("# Acme Coverage Report\n"),
+            "expected the title as the H1 headline at the top; got:\n{out}",
+        );
+        assert!(out.contains(&format!(
+            "## {TEST_TOOL_NAME} v{TEST_TOOL_VERSION} — CRAP Score Analysis"
+        )));
+        // The tool line must NOT remain a top-level `#` H1 when a title
+        // labels the scorecard.
+        assert!(!out.contains(&format!(
+            "\n# {TEST_TOOL_NAME} v{TEST_TOOL_VERSION} — CRAP Score Analysis"
+        )));
+    }
+
+    #[test]
+    fn subtitle_renders_beneath_the_markdown_title() {
+        let result = make_multi_function_result();
+        let out = md_labeled(
+            &make_view_default(&result),
+            Some("Acme Coverage Report"),
+            Some("nightly build"),
+        );
+        assert!(
+            out.starts_with("# Acme Coverage Report\n\nnightly build\n"),
+            "expected the subtitle on its own paragraph beneath the title; got:\n{out}",
+        );
+    }
+
+    #[test]
+    fn absent_markdown_title_subtitle_is_byte_identical() {
+        let result = make_multi_function_result();
+        // Absent title/subtitle must be byte-identical to the default —
+        // the template ws-strips the absent arms, so no empty line drift.
+        let labeled = md_labeled(&make_view_default(&result), None, None);
+        let default = md(&make_view_default(&result));
+        assert_eq!(
+            labeled, default,
+            "absent title/subtitle must produce the unlabeled markdown verbatim",
+        );
+        assert!(
+            default.starts_with(&format!(
+                "# {TEST_TOOL_NAME} v{TEST_TOOL_VERSION} — CRAP Score Analysis"
+            )),
+            "default header must lead with the tool/version H1, no empty line above",
+        );
     }
 
     #[test]
@@ -589,6 +685,8 @@ mod tests {
             10,
             &test_meta(),
             ComplexityMetric::Cognitive,
+            None,
+            None,
         );
         assert!(out.contains("## Summary"));
         assert!(out.contains("## All functions"));
@@ -646,6 +744,8 @@ mod tests {
             10,
             &test_meta(),
             ComplexityMetric::Cognitive,
+            None,
+            None,
         );
         assert!(out.contains("## All functions"));
         assert!(out.contains("L12 if-branch +1"));
@@ -700,6 +800,8 @@ mod tests {
             10,
             &test_meta(),
             ComplexityMetric::Cognitive,
+            None,
+            None,
         );
         insta::assert_snapshot!(out);
     }
@@ -755,6 +857,8 @@ mod tests {
             10,
             &test_meta(),
             ComplexityMetric::Cognitive,
+            None,
+            None,
         );
         assert!(out.contains("## CRAP Scorecard"));
         assert!(out.contains("- **Delta status:** FAIL"));
@@ -776,6 +880,8 @@ mod tests {
             10,
             &test_meta(),
             ComplexityMetric::Cognitive,
+            None,
+            None,
         );
         assert!(out.contains("### Regressions"));
         assert!(out.contains("parse_record"));
@@ -796,6 +902,8 @@ mod tests {
             10,
             &test_meta(),
             ComplexityMetric::Cognitive,
+            None,
+            None,
         );
         assert!(out.contains("### New violations"));
         assert!(out.contains("new_fn"));
@@ -823,6 +931,8 @@ mod tests {
             10,
             &test_meta(),
             ComplexityMetric::Cognitive,
+            None,
+            None,
         );
         insta::assert_snapshot!(out);
     }

--- a/crates/crap-core/src/adapters/reporters/markdown.rs
+++ b/crates/crap-core/src/adapters/reporters/markdown.rs
@@ -614,6 +614,23 @@ mod tests {
     }
 
     #[test]
+    fn subtitle_without_title_renders_above_markdown_tool_line() {
+        let result = make_multi_function_result();
+        let out = md_labeled(&make_view_default(&result), None, Some("nightly build"));
+        // A subtitle set without a title renders as a plain line above
+        // the tool/version line, which stays the `#` H1 (no title to
+        // demote it). Exercises the template's `{%- else -%}` branch's
+        // inner subtitle arm.
+        assert!(
+            out.starts_with("nightly build\n\n# "),
+            "expected the subtitle above the tool H1; got:\n{out}",
+        );
+        assert!(out.contains(&format!(
+            "# {TEST_TOOL_NAME} v{TEST_TOOL_VERSION} — CRAP Score Analysis"
+        )));
+    }
+
+    #[test]
     fn absent_markdown_title_subtitle_is_byte_identical() {
         let result = make_multi_function_result();
         // Absent title/subtitle must be byte-identical to the default —

--- a/crates/crap-core/src/adapters/reporters/table.rs
+++ b/crates/crap-core/src/adapters/reporters/table.rs
@@ -32,6 +32,8 @@ pub fn format_table(
         false,
         tool_name,
         tool_version,
+        None,
+        None,
     )
 }
 
@@ -47,6 +49,14 @@ pub fn format_table(
 /// are threaded from the caller — `env!("CARGO_PKG_NAME")` and
 /// `env!("CARGO_PKG_VERSION")` resolve against `crap-core` here, not
 /// the adapter binary, so the calling binary supplies its own identity.
+///
+/// `title` and `subtitle` are the optional `[output] title` / `subtitle`
+/// config labels (crap-rs#352). When `title` is `Some`, it is emitted as
+/// a header line above the tool/version line; when `subtitle` is `Some`,
+/// it renders on the line beneath the title. Both default to `None`, in
+/// which case the header is byte-identical to the unlabeled default — no
+/// empty title/subtitle line is emitted.
+#[allow(clippy::too_many_arguments)]
 pub fn format_table_with_explain(
     view: &AnalysisView<'_>,
     delta: Option<&DeltaView<'_>>,
@@ -55,10 +65,23 @@ pub fn format_table_with_explain(
     explain: bool,
     tool_name: &str,
     tool_version: &str,
+    title: Option<&str>,
+    subtitle: Option<&str>,
 ) -> String {
     let mut output = String::new();
 
-    // Header
+    // Header — the configured title labels the scorecard above the
+    // tool/version line; the subtitle renders beneath the title. Each is
+    // gated on `Some` independently so the absent path emits no empty
+    // line and stays byte-identical to the unlabeled default.
+    if let Some(title) = title {
+        output.push_str(title);
+        output.push('\n');
+    }
+    if let Some(subtitle) = subtitle {
+        output.push_str(subtitle);
+        output.push('\n');
+    }
     output.push_str(&format!(
         "{tool_name} v{tool_version} — CRAP Score Analysis\n",
     ));
@@ -807,6 +830,116 @@ mod tests {
         assert!(output.starts_with(&format!("{TEST_TOOL_NAME} v{TEST_TOOL_VERSION}")));
     }
 
+    // ── [output] title / subtitle labeling (crap-rs#352) ────────────────
+
+    #[test]
+    fn title_labels_the_scorecard_header() {
+        let _guard = acquire_color_lock();
+        colored::control::set_override(false);
+        let result = make_multi_function_result();
+        let output = format_table_with_explain(
+            &make_view_default(&result),
+            None,
+            8.0,
+            false,
+            false,
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
+            Some("Acme Coverage Report"),
+            None,
+        );
+        // The configured title labels the header — emitted on the first
+        // line, above the tool/version line.
+        assert!(
+            output.starts_with("Acme Coverage Report\n"),
+            "expected the title on the first header line; got:\n{output}",
+        );
+        assert!(output.contains(&format!("{TEST_TOOL_NAME} v{TEST_TOOL_VERSION}")));
+    }
+
+    #[test]
+    fn subtitle_renders_beneath_the_title() {
+        let _guard = acquire_color_lock();
+        colored::control::set_override(false);
+        let result = make_multi_function_result();
+        let output = format_table_with_explain(
+            &make_view_default(&result),
+            None,
+            8.0,
+            false,
+            false,
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
+            Some("Acme Coverage Report"),
+            Some("nightly build"),
+        );
+        assert!(
+            output.starts_with("Acme Coverage Report\nnightly build\n"),
+            "expected the subtitle beneath the title; got:\n{output}",
+        );
+    }
+
+    #[test]
+    fn absent_title_and_subtitle_emit_no_extra_lines() {
+        let _guard = acquire_color_lock();
+        colored::control::set_override(false);
+        let result = make_multi_function_result();
+        // Absent title/subtitle must be byte-identical to the unlabeled
+        // default — `format_table` is the `None, None` wrapper, so both
+        // paths must produce the exact same bytes (no empty header line).
+        let labeled = format_table_with_explain(
+            &make_view_default(&result),
+            None,
+            8.0,
+            false,
+            false,
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
+            None,
+            None,
+        );
+        let default = format_table(
+            &make_view_default(&result),
+            8.0,
+            false,
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
+        );
+        assert_eq!(
+            labeled, default,
+            "absent title/subtitle must be byte-identical to the unlabeled default",
+        );
+        assert!(
+            default.starts_with(&format!("{TEST_TOOL_NAME} v{TEST_TOOL_VERSION}")),
+            "default header must lead with the tool/version line, no empty line above",
+        );
+    }
+
+    #[test]
+    fn subtitle_without_title_renders_above_tool_line() {
+        let _guard = acquire_color_lock();
+        colored::control::set_override(false);
+        let result = make_multi_function_result();
+        let output = format_table_with_explain(
+            &make_view_default(&result),
+            None,
+            8.0,
+            false,
+            false,
+            TEST_TOOL_NAME,
+            TEST_TOOL_VERSION,
+            None,
+            Some("nightly build"),
+        );
+        // A subtitle set without a title still renders (gated
+        // independently), above the tool/version line, with no empty
+        // title line preceding it.
+        assert!(
+            output.starts_with("nightly build\n"),
+            "expected the subtitle on the first line when no title is set; got:\n{output}",
+        );
+    }
+
     #[test]
     fn test_summary_line_contents() {
         let _guard = acquire_color_lock();
@@ -1101,6 +1234,8 @@ mod tests {
             true,
             TEST_TOOL_NAME,
             TEST_TOOL_VERSION,
+            None,
+            None,
         );
         assert!(output.contains("Legend: +1 = base structural increment."));
         assert!(output.contains("+N (nested) = +1 base plus +(N-1)"));
@@ -1138,6 +1273,8 @@ mod tests {
             true,
             TEST_TOOL_NAME,
             TEST_TOOL_VERSION,
+            None,
+            None,
         );
         assert!(!output.contains("Legend:"));
         assert!(!output.contains("line 3: match (+3 (nested))"));
@@ -1179,6 +1316,8 @@ mod tests {
             true,
             TEST_TOOL_NAME,
             TEST_TOOL_VERSION,
+            None,
+            None,
         );
         assert!(!output.contains("Legend:"));
     }
@@ -1598,6 +1737,8 @@ mod tests {
             false,
             TEST_TOOL_NAME,
             TEST_TOOL_VERSION,
+            None,
+            None,
         );
         assert!(
             output.contains("Delta vs baseline:"),
@@ -1628,6 +1769,8 @@ mod tests {
             false,
             TEST_TOOL_NAME,
             TEST_TOOL_VERSION,
+            None,
+            None,
         );
         // Per-change rows present
         assert!(output.contains("added"));
@@ -1651,6 +1794,8 @@ mod tests {
             false,
             TEST_TOOL_NAME,
             TEST_TOOL_VERSION,
+            None,
+            None,
         );
         assert!(!output.contains("Delta vs baseline"));
     }
@@ -1669,6 +1814,8 @@ mod tests {
             false,
             TEST_TOOL_NAME,
             TEST_TOOL_VERSION,
+            None,
+            None,
         );
         insta::assert_snapshot!(output);
     }

--- a/crates/crap-core/src/cli/mod.rs
+++ b/crates/crap-core/src/cli/mod.rs
@@ -1119,6 +1119,14 @@ struct EffectiveInputs {
     /// only by `format_github_annotations` — every other reporter
     /// ignores it.
     annotation_limit: usize,
+    /// Configured scorecard title from `[output] title` (crap-rs#352).
+    /// `None` renders the default unlabeled header. Top-level only — no
+    /// per-language overlay (the unified scorecard is one header, see
+    /// D20). Honored by the table / markdown / html reporters.
+    title: Option<String>,
+    /// Configured scorecard subtitle from `[output] subtitle`. `None`
+    /// emits no subtitle line. Threaded alongside `title`.
+    subtitle: Option<String>,
 }
 
 /// In-flight pipeline state assembled by `prepare_pipeline`. Owns the
@@ -1182,6 +1190,12 @@ fn merge_effective_inputs(
         .annotation_limit
         .or_else(|| file_config.as_ref().and_then(|c| c.output.annotation_limit))
         .unwrap_or(10) as usize;
+    // Scorecard title / subtitle (crap-rs#352) come from the top-level
+    // `[output]` table only — they are not per-language (D20: the
+    // unified scorecard is one card with one header). No default: `None`
+    // means the reporters render the unlabeled header.
+    let title = file_config.as_ref().and_then(|c| c.output.title.clone());
+    let subtitle = file_config.as_ref().and_then(|c| c.output.subtitle.clone());
     EffectiveInputs {
         src,
         metric,
@@ -1189,6 +1203,8 @@ fn merge_effective_inputs(
         threshold,
         exclude,
         annotation_limit,
+        title,
+        subtitle,
     }
 }
 
@@ -1545,6 +1561,8 @@ fn render_format<P: ParseDiagnostic>(
             cli.display.explain,
             meta.tool_name,
             meta.tool_version,
+            inputs.title.as_deref(),
+            inputs.subtitle.as_deref(),
         ),
         FormatArg::Json | FormatArg::Advice => {
             format_as_json(cli, view, delta_view, delta_state, analysis, inputs, meta)?
@@ -1559,6 +1577,8 @@ fn render_format<P: ParseDiagnostic>(
             cli.display.md_top,
             meta,
             inputs.metric,
+            inputs.title.as_deref(),
+            inputs.subtitle.as_deref(),
         ),
         FormatArg::Csv => reporters::format_csv(view, delta_view, inputs.metric),
         // SARIF is a gate translation, not a display: it iterates
@@ -1576,9 +1596,15 @@ fn render_format<P: ParseDiagnostic>(
         FormatArg::ScorecardRow => {
             format_as_scorecard_row(delta_state, &analysis.result, inputs.threshold)
         }
-        FormatArg::Html => {
-            reporters::format_html(view, delta_view, inputs.threshold, meta, inputs.metric)
-        }
+        FormatArg::Html => reporters::format_html(
+            view,
+            delta_view,
+            inputs.threshold,
+            meta,
+            inputs.metric,
+            inputs.title.as_deref(),
+            inputs.subtitle.as_deref(),
+        ),
         // GitHub Actions annotations is a gate translation like SARIF —
         // iterates `view.full.functions` regardless of View shaping so
         // PR annotations reflect the gate, not a presentation choice.
@@ -3292,6 +3318,8 @@ mod tests {
             threshold: 15.0,
             exclude: Vec::new(),
             annotation_limit: 10,
+            title: None,
+            subtitle: None,
         }
     }
 

--- a/crates/crap-core/templates/html_report.html
+++ b/crates/crap-core/templates/html_report.html
@@ -382,7 +382,10 @@ footer.report-footer {
 
 <!-- ── Header ───────────────────────────────────────────────────────── -->
 <header class="report-header">
-  <h1>{{ tool_name }} report</h1>
+  <h1>{% if report_title.is_some() %}{{ report_title.as_ref().unwrap() }}{% else %}{{ tool_name }} report{% endif %}</h1>
+{%- if subtitle.is_some() %}
+  <span class="subtitle">{{ subtitle.as_ref().unwrap() }}</span>
+{%- endif %}
   <span class="ver">v{{ tool_version }}</span>
   <span class="grow"></span>
   <span class="verdict is-{{ verdict_class }}" aria-label="Verdict: {{ verdict_label }}">

--- a/crates/crap-core/templates/html_report.html
+++ b/crates/crap-core/templates/html_report.html
@@ -382,9 +382,9 @@ footer.report-footer {
 
 <!-- ── Header ───────────────────────────────────────────────────────── -->
 <header class="report-header">
-  <h1>{% if report_title.is_some() %}{{ report_title.as_ref().unwrap() }}{% else %}{{ tool_name }} report{% endif %}</h1>
-{%- if subtitle.is_some() %}
-  <span class="subtitle">{{ subtitle.as_ref().unwrap() }}</span>
+  <h1>{% if let Some(report_title) = report_title %}{{ report_title }}{% else %}{{ tool_name }} report{% endif %}</h1>
+{%- if let Some(subtitle) = subtitle %}
+  <span class="subtitle">{{ subtitle }}</span>
 {%- endif %}
   <span class="ver">v{{ tool_version }}</span>
   <span class="grow"></span>

--- a/crates/crap-core/templates/markdown_report.txt
+++ b/crates/crap-core/templates/markdown_report.txt
@@ -24,15 +24,15 @@
    offset the scorecard composite action applies (`# `→`#### `, `## `→
    `##### `) is content-agnostic, so the title/tool levels nest cleanly
    under the action's `### Rust (crap4rs)` wrapper either way. -#}
-{%- if title.is_some() -%}
-# {{ title.as_ref().unwrap() }}
-{% if subtitle.is_some() %}
-{{ subtitle.as_ref().unwrap() }}
+{%- if let Some(title) = title -%}
+# {{ title }}
+{% if let Some(subtitle) = subtitle %}
+{{ subtitle }}
 {% endif %}
 ## {{ tool_name }} v{{ tool_version }} — CRAP Score Analysis
 {%- else -%}
-{%- if subtitle.is_some() -%}
-{{ subtitle.as_ref().unwrap() }}
+{%- if let Some(subtitle) = subtitle -%}
+{{ subtitle }}
 
 {% endif -%}
 # {{ tool_name }} v{{ tool_version }} — CRAP Score Analysis

--- a/crates/crap-core/templates/markdown_report.txt
+++ b/crates/crap-core/templates/markdown_report.txt
@@ -10,8 +10,33 @@
    composes structure.
 
    escape = "none" because markdown special chars (|, *, _, #) must
-   pass through verbatim. Cell escaping is the reporter's job. -#}
+   pass through verbatim. Cell escaping is the reporter's job.
+
+   `[output] title` / `subtitle` (crap-rs#352): a configured title is the
+   prominent headline — it takes the `#` H1 and the tool/version line
+   demotes to `##` (attribution). This keeps prominence consistent with
+   the table reporter (title-on-top) and the HTML reporter (title-as-h1):
+   the configured label is the banner across all three surfaces. The
+   subtitle renders on a plain line beneath. Each arm is gated +
+   whitespace-stripped so the absent path emits ZERO bytes — and when no
+   title is set the tool/version line stays at `#`, byte-identical to the
+   pre-#352 render (existing snapshots untouched). The fixed heading
+   offset the scorecard composite action applies (`# `→`#### `, `## `→
+   `##### `) is content-agnostic, so the title/tool levels nest cleanly
+   under the action's `### Rust (crap4rs)` wrapper either way. -#}
+{%- if title.is_some() -%}
+# {{ title.as_ref().unwrap() }}
+{% if subtitle.is_some() %}
+{{ subtitle.as_ref().unwrap() }}
+{% endif %}
+## {{ tool_name }} v{{ tool_version }} — CRAP Score Analysis
+{%- else -%}
+{%- if subtitle.is_some() -%}
+{{ subtitle.as_ref().unwrap() }}
+
+{% endif -%}
 # {{ tool_name }} v{{ tool_version }} — CRAP Score Analysis
+{%- endif %}
 
 {% match body -%}
 {%- when MarkdownBody::Empty -%}

--- a/crates/crap-core/tests/multi_lang_passthrough.rs
+++ b/crates/crap-core/tests/multi_lang_passthrough.rs
@@ -55,7 +55,18 @@ fn single_language_passthrough_is_byte_identical_to_direct_format_html() {
 
     // Direct path: what every existing single-binary consumer of
     // `--format html` sees today.
-    let direct = format_html(&view, None, 8.0, &test_meta(), ComplexityMetric::Cognitive);
+    // `None, None` for `[output]` title/subtitle: the multi-language
+    // passthrough never threads a scorecard label (crap-rs#352, D20), so
+    // the direct comparison must also pass `None` to stay byte-identical.
+    let direct = format_html(
+        &view,
+        None,
+        8.0,
+        &test_meta(),
+        ComplexityMetric::Cognitive,
+        None,
+        None,
+    );
 
     // Multi-language passthrough: construct a single-element
     // `MultiLangContext` and route through `format_html_multi`.


### PR DESCRIPTION
## Summary

Threads the parsed `[output] title` / `[output] subtitle` config fields (landed by #348) through the **table, markdown, and HTML** reporter call sites so a configured scorecard label appears in the output. This is the durable, config-driven replacement for #336's caller-local `comment-preamble` stopgap.

Values flow: CLI-flag-absent → `file_config.output.title/subtitle` → `EffectiveInputs.{title,subtitle}` (top-level only, **no** per-language overlay — D20: the unified scorecard is one card with one header) → the three reporter arms in `render_format`. No default — `None` renders the unlabeled header.

## Prominence model (consistent across surfaces)

The configured title is the **headline**; the tool/version line is **attribution** — the same prominence on all three surfaces (the "consistent across surfaces" AC):

- **Table**: title line → subtitle line → tool/version line.
- **Markdown**: title takes the `#` H1; the tool/version line demotes to `##` when a title is set (stays `#` when absent — byte-identical). The scorecard composite action's fixed heading-offset transform (`# `→`#### `, `## `→`##### `) is content-agnostic, so title/tool nest cleanly one level apart under its `### Rust (crap4rs)` wrapper (verified by piping labeled markdown through the action's `sed`).
- **HTML**: the title replaces the `<tool> report` `<h1>` and folds into the `<title>` element; the subtitle renders in `<span class="subtitle">`.

## Absent path (AC4)

Absent title/subtitle is **byte-identical** to the unlabeled default on every surface — no empty title/subtitle line/element emitted. Guarded explicitly via `format_table`/`md`/`html` `None,None` wrappers + askama whitespace control, and locked by byte-equality tests. All existing table/markdown/html snapshots are unchanged.

## Multi-language renderer untouched

`format_html_multi`'s single-language passthrough passes `None,None`, keeping the unified-renderer output byte-identical; the multi-lang snapshots don't move (D20 — per-language titles would fragment a single composed header).

## CLI flag

**No CLI flag added.** The config-driven path is the requirement; a flag would add clap surface + help-text snapshot churn for no current need. Easy to add later if a per-run override is wanted (would mirror `annotation_limit`'s CLI-wins precedence).

## Tests

TDD: labeled-header present (title-only, title+subtitle, subtitle-only), absent-path byte-identity, and HTML auto-escaping of user-supplied strings (askama numeric entities, no injection). Dogfooded end-to-end via the `crap4rs` binary against a temp project with a real `crap.toml`.

## Gates (all green)

- `cargo fmt --check` ✅
- `cargo +1.96.0 clippy --workspace --all-targets -- -D warnings` ✅
- `cargo nextest run --workspace --all-targets` — 1312 passed ✅
- `cargo +1.93 check --workspace --all-targets` (MSRV) ✅
- `scripts/bdd-tracked-lint.py` / `scripts/mutants-skip-lint.py` ✅

## To ratify at merge

1. **Subtitle-without-title semantics** — the AC phrases subtitle relative to "the title"; a subtitle set without a title renders standalone (config shown, never silently dropped). Any rejection/validation, if wanted, belongs in #348's parse layer, not the reporter.
2. **Public API signature change** — `format_table_with_explain`, `format_markdown`, `format_html` (all `pub`, re-exported by crap4rs) gained `title`/`subtitle` params. No external caller (verified); acceptable minor-bump break at crap-core 0.8.0, surfaced here for visibility.

Closes #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)