### PR TITLE
chore(bdd): #280 — enforce one-status-tag-per-scenario + backfill delta.feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1582,16 +1582,25 @@ jobs:
         run: python3 scripts/mutants-skip-lint.py
 
   bdd-tracked-lint:
-    # Mechanical enforcement of AGENTS.md "BDD hygiene" Rule 2: every
-    # `@unwired` or `@wip` scenario across `crates/*/tests/features/`
-    # must carry a `# tracked: crap-rs#<n>` comment inside its
-    # scenario block, naming the issue that owns the wiring deferral.
-    # Without this gate, the rule was documented but unenforced —
+    # Mechanical enforcement of AGENTS.md "BDD hygiene" Rules 1 and 2
+    # across `crates/*/tests/features/` (single script, two rules):
+    #   Rule 1 — every `Scenario:` / `Scenario Outline:` carries EXACTLY
+    #     ONE status tag (`@wired` / `@unwired` / `@wip`). Zero status
+    #     tags (the scenario escapes the lexicon) and more than one
+    #     (mutually-exclusive tags can't coexist) both fail. Added in
+    #     crap-rs#280 after CodeRabbit flagged 45 untagged scenarios in
+    #     delta.feature that silently passed the Rule-2-only lint.
+    #   Rule 2 — every `@unwired` / `@wip` scenario carries a
+    #     `# tracked: crap-rs#<n>` comment inside its scenario block,
+    #     naming the issue that owns the wiring deferral.
+    # Without this gate, the rules were documented but unenforced —
     # documentation rots; CI doesn't.
     #
     # See `scripts/bdd-tracked-lint.py` for the parser shape and
     # limitations. Mirrors the `lefthook.yml` pre-push step — single
-    # source of truth in the script.
+    # source of truth in the script. The job id + display name are kept
+    # as `bdd-tracked-lint` (unchanged from the Rule-2-only era) so a
+    # branch-protection required-check reference does not break.
     #
     # Conventions follow the post-#264 supply-chain hardening: scoped
     # `permissions: contents: read`, `persist-credentials: false` on
@@ -1606,7 +1615,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: 'Lint `# tracked: crap-rs#<n>` comment coverage of @unwired/@wip scenarios'
+      - name: Self-test the BDD-hygiene lint logic (Rule 1 + Rule 2 fixtures)
+        run: python3 scripts/bdd-tracked-lint.py --self-test
+      - name: 'Lint status-tag (Rule 1) + `# tracked:` (Rule 2) coverage of every scenario'
         run: python3 scripts/bdd-tracked-lint.py
 
   config-discovery-lint:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,11 @@ on us without false positives.
    commonly mixes wired and unwired scenarios while harness coverage
    grows.
 
+   Mechanical enforcement: the same `scripts/bdd-tracked-lint.py` that
+   owns Rule 2 (run from `lefthook.yml` pre-push and the
+   `bdd-tracked-lint` CI job) also rejects any scenario carrying ZERO
+   status tags or MORE THAN ONE. Documentation rots; CI doesn't.
+
 2. **`@unwired` and `@wip` require a tracking comment.** Inside the
    scenario block, add a Gherkin comment in this exact shape so it
    stays greppable (mirrors `~/.claude/rules/exclusions.md`):

--- a/crates/crap4rs/tests/features/delta.feature
+++ b/crates/crap4rs/tests/features/delta.feature
@@ -22,7 +22,9 @@ Feature: --baseline delta analysis (Bundle E, issue #81)
 
   # ── Domain: FunctionChange classification ──────────────────────────
 
+  @unwired
   Scenario: Identical baseline and current produces all-Modified delta
+    # tracked: crap-rs#169 — delta.feature is spec-only; no cucumber harness wires --baseline delta scenarios yet
     Given the baseline JSON encodes the exact current AnalysisResult
     When `delta::compute(baseline, current)` runs
     Then every `FunctionChange` is `Modified`
@@ -32,21 +34,27 @@ Feature: --baseline delta analysis (Bundle E, issue #81)
     And `delta.summary.new_violations` is `0`
     And `delta.summary.passed` is `true`
 
+  @unwired
   Scenario: Function present in current only is classified Added
+    # tracked: crap-rs#169 — delta.feature is spec-only; no cucumber harness wires --baseline delta scenarios yet
     Given the baseline JSON does not contain function `parser::tokenize`
     And the current analysis does contain `parser::tokenize` with score 31
     When the delta is computed
     Then `parser::tokenize` is in `delta.changes` as `Added` with current.score = 31
     And `delta.summary.added` includes that function
 
+  @unwired
   Scenario: Function present in baseline only is classified Removed
+    # tracked: crap-rs#169 — delta.feature is spec-only; no cucumber harness wires --baseline delta scenarios yet
     Given the baseline JSON contains function `legacy::frob` with score 8
     And the current analysis does not contain `legacy::frob`
     When the delta is computed
     Then `legacy::frob` is in `delta.changes` as `Removed` with baseline.score = 8
     And `delta.summary.removed` includes that function
 
+  @unwired
   Scenario: Function present in both is classified Modified
+    # tracked: crap-rs#169 — delta.feature is spec-only; no cucumber harness wires --baseline delta scenarios yet
     Given baseline contains `cli::run_inner` with score 8
     And current contains `cli::run_inner` with score 24
     When the delta is computed
@@ -54,7 +62,9 @@ Feature: --baseline delta analysis (Bundle E, issue #81)
     And `delta.summary.regressions` includes that function
     And `delta.summary.modified` is incremented
 
+  @unwired
   Scenario: Function with score_delta < 0 is counted as improvement
+    # tracked: crap-rs#169 — delta.feature is spec-only; no cucumber harness wires --baseline delta scenarios yet
     Given baseline contains `parser::tokenize` with score 47
     And current contains `parser::tokenize` with score 12
     When the delta is computed
@@ -64,13 +74,17 @@ Feature: --baseline delta analysis (Bundle E, issue #81)
 
   # ── Domain: identity matching ──────────────────────────────────────
 
+  @unwired
   Scenario: Functions are matched by (file_path, qualified_name)
+    # tracked: crap-rs#169 — delta.feature is spec-only; no cucumber harness wires --baseline delta scenarios yet
     Given baseline contains `src/foo.rs::module::fn_a`
     And current contains `src/foo.rs::module::fn_a`
     When the delta is computed
     Then the function is `Modified` (matched), not `Added`+`Removed`
 
+  @unwired
   Scenario: Same name in different files counts as separate functions
+    # tracked: crap-rs#169 — delta.feature is spec-only; no cucumber harness wires --baseline delta scenarios yet
     Given baseline contains `src/a.rs::helpers::log`
     And current contains `src/b.rs::helpers::log` (file moved, same name)
     When the delta is computed
@@ -78,7 +92,9 @@ Feature: --baseline delta analysis (Bundle E, issue #81)
     And one `Added` change for `src/b.rs::helpers::log`
     # Rename/move detection is a v0.3.0 follow-up
 
+  @unwired
   Scenario: Same-file rename produces Add+Remove
+    # tracked: crap-rs#169 — delta.feature is spec-only; no cucumber harness wires --baseline delta scenarios yet
     Given baseline contains `src/foo.rs::utils::compute_v1`
     And current contains `src/foo.rs::utils::compute_v2` (renamed)
     When the delta is computed
@@ -87,7 +103,9 @@ Feature: --baseline delta analysis (Bundle E, issue #81)
 
   # ── Domain: new_violations gate counting ───────────────────────────
 
+  @unwired
   Scenario: Added function over threshold counts as new_violation
+    # tracked: crap-rs#169 — delta.feature is spec-only; no cucumber harness wires --baseline delta scenarios yet
     Given threshold is 25
     And baseline does not contain `wild::beast`
     And current contains `wild::beast` with score 31
@@ -95,14 +113,18 @@ Feature: --baseline delta analysis (Bundle E, issue #81)
     Then `delta.summary.new_violations` is `1`
     And `delta.summary.passed` is `false`
 
+  @unwired
   Scenario: Modified function crossing from passing to failing counts as new_violation
+    # tracked: crap-rs#169 — delta.feature is spec-only; no cucumber harness wires --baseline delta scenarios yet
     Given threshold is 25
     And baseline contains `cli::run_inner` with score 8 (passing)
     And current contains `cli::run_inner` with score 47 (failing)
     When the delta is computed
     Then `delta.summary.new_violations` is `1`
 
+  @unwired
   Scenario: Modified function getting worse but still passing does NOT count as new_violation
+    # tracked: crap-rs#169 — delta.feature is spec-only; no cucumber harness wires --baseline delta scenarios yet
     Given threshold is 25
     And baseline contains `parser::tokenize` with score 8
     And current contains `parser::tokenize` with score 20 (still passing)
@@ -110,7 +132,9 @@ Feature: --baseline delta analysis (Bundle E, issue #81)
     Then `delta.summary.regressions` is `1`
     And `delta.summary.new_violations` is `0`
 
+  @unwired
   Scenario: Modified function that was already failing in baseline does NOT count
+    # tracked: crap-rs#169 — delta.feature is spec-only; no cucumber harness wires --baseline delta scenarios yet
     Given threshold is 25
     And baseline contains `legacy::frob` with score 47 (already failing)
     And current contains `legacy::frob` with score 60 (still failing, worse)
@@ -121,21 +145,29 @@ Feature: --baseline delta analysis (Bundle E, issue #81)
 
   # ── DeltaViewSpec: filter, sort, truncate ──────────────────────────
 
+  @unwired
   Scenario: Default DeltaViewSpec is filter=all, sort=score_delta desc
+    # tracked: crap-rs#169 — delta.feature is spec-only; no cucumber harness wires --baseline delta scenarios yet
     When `delta::apply(&delta, DeltaViewSpec::default())` runs
     Then `view.shown` contains every `FunctionChange` in `delta.changes`
     And rows are ordered by signed `score_delta` descending (regressions first, improvements last)
 
+  @unwired
   Scenario: Filter by change_kinds=[added] returns only Added
+    # tracked: crap-rs#169 — delta.feature is spec-only; no cucumber harness wires --baseline delta scenarios yet
     When `delta::apply` is called with `filters.change_kinds = Some({Added})`
     Then `view.shown` contains only `Added` variants
 
+  @unwired
   Scenario: Sort by current_crap descending
+    # tracked: crap-rs#169 — delta.feature is spec-only; no cucumber harness wires --baseline delta scenarios yet
     When `delta::apply` is called with `sort = CurrentCrap`
     Then rows are ordered by current.score descending
     And `Removed` entries (no current score) sort last
 
+  @unwired
   Scenario: Truncate by limit
+    # tracked: crap-rs#169 — delta.feature is spec-only; no cucumber harness wires --baseline delta scenarios yet
     Given `delta.changes` has 10 entries
     When `delta::apply` is called with `limit = Some(3)`
     Then `view.shown.len()` is `3`
@@ -144,33 +176,43 @@ Feature: --baseline delta analysis (Bundle E, issue #81)
 
   # ── CLI: --baseline flag resolution ────────────────────────────────
 
+  @unwired
   Scenario: --baseline flag loads JSON envelope and emits delta block
+    # tracked: crap-rs#169 — delta.feature is spec-only; no cucumber harness wires --baseline delta scenarios yet
     When the operator runs `crap4rs --coverage lcov.info --baseline baseline.json --format json`
     Then the JSON envelope contains a top-level `delta` key
     And `delta.summary` is present
     And `delta.spec` echoes resolved DeltaViewSpec
     And `delta.shown` is a denormalized array of FunctionChange entries
 
+  @unwired
   Scenario: Without --baseline, JSON envelope omits delta key entirely
+    # tracked: crap-rs#169 — delta.feature is spec-only; no cucumber harness wires --baseline delta scenarios yet
     When the operator runs `crap4rs --coverage lcov.info --format json`
     Then the JSON envelope does NOT contain a `delta` key
     And the envelope is byte-identical to today's output
 
+  @unwired
   Scenario: Without --baseline, all reporters render today's output unchanged
+    # tracked: crap-rs#169 — delta.feature is spec-only; no cucumber harness wires --baseline delta scenarios yet
     When the operator runs `crap4rs --coverage lcov.info --format markdown` (no --baseline)
     Then the markdown output contains the existing summary block only
     And no "Delta" section appears
 
   # ── CLI: gate semantics ────────────────────────────────────────────
 
+  @unwired
   Scenario: --baseline alone is informational — exit code reflects only threshold gate
+    # tracked: crap-rs#169 — delta.feature is spec-only; no cucumber harness wires --baseline delta scenarios yet
     Given the current analysis has 3 threshold violations (exit 1 today)
     And the baseline has 3 threshold violations (no new violations introduced)
     When the operator runs `crap4rs --coverage lcov.info --baseline baseline.json`
     Then the process exits 1 (because of the threshold gate, NOT delta)
     And `delta.summary.passed` is `true`
 
+  @unwired
   Scenario: --baseline alone with passing analysis exits 0 even if delta has regressions
+    # tracked: crap-rs#169 — delta.feature is spec-only; no cucumber harness wires --baseline delta scenarios yet
     Given the current analysis has 0 threshold violations
     And the baseline shows the current PR introduced 2 new regressions
     When the operator runs `crap4rs --coverage lcov.info --baseline baseline.json`
@@ -179,132 +221,174 @@ Feature: --baseline delta analysis (Bundle E, issue #81)
     And `delta.summary.passed` is `false`
     # Default behavior: delta is informational, doesn't gate
 
+  @unwired
   Scenario: --delta-gate makes delta contribute to exit code
+    # tracked: crap-rs#169 — delta.feature is spec-only; no cucumber harness wires --baseline delta scenarios yet
     Given the current analysis has 0 threshold violations
     And the baseline shows this PR introduced 1 new violation
     When the operator runs `crap4rs --coverage lcov.info --baseline baseline.json --delta-gate`
     Then the process exits 1 (delta gate fired)
     And `delta.summary.passed` is `false`
 
+  @unwired
   Scenario: --delta-gate without new violations exits 0
+    # tracked: crap-rs#169 — delta.feature is spec-only; no cucumber harness wires --baseline delta scenarios yet
     Given the current analysis has 0 threshold violations
     And the baseline shows no new violations introduced
     When the operator runs `crap4rs --coverage lcov.info --baseline baseline.json --delta-gate`
     Then the process exits 0
     And `delta.summary.passed` is `true`
 
+  @unwired
   Scenario: --no-fail overrides --delta-gate (truth still in JSON)
+    # tracked: crap-rs#169 — delta.feature is spec-only; no cucumber harness wires --baseline delta scenarios yet
     Given the current analysis is failing AND the delta has new violations
     When the operator runs `crap4rs --coverage lcov.info --baseline baseline.json --delta-gate --no-fail`
     Then the process exits 0
     And `result.passed` is `false`
     And `delta.summary.passed` is `false`
 
+  @unwired
   Scenario: --no-fail without --delta-gate behaves as today
+    # tracked: crap-rs#169 — delta.feature is spec-only; no cucumber harness wires --baseline delta scenarios yet
     When the operator runs `crap4rs --coverage lcov.info --baseline baseline.json --no-fail`
     Then the process exits 0 regardless of threshold violations
     And the delta is still surfaced informationally
 
   # ── CLI: shaping flags compose with delta ──────────────────────────
 
+  @unwired
   Scenario: --delta-top truncates delta.shown
+    # tracked: crap-rs#169 — delta.feature is spec-only; no cucumber harness wires --baseline delta scenarios yet
     Given the delta has 10 changes
     When the operator runs `crap4rs … --baseline baseline.json --delta-top 3 --format json`
     Then `delta.shown.len()` is `3`
     And `delta.eligible_count` is `10`
     And `delta.truncated` is `true`
 
+  @unwired
   Scenario: --delta-sort current-crap orders by current score
+    # tracked: crap-rs#169 — delta.feature is spec-only; no cucumber harness wires --baseline delta scenarios yet
     When the operator runs `crap4rs … --baseline baseline.json --delta-sort current-crap --format json`
     Then `delta.spec.sort` is `"current_crap"`
     And `delta.shown` is ordered by current.score descending
 
+  @unwired
   Scenario: --delta-only filters to specified change kinds
+    # tracked: crap-rs#169 — delta.feature is spec-only; no cucumber harness wires --baseline delta scenarios yet
     When the operator runs `crap4rs … --baseline baseline.json --delta-only added,modified --format json`
     Then `delta.shown` contains only `Added` and `Modified` entries
     And `Removed` entries are absent
 
   # ── Reporter rendering ─────────────────────────────────────────────
 
+  @unwired
   Scenario: Table reporter renders Delta section under analysis table
+    # tracked: crap-rs#169 — delta.feature is spec-only; no cucumber harness wires --baseline delta scenarios yet
     When the operator runs `crap4rs --coverage lcov.info --baseline baseline.json` (default --format table)
     Then stdout contains the existing analysis table
     And below it a "Delta vs baseline" header
     And a per-change row table with columns: kind, path, function, baseline, current, Δ
     And a delta summary line: "+N added, M removed, K modified, R regressions, I improvements, V new violations"
 
+  @unwired
   Scenario: Markdown reporter renders PR-comment scorecard
+    # tracked: crap-rs#169 — delta.feature is spec-only; no cucumber harness wires --baseline delta scenarios yet
     When the operator runs `crap4rs --coverage lcov.info --baseline baseline.json --format markdown`
     Then stdout contains a "## CRAP Scorecard" header
     And a Status line ("PASS" or "FAIL" per result.passed)
     And a Delta vs baseline counts block
     And tables for biggest regressions and new violations
 
+  @unwired
   Scenario: CSV reporter adds change_kind column
+    # tracked: crap-rs#169 — delta.feature is spec-only; no cucumber harness wires --baseline delta scenarios yet
     When the operator runs `crap4rs --coverage lcov.info --baseline baseline.json --format csv`
     Then the CSV header has 11 columns: existing 10 + `change_kind`
     And data rows include the change kind for each delta entry
 
+  @unwired
   Scenario: --minimal-view does NOT suppress delta block
+    # tracked: crap-rs#169 — delta.feature is spec-only; no cucumber harness wires --baseline delta scenarios yet
     When the operator runs `crap4rs … --baseline baseline.json --minimal-view --format json`
     Then `view.shown` is omitted (existing --minimal-view behavior)
     And `delta.shown` is still present (delta is the whole reason for invocation)
 
   # ── JSON envelope shape ────────────────────────────────────────────
 
+  @unwired
   Scenario: schema_version stays at 1 (additive)
+    # tracked: crap-rs#169 — delta.feature is spec-only; no cucumber harness wires --baseline delta scenarios yet
     When the operator runs `crap4rs … --baseline baseline.json --format json`
     Then `schema_version` is `1`
     And `delta` is a sibling of `result` and `view`
 
+  @unwired
   Scenario: delta block contains baseline metadata
+    # tracked: crap-rs#169 — delta.feature is spec-only; no cucumber harness wires --baseline delta scenarios yet
     When the operator runs `crap4rs … --baseline baseline.json --format json`
     Then `delta.baseline_tool_version` matches the baseline's tool_version
     And `delta.baseline_timestamp` matches the baseline's timestamp
     And `delta.baseline_ref` is `null` (reserved for future --baseline-ref flag)
 
+  @unwired
   Scenario: delta block propagates baseline diagnostics
+    # tracked: crap-rs#169 — delta.feature is spec-only; no cucumber harness wires --baseline delta scenarios yet
     Given the baseline JSON includes a `diagnostics` field
     When the operator runs `crap4rs … --baseline baseline.json --format json`
     Then `delta.baseline_diagnostics` reflects the baseline's diagnostics
 
   # ── Validation errors ──────────────────────────────────────────────
 
+  @unwired
   Scenario: --baseline with non-existent path exits 2
+    # tracked: crap-rs#169 — delta.feature is spec-only; no cucumber harness wires --baseline delta scenarios yet
     When the operator runs `crap4rs --coverage lcov.info --baseline /nonexistent.json`
     Then the process exits 2
     And stderr contains "baseline file not found"
 
+  @unwired
   Scenario: --baseline with malformed JSON exits 2
+    # tracked: crap-rs#169 — delta.feature is spec-only; no cucumber harness wires --baseline delta scenarios yet
     Given `bad.json` is not valid JSON
     When the operator runs `crap4rs --coverage lcov.info --baseline bad.json`
     Then the process exits 2
     And stderr contains "failed to parse baseline JSON"
 
+  @unwired
   Scenario: --baseline with mismatched schema_version exits 2
+    # tracked: crap-rs#169 — delta.feature is spec-only; no cucumber harness wires --baseline delta scenarios yet
     Given `future.json` declares `schema_version: 2`
     When the operator runs `crap4rs --coverage lcov.info --baseline future.json`
     Then the process exits 2
     And stderr contains "unsupported baseline schema_version"
 
+  @unwired
   Scenario: --delta-only with unknown kind exits 2
+    # tracked: crap-rs#169 — delta.feature is spec-only; no cucumber harness wires --baseline delta scenarios yet
     When the operator runs `crap4rs … --baseline baseline.json --delta-only nonsense`
     Then the process exits 2
     And stderr contains "invalid value 'nonsense' for '--delta-only'"
 
+  @unwired
   Scenario: --delta-sort with unknown key exits 2
+    # tracked: crap-rs#169 — delta.feature is spec-only; no cucumber harness wires --baseline delta scenarios yet
     When the operator runs `crap4rs … --baseline baseline.json --delta-sort nonsense`
     Then the process exits 2
     And stderr contains "invalid value 'nonsense' for '--delta-sort'"
 
+  @unwired
   Scenario: --delta-top with negative value exits 2
+    # tracked: crap-rs#169 — delta.feature is spec-only; no cucumber harness wires --baseline delta scenarios yet
     When the operator runs `crap4rs … --baseline baseline.json --delta-top -5`
     Then the process exits 2
     And stderr contains "invalid value '-5' for '--delta-top'"
 
   # ── Help discoverability ───────────────────────────────────────────
 
+  @unwired
   Scenario: --help advertises --baseline and --delta-gate
+    # tracked: crap-rs#169 — delta.feature is spec-only; no cucumber harness wires --baseline delta scenarios yet
     When the operator runs `crap4rs --help`
     Then stdout mentions "--baseline"
     And stdout mentions "--delta-gate"
@@ -313,20 +397,26 @@ Feature: --baseline delta analysis (Bundle E, issue #81)
 
   # ── Walking-skeleton invariants (property-tested) ──────────────────
 
+  @unwired
   Scenario: Identity invariant — compute(r, r) yields all-Modified, all zero
+    # tracked: crap-rs#169 — delta.feature is spec-only; no cucumber harness wires --baseline delta scenarios yet
     Given any `AnalysisResult` r
     When `delta::compute(r.clone(), r)` runs
     Then every change is `Modified` with `score_delta == 0.0`
     And `delta.summary.regressions == 0`
     And `delta.summary.new_violations == 0`
 
+  @unwired
   Scenario: Containment invariant — view.shown is a subset of delta.changes
+    # tracked: crap-rs#169 — delta.feature is spec-only; no cucumber harness wires --baseline delta scenarios yet
     Given any `AnalysisDelta` and any `DeltaViewSpec`
     When `delta::apply(&delta, spec)` runs
     Then every entry in `view.shown` exists in `delta.changes`
     And `view.eligible_count <= delta.changes.len()`
 
+  @unwired
   Scenario: Gate orthogonality — result.passed is unaffected by --baseline
+    # tracked: crap-rs#169 — delta.feature is spec-only; no cucumber harness wires --baseline delta scenarios yet
     Given any current analysis r
     When the operator runs `crap4rs … --baseline X --format json` and `crap4rs … --format json` (without baseline)
     Then `result` (and `result.passed`) is byte-identical between the two runs

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -93,10 +93,14 @@ pre-push:
       run: python3 scripts/mutants-skip-lint.py
       timeout: 30s
     bdd-tracked-lint:
-      # Mechanical enforcement of AGENTS.md "BDD hygiene" Rule 2: every
-      # `@unwired` or `@wip` scenario across `crates/*/tests/features/`
-      # must carry a `# tracked: crap-rs#<n>` comment inside its
-      # scenario block, naming the issue that owns the wiring deferral.
+      # Mechanical enforcement of AGENTS.md "BDD hygiene" Rules 1 and 2
+      # across `crates/*/tests/features/`:
+      #   Rule 1 — every `Scenario:` / `Scenario Outline:` carries
+      #     EXACTLY ONE status tag (`@wired` / `@unwired` / `@wip`);
+      #     zero or more-than-one both fail.
+      #   Rule 2 — every `@unwired` / `@wip` scenario carries a
+      #     `# tracked: crap-rs#<n>` comment inside its scenario block,
+      #     naming the issue that owns the wiring deferral.
       # Local-velocity layer of the same check that
       # `.github/workflows/ci.yml`'s `bdd-tracked-lint` job runs on
       # every push. Single source of truth: `scripts/bdd-tracked-lint.py`.

--- a/scripts/bdd-tracked-lint.py
+++ b/scripts/bdd-tracked-lint.py
@@ -1,13 +1,20 @@
 #!/usr/bin/env python3
-"""BDD tracked-comment lint — mechanical enforcement of the AGENTS.md
-"BDD hygiene" Rule 2: every `@unwired` or `@wip` scenario must carry a
-`# tracked: crap-rs#<n>` comment inside its scenario block, naming the
-issue that captures the wiring deferral.
+"""BDD hygiene lint — mechanical enforcement of two AGENTS.md
+"BDD hygiene" rules over every `Scenario:` / `Scenario Outline:`:
 
-The *why* lives in `AGENTS.md` ("BDD hygiene" → Rule 2 → "@unwired and
-@wip require a tracking comment"). This script is the *what*: replaces
-the documented rule with a CI + lefthook gate so a future agent cannot
-land a deferred scenario without naming the deferral's owning issue.
+* **Rule 1 (status-tag presence):** every scenario carries EXACTLY ONE
+  status tag from `@wired` / `@unwired` / `@wip`. Zero status tags
+  (the scenario silently escapes the wired/unwired/wip lexicon) and
+  more than one (mutually-exclusive tags can't coexist) both fail.
+* **Rule 2 (tracking-comment presence):** every `@unwired` or `@wip`
+  scenario carries a `# tracked: crap-rs#<n> — <reason>` comment inside
+  its scenario block, naming the issue that owns the wiring deferral.
+
+The *why* lives in `AGENTS.md` ("BDD hygiene" → Rules 1 and 2). This
+script is the *what*: replaces the documented rules with a CI +
+lefthook gate so a future agent cannot land an untagged / multiply-
+tagged scenario (Rule 1) or a deferred scenario without naming the
+deferral's owning issue (Rule 2).
 
 Same mechanical-enforcement pattern as `scripts/mutants-skip-lint.py`
 (documentation rots; CI doesn't). Single source of truth in this
@@ -21,10 +28,20 @@ Algorithm:
      the contiguous tag line(s) immediately preceding a `Scenario:` or
      `Scenario Outline:` header with that header and its body
      (everything up to the next tag-line / scenario-header / EOF).
-  2. For each block, if any tag line carries `@unwired` or `@wip`,
-     scan the body lines for a `# tracked: crap-rs#<n>` comment.
-  3. Report (file, scenario line, scenario title, tag) for every
-     missing tracked-comment. Exit 1 on any miss, 0 otherwise.
+  2. Rule 1: count the status tags (`@wired`/`@unwired`/`@wip`) across
+     the block's tag lines. Report a violation unless the count is
+     exactly 1.
+  3. Rule 2: if the (single) status tag is `@unwired` or `@wip`, scan
+     the body lines for a `# tracked: crap-rs#<n>` comment; report a
+     violation if absent.
+  4. Collect violations from BOTH rules across all files; exit 1 if any
+     fired, 0 otherwise. Rule 1 does not short-circuit Rule 2 — a
+     scenario can carry exactly one `@unwired` tag (Rule 1 ok) yet
+     still miss its tracked-comment (Rule 2 fails).
+
+A `--self-test` flag exercises both rule branches against in-memory
+fixtures (zero-tag fail, multi-tag fail, single-tag pass, untracked
+deferral fail) so the lint logic itself is regression-guarded.
 
 Limitations:
 
@@ -52,11 +69,17 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
-# A status tag MUST appear on its own tag line (Gherkin convention),
-# leading whitespace allowed, followed by `@unwired` or `@wip` as a
-# discrete token (separated by whitespace from other tags on the same
-# line, if any).
+# Rule 2 helper: the *deferral* status tags only (`@unwired` / `@wip`),
+# the two that require a `# tracked:` comment. A status tag MUST appear
+# on its own tag line (Gherkin convention), leading whitespace allowed,
+# as a discrete token (separated by whitespace from other tags on the
+# same line, if any).
 STATUS_TAG_RE = re.compile(r"(?:^|\s)@(unwired|wip)(?=\s|$)")
+# Rule 1 helper: ALL three mutually-exclusive status tags. Distinct
+# from STATUS_TAG_RE (which omits `@wired`) so a `@wired` scenario reads
+# as one status tag, not zero. Word-bounded so a scope tag like
+# `@smoke` (or a future `@wired_up`) is NOT miscounted as a status tag.
+STATUS_COUNT_RE = re.compile(r"(?:^|\s)@(wired|unwired|wip)(?=\s|$)")
 TAG_LINE_RE = re.compile(r"^\s*@")
 SCENARIO_LINE_RE = re.compile(r"^\s*Scenario(?::|\s+Outline:)\s*(.*)$")
 # Enforce the AGENTS.md "BDD hygiene" Rule 2 example shape exactly:
@@ -89,6 +112,18 @@ class ScenarioBlock:
             if m:
                 return f"@{m.group(1)}"
         return None
+
+    def status_tags(self) -> list[str]:
+        """Every status tag (`@wired`/`@unwired`/`@wip`) across all of
+        this block's tag lines, in source order. Rule 1 requires the
+        list to have length exactly 1; this method is the count source.
+        Multiple status tags on one line and across several tag lines
+        are both captured."""
+        found: list[str] = []
+        for _, txt in self.tag_lines:
+            for m in STATUS_COUNT_RE.finditer(txt):
+                found.append(f"@{m.group(1)}")
+        return found
 
     def has_tracked_comment(self) -> bool:
         return any(TRACKED_RE.search(txt) for _, txt in self.body_lines)
@@ -157,6 +192,62 @@ def parse_blocks(feature_path: Path) -> list[ScenarioBlock]:
     return blocks
 
 
+def check_block(block: ScenarioBlock, rel: Path) -> list[str]:
+    """Apply both BDD-hygiene rules to one scenario block. Returns a
+    list of formatted violation messages (empty when the block is
+    clean). Rule 1 and Rule 2 are independent — a block can fail both,
+    or pass Rule 1 yet fail Rule 2, so neither short-circuits the
+    other."""
+    violations: list[str] = []
+
+    # Rule 1: exactly one status tag.
+    statuses = block.status_tags()
+    if len(statuses) == 0:
+        violations.append(
+            f"\nbdd-tracked-lint: missing status tag (Rule 1)\n"
+            f"  {rel}:{block.header_line}  Scenario: {block.title}\n"
+            f"  carries no status tag. Every scenario MUST carry exactly "
+            f"one of `@wired` / `@unwired` / `@wip`.\n\n"
+            f"  Fix: add a status tag on the line directly above the "
+            f"`Scenario:` header. Default to `@unwired` (with a "
+            f"`# tracked: crap-rs#<n>` comment in the body) for a scenario "
+            f"no harness exercises yet; see AGENTS.md \"BDD hygiene\" "
+            f"Rule 1 for why."
+        )
+    elif len(statuses) > 1:
+        violations.append(
+            f"\nbdd-tracked-lint: multiple status tags (Rule 1)\n"
+            f"  {rel}:{block.header_line}  Scenario: {block.title}\n"
+            f"  carries {len(statuses)} status tags "
+            f"({', '.join(statuses)}). The status tags are mutually "
+            f"exclusive — a scenario MUST carry exactly one.\n\n"
+            f"  Fix: keep the single tag that reflects the scenario's "
+            f"true wiring state and remove the rest; see AGENTS.md "
+            f"\"BDD hygiene\" Rule 1 for why."
+        )
+
+    # Rule 2: `@unwired` / `@wip` scenarios need a `# tracked:` comment.
+    # Uses status_tag() (the deferral-only scanner) so the rule fires
+    # whenever a deferral tag is present, independent of Rule 1's count.
+    status = block.status_tag()
+    if status in ("@unwired", "@wip") and not block.has_tracked_comment():
+        violations.append(
+            f"\nbdd-tracked-lint: missing tracked-comment on "
+            f"{status} scenario (Rule 2)\n"
+            f"  {rel}:{block.header_line}  Scenario: {block.title}\n"
+            f"  carries `{status}` but no `# tracked: crap-rs#<n>` "
+            f"comment in its body.\n\n"
+            f"  Fix: add a comment of the exact shape\n"
+            f"    # tracked: crap-rs#<n> — <one-line reason>\n"
+            f"  inside the scenario block (between the `Scenario:` "
+            f"header and the next scenario). Open or reuse a "
+            f"tracking issue first; see AGENTS.md \"BDD hygiene\" "
+            f"Rule 2 for why."
+        )
+
+    return violations
+
+
 def lint(repo_root: Path) -> int:
     errors: list[str] = []
     scanned = 0
@@ -166,45 +257,127 @@ def lint(repo_root: Path) -> int:
         if not abs_dir.is_dir():
             continue
         for feature_path in sorted(abs_dir.rglob("*.feature")):
+            rel = feature_path.relative_to(repo_root)
             for block in parse_blocks(feature_path):
                 scanned += 1
-                status = block.status_tag()
-                if status not in ("@unwired", "@wip"):
-                    continue
-                deferred += 1
-                if block.has_tracked_comment():
-                    continue
-                rel = feature_path.relative_to(repo_root)
-                errors.append(
-                    f"\nbdd-tracked-lint: missing tracked-comment on "
-                    f"{status} scenario\n"
-                    f"  {rel}:{block.header_line}  Scenario: {block.title}\n"
-                    f"  carries `{status}` but no `# tracked: crap-rs#<n>` "
-                    f"comment in its body.\n\n"
-                    f"  Fix: add a comment of the exact shape\n"
-                    f"    # tracked: crap-rs#<n> — <one-line reason>\n"
-                    f"  inside the scenario block (between the `Scenario:` "
-                    f"header and the next scenario). Open or reuse a "
-                    f"tracking issue first; see AGENTS.md \"BDD hygiene\" "
-                    f"Rule 2 for why."
-                )
+                if block.status_tag() in ("@unwired", "@wip"):
+                    deferred += 1
+                errors.extend(check_block(block, rel))
 
     if errors:
         for msg in errors:
             print(msg, file=sys.stderr)
+        n = len(errors)
         print(
-            f"\nbdd-tracked-lint: {len(errors)} uncovered {('scenario' if len(errors) == 1 else 'scenarios')}; "
-            f"see above ({scanned} scanned, {deferred} deferred)",
+            f"\nbdd-tracked-lint: {n} BDD-hygiene "
+            f"{'violation' if n == 1 else 'violations'}; see above "
+            f"({scanned} scanned, {deferred} deferred)",
             file=sys.stderr,
         )
         return 1
 
     print(
-        f"bdd-tracked-lint: ok ({deferred} deferred scenarios all carry "
-        f"a `# tracked: crap-rs#<n>` comment; {scanned} scanned)"
+        f"bdd-tracked-lint: ok (Rule 1: all {scanned} scenarios carry "
+        f"exactly one status tag; Rule 2: all {deferred} deferred "
+        f"scenarios carry a `# tracked: crap-rs#<n>` comment)"
     )
     return 0
 
 
+def self_test() -> int:
+    """Exercise both rule branches against in-memory fixtures so the
+    lint logic is regression-guarded independently of the live corpus.
+    Each fixture is written to a temp `crates/<crate>/tests/features/`
+    tree (the same layout the live lint globs) and run through `lint`,
+    asserting the expected exit code. Returns 0 on all-pass, 1 on any
+    failure."""
+    import tempfile
+
+    cases: list[tuple[str, str, int]] = [
+        (
+            "rule1-zero-tag-fails",
+            "Feature: F\n\n  Scenario: no status tag\n"
+            "    When x\n    Then y\n",
+            1,
+        ),
+        (
+            "rule1-multi-tag-fails",
+            "Feature: F\n\n  @wired\n  @unwired\n  Scenario: two status tags\n"
+            "    # tracked: crap-rs#169 — fixture\n    When x\n    Then y\n",
+            1,
+        ),
+        (
+            "rule1-multi-tag-same-line-fails",
+            "Feature: F\n\n  @wired @wip\n  Scenario: two on one line\n"
+            "    # tracked: crap-rs#169 — fixture\n    When x\n    Then y\n",
+            1,
+        ),
+        (
+            "wired-single-tag-passes",
+            "Feature: F\n\n  @wired\n  Scenario: one wired tag\n"
+            "    When x\n    Then y\n",
+            0,
+        ),
+        (
+            "unwired-tracked-passes",
+            "Feature: F\n\n  @unwired\n  Scenario: deferred and tracked\n"
+            "    # tracked: crap-rs#169 — fixture reason\n"
+            "    When x\n    Then y\n",
+            0,
+        ),
+        (
+            "rule2-unwired-untracked-fails",
+            "Feature: F\n\n  @unwired\n  Scenario: deferred but untracked\n"
+            "    When x\n    Then y\n",
+            1,
+        ),
+        (
+            "scope-tag-not-counted-as-status",
+            "Feature: F\n\n  @wired @smoke\n  Scenario: status plus scope\n"
+            "    When x\n    Then y\n",
+            0,
+        ),
+        (
+            "outline-zero-tag-fails",
+            "Feature: F\n\n  Scenario Outline: untagged outline\n"
+            "    When <x>\n    Then ok\n\n  Examples:\n      | x |\n      | 1 |\n",
+            1,
+        ),
+    ]
+
+    failures = 0
+    for name, body, expected in cases:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            feat_dir = root / "crates" / "fixture" / "tests" / "features"
+            feat_dir.mkdir(parents=True)
+            (feat_dir / f"{name}.feature").write_text(body)
+            # Silence the per-case stdout/stderr; only the exit code matters.
+            import contextlib
+            import io
+
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf), contextlib.redirect_stderr(buf):
+                got = lint(root)
+            if got != expected:
+                print(
+                    f"bdd-tracked-lint --self-test: FAIL {name}: "
+                    f"expected exit {expected}, got {got}",
+                    file=sys.stderr,
+                )
+                failures += 1
+
+    if failures:
+        print(
+            f"bdd-tracked-lint --self-test: {failures} case(s) failed",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"bdd-tracked-lint --self-test: ok ({len(cases)} cases passed)")
+    return 0
+
+
 if __name__ == "__main__":
+    if "--self-test" in sys.argv[1:]:
+        sys.exit(self_test())
     sys.exit(lint(Path(__file__).resolve().parent.parent))

--- a/scripts/bdd-tracked-lint.py
+++ b/scripts/bdd-tracked-lint.py
@@ -134,7 +134,7 @@ def parse_blocks(feature_path: Path) -> list[ScenarioBlock]:
     the next `Scenario:`/`Scenario Outline:` header; treat everything
     up to the next tag-line, scenario-header, or EOF as that scenario's
     body."""
-    lines = feature_path.read_text().splitlines()
+    lines = feature_path.read_text(encoding="utf-8").splitlines()
     blocks: list[ScenarioBlock] = []
 
     i = 0
@@ -351,7 +351,7 @@ def self_test() -> int:
             root = Path(td)
             feat_dir = root / "crates" / "fixture" / "tests" / "features"
             feat_dir.mkdir(parents=True)
-            (feat_dir / f"{name}.feature").write_text(body)
+            (feat_dir / f"{name}.feature").write_text(body, encoding="utf-8")
             # Silence the per-case stdout/stderr; only the exit code matters.
             import contextlib
             import io
@@ -365,6 +365,8 @@ def self_test() -> int:
                     f"expected exit {expected}, got {got}",
                     file=sys.stderr,
                 )
+                print("Captured output:", file=sys.stderr)
+                print(buf.getvalue(), file=sys.stderr)
                 failures += 1
 
     if failures:


### PR DESCRIPTION
## Summary
Extends `scripts/bdd-tracked-lint.py` to enforce AGENTS.md BDD-hygiene **Rule 1** (exactly one `@wired`/`@unwired`/`@wip` status tag per scenario) alongside the existing Rule 2, and backfills the 45 untagged scenarios in `delta.feature`. Surfaced by CodeRabbit on PR #279.

## What shipped
- Rule 1 added to `bdd-tracked-lint.py` (single script, two rules) + a `--self-test` CI step (8 fixture cases). Zero-tag and multi-tag both fail.
- `delta.feature`: 45 scenarios tagged `@unwired` + `# tracked: crap-rs#169` (spec-only; no harness wires delta `--baseline` scenarios yet).
- **No redundant CI job**: the existing `bdd-tracked-lint` CI job + lefthook pre-push hook already invoke the script, so Rule 1 is enforced automatically. Job id/display name kept as `bdd-tracked-lint` so branch-protection required-check refs don't break. (Conscious deviation from the literal "new job" AC wording — the single-source-of-truth pattern is better served by extending the one script.)
- AGENTS.md Rule 1 cross-references the mechanical enforcement.
- Audit: delta.feature was the sole Rule 1 violation across all 430 scenarios / 27 feature files; crap4ts features audited clean (untouched).

## Closes
Closes #280

(#169 stays open — it's the permanent `# tracked:` umbrella this backfill points at.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)