### PR TITLE
feat(core+cli): config loader hardening (#339 #340 #341 #342)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1638,6 +1638,36 @@ jobs:
       - name: Lint in-repo `--src` adapter invocations carry an explicit `--config`
         run: python3 scripts/config-discovery-lint.py
 
+  config-ast-purity-lint:
+    # Mechanical enforcement of the crap-rs#342 rule: crap-core's config
+    # adapter (`crates/crap-core/src/adapters/config.rs`) must stay
+    # name-agnostic — no per-adapter literals (`"crap4rs.toml"`,
+    # `"crap4ts.toml"`, `"crap4rs"`, `"crap4ts"`) in source OR inline
+    # tests. The per-adapter names belong only in each binary's
+    # `AdapterMeta::config_file_names`; discovery flows through that, so a
+    # literal in config.rs is a layering smell. The unified `"crap.toml"`
+    # and adapter names in `//`/`///` comments are allowed (the gate
+    # matches string literals only).
+    #
+    # See `scripts/config-ast-purity-lint.py` for the matcher + limitation
+    # notes. Mirrors the `lefthook.yml` pre-push step — single source of
+    # truth in the script.
+    #
+    # Conventions follow the supply-chain hardening: scoped
+    # `permissions: contents: read`, `persist-credentials: false` on
+    # checkout, no cache (pure-Python, sub-second).
+    name: config-ast-purity lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Lint crap-core config.rs carries no per-adapter literals
+        run: python3 scripts/config-ast-purity-lint.py
+
   templated-example-lint:
     # Mechanical structural lint for the consumer-facing templated
     # example at `.github/workflows/examples/crap-scorecard.yml`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1609,6 +1609,35 @@ jobs:
       - name: 'Lint `# tracked: crap-rs#<n>` comment coverage of @unwired/@wip scenarios'
         run: python3 scripts/bdd-tracked-lint.py
 
+  config-discovery-lint:
+    # Mechanical enforcement of the crap-rs#339 C-2 isolation rule: any
+    # analyzer-shelling test that passes an IN-REPO `--src` (a string
+    # literal / format!) without a covering `--config` and without a
+    # tempdir `.current_dir(...)` would, under walk-upward discovery,
+    # climb into the repo-root `crap.toml` (crap-rs#346) and let its
+    # wire-envelope / parity / schema snapshot drift on an unrelated
+    # sibling merge. The fix is an explicit empty `--config` fixture;
+    # this job is its enforcement — documentation rots, CI doesn't.
+    #
+    # See `scripts/config-discovery-lint.py` for the per-invocation
+    # detection shape and limitation notes. Mirrors the `lefthook.yml`
+    # pre-push step — single source of truth in the script.
+    #
+    # Conventions follow the supply-chain hardening: scoped
+    # `permissions: contents: read`, `persist-credentials: false` on
+    # checkout, no cache (pure-Python, sub-second).
+    name: config-discovery lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Lint in-repo `--src` adapter invocations carry an explicit `--config`
+        run: python3 scripts/config-discovery-lint.py
+
   templated-example-lint:
     # Mechanical structural lint for the consumer-facing templated
     # example at `.github/workflows/examples/crap-scorecard.yml`.

--- a/crates/crap-core/CHANGELOG.md
+++ b/crates/crap-core/CHANGELOG.md
@@ -8,6 +8,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `crap-core` is the language-agnostic foundation shared by the
 `crap4rs` (Rust) and `crap4ts` (TypeScript) adapters.
 
+## [Unreleased]
+
+### Changed
+
+- Config-file auto-discovery now **walks upward**: when no explicit
+    `--config` is given, the loader searches the run's anchor directory
+    (the first `--src` root, or the working directory when `--src` is
+    empty) and every ancestor up to the filesystem root, and the
+    nearest directory holding any candidate wins. This lets
+    `crap4rs --src crates/foo` (run from a repo root) discover the
+    repo-root `crap.toml`, and `cd crates && crap4rs --src foo` discover
+    a `crap.toml` one level up. The previous behavior only inspected the
+    working directory. Within each directory the canonical-over-legacy
+    ordering and the same-directory shadow notice are unchanged; a file
+    in a parent directory is never reported as shadowed. Pass an explicit
+    `--config <path>` to bypass discovery entirely. (crap-rs#339)
+    - Edge case: the walk has no `.git` / workspace-root boundary, so a
+        stray `crap.toml` in `$HOME` (or any ancestor above your project)
+        is discovered when no nearer config exists. Use `--config` to
+        pin the file explicitly if an ancestor config is unwanted.
+
+### Internal
+
+- The config loader is now `anyhow`-free: `discover_config`,
+    `load_config`, and the parse/validate helpers return a typed
+    `crap_core::adapters::config::ConfigError`
+    (`thiserror` + `#[non_exhaustive]`); the CLI boundary lifts it into
+    `anyhow` so user-facing output is unchanged. (crap-rs#340)
+- The parsed config POD types (`FileConfig`, `OutputConfig`,
+    `LangConfig`, `ViewPreset`) moved to
+    `crap_core::domain::config`; they are re-exported from
+    `crap_core::adapters::config` so existing import paths keep working.
+    (crap-rs#341)
+
 ## [0.8.0]
 
 ### Added

--- a/crates/crap-core/src/adapters/config.rs
+++ b/crates/crap-core/src/adapters/config.rs
@@ -320,63 +320,105 @@ pub struct ConfigDiscovery {
     pub shadowed: Vec<PathBuf>,
 }
 
-/// Discover the adapter's config file by walking `candidates` in priority
-/// order; the first *existing* file wins.
+/// Discover the adapter's config file by walking upward from `start`
+/// (and every ancestor directory) and, within each directory, resolving
+/// `file_names` in priority order. **The first ancestor directory that
+/// yields any candidate wins** — the walk stops there.
 ///
-/// Candidates may be relative or absolute paths; this function never
-/// touches the working directory itself, so it is CWD-agnostic. In
-/// production the CLI layer passes bare relative names
-/// (`PathBuf::from("crap.toml")`), which resolve CWD-relative when
-/// `metadata` is called; tests pass tempdir-qualified absolute paths to
-/// stay safe under parallel execution (no process-wide CWD mutation).
-/// Index 0 is the canonical name (`crap.toml`); later entries are legacy
-/// per-adapter fallbacks (`crap4rs.toml` / `crap4ts.toml`).
+/// `start` is the directory the search anchors on — in production the
+/// first `--src` root, or the working directory when `--src` is empty.
+/// It is **absolutized** via [`std::path::absolute`] before walking
+/// (NOT canonicalized): `Path::ancestors()` is purely *lexical*, so
+/// `"crates/foo".ancestors()` would yield `["crates/foo", "crates", ""]`
+/// and never climb to the real repo root. `absolute` makes the path
+/// absolute by prepending the process CWD when it is relative, so the
+/// ancestors are the genuine on-disk parent chain — without touching the
+/// filesystem, resolving symlinks, or erroring on a non-existent path
+/// (which `canonicalize` would). Because it consults the process CWD only
+/// (never *mutates* it), the function stays parallel-safe under nextest;
+/// a relative `start` resolves against whatever CWD the caller runs in.
 ///
-/// Discovery is by *existence*, not parseability: a present-but-malformed
-/// canonical file still wins, and surfaces its parse error downstream — it
-/// never silently falls through to a stale legacy file that happens to
-/// parse.
+/// Within each directory the resolution mirrors the single-directory
+/// contract: index 0 in `file_names` is the canonical name (`crap.toml`);
+/// later entries are legacy per-adapter fallbacks. Discovery is by
+/// *existence*, not parseability — a present-but-malformed canonical file
+/// still wins and surfaces its parse error downstream, never silently
+/// falling through to a stale legacy file that happens to parse. Only
+/// `io::ErrorKind::NotFound` advances to the next name; any other I/O
+/// error (e.g. `PermissionDenied`) short-circuits with `Err` so a
+/// permission problem on the canonical config surfaces rather than being
+/// masked by a legacy-config deprecation warning.
 ///
-/// While searching for the winner, only `io::ErrorKind::NotFound` advances
-/// to the next candidate. Any other I/O error (e.g. `PermissionDenied` on
-/// a higher-priority file) short-circuits and returns `Err`: a permission
-/// problem on the canonical config must surface, never be masked by
-/// emitting a legacy-config deprecation warning for a file the operator
-/// cannot read.
+/// Shadow detection stays **same-directory only**: lower-priority names
+/// that also exist *in the winning directory* are reported as `shadowed`
+/// (safe to remove). A file in a *parent* directory is never reported as
+/// shadowed — the operator is never told a file outside the chosen
+/// config's directory is redundant.
 ///
-/// Returns `Ok(Some(ConfigDiscovery))` when a candidate exists,
-/// `Ok(None)` when none do.
-pub fn discover_config(candidates: &[PathBuf]) -> Result<Option<ConfigDiscovery>, ConfigError> {
-    for (index, candidate) in candidates.iter().enumerate() {
-        match std::fs::metadata(candidate) {
+/// The walk climbs to the filesystem root with no `.git` / workspace
+/// boundary stop. One consequence to be aware of: a stray `crap.toml` in
+/// `$HOME` (or any ancestor above the project) will be discovered when no
+/// nearer config exists. Pass an explicit `--config` to bypass discovery
+/// entirely.
+///
+/// Returns `Ok(Some(ConfigDiscovery))` when a candidate exists in some
+/// ancestor directory, `Ok(None)` when none do anywhere up to the root.
+pub fn discover_config(
+    start: &Path,
+    file_names: &[&str],
+) -> Result<Option<ConfigDiscovery>, ConfigError> {
+    // Absolutize so `.ancestors()` climbs the real parent chain rather
+    // than the lexical components of a relative `start` (C-1). On the
+    // rare error path (e.g. an empty path) fall back to the raw `start`
+    // so a single-dir lookup still works.
+    let anchored = std::path::absolute(start).unwrap_or_else(|_| start.to_path_buf());
+
+    for dir in anchored.ancestors() {
+        if let Some(found) = discover_in_dir(dir, file_names)? {
+            return Ok(Some(found));
+        }
+    }
+    Ok(None)
+}
+
+/// Run the ordered-name resolution within a single directory. Returns
+/// `Ok(Some(_))` for the highest-priority existing file (with any
+/// lower-priority same-dir files recorded as `shadowed`), `Ok(None)`
+/// when no candidate exists here (so the caller advances to the parent),
+/// or `Err` on a non-`NotFound` I/O error probing a candidate.
+fn discover_in_dir(
+    dir: &Path,
+    file_names: &[&str],
+) -> Result<Option<ConfigDiscovery>, ConfigError> {
+    for (index, name) in file_names.iter().enumerate() {
+        let candidate = dir.join(name);
+        match std::fs::metadata(&candidate) {
             Ok(m) if m.is_file() => {
-                // Winner found. Report any lower-priority candidates that
-                // also exist as `shadowed` so the operator can delete them.
-                // Best-effort and existence-confirmed: only paths that are
-                // genuinely files are recorded. A metadata error on a
-                // lower-priority candidate is irrelevant — we already hold a
-                // valid winner — and must never produce a spurious shadow
-                // warning for a phantom or inaccessible path.
-                let shadowed = candidates[index + 1..]
+                // Winner found. Report any lower-priority names that also
+                // exist *in this same directory* as `shadowed` so the
+                // operator can delete them. Existence-confirmed via
+                // `is_file()` (not `exists()`): a directory at a
+                // lower-priority name is never reported as shadowed.
+                let shadowed = file_names[index + 1..]
                     .iter()
+                    .map(|n| dir.join(n))
                     .filter(|p| p.is_file())
-                    .cloned()
                     .collect();
                 return Ok(Some(ConfigDiscovery {
-                    path: candidate.clone(),
+                    path: candidate,
                     used_index: index,
                     shadowed,
                 }));
             }
-            // Exists but not a regular file (directory, etc.) — not a config
-            // we can load; advance to the next candidate.
+            // Exists but not a regular file (directory, etc.) — not a
+            // config we can load; advance to the next name.
             Ok(_) => continue,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
             // Construct the variant manually (not `#[from]`) so the
             // load-bearing `path` survives onto the error (I-4).
             Err(source) => {
                 return Err(ConfigError::Access {
-                    path: candidate.clone(),
+                    path: candidate,
                     source,
                 });
             }
@@ -1611,8 +1653,11 @@ threshold = 0.0
 
     #[test]
     fn load_config_valid_file() {
+        // `load_config` is name-agnostic — it loads whatever path it is
+        // handed. The unified canonical name keeps this in step with the
+        // config-ast-purity gate (crap-rs#342).
         let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("crap4rs.toml");
+        let path = dir.path().join("crap.toml");
         std::fs::write(&path, "threshold = 10.0\n").unwrap();
 
         let config = load_config(&path).unwrap();
@@ -1622,7 +1667,7 @@ threshold = 0.0
     #[test]
     fn load_config_invalid_toml() {
         let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("crap4rs.toml");
+        let path = dir.path().join("crap.toml");
         std::fs::write(&path, "not valid toml [[[").unwrap();
 
         let err = load_config(&path).unwrap_err();
@@ -1930,29 +1975,48 @@ nonsense_field = "x"
         );
     }
 
-    // ── discover_config ordered dual-discovery (4 back-compat cases) ──
+    // ── discover_config walk-upward + within-dir ordered discovery ────
     //
-    // `discover_config` walks an ordered candidate list (full paths;
-    // the caller joins names to the working dir) and returns the
-    // highest-priority *existing* file. Index 0 is canonical (`crap.toml`),
-    // the rest are legacy fallbacks. These four cases pin the back-compat
-    // contract: a unified `crap.toml` wins; a lone legacy file is still
-    // discovered (and reported via `used_index > 0` so the CLI can nudge a
-    // rename); a co-present legacy file is reported as `shadowed`; an empty
-    // directory discovers nothing. Tempdir-qualified paths keep this safe
-    // under nextest's parallel execution model (no process-wide CWD).
+    // `discover_config(start, file_names)` absolutizes `start`, walks its
+    // ancestor directories, and within each directory resolves the
+    // ordered `file_names` (index 0 canonical, the rest legacy
+    // fallbacks). The first ancestor directory yielding any candidate
+    // wins. These cases pin the WITHIN-DIR contract (the same-dir
+    // back-compat the single-directory loader had): a canonical file
+    // wins; a lone legacy file is discovered at `used_index > 0`; a
+    // co-present legacy file is reported as `shadowed`; an empty tree
+    // discovers nothing; a directory at a name is skipped; a non-NotFound
+    // I/O error bails. The CROSS-DIR contract (walk-upward, nearest-dir
+    // wins) is pinned by the dedicated ancestor / nearest-wins cases
+    // below. The synthetic adapter names keep the analyzer's own
+    // per-adapter literals (`crap4rs.toml` / `crap4ts.toml`) out of this
+    // module per the config-ast-purity gate (crap-rs#342) — discovery is
+    // name-agnostic, so synthetic names exercise the identical code path.
+    //
+    // `start` is the tempdir itself in the same-dir cases, so the winning
+    // directory is the first ancestor and no climb occurs. Tempdir-rooted
+    // (absolute) starts keep this safe under nextest's parallel execution
+    // model (no process-wide CWD dependence).
+
+    /// Canonical adapter config name used in the discovery unit tests —
+    /// synthetic so the per-adapter analyzer names stay out of this
+    /// module (crap-rs#342). The unified `crap.toml` and the synthetic
+    /// legacy below exercise the same name-agnostic discovery path.
+    const TEST_CANONICAL: &str = "crap.toml";
+    /// Synthetic legacy fallback name (index 1) for the discovery tests.
+    const TEST_LEGACY: &str = "test-adapter-legacy.toml";
+    const TEST_NAMES: &[&str] = &[TEST_CANONICAL, TEST_LEGACY];
 
     #[test]
     fn discover_config_canonical_only_wins_at_index_zero() {
         let dir = tempfile::tempdir().unwrap();
-        let canonical = dir.path().join("crap.toml");
+        let canonical = dir.path().join(TEST_CANONICAL);
         std::fs::write(&canonical, "threshold = 22.0\n").unwrap();
 
-        let candidates = vec![canonical.clone(), dir.path().join("crap4rs.toml")];
-        let disc = discover_config(&candidates).unwrap().unwrap();
+        let disc = discover_config(dir.path(), TEST_NAMES).unwrap().unwrap();
 
         assert_eq!(disc.path, canonical);
-        assert_eq!(disc.used_index, 0, "canonical crap.toml is index 0");
+        assert_eq!(disc.used_index, 0, "canonical name is index 0");
         assert!(
             disc.shadowed.is_empty(),
             "no legacy file present, nothing shadowed"
@@ -1962,13 +2026,12 @@ nonsense_field = "x"
     #[test]
     fn discover_config_legacy_only_falls_back_at_index_one() {
         let dir = tempfile::tempdir().unwrap();
-        let legacy = dir.path().join("crap4rs.toml");
+        let legacy = dir.path().join(TEST_LEGACY);
         std::fs::write(&legacy, "threshold = 9.0\n").unwrap();
 
-        // crap.toml (index 0) is absent → discovery advances to the legacy
-        // fallback at index 1.
-        let candidates = vec![dir.path().join("crap.toml"), legacy.clone()];
-        let disc = discover_config(&candidates).unwrap().unwrap();
+        // Canonical (index 0) is absent → discovery advances to the legacy
+        // fallback at index 1 within the same directory.
+        let disc = discover_config(dir.path(), TEST_NAMES).unwrap().unwrap();
 
         assert_eq!(disc.path, legacy);
         assert_eq!(disc.used_index, 1, "legacy fallback is index 1");
@@ -1981,15 +2044,14 @@ nonsense_field = "x"
     #[test]
     fn discover_config_both_present_canonical_wins_legacy_shadowed() {
         let dir = tempfile::tempdir().unwrap();
-        let canonical = dir.path().join("crap.toml");
-        let legacy = dir.path().join("crap4rs.toml");
+        let canonical = dir.path().join(TEST_CANONICAL);
+        let legacy = dir.path().join(TEST_LEGACY);
         std::fs::write(&canonical, "threshold = 22.0\n").unwrap();
         std::fs::write(&legacy, "threshold = 9.0\n").unwrap();
 
-        let candidates = vec![canonical.clone(), legacy.clone()];
-        let disc = discover_config(&candidates).unwrap().unwrap();
+        let disc = discover_config(dir.path(), TEST_NAMES).unwrap().unwrap();
 
-        assert_eq!(disc.path, canonical, "canonical wins by list order");
+        assert_eq!(disc.path, canonical, "canonical wins by name order");
         assert_eq!(disc.used_index, 0);
         assert_eq!(
             disc.shadowed,
@@ -2000,34 +2062,32 @@ nonsense_field = "x"
 
     #[test]
     fn discover_config_neither_present_returns_none() {
+        // An empty tempdir tree (its ancestors are real but carry no
+        // candidate up to the root). Discovery returns None rather than
+        // climbing into an unrelated config — the tempdir lives under the
+        // system temp root, which has no config.
         let dir = tempfile::tempdir().unwrap();
-        let candidates = vec![
-            dir.path().join("crap.toml"),
-            dir.path().join("crap4rs.toml"),
-        ];
 
         assert_eq!(
-            discover_config(&candidates).unwrap(),
+            discover_config(dir.path(), TEST_NAMES).unwrap(),
             None,
-            "no candidate exists → no config discovered"
+            "no candidate in the tree → no config discovered"
         );
     }
 
     #[test]
     fn discover_config_non_file_at_canonical_advances_to_legacy() {
-        // A non-regular file at the canonical position (here a directory
-        // literally named `crap.toml`) is not a config we can load, so
-        // discovery advances to the legacy fallback rather than treating
-        // the directory as the winner or erroring. Pins the `Ok(_) =>
-        // continue` arm.
+        // A non-regular file at the canonical position (a directory at the
+        // canonical name) is not a config we can load, so discovery
+        // advances to the legacy fallback within the same directory rather
+        // than treating the directory as the winner or erroring. Pins the
+        // `Ok(_) => continue` arm.
         let dir = tempfile::tempdir().unwrap();
-        let canonical = dir.path().join("crap.toml");
-        std::fs::create_dir(&canonical).unwrap();
-        let legacy = dir.path().join("crap4rs.toml");
+        std::fs::create_dir(dir.path().join(TEST_CANONICAL)).unwrap();
+        let legacy = dir.path().join(TEST_LEGACY);
         std::fs::write(&legacy, "threshold = 9.0\n").unwrap();
 
-        let candidates = vec![canonical, legacy.clone()];
-        let disc = discover_config(&candidates).unwrap().unwrap();
+        let disc = discover_config(dir.path(), TEST_NAMES).unwrap().unwrap();
 
         assert_eq!(disc.path, legacy, "directory at index 0 is skipped");
         assert_eq!(disc.used_index, 1);
@@ -2037,16 +2097,15 @@ nonsense_field = "x"
     #[test]
     fn discover_config_non_file_shadow_candidate_is_not_recorded() {
         // A lower-priority candidate that exists but is not a regular file
-        // (a directory named `crap4rs.toml`) must NOT appear in `shadowed`
-        // — the filter is `is_file()`, not `exists()`, so the operator is
+        // (a directory at the legacy name) must NOT appear in `shadowed` —
+        // the filter is `is_file()`, not `exists()`, so the operator is
         // never told to "remove" a directory. Pins the shadow filter.
         let dir = tempfile::tempdir().unwrap();
-        let canonical = dir.path().join("crap.toml");
+        let canonical = dir.path().join(TEST_CANONICAL);
         std::fs::write(&canonical, "threshold = 22.0\n").unwrap();
-        std::fs::create_dir(dir.path().join("crap4rs.toml")).unwrap();
+        std::fs::create_dir(dir.path().join(TEST_LEGACY)).unwrap();
 
-        let candidates = vec![canonical.clone(), dir.path().join("crap4rs.toml")];
-        let disc = discover_config(&candidates).unwrap().unwrap();
+        let disc = discover_config(dir.path(), TEST_NAMES).unwrap().unwrap();
 
         assert_eq!(disc.path, canonical);
         assert_eq!(disc.used_index, 0);
@@ -2060,20 +2119,20 @@ nonsense_field = "x"
     #[cfg(unix)]
     fn discover_config_permission_error_short_circuits_no_legacy_fallthrough() {
         // The load-bearing contract: a non-`NotFound` I/O error (here
-        // `PermissionDenied`) on a higher-priority candidate must bail,
-        // never silently fall through to a co-present legacy file. Without
-        // this, an unreadable `crap.toml` would be masked by a stale
-        // `crap4rs.toml` and the operator would get a confusing legacy
-        // deprecation warning instead of a permissions error.
+        // `PermissionDenied`) probing a candidate must bail, never
+        // silently fall through to a co-present legacy file. Without this,
+        // an unreadable canonical config would be masked by a stale legacy
+        // file and the operator would get a confusing legacy deprecation
+        // warning instead of a permissions error.
         use std::os::unix::fs::PermissionsExt;
 
         let dir = tempfile::tempdir().unwrap();
-        let canonical = dir.path().join("crap.toml");
+        let canonical = dir.path().join(TEST_CANONICAL);
         std::fs::write(&canonical, "threshold = 22.0\n").unwrap();
-        let legacy = dir.path().join("crap4rs.toml");
+        let legacy = dir.path().join(TEST_LEGACY);
         std::fs::write(&legacy, "threshold = 9.0\n").unwrap();
 
-        // Block traversal of the parent dir so `metadata(canonical)` yields
+        // Block traversal of the dir so `metadata(canonical)` yields
         // PermissionDenied (chmod 000 on the file itself still permits
         // `metadata`, which reads the inode, not contents).
         std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o000)).unwrap();
@@ -2082,7 +2141,7 @@ nonsense_field = "x"
         // bypasses the check), this branch is untestable here — restore and
         // skip rather than emit a false failure.
         let still_readable = std::fs::metadata(&canonical).is_ok();
-        let result = discover_config(&[canonical, legacy]);
+        let result = discover_config(dir.path(), TEST_NAMES);
         std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o755)).unwrap();
 
         if still_readable {
@@ -2092,6 +2151,65 @@ nonsense_field = "x"
         assert!(
             err.to_string().contains("cannot access config file"),
             "got: {err}"
+        );
+    }
+
+    // ── walk-upward cross-dir contract (crap-rs#339) ──────────────────
+
+    #[test]
+    fn discover_config_finds_config_in_an_ancestor_directory() {
+        // The walk-upward core: a config in a *parent* of `start` is
+        // found when `start` itself has none. `start` is an absolute
+        // nested tempdir path, so `.ancestors()` climbs to the parent
+        // holding the config. (The relative-`start`-from-a-nested-CWD
+        // case — which is what truly exercises the `std::path::absolute`
+        // C-1 fix — lives in the subprocess regression test in
+        // crap4rs/tests/config_discovery_integration.rs, because a unit
+        // test cannot control the process CWD parallel-safely.)
+        let root = tempfile::tempdir().unwrap();
+        let canonical = root.path().join(TEST_CANONICAL);
+        std::fs::write(&canonical, "threshold = 22.0\n").unwrap();
+        let nested = root.path().join("crates").join("sub");
+        std::fs::create_dir_all(&nested).unwrap();
+
+        let disc = discover_config(&nested, TEST_NAMES).unwrap().unwrap();
+
+        assert_eq!(
+            disc.path, canonical,
+            "discovery must climb to the ancestor config"
+        );
+        assert_eq!(disc.used_index, 0);
+    }
+
+    #[test]
+    fn discover_config_nearest_dir_wins_nearer_legacy_beats_farther_canonical() {
+        // I-2: "first ancestor dir with any candidate wins, ordered names
+        // within that dir." A nearer legacy file beats a farther canonical
+        // — the nearest directory holding ANY candidate stops the walk, so
+        // its (legacy) file wins even though a canonical exists higher up.
+        // This is NEW behavior vs the within-dir canonical-over-legacy
+        // guarantee, and is a conscious nearest-wins decision (recorded in
+        // the closeout ADR). Shadow detection stays same-dir: the farther
+        // canonical is NOT reported as shadowed (no cross-dir "safe to
+        // remove" notice).
+        let root = tempfile::tempdir().unwrap();
+        let far_canonical = root.path().join(TEST_CANONICAL);
+        std::fs::write(&far_canonical, "threshold = 22.0\n").unwrap();
+        let child = root.path().join("child");
+        std::fs::create_dir(&child).unwrap();
+        let near_legacy = child.join(TEST_LEGACY);
+        std::fs::write(&near_legacy, "threshold = 9.0\n").unwrap();
+
+        let disc = discover_config(&child, TEST_NAMES).unwrap().unwrap();
+
+        assert_eq!(
+            disc.path, near_legacy,
+            "the nearer legacy file wins over the farther canonical"
+        );
+        assert_eq!(disc.used_index, 1, "the winner is the legacy name");
+        assert!(
+            disc.shadowed.is_empty(),
+            "the farther canonical is in a different dir — never reported as shadowed"
         );
     }
 }

--- a/crates/crap-core/src/adapters/config.rs
+++ b/crates/crap-core/src/adapters/config.rs
@@ -19,109 +19,17 @@ use crate::domain::threshold::{ThresholdOverride, ThresholdPreset, is_valid_thre
 use crate::domain::types::ComplexityMetric;
 use crate::domain::view::{CoverageRange, CoverageRangeError, GroupKey, SortKey};
 
-// ── Public config type (adapter output) ────────────────────────────
-
-/// Parsed configuration from a TOML file.
-///
-/// All fields are optional — missing fields mean "use CLI default."
-/// The CLI layer merges this with command-line flags.
-///
-/// This is the **parsed projection**: its fields are domain types
-/// (`ThresholdPreset`, `ComplexityMetric`, `PathBuf`, …), the shape the
-/// rest of crap-core consumes. It is deliberately distinct from
-/// [`ConfigSchema`] (the wire/documented type) — see the WHY note on
-/// `ConfigSchema`.
-#[derive(Debug, Clone, Default)]
-pub struct FileConfig {
-    pub threshold: Option<f64>,
-    pub preset: Option<ThresholdPreset>,
-    pub metric: Option<ComplexityMetric>,
-    /// Source roots the analyzer walks, in declaration order.
-    ///
-    /// Empty means "unset, defer to CLI / the `["src"]` default." A
-    /// single root keeps src-relative identity (byte-identical
-    /// back-compat); multiple roots key git-toplevel-relative (D18,
-    /// enforced downstream by `cli::resolve_identity_base`). The TOML
-    /// `src` key accepts either a bare string (`src = "crates"`) or an
-    /// array (`src = ["a", "b"]`) — both deserialize into this list.
-    pub src: Vec<PathBuf>,
-    pub exclude: Option<Vec<String>>,
-    pub overrides: Vec<ThresholdOverride>,
-    /// Saved view presets keyed by preset name.
-    ///
-    /// Each `[views.<name>]` block in TOML deserializes into a
-    /// [`ViewPreset`]; the CLI layer resolves `--view <name>` against
-    /// this map and folds preset values into `Cli` before
-    /// `build_view_spec`.
-    pub views: HashMap<String, ViewPreset>,
-    /// Per-language override sections keyed by language name.
-    ///
-    /// Each `[language.<name>]` block in TOML deserializes into a
-    /// [`LangConfig`]; the CLI layer selects the running adapter's
-    /// section via `AdapterMeta::config_lang_key` and overlays it over
-    /// the shared top-level defaults (per-language wins). Languages the
-    /// adapter doesn't recognize are simply never selected.
-    pub language: HashMap<String, LangConfig>,
-    /// Output-shaping settings under `[output]`.
-    ///
-    /// Reporter-specific knobs (`annotation_limit`, `title`,
-    /// `subtitle`) live here so they share a single TOML namespace
-    /// rather than polluting the top-level table. Missing `[output]`
-    /// blocks deserialize to `OutputConfig::default()`.
-    pub output: OutputConfig,
-}
-
-/// Reporter-level output settings (TOML `[output]` table).
-///
-/// All fields are optional — missing fields mean "use CLI default."
-#[derive(Debug, Clone, Default, PartialEq)]
-pub struct OutputConfig {
-    /// Cap on the number of `::warning` annotations emitted by the
-    /// `github-annotations` reporter per invocation. `None` defers to
-    /// the CLI default (10); a CLI `--annotation-limit` flag always
-    /// wins over this value when both are set.
-    pub annotation_limit: Option<u32>,
-    /// Scorecard title — a single header label for the whole report.
-    /// `None` renders the default unlabeled header.
-    pub title: Option<String>,
-    /// Scorecard subtitle, rendered beneath the title. `None` emits no
-    /// subtitle line.
-    pub subtitle: Option<String>,
-}
-
-/// Per-language config overrides (TOML `[language.<name>]` table).
-///
-/// A language section may assert any subset of the shared top-level
-/// knobs that are meaningful per-language; the CLI layer overlays a
-/// `Some` here over the inherited shared value. `preset` and
-/// `threshold` remain mutually exclusive — a section asserting both is
-/// rejected at parse time, the same as the top level.
-#[derive(Debug, Clone, Default, PartialEq)]
-pub struct LangConfig {
-    pub threshold: Option<f64>,
-    pub preset: Option<ThresholdPreset>,
-    pub metric: Option<ComplexityMetric>,
-    pub exclude: Option<Vec<String>>,
-}
-
-/// Saved view preset.
-///
-/// All fields are optional — `None` means "preset does not assert this
-/// field, defer to CLI / defaults." Booleans are `Option<bool>` so the
-/// preset can distinguish "absent" from "explicitly false," which lets
-/// the CLI layer treat a CLI bool of `false` as "user didn't say"
-/// (OR-merge semantics — see `apply_preset_to_cli`).
-#[derive(Debug, Clone, Default, PartialEq)]
-pub struct ViewPreset {
-    pub top: Option<u32>,
-    pub min_coverage: Option<f64>,
-    pub max_coverage: Option<f64>,
-    pub sort: Option<SortKey>,
-    pub only_failing: Option<bool>,
-    pub no_fail: Option<bool>,
-    pub group_by: Option<GroupKey>,
-    pub minimal_view: Option<bool>,
-}
+// ── Parsed config types (re-exported from domain) ──────────────────
+//
+// The parsed-projection POD types (`FileConfig`, `OutputConfig`,
+// `LangConfig`, `ViewPreset`) live in `crate::domain::config` — they are
+// the language-agnostic shape the core merges and analyzes (#341). They
+// are re-exported here so this adapter (which constructs them in
+// `parse_config`) and existing consumers (`cli::mod`, `cli::view_args`)
+// keep importing them from `adapters::config` unchanged. The
+// wire/schema family below (`ConfigSchema` et al., schemars + documented)
+// stays in this adapter layer.
+pub use crate::domain::config::{FileConfig, LangConfig, OutputConfig, ViewPreset};
 
 // ── Config schema — the public, documented WIRE type ───────────────
 //

--- a/crates/crap-core/src/adapters/config.rs
+++ b/crates/crap-core/src/adapters/config.rs
@@ -8,7 +8,6 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context, Result};
 use documented::DocumentedFields;
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -190,6 +189,114 @@ pub struct LangSchema {
     pub exclude: Option<Vec<String>>,
 }
 
+// ── Typed loader error ─────────────────────────────────────────────
+
+/// Errors the config loader can produce.
+///
+/// Co-located with the loader (matching the `CrapError` /
+/// `CoverageRangeError` precedent) and `#[non_exhaustive]` so adding a
+/// variant is not a breaking change. The loader's public surface
+/// (`discover_config`, `load_config`) and its private parse/validate
+/// helpers all return `Result<_, ConfigError>`; the CLI boundary
+/// (`cli::load_file_config` and the adapter binaries) lifts it into
+/// `anyhow::Error` via `?`, where `render_error`'s `{:#}` walks the
+/// `#[source]` chain to print the path-bearing wrapper plus its cause.
+///
+/// The error is **two-layer** by design: `Toml` carries only the raw
+/// `toml::de::Error` (path-less — `parse_config` has no path) and
+/// interpolates it directly so an in-crate `parse_config(..).to_string()`
+/// surfaces the underlying deserialize message; `Parse` is the
+/// path-bearing wrapper `load_config` adds, whose Display names the file
+/// and the word "parse" without flattening the source (thiserror's
+/// Display does not walk `#[source]`).
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum ConfigError {
+    /// A non-`NotFound` I/O error while probing a discovery candidate
+    /// (e.g. `PermissionDenied` on a higher-priority file). Surfaces
+    /// rather than being masked by a legacy-config fall-through.
+    #[error("cannot access config file {path}: {source}\n  hint: check file permissions", path = path.display())]
+    Access {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    /// Failed to read the config file's contents.
+    #[error("failed to read config file: {path}", path = path.display())]
+    Read {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    /// The path-bearing wrapper `load_config` adds around a parse
+    /// failure, so the user sees which file failed. Its Display names
+    /// the file and "parse"; the underlying `ConfigError` (a `Toml` or
+    /// a validation variant) is the `#[source]`.
+    #[error("failed to parse config file: {path}", path = path.display())]
+    Parse {
+        path: PathBuf,
+        #[source]
+        source: Box<ConfigError>,
+    },
+    /// Raw TOML deserialize failure (path-less). Interpolates its source
+    /// so `parse_config(..).to_string()` shows the underlying message
+    /// (e.g. an `unknown field` from `deny_unknown_fields`).
+    #[error("{0}")]
+    Toml(#[from] toml::de::Error),
+    /// `preset` and `threshold` both set. `section` names the
+    /// `[language.<name>]` block when the conflict is per-language,
+    /// `None` at the top level.
+    #[error("{}preset and threshold are mutually exclusive in config", section_prefix(.section))]
+    MutuallyExclusive { section: Option<String> },
+    /// A `threshold` (top-level or per-language) that is not finite and
+    /// positive.
+    #[error("{}threshold must be a finite positive number, got: {value}", section_prefix(.section))]
+    InvalidThreshold { value: f64, section: Option<String> },
+    /// An `[[overrides]]` `threshold` that is not finite and positive.
+    #[error(
+        "override threshold must be a finite positive number, got: {value} (pattern: {pattern})"
+    )]
+    InvalidOverrideThreshold { value: f64, pattern: String },
+    /// An `[output] annotation_limit` outside `1..=100`.
+    #[error(
+        "output.annotation_limit must be in 1..=100, got: {value}\n  hint: matches the CLI `--annotation-limit` range; 0 disables emission, > 100 floods the GH Actions per-step cap"
+    )]
+    InvalidAnnotationLimit { value: u32 },
+    /// An unrecognized `preset` string.
+    #[error("unknown preset: {value}\n  valid values: strict, default, lenient")]
+    UnknownPreset { value: String },
+    /// An unrecognized `metric` string.
+    #[error("unknown metric: {value}\n  valid values: cognitive, cyclomatic")]
+    UnknownMetric { value: String },
+    /// An unrecognized view-preset `sort` string. `preset` names the
+    /// `[views.<name>]` block.
+    #[error(
+        "preset `{preset}`: unknown sort: {value}\n  valid values: crap, coverage, complexity, path"
+    )]
+    UnknownSortKey { preset: String, value: String },
+    /// An unrecognized view-preset `group_by` string.
+    #[error("preset `{preset}`: unknown group_by: {value}\n  valid values: file")]
+    UnknownGroupKey { preset: String, value: String },
+    /// A view-preset coverage bound outside `[0, 100]`.
+    #[error("preset `{preset}`: coverage value out of range: {value}\n  valid range: [0, 100]")]
+    CoverageOutOfRange { preset: String, value: f64 },
+    /// A view-preset `min_coverage` greater than its `max_coverage`.
+    #[error("preset `{preset}`: min_coverage ({min}) must not exceed max_coverage ({max})")]
+    CoverageMinExceedsMax { preset: String, min: f64, max: f64 },
+}
+
+/// Render a `[language.<name>]: ` prefix for the section-scoped error
+/// variants, or empty string at the top level. Keeps the per-section
+/// variants' Display byte-identical to the previous `bail!` messages
+/// (so `"language.rust"` stays asserted) without duplicating two
+/// `#[error]` strings per variant.
+fn section_prefix(section: &Option<String>) -> String {
+    match section {
+        Some(name) => format!("[language.{name}]: "),
+        None => String::new(),
+    }
+}
+
 // ── Public API ─────────────────────────────────────────────────────
 
 /// Outcome of an ordered config-file discovery scan.
@@ -239,7 +346,7 @@ pub struct ConfigDiscovery {
 ///
 /// Returns `Ok(Some(ConfigDiscovery))` when a candidate exists,
 /// `Ok(None)` when none do.
-pub fn discover_config(candidates: &[PathBuf]) -> Result<Option<ConfigDiscovery>> {
+pub fn discover_config(candidates: &[PathBuf]) -> Result<Option<ConfigDiscovery>, ConfigError> {
     for (index, candidate) in candidates.iter().enumerate() {
         match std::fs::metadata(candidate) {
             Ok(m) if m.is_file() => {
@@ -265,25 +372,33 @@ pub fn discover_config(candidates: &[PathBuf]) -> Result<Option<ConfigDiscovery>
             // we can load; advance to the next candidate.
             Ok(_) => continue,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
-            Err(e) => anyhow::bail!(
-                "cannot access config file {}: {e}\n  hint: check file permissions",
-                candidate.display()
-            ),
+            // Construct the variant manually (not `#[from]`) so the
+            // load-bearing `path` survives onto the error (I-4).
+            Err(source) => {
+                return Err(ConfigError::Access {
+                    path: candidate.clone(),
+                    source,
+                });
+            }
         }
     }
     Ok(None)
 }
 
 /// Load and parse a config file from the given path.
-pub fn load_config(path: &Path) -> Result<FileConfig> {
-    let content = std::fs::read_to_string(path)
-        .with_context(|| format!("failed to read config file: {}", path.display()))?;
-    parse_config(&content)
-        .with_context(|| format!("failed to parse config file: {}", path.display()))
+pub fn load_config(path: &Path) -> Result<FileConfig, ConfigError> {
+    let content = std::fs::read_to_string(path).map_err(|source| ConfigError::Read {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    parse_config(&content).map_err(|source| ConfigError::Parse {
+        path: path.to_path_buf(),
+        source: Box::new(source),
+    })
 }
 
 /// Parse TOML content into a `FileConfig`.
-fn parse_config(content: &str) -> Result<FileConfig> {
+fn parse_config(content: &str) -> Result<FileConfig, ConfigError> {
     let raw: ConfigSchema = toml::from_str(content)?;
     validate_raw_config(&raw)?;
 
@@ -304,18 +419,18 @@ fn parse_config(content: &str) -> Result<FileConfig> {
         .into_iter()
         .map(|(name, raw_preset)| {
             let preset = parse_view_preset(&name, raw_preset)?;
-            Ok::<_, anyhow::Error>((name, preset))
+            Ok::<_, ConfigError>((name, preset))
         })
-        .collect::<Result<HashMap<_, _>>>()?;
+        .collect::<Result<HashMap<_, _>, _>>()?;
 
     let language = raw
         .language
         .into_iter()
         .map(|(name, raw_lang)| {
             let lang = parse_lang_config(&name, raw_lang)?;
-            Ok::<_, anyhow::Error>((name, lang))
+            Ok::<_, ConfigError>((name, lang))
         })
-        .collect::<Result<HashMap<_, _>>>()?;
+        .collect::<Result<HashMap<_, _>, _>>()?;
 
     Ok(FileConfig {
         threshold: raw.threshold,
@@ -337,14 +452,19 @@ fn parse_config(content: &str) -> Result<FileConfig> {
 /// Project a per-language wire section into its parsed [`LangConfig`].
 /// Carries the same `preset`/`threshold` mutual-exclusion and metric
 /// validation the top level enforces, naming the offending section.
-fn parse_lang_config(name: &str, raw: LangSchema) -> Result<LangConfig> {
+fn parse_lang_config(name: &str, raw: LangSchema) -> Result<LangConfig, ConfigError> {
     if raw.preset.is_some() && raw.threshold.is_some() {
-        anyhow::bail!("[language.{name}]: preset and threshold are mutually exclusive in config");
+        return Err(ConfigError::MutuallyExclusive {
+            section: Some(name.to_string()),
+        });
     }
     if let Some(t) = raw.threshold
         && !is_valid_threshold(t)
     {
-        anyhow::bail!("[language.{name}]: threshold must be a finite positive number, got: {t}");
+        return Err(ConfigError::InvalidThreshold {
+            value: t,
+            section: Some(name.to_string()),
+        });
     }
     let metric = raw.metric.as_deref().map(parse_metric).transpose()?;
     let preset = raw.preset.as_deref().map(parse_preset).transpose()?;
@@ -356,22 +476,24 @@ fn parse_lang_config(name: &str, raw: LangSchema) -> Result<LangConfig> {
     })
 }
 
-fn validate_raw_config(raw: &ConfigSchema) -> Result<()> {
+fn validate_raw_config(raw: &ConfigSchema) -> Result<(), ConfigError> {
     if raw.preset.is_some() && raw.threshold.is_some() {
-        anyhow::bail!("preset and threshold are mutually exclusive in config");
+        return Err(ConfigError::MutuallyExclusive { section: None });
     }
     if let Some(t) = raw.threshold
         && !is_valid_threshold(t)
     {
-        anyhow::bail!("threshold must be a finite positive number, got: {t}");
+        return Err(ConfigError::InvalidThreshold {
+            value: t,
+            section: None,
+        });
     }
     for o in &raw.overrides {
         if !is_valid_threshold(o.threshold) {
-            anyhow::bail!(
-                "override threshold must be a finite positive number, got: {} (pattern: {})",
-                o.threshold,
-                o.pattern
-            );
+            return Err(ConfigError::InvalidOverrideThreshold {
+                value: o.threshold,
+                pattern: o.pattern.clone(),
+            });
         }
     }
     // Mirror the CLI's `clap::value_parser!(u32).range(1..=100)` on
@@ -383,14 +505,12 @@ fn validate_raw_config(raw: &ConfigSchema) -> Result<()> {
     if let Some(limit) = raw.output.annotation_limit
         && !(1..=100).contains(&limit)
     {
-        anyhow::bail!(
-            "output.annotation_limit must be in 1..=100, got: {limit}\n  hint: matches the CLI `--annotation-limit` range; 0 disables emission, > 100 floods the GH Actions per-step cap"
-        );
+        return Err(ConfigError::InvalidAnnotationLimit { value: limit });
     }
     Ok(())
 }
 
-fn parse_view_preset(name: &str, raw: ViewPresetSchema) -> Result<ViewPreset> {
+fn parse_view_preset(name: &str, raw: ViewPresetSchema) -> Result<ViewPreset, ConfigError> {
     let sort = raw
         .sort
         .as_deref()
@@ -414,24 +534,26 @@ fn parse_view_preset(name: &str, raw: ViewPresetSchema) -> Result<ViewPreset> {
     })
 }
 
-fn parse_sort_key(preset_name: &str, s: &str) -> Result<SortKey> {
+fn parse_sort_key(preset_name: &str, s: &str) -> Result<SortKey, ConfigError> {
     match s {
         "crap" => Ok(SortKey::Crap),
         "coverage" => Ok(SortKey::Coverage),
         "complexity" => Ok(SortKey::Complexity),
         "path" => Ok(SortKey::Path),
-        other => anyhow::bail!(
-            "preset `{preset_name}`: unknown sort: {other}\n  valid values: crap, coverage, complexity, path"
-        ),
+        other => Err(ConfigError::UnknownSortKey {
+            preset: preset_name.to_string(),
+            value: other.to_string(),
+        }),
     }
 }
 
-fn parse_group_key(preset_name: &str, s: &str) -> Result<GroupKey> {
+fn parse_group_key(preset_name: &str, s: &str) -> Result<GroupKey, ConfigError> {
     match s {
         "file" => Ok(GroupKey::File),
-        other => {
-            anyhow::bail!("preset `{preset_name}`: unknown group_by: {other}\n  valid values: file")
-        }
+        other => Err(ConfigError::UnknownGroupKey {
+            preset: preset_name.to_string(),
+            value: other.to_string(),
+        }),
     }
 }
 
@@ -444,7 +566,7 @@ fn validate_preset_coverage_range(
     preset_name: &str,
     min: Option<f64>,
     max: Option<f64>,
-) -> Result<()> {
+) -> Result<(), ConfigError> {
     if min.is_none() && max.is_none() {
         return Ok(());
     }
@@ -457,29 +579,38 @@ fn validate_preset_coverage_range(
     // explicit arm here.
     match CoverageRange::new(lo, hi) {
         Ok(_) => Ok(()),
-        Err(CoverageRangeError::OutOfRange { value }) => anyhow::bail!(
-            "preset `{preset_name}`: coverage value out of range: {value}\n  valid range: [0, 100]"
-        ),
-        Err(CoverageRangeError::MinExceedsMax { min, max }) => anyhow::bail!(
-            "preset `{preset_name}`: min_coverage ({min}) must not exceed max_coverage ({max})"
-        ),
+        Err(CoverageRangeError::OutOfRange { value }) => Err(ConfigError::CoverageOutOfRange {
+            preset: preset_name.to_string(),
+            value,
+        }),
+        Err(CoverageRangeError::MinExceedsMax { min, max }) => {
+            Err(ConfigError::CoverageMinExceedsMax {
+                preset: preset_name.to_string(),
+                min,
+                max,
+            })
+        }
     }
 }
 
-fn parse_preset(s: &str) -> Result<ThresholdPreset> {
+fn parse_preset(s: &str) -> Result<ThresholdPreset, ConfigError> {
     match s {
         "strict" => Ok(ThresholdPreset::Strict),
         "default" => Ok(ThresholdPreset::Default),
         "lenient" => Ok(ThresholdPreset::Lenient),
-        other => anyhow::bail!("unknown preset: {other}\n  valid values: strict, default, lenient"),
+        other => Err(ConfigError::UnknownPreset {
+            value: other.to_string(),
+        }),
     }
 }
 
-fn parse_metric(s: &str) -> Result<ComplexityMetric> {
+fn parse_metric(s: &str) -> Result<ComplexityMetric, ConfigError> {
     match s {
         "cognitive" => Ok(ComplexityMetric::Cognitive),
         "cyclomatic" => Ok(ComplexityMetric::Cyclomatic),
-        other => anyhow::bail!("unknown metric: {other}\n  valid values: cognitive, cyclomatic"),
+        other => Err(ConfigError::UnknownMetric {
+            value: other.to_string(),
+        }),
     }
 }
 
@@ -977,6 +1108,83 @@ pub fn all_schema_field_docs() -> Vec<(String, &'static str)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── Typed `ConfigError` contract (#340) ──────────────────────────
+    //
+    // The substring assertions scattered through this module pin the
+    // user-facing Display text; these pin the *typed* shape — that
+    // `parse_config` / `load_config` return concrete `ConfigError`
+    // variants the caller can match on, not stringly-typed errors. The
+    // two-layer design (I-3) is asserted explicitly: a path-less `Toml`
+    // from `parse_config` wraps into a path-bearing `Parse` at
+    // `load_config`, and the `Parse` Display names the file + "parse"
+    // without flattening the source (thiserror Display does not walk
+    // `#[source]`).
+
+    #[test]
+    fn parse_config_returns_typed_mutually_exclusive() {
+        let err = parse_config("preset = \"strict\"\nthreshold = 10.0\n").unwrap_err();
+        assert!(
+            matches!(err, ConfigError::MutuallyExclusive { section: None }),
+            "expected top-level MutuallyExclusive, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn parse_config_returns_typed_unknown_metric() {
+        let err = parse_config("metric = \"halstead\"\n").unwrap_err();
+        match err {
+            ConfigError::UnknownMetric { value } => assert_eq!(value, "halstead"),
+            other => panic!("expected UnknownMetric, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_config_returns_typed_toml_on_malformed() {
+        let err = parse_config("this is not toml [[[").unwrap_err();
+        assert!(
+            matches!(err, ConfigError::Toml(_)),
+            "expected Toml variant, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn load_config_wraps_parse_in_path_bearing_parse_variant() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("crap.toml");
+        std::fs::write(&path, "threshold = not_a_number\n").unwrap();
+
+        let err = load_config(&path).unwrap_err();
+        // Outer layer: path-bearing Parse whose Display names the file
+        // and "parse" (the through-binary anyhow `{:#}` anchor).
+        match &err {
+            ConfigError::Parse { path: p, source } => {
+                assert_eq!(p, &path);
+                // Inner layer: the path-less Toml deserialize error.
+                assert!(
+                    matches!(**source, ConfigError::Toml(_)),
+                    "Parse source should be Toml, got: {source:?}"
+                );
+            }
+            other => panic!("expected Parse, got: {other:?}"),
+        }
+        let msg = err.to_string();
+        assert!(msg.contains("parse"), "Display must name 'parse': {msg}");
+        assert!(
+            msg.contains("crap.toml"),
+            "Display must name the file: {msg}"
+        );
+    }
+
+    #[test]
+    fn load_config_missing_file_is_typed_read_error() {
+        let err = load_config(Path::new("definitely-nonexistent-config.toml")).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::Read { .. }),
+            "expected Read variant, got: {err:?}"
+        );
+        assert!(err.to_string().contains("failed to read config file"));
+    }
 
     // ── Tooling spike (walking-skeleton step 1) ──────────────────────
     //

--- a/crates/crap-core/src/cli/mod.rs
+++ b/crates/crap-core/src/cli/mod.rs
@@ -1778,16 +1778,27 @@ fn load_file_config(
         let cfg = config::load_config(path)?;
         Ok(Some((cfg, path.clone())))
     } else {
-        // Auto-discovery: search the adapter's ordered names (canonical
-        // first, legacy fallbacks after) relative to the working directory.
-        // Bare names resolve CWD-relative, identical to the previous
-        // single-name behavior.
-        let candidates: Vec<std::path::PathBuf> = meta
-            .config_file_names
-            .iter()
-            .map(std::path::PathBuf::from)
-            .collect();
-        match config::discover_config(&candidates)? {
+        // Auto-discovery: walk upward from the run's anchor directory,
+        // resolving the adapter's ordered names (canonical first, legacy
+        // fallbacks after) within each ancestor; the nearest directory
+        // with any candidate wins (crap-rs#339).
+        //
+        // Anchor on the RAW first `--src` (`cli.input.src`, not the
+        // post-merge effective src), falling back to the working
+        // directory (`.`) when `--src` is empty. This MUST precede the
+        // config→`src` merge: `prepare_pipeline` runs `load_file_config`
+        // before `merge_effective_inputs`, and the config can *set* `src`
+        // — anchoring discovery on the effective src would be circular
+        // (need the config to find the config). `absolute(".")` resolves
+        // to the working directory, preserving the prior CWD-relative
+        // back-compat (a `crap.toml` in CWD is still the nearest match).
+        let start = cli
+            .input
+            .src
+            .first()
+            .cloned()
+            .unwrap_or_else(|| std::path::PathBuf::from("."));
+        match config::discover_config(&start, meta.config_file_names)? {
             Some(disc) => {
                 // The rename target is the canonical name (the single
                 // source of truth for "first = canonical"); the shadower

--- a/crates/crap-core/src/domain/config.rs
+++ b/crates/crap-core/src/domain/config.rs
@@ -1,0 +1,127 @@
+//! Parsed configuration types — the **parsed projection** the analyzer
+//! consumes after a config file is loaded and validated.
+//!
+//! These are pure domain POD types: their fields are domain types
+//! (`ThresholdPreset`, `ComplexityMetric`, `PathBuf`, …), language- and
+//! format-agnostic, built imperatively by the adapter's `parse_config`.
+//! They are deliberately distinct from the adapter's wire/schema family
+//! (the `Deserialize + JsonSchema` types that describe `crap.toml`
+//! verbatim and stay in the adapters layer): the wire types hold values
+//! *as the user types them* (`preset = "strict"` is a string), while
+//! these hold the *parsed* values the rest of crap-core operates on.
+//!
+//! They live in `domain/` (not adapters) because they are the shape the
+//! language-agnostic core merges and analyzes — every adapter, Rust or
+//! TypeScript, produces the same `FileConfig`. The adapter layer
+//! re-exports them so existing consumers compile unchanged.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use super::threshold::{ThresholdOverride, ThresholdPreset};
+use super::types::ComplexityMetric;
+use super::view::{GroupKey, SortKey};
+
+/// Parsed configuration from a TOML file.
+///
+/// All fields are optional — missing fields mean "use CLI default."
+/// The CLI layer merges this with command-line flags.
+///
+/// This is the **parsed projection**: its fields are domain types
+/// (`ThresholdPreset`, `ComplexityMetric`, `PathBuf`, …), the shape the
+/// rest of crap-core consumes. It is deliberately distinct from the
+/// adapter's wire/schema type (the `Deserialize + JsonSchema` config
+/// schema that lives in the adapters layer and describes `crap.toml`
+/// verbatim): the wire type holds values as the user types them, this
+/// holds the parsed values the analyzer operates on.
+#[derive(Debug, Clone, Default)]
+pub struct FileConfig {
+    pub threshold: Option<f64>,
+    pub preset: Option<ThresholdPreset>,
+    pub metric: Option<ComplexityMetric>,
+    /// Source roots the analyzer walks, in declaration order.
+    ///
+    /// Empty means "unset, defer to CLI / the `["src"]` default." A
+    /// single root keeps src-relative identity (byte-identical
+    /// back-compat); multiple roots key git-toplevel-relative (D18,
+    /// enforced downstream by `cli::resolve_identity_base`). The TOML
+    /// `src` key accepts either a bare string (`src = "crates"`) or an
+    /// array (`src = ["a", "b"]`) — both deserialize into this list.
+    pub src: Vec<PathBuf>,
+    pub exclude: Option<Vec<String>>,
+    pub overrides: Vec<ThresholdOverride>,
+    /// Saved view presets keyed by preset name.
+    ///
+    /// Each `[views.<name>]` block in TOML deserializes into a
+    /// [`ViewPreset`]; the CLI layer resolves `--view <name>` against
+    /// this map and folds preset values into `Cli` before
+    /// `build_view_spec`.
+    pub views: HashMap<String, ViewPreset>,
+    /// Per-language override sections keyed by language name.
+    ///
+    /// Each `[language.<name>]` block in TOML deserializes into a
+    /// [`LangConfig`]; the CLI layer selects the running adapter's
+    /// section via `AdapterMeta::config_lang_key` and overlays it over
+    /// the shared top-level defaults (per-language wins). Languages the
+    /// adapter doesn't recognize are simply never selected.
+    pub language: HashMap<String, LangConfig>,
+    /// Output-shaping settings under `[output]`.
+    ///
+    /// Reporter-specific knobs (`annotation_limit`, `title`,
+    /// `subtitle`) live here so they share a single TOML namespace
+    /// rather than polluting the top-level table. Missing `[output]`
+    /// blocks deserialize to `OutputConfig::default()`.
+    pub output: OutputConfig,
+}
+
+/// Reporter-level output settings (TOML `[output]` table).
+///
+/// All fields are optional — missing fields mean "use CLI default."
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct OutputConfig {
+    /// Cap on the number of `::warning` annotations emitted by the
+    /// `github-annotations` reporter per invocation. `None` defers to
+    /// the CLI default (10); a CLI `--annotation-limit` flag always
+    /// wins over this value when both are set.
+    pub annotation_limit: Option<u32>,
+    /// Scorecard title — a single header label for the whole report.
+    /// `None` renders the default unlabeled header.
+    pub title: Option<String>,
+    /// Scorecard subtitle, rendered beneath the title. `None` emits no
+    /// subtitle line.
+    pub subtitle: Option<String>,
+}
+
+/// Per-language config overrides (TOML `[language.<name>]` table).
+///
+/// A language section may assert any subset of the shared top-level
+/// knobs that are meaningful per-language; the CLI layer overlays a
+/// `Some` here over the inherited shared value. `preset` and
+/// `threshold` remain mutually exclusive — a section asserting both is
+/// rejected at parse time, the same as the top level.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct LangConfig {
+    pub threshold: Option<f64>,
+    pub preset: Option<ThresholdPreset>,
+    pub metric: Option<ComplexityMetric>,
+    pub exclude: Option<Vec<String>>,
+}
+
+/// Saved view preset.
+///
+/// All fields are optional — `None` means "preset does not assert this
+/// field, defer to CLI / defaults." Booleans are `Option<bool>` so the
+/// preset can distinguish "absent" from "explicitly false," which lets
+/// the CLI layer treat a CLI bool of `false` as "user didn't say"
+/// (OR-merge semantics — see `apply_preset_to_cli`).
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct ViewPreset {
+    pub top: Option<u32>,
+    pub min_coverage: Option<f64>,
+    pub max_coverage: Option<f64>,
+    pub sort: Option<SortKey>,
+    pub only_failing: Option<bool>,
+    pub no_fail: Option<bool>,
+    pub group_by: Option<GroupKey>,
+    pub minimal_view: Option<bool>,
+}

--- a/crates/crap-core/src/domain/mod.rs
+++ b/crates/crap-core/src/domain/mod.rs
@@ -1,3 +1,4 @@
+pub mod config;
 pub mod crap;
 pub mod delta;
 pub mod diagnostic;

--- a/crates/crap-core/tests/default_gate_threshold.rs
+++ b/crates/crap-core/tests/default_gate_threshold.rs
@@ -143,6 +143,12 @@ fn crap4rs_threshold(extra_args: &[&str]) -> f64 {
             "../crap4rs/tests/fixtures/crap4rs-self.lcov",
             "--src",
             "../crap4rs/src",
+            // Explicit empty `--config` short-circuits walk-upward
+            // discovery (crap-rs#339). Load-bearing here: this test asserts
+            // the BUILT-IN default threshold, so it must not read the
+            // repo-root `crap.toml`'s `preset` (crap-rs#346). See the fixture.
+            "--config",
+            "tests/fixtures/empty-config.toml",
         ])
         .args(extra_args)
         .args(["--format", "json", "--no-fail"])

--- a/crates/crap-core/tests/fixtures/empty-config.toml
+++ b/crates/crap-core/tests/fixtures/empty-config.toml
@@ -1,0 +1,13 @@
+# Intentionally empty config fixture (crap-rs#339 / C-2).
+#
+# Passed as an explicit `--config` to analyzer-shelling canary tests that
+# use an IN-REPO `--src` (e.g. `../crap4rs/src`). An explicit `--config`
+# short-circuits walk-upward discovery (cli/mod.rs `load_file_config`), so
+# the canary never climbs into the repo-root `crap.toml` (crap-rs#346) and
+# its wire-envelope / parity snapshot stays hermetic — pinned to the
+# analyzer output, not to whatever the in-repo config currently sets.
+#
+# Empty body => parses to `FileConfig::default()`, which is byte-identical
+# to "no config" through `merge_effective_inputs` (every field falls
+# through the same CLI > config > default cascade), so passing this is
+# behaviorally equivalent to the pre-#346 hermetic state.

--- a/crates/crap-core/tests/risk_level_cross_adapter.rs
+++ b/crates/crap-core/tests/risk_level_cross_adapter.rs
@@ -171,6 +171,11 @@ fn run_crap4rs_json() -> Value {
             "../crap4rs/tests/fixtures/crap4rs-self.lcov",
             "--src",
             "../crap4rs/src",
+            // Explicit empty `--config` short-circuits walk-upward
+            // discovery (crap-rs#339) so this in-repo `--src` canary stays
+            // hermetic against the repo-root `crap.toml`. See the fixture.
+            "--config",
+            "tests/fixtures/empty-config.toml",
             "--threshold",
             "8",
             "--format",

--- a/crates/crap-core/tests/scorecard_row_parity.rs
+++ b/crates/crap-core/tests/scorecard_row_parity.rs
@@ -145,6 +145,11 @@ fn run_crap4rs_row(threshold: &str) -> Value {
             "../crap4rs/tests/fixtures/crap4rs-self.lcov",
             "--src",
             "../crap4rs/src",
+            // Explicit empty `--config` short-circuits walk-upward
+            // discovery (crap-rs#339) so this in-repo `--src` canary stays
+            // hermetic against the repo-root `crap.toml`. See the fixture.
+            "--config",
+            "tests/fixtures/empty-config.toml",
             "--threshold",
             threshold,
             "--format",

--- a/crates/crap-core/tests/wire_envelope_crap4rs.rs
+++ b/crates/crap-core/tests/wire_envelope_crap4rs.rs
@@ -77,6 +77,12 @@ fn envelope() {
             "../crap4rs/tests/fixtures/crap4rs-self.lcov",
             "--src",
             "../crap4rs/src",
+            // Explicit empty `--config` short-circuits walk-upward
+            // discovery (crap-rs#339), so this in-repo `--src` canary never
+            // climbs into the repo-root `crap.toml` (crap-rs#346) and the
+            // snapshot stays hermetic. See the fixture's header.
+            "--config",
+            "tests/fixtures/empty-config.toml",
             "--threshold",
             "8",
             "--format",

--- a/crates/crap4rs/CHANGELOG.md
+++ b/crates/crap4rs/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Config auto-discovery now walks **upward** from the `--src` anchor
+    (or the working directory when `--src` is omitted): `crap4rs --src
+    crates/foo` run from a repo root discovers the repo-root
+    `crap.toml`, and `cd crates && crap4rs --src foo` discovers a
+    `crap.toml` one level up. The previous behavior inspected only the
+    working directory. Pass an explicit `--config <path>` to bypass
+    discovery. Note: the walk has no `.git`/workspace stop, so a stray
+    `crap.toml` in `$HOME` (or any ancestor) is discovered when no
+    nearer config exists. (crap-rs#339; see `crap-core` CHANGELOG.)
+
 ## [0.6.0](https://github.com/breezy-bays-labs/crap-rs/compare/crap4rs-v0.5.0...crap4rs-v0.6.0) - 2026-05-24
 
 ### Added

--- a/crates/crap4rs/tests/config_discovery_integration.rs
+++ b/crates/crap4rs/tests/config_discovery_integration.rs
@@ -175,3 +175,41 @@ fn malformed_canonical_crap_toml_errors_without_legacy_fallthrough() {
         "must not fall through to the legacy config; stdout: {stdout}"
     );
 }
+
+#[test]
+fn walk_upward_finds_ancestor_config_from_nested_relative_src() {
+    // crap-rs#339 C-1 regression guard. This is the ONE shape that
+    // distinguishes the `std::path::absolute(start)` fix from a lexical
+    // `start.ancestors()`: a NESTED working directory with a RELATIVE
+    // `--src`. `Path::ancestors()` is lexical, so `"src".ancestors()`
+    // would yield `["src", ""]` and never climb to the real parent — the
+    // walk-upward feature would silently find nothing and fall back to
+    // the built-in default. Absolutizing `start` against the process CWD
+    // first makes the ancestor chain the genuine on-disk parents.
+    //
+    // The crap-core unit tests can't catch this: they pass absolute
+    // tempdir starts (which already climb to `/`), and a unit test cannot
+    // control the process CWD parallel-safely. Only a subprocess with a
+    // controlled `current_dir` + relative `--src` exercises the bug.
+    //
+    // Layout: `crap.toml` (threshold 22) at the tempdir root; the source
+    // tree + LCOV one level down in `sub/`. Run from `sub/` with
+    // `--src src`. Lexical bug → falls to the default `threshold (15)`;
+    // absolutized → climbs to the ancestor `threshold (22)`.
+    let root = tempfile::tempdir().unwrap();
+    std::fs::write(root.path().join("crap.toml"), "threshold = 22.0\n").unwrap();
+    let sub = root.path().join("sub");
+    std::fs::create_dir_all(&sub).unwrap();
+    seed_project(&sub);
+
+    let out = run_summary(&sub);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(out.status.success(), "run should succeed; stderr: {stderr}");
+    assert!(
+        stdout.contains("threshold (22)"),
+        "walk-upward must discover the ancestor crap.toml from a nested relative --src \
+         (a lexical `ancestors()` would fall to the default 15); stdout: {stdout}"
+    );
+}

--- a/crates/crap4rs/tests/fixtures/empty-config.toml
+++ b/crates/crap4rs/tests/fixtures/empty-config.toml
@@ -1,0 +1,8 @@
+# Intentionally empty config fixture (crap-rs#339 / C-2).
+#
+# Passed as an explicit `--config` by analyzer-shelling tests that use an
+# IN-REPO `--src` (here `{CARGO_MANIFEST_DIR}/src`). An explicit `--config` short-circuits
+# walk-upward discovery, so the test never climbs into the repo-root
+# `crap.toml` (crap-rs#346) and its schema-validated output stays
+# hermetic. Empty body parses to `FileConfig::default()`, behaviorally
+# equivalent to "no config" through the merge cascade.

--- a/crates/crap4rs/tests/scorecard_row_integration.rs
+++ b/crates/crap4rs/tests/scorecard_row_integration.rs
@@ -143,6 +143,12 @@ fn cli_dispatch_emits_scorecard_row_validating_against_schema() {
             &format!("{manifest_dir}/tests/fixtures/crap4rs-self.lcov"),
             "--src",
             &format!("{manifest_dir}/src"),
+            // Explicit empty `--config` short-circuits walk-upward
+            // discovery (crap-rs#339): this in-repo `--src` would otherwise
+            // climb into the repo-root `crap.toml` (crap-rs#346) and the
+            // schema-validated output could shift. See the fixture header.
+            "--config",
+            &format!("{manifest_dir}/tests/fixtures/empty-config.toml"),
             "--format",
             "scorecard-row",
             "--no-fail",

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -102,6 +102,17 @@ pre-push:
       # every push. Single source of truth: `scripts/bdd-tracked-lint.py`.
       run: python3 scripts/bdd-tracked-lint.py
       timeout: 30s
+    config-discovery-lint:
+      # Mechanical enforcement of the crap-rs#339 C-2 isolation rule:
+      # analyzer-shelling tests with an IN-REPO `--src` and no `--config`
+      # (and no tempdir `.current_dir(...)`) would climb into the repo-root
+      # `crap.toml` under walk-upward discovery and drift their snapshots
+      # on unrelated sibling merges. Local-velocity layer of the same check
+      # that `.github/workflows/ci.yml`'s `config-discovery-lint` job runs
+      # on every push. Single source of truth:
+      # `scripts/config-discovery-lint.py`.
+      run: python3 scripts/config-discovery-lint.py
+      timeout: 30s
     clippy:
       run: cargo clippy --workspace --all-targets -- -D warnings
       timeout: 300s

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -113,6 +113,17 @@ pre-push:
       # `scripts/config-discovery-lint.py`.
       run: python3 scripts/config-discovery-lint.py
       timeout: 30s
+    config-ast-purity-lint:
+      # Mechanical enforcement of the crap-rs#342 rule: crap-core's config
+      # adapter (config.rs) must carry no per-adapter literals
+      # (`"crap4rs.toml"` / `"crap4ts.toml"` / `"crap4rs"` / `"crap4ts"`)
+      # in source or inline tests — those belong only in each binary's
+      # AdapterMeta. Local-velocity layer of the same check that
+      # `.github/workflows/ci.yml`'s `config-ast-purity-lint` job runs on
+      # every push. Single source of truth:
+      # `scripts/config-ast-purity-lint.py`.
+      run: python3 scripts/config-ast-purity-lint.py
+      timeout: 30s
     clippy:
       run: cargo clippy --workspace --all-targets -- -D warnings
       timeout: 300s

--- a/packages/crap4ts/CHANGELOG.md
+++ b/packages/crap4ts/CHANGELOG.md
@@ -13,6 +13,17 @@ shared-core development.
 
 ## [Unreleased]
 
+### Changed
+
+- Config auto-discovery now walks **upward** from the `--src` anchor
+    (or the working directory when `--src` is omitted): a subdirectory
+    `--src` discovers a `crap.toml` higher up the tree, where the
+    previous behavior inspected only the working directory. Pass an
+    explicit `--config <path>` to bypass discovery. Note: the walk has
+    no `.git`/workspace stop, so a stray `crap.toml` in `$HOME` (or any
+    ancestor) is discovered when no nearer config exists. (crap-rs#339;
+    see `crap-core` CHANGELOG.)
+
 ## [2.0.0-rc.3](https://github.com/breezy-bays-labs/crap-rs/compare/crap4ts-v2.0.0-rc.2...crap4ts-v2.0.0-rc.3) - 2026-05-24
 
 ### Added

--- a/scripts/config-ast-purity-lint.py
+++ b/scripts/config-ast-purity-lint.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Config-AST-purity lint — mechanical guard for crap-rs#342.
+
+`crates/crap-core/src/adapters/config.rs` is language-agnostic: config
+discovery flows through `AdapterMeta::config_file_names`, so the loader
+never needs to know any adapter's per-adapter config name. The ONE correct
+home for the per-adapter literals (`crap4rs.toml` / `crap4ts.toml`) is each
+adapter binary's `AdapterMeta` declaration (`crap4rs/src/main.rs`,
+`crap4ts/src/main.rs`) — NOT crap-core. A per-adapter literal creeping into
+config.rs (source or its inline tests) is a layering smell: it couples the
+shared loader to a specific adapter and would have to be touched if a third
+`*-core` adapter with its own config name were ever added.
+
+This lint fails the build if config.rs contains any double-quoted
+**per-adapter** literal:
+
+  "crap4rs.toml"  "crap4ts.toml"  "crap4rs"  "crap4ts"
+
+## Allowed (NOT flagged)
+
+* `"crap.toml"` — the unified, language-neutral canonical name. It is
+  shared by every adapter and is the right thing for the loader/tests to
+  reference; it is not adapter-specific.
+* `///` doc comments and `//` line comments that mention an adapter by
+  name in prose. The gate matches only `"..."` STRING LITERALS; comments
+  are stripped before matching. (config.rs's discovery rustdoc legitimately
+  names `crap4rs.toml` / `crap4ts.toml` as examples of legacy fallbacks.)
+* Bare language keys like `"rust"` / `"typescript"` (the `[language.*]`
+  section names) — these are not adapter binary names.
+
+## Scope
+
+`crates/crap-core/src/adapters/config.rs` ONLY. The adapter binaries are
+intentionally excluded — their `config_file_names: &["crap.toml",
+"crap4rs.toml"]` declarations are the correct, only home for those literals.
+
+## Limitations
+
+* Block comments (`/* ... */`) are not stripped. config.rs uses only `//`
+  and `///` comments; if a block comment is introduced and mentions a
+  forbidden literal in prose, extend the stripper.
+* String literals are matched textually, so a forbidden token assembled at
+  runtime (`format!("crap4{}", "rs")`) is not caught. No such construction
+  exists; closing it would need real parsing.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+TARGET = Path("crates/crap-core/src/adapters/config.rs")
+
+# Per-adapter literals that must not appear as STRING LITERALS in config.rs.
+# `"crap.toml"` is deliberately absent (the allowed unified name); none of
+# these patterns match it.
+FORBIDDEN = [
+    '"crap4rs.toml"',
+    '"crap4ts.toml"',
+    '"crap4rs"',
+    '"crap4ts"',
+]
+
+
+def strip_comments(text: str) -> str:
+    """Drop `//`-to-EOL (covers `///` doc comments and `//` line comments)
+    so an adapter name mentioned in prose does not count. Block comments
+    are out of scope (see Limitations)."""
+    return "\n".join(line.split("//", 1)[0] for line in text.splitlines())
+
+
+def lint(repo_root: Path) -> int:
+    target = repo_root / TARGET
+    if not target.exists():
+        print(f"config-ast-purity-lint: {TARGET} not found", file=sys.stderr)
+        return 1
+
+    raw = target.read_text()
+    code = strip_comments(raw)
+    code_lines = code.splitlines()
+
+    errors = 0
+    for lineno, line in enumerate(code_lines, start=1):
+        for literal in FORBIDDEN:
+            if literal in line:
+                print(
+                    f"\nconfig-ast-purity-lint: forbidden per-adapter literal "
+                    f"{literal}\n"
+                    f"  {TARGET}:{lineno}\n"
+                    f"  crap-core's config adapter must stay name-agnostic "
+                    f"(crap-rs#342).\n"
+                    f"  Per-adapter config names belong in each binary's "
+                    f"AdapterMeta\n"
+                    f"  (crap4rs/src/main.rs, crap4ts/src/main.rs), not here.\n\n"
+                    f"  Fix: use the unified `\"crap.toml\"`, or — in tests — a\n"
+                    f"  synthetic name (discovery is name-agnostic, so a\n"
+                    f"  synthetic canonical/legacy pair exercises the same path).\n",
+                    file=sys.stderr,
+                )
+                errors += 1
+
+    if errors:
+        print(
+            f"config-ast-purity-lint: {errors} forbidden per-adapter literal(s) "
+            f"in {TARGET}; see above",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"config-ast-purity-lint: ok ({TARGET} carries no per-adapter literals)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(lint(Path(__file__).resolve().parent.parent))

--- a/scripts/config-discovery-lint.py
+++ b/scripts/config-discovery-lint.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Config-discovery isolation lint — mechanical guard for crap-rs#339 C-2.
+
+#339 makes config discovery walk UPWARD from the run's `--src` anchor. That
+is desired for the production scorecard (a subdir `--src` finds the repo-root
+`crap.toml`, crap-rs#346) but HAZARDOUS for analyzer-shelling canary /
+integration tests: any test that shells the adapter binary with an IN-REPO
+`--src` (e.g. `../crap4rs/src`, `{manifest_dir}/src`) and NO `--config` now
+climbs into the repo-root `crap.toml` and picks up its `threshold`/`metric`/
+`exclude`/`title`. Its wire-envelope / parity / schema snapshot would then
+shift on a SIBLING merge that edits root `crap.toml`, not on a deliberate
+analyzer change — defeating the canary, the exact #224 silently-dead-gate
+failure mode.
+
+The fix is an explicit `--config <empty fixture>`, which short-circuits
+discovery (cli/mod.rs `load_file_config`). This lint is that fix's enforcement
+("documentation rots; CI doesn't"): it fails the build if any
+analyzer-shelling test passes an in-repo `--src` without a covering `--config`.
+
+## What counts as an adapter invocation
+
+Two shapes, both detected:
+
+  * `Command::cargo_bin("crap4rs"|"crap4ts")` ...
+  * `let b = env!("CARGO_BIN_EXE_crap4rs"|"...crap4ts"); Command::new(b)...`
+    (the binary is bound to a `BINARY`/`binary` const/let, then `Command::new`
+    shells it — the cargo_bin-only shape would miss these, e.g.
+    `scorecard_row_integration.rs`).
+
+The builder CHAIN is aggregated from the invocation start to the terminal
+`.output()` / `.assert()` — args are split across multiple `.args([...])` /
+`.arg(...)` calls (e.g. `default_gate_threshold` puts `--config` in the first
+array and a runtime `extra_args` in the middle).
+
+## The hazard rule (structural, NOT crate-name based)
+
+FLAG an adapter invocation iff ALL of:
+
+  1. the chain has **no `--config`** argument, AND
+  2. the command has **no `.current_dir(...)`** call (a `current_dir`
+     re-roots relative `--src` into a tempdir → hermetic), AND
+  3. the chain has a `--src` whose immediately-following value is a
+     **string literal** (`"..."`) or a `format!(...)` — an in-repo path
+     baked into the test source. A `--src` followed by a bare runtime
+     variable (`.arg(&root)`, `--src", path`) is a tempdir path → exempt.
+
+Keying on structure (not on `crap4`/`/src` content) also catches a future
+bare `--src "src"` with no `current_dir` (which would resolve into the crate
+dir and leak) and a `--src "../crap-core/src"` hazard a content rule misses.
+
+## Limitations (documented, not chased — mirrors mutants-skip-lint.py)
+
+* **Only the `.args([..., "--src", "literal", ...])` ARRAY form is
+  matched.** `SRC_LITERAL_RE` keys on `"--src"` immediately followed (after
+  a comma) by a string-literal / `format!`. The split-statement
+  `.push("--src".into()); .push(<value>)` form (e.g.
+  `github_annotations_cucumber.rs`) and the chained
+  `.arg("--src").arg(<value>)` form are NOT matched, so an in-repo `--src`
+  expressed that way is a false NEGATIVE. Both shapes were audited at
+  introduction (crap-rs#339): every such invocation today either runs under
+  `.current_dir(<tempdir>)` or passes a tempdir-derived `--src`, so the gap
+  is currently inert. If a future test adds an in-repo `--src` via `.push`
+  or chained `.arg`, broaden `SRC_LITERAL_RE` to cover those forms (the
+  chain-window aggregation already spans them; only the regex is narrow).
+* `.current_dir(<an in-repo dir>)` + literal `--src` + no `--config` is a
+  false NEGATIVE. No test does this (it's a bizarre shape); closing it would
+  need to distinguish in-repo from tempdir `current_dir` arguments, which
+  needs runtime knowledge the lint can't have. Out of scope.
+* Helper-mediated invocations where the bin name or `--src` is passed as a
+  parameter are not traced. None present today.
+* Brace/bracket tracking is line-comment-aware but not block-comment- or
+  string-brace-aware. No current test exhibits the pattern.
+
+If any gap produces a real regression, extend the lint.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# Scan both crates whose tests shell the adapter binaries with in-repo
+# `--src`. crap4ts/tests is intentionally out of scope: by convention its
+# analyzer-shelling tests build a tempdir fixture and pass `.arg(&root)`
+# (a runtime variable) — exempt by rule 3 anyway, and excluding the dir
+# keeps the scan focused on where the hazard actually lives.
+SCAN_DIRS = [
+    Path("crates/crap-core/tests"),
+    Path("crates/crap4rs/tests"),
+]
+
+# An adapter invocation begins at either marker.
+CARGO_BIN_RE = re.compile(r'cargo_bin\(\s*"(?:crap4rs|crap4ts)"\s*,?\s*\)')
+# `env!("CARGO_BIN_EXE_crap4rs")` bound to a name → `Command::new(name)`.
+BIN_EXE_BIND_RE = re.compile(
+    r'(?:const|let)\s+([A-Za-z_][A-Za-z_0-9]*)\s*(?::\s*&str\s*)?=\s*'
+    r'env!\(\s*"CARGO_BIN_EXE_crap4(?:rs|ts)"\s*\)'
+)
+COMMAND_NEW_RE = re.compile(r'Command::new\(\s*([A-Za-z_][A-Za-z_0-9]*)\s*\)')
+
+# A `--src` whose next token is a string literal or a format! macro is an
+# in-repo path baked into the test source (the hazard). A `--src` followed
+# by a bare identifier (`path`, `&root`) is a runtime tempdir path (exempt).
+# `\s*` spans the newline rustfmt inserts between `"--src",` and its value.
+SRC_LITERAL_RE = re.compile(r'"--src"\s*,\s*(?:"|&?format!\()')
+HAS_CONFIG_RE = re.compile(r'"--config"')
+HAS_CURRENT_DIR_RE = re.compile(r'\.current_dir\(')
+
+
+def strip_line_comments(text: str) -> str:
+    """Drop `//`-to-EOL on each line so a `--config` mentioned in a comment
+    does not count as a real argument (and brace counting stays honest)."""
+    out = []
+    for line in text.splitlines():
+        out.append(line.split("//", 1)[0])
+    return "\n".join(out)
+
+
+def chain_window(text: str, start: int) -> tuple[str, int]:
+    """Return the builder-chain substring from `start` to the terminal
+    `.output()`/`.assert()` (inclusive), plus its end offset. Falls back to
+    the next `;` if no terminal is found."""
+    terminal = re.compile(r'\.(?:output|assert)\(\)')
+    m = terminal.search(text, start)
+    if m:
+        return text[start : m.end()], m.end()
+    semi = text.find(";", start)
+    end = semi if semi != -1 else len(text)
+    return text[start:end], end
+
+
+def find_invocations(text: str) -> list[int]:
+    """Return start offsets of every adapter invocation in `text`.
+
+    A `cargo_bin("crap4rs"|...)` match is itself the invocation. An
+    `env!("CARGO_BIN_EXE_...")` binding records the bound name; each later
+    `Command::new(<that name>)` is an invocation start."""
+    starts: list[int] = []
+    bound: set[str] = set()
+    for m in BIN_EXE_BIND_RE.finditer(text):
+        bound.add(m.group(1))
+    for m in CARGO_BIN_RE.finditer(text):
+        starts.append(m.start())
+    if bound:
+        for m in COMMAND_NEW_RE.finditer(text):
+            if m.group(1) in bound:
+                starts.append(m.start())
+    return sorted(starts)
+
+
+def lint_file(rs_file: Path, repo_root: Path) -> list[str]:
+    raw = rs_file.read_text()
+    text = strip_line_comments(raw)
+    findings: list[str] = []
+    for start in find_invocations(text):
+        chain, _end = chain_window(text, start)
+        if HAS_CONFIG_RE.search(chain):
+            continue
+        if HAS_CURRENT_DIR_RE.search(chain):
+            continue
+        if not SRC_LITERAL_RE.search(chain):
+            continue
+        lineno = text.count("\n", 0, start) + 1
+        rel = rs_file.relative_to(repo_root)
+        findings.append(
+            f"\nconfig-discovery-lint: in-repo `--src` without `--config`\n"
+            f"  {rel}:{lineno}\n"
+            f"  This adapter invocation passes a string-literal/format! `--src`\n"
+            f"  (an in-repo path) with no `--config` and no `.current_dir(...)`.\n"
+            f"  Walk-upward discovery (crap-rs#339) will climb into the repo-root\n"
+            f"  `crap.toml` (crap-rs#346) and the snapshot/parity output can shift\n"
+            f"  on an unrelated sibling merge.\n\n"
+            f"  Fix: pass an explicit empty `--config` fixture (e.g.\n"
+            f"  `tests/fixtures/empty-config.toml`) to short-circuit discovery,\n"
+            f"  OR run the command under `.current_dir(<tempdir>)` with a\n"
+            f"  tempdir-relative `--src`. See scripts/config-discovery-lint.py.\n"
+        )
+    return findings
+
+
+def lint(repo_root: Path) -> int:
+    findings: list[str] = []
+    for scan_dir in SCAN_DIRS:
+        abs_dir = repo_root / scan_dir
+        if not abs_dir.exists():
+            continue
+        for rs_file in sorted(abs_dir.rglob("*.rs")):
+            findings.extend(lint_file(rs_file, repo_root))
+
+    if findings:
+        for f in findings:
+            print(f, file=sys.stderr)
+        print(
+            f"config-discovery-lint: {len(findings)} unisolated in-repo `--src` "
+            f"invocation(s); see above",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("config-discovery-lint: ok (every in-repo `--src` adapter invocation "
+          "passes `--config` or runs under a tempdir current_dir)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(lint(Path(__file__).resolve().parent.parent))


### PR DESCRIPTION
## Summary
Production-readiness winnowing of the #334 config tech-debt cluster. Hardens the crap-core config loader along the (proposed) cross-tool config ADR: walk-upward discovery, typed errors, POD relocation, and an adapter-name purity gate. One PR, four reviewer-atomic commits.

## What shipped
- **#341** — relocate parsed POD config types (`FileConfig`/`OutputConfig`/`LangConfig`/`ViewPreset`) `adapters::config` → `domain::config`, re-exported for zero consumer churn (`ConfigSchema` wire family stays in adapters per D20).
- **#340** — typed `ConfigError` (`thiserror` + `#[non_exhaustive]`), loader is anyhow-free; CLI wraps at the boundary. Two-layer by design (path-less `Toml` interpolates its source; `load_config` adds a path-bearing `Parse` wrapper).
- **#339** — walk-upward discovery: `discover_config(start, file_names)` absolutizes `start` and climbs `ancestors()`, anchored on the raw `--src`; nearest ancestor dir with a candidate wins, ordered-name + same-dir shadow within it. CHANGELOG entries added.
- **#342** — `config-ast-purity-lint` CI gate + lefthook hook forbidding per-adapter name literals in `crap-core::adapters::config`.

## Review rigor
CAO + CEng audited the plan pre-build and caught two CRITICALs now fixed and guarded by discriminating tests: (1) `Path::ancestors()` is lexical — walk-upward needed `std::path::absolute()` or it was a no-op in production with green tests; (2) walk-upward would have leaked the repo-root `crap.toml` into the in-repo-`--src` canaries — fixed with explicit `--config` isolation + a `config-discovery-lint` CI guard.

#343 was closed separately as skip-by-decision — `FileConfig` is parse-only, so the round-trip property is structurally inapplicable under the D20 two-type split.

## Closes
Closes #339
Closes #340
Closes #341
Closes #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Configuration auto-discovery now walks upward from the source directory to find config files in ancestor directories, selecting the nearest match.
  * Explicit `--config` parameter now available to bypass discovery entirely.

* **Documentation**
  * Updated changelogs documenting new config discovery behavior and error handling improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->