### PR TITLE
test(crap4rs): #262 — rewrite cli_init.feature to the #347 init contract + gate 4 wired cucumber harnesses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,16 @@ jobs:
       # `.config/nextest.toml` and they run via `cargo test`. Without
       # this step the `@wired` BDD status would be enforced only by the
       # `lefthook.yml` pre-push hook, not on every PR.
+      #
+      # Ordering is load-bearing for `multi_lang_html_cucumber`: it
+      # resolves the `crap-render` binary via
+      # `assert_cmd::cargo_bin("crap-render")`. `crap-render` ships in
+      # crap-core, not crap4rs, so `CARGO_BIN_EXE_crap-render` is unset
+      # for this crap4rs-package test — `cargo_bin` instead discovers
+      # the binary in the shared target dir. The preceding
+      # `cargo nextest run --workspace --all-targets` step builds it
+      # there. Keep that step before this one; reordering would leave
+      # crap-render unbuilt and silently break this harness.
       - run: >-
           cargo test
           --test json_reporter_cucumber
@@ -99,6 +109,10 @@ jobs:
           --test arrow_function_coverage_cucumber
           --test file_extensions_cucumber
           --test branch_coverage_cucumber
+          --test cli_init_cucumber
+          --test cli_ergonomics_cucumber
+          --test github_annotations_cucumber
+          --test multi_lang_html_cucumber
 
   crap4ts-build:
     # Per-platform build check for the new `crap4ts` shell crate (S5,

--- a/crates/crap4rs/tests/cli_init_cucumber.rs
+++ b/crates/crap4rs/tests/cli_init_cucumber.rs
@@ -1,13 +1,19 @@
 //! Cucumber-rs runner for `@wired`-tagged scenarios in
 //! `tests/features/cli_init.feature` (crap-rs#73).
 //!
-//! Each scenario sets up a tempdir (potentially with a `src/` or
-//! `crates/` subdirectory to exercise auto-detect) and invokes the
-//! `crap4rs init` subcommand via `CARGO_BIN_EXE_crap4rs`. Cross-adapter
-//! parity (`crap4ts init` also writing the canonical `crap.toml`) is
-//! exercised by the plain integration test at `crates/crap4ts/tests/cli_init_integration.rs`
-//! — that env var is per-package and `CARGO_BIN_EXE_crap4ts` is not
-//! available inside crap4rs's harness.
+//! `crap4rs init` emits one deterministic document — the exhaustive
+//! annotated config reference — identical regardless of CLI flags,
+//! piped stdin, or the project's directory layout. There is no
+//! auto-detect and no interactive prompt; `--non-interactive` is a
+//! retained no-op. Scenarios set up a tempdir (some with a `crates/`
+//! subdirectory to prove the layout is ignored, some seeding an
+//! existing `crap.toml` to exercise the collision/`--force` paths) and
+//! invoke the `crap4rs init` subcommand via `CARGO_BIN_EXE_crap4rs`.
+//! Cross-adapter parity (`crap4ts init` also writing the canonical
+//! `crap.toml`) is exercised by the plain integration test at
+//! `crates/crap4ts/tests/cli_init_integration.rs` — that env var is
+//! per-package and `CARGO_BIN_EXE_crap4ts` is not available inside
+//! crap4rs's harness.
 //!
 //! The harness uses `filter_run_and_exit` with the `@wired` filter
 //! pattern per AGENTS.md § BDD hygiene rule 5; `@unwired` scenarios
@@ -76,16 +82,6 @@ fn given_empty_dir(world: &mut InitWorld) {
 fn given_dir_with_subdir(world: &mut InitWorld, name: String) {
     let (dir, path) = fresh_tempdir();
     std::fs::create_dir_all(path.join(&name)).expect("create subdir");
-    world.project_dir = Some(path);
-    world._tempdir = Some(dir);
-}
-
-#[given(
-    regex = r#"^a project directory with a "([^"]+)" subdirectory but no "([^"]+)" subdirectory$"#
-)]
-fn given_dir_with_subdir_but_not(world: &mut InitWorld, present: String, _absent: String) {
-    let (dir, path) = fresh_tempdir();
-    std::fs::create_dir_all(path.join(&present)).expect("create subdir");
     world.project_dir = Some(path);
     world._tempdir = Some(dir);
 }
@@ -219,28 +215,21 @@ fn then_loads(world: &mut InitWorld) {
     );
 }
 
-#[then(regex = r#"^the loaded config has preset "([^"]+)"$"#)]
-fn then_loaded_preset(world: &mut InitWorld, expected: String) {
+#[then("the loaded config has no top-level preset")]
+fn then_loaded_no_preset(world: &mut InitWorld) {
+    // The exhaustive dump sets `threshold` live and leaves `preset` as a
+    // commented-out alternative, so a freshly generated config has no
+    // top-level `preset` key once parsed. Parsing (rather than a text
+    // `does not contain` check) is the honest assertion here: a bare
+    // `preset = "default"` substring also appears on commented lines in
+    // the dump, so only the parsed TOML can prove the key is absent.
     let path = world.config_path("crap.toml");
     let content = std::fs::read_to_string(&path).expect("read config");
     let parsed: toml::Value = toml::from_str(&content).expect("parse config");
-    let preset = parsed
-        .get("preset")
-        .and_then(|v| v.as_str())
-        .expect("preset key missing or wrong type");
-    assert_eq!(preset, expected);
-}
-
-#[then(regex = r#"^the loaded config has src "([^"]+)"$"#)]
-fn then_loaded_src(world: &mut InitWorld, expected: String) {
-    let path = world.config_path("crap.toml");
-    let content = std::fs::read_to_string(&path).expect("read config");
-    let parsed: toml::Value = toml::from_str(&content).expect("parse config");
-    let src = parsed
-        .get("src")
-        .and_then(|v| v.as_str())
-        .expect("src key missing or wrong type");
-    assert_eq!(src, expected);
+    assert!(
+        parsed.get("preset").is_none(),
+        "generated config must not set a top-level preset (it is the commented alternative to a live threshold)\nfull content:\n{content}",
+    );
 }
 
 #[then(regex = r#"^stderr contains "([^"]+)"$"#)]

--- a/crates/crap4rs/tests/features/cli_init.feature
+++ b/crates/crap4rs/tests/features/cli_init.feature
@@ -1,77 +1,69 @@
 Feature: crap4rs init subcommand
 
-  `crap4rs init` generates a starter `crap.toml` in the current
-  directory. Interactive by default (one prompt: threshold preset),
-  `--non-interactive` for CI, `--force` to overwrite an existing
-  config. crap4ts inherits the same behavior via `AdapterMeta`
-  (`config_file_names`, `extensions`) and writes the same canonical
-  `crap.toml` (the legacy per-adapter names are discovery fallbacks only).
+  `crap4rs init` writes a starter `crap.toml` to the current directory.
+  As of the init rewrite, the output is a single deterministic document:
+  the exhaustive annotated config reference (every supported option
+  present, each annotated with an explanatory comment). The same content
+  is emitted regardless of CLI flags, piped stdin, or the project's
+  directory layout — there is no auto-detect and no interactive prompt.
+  `--non-interactive` is retained for back-compat but no longer changes
+  the output. `--force` overwrites an existing config; without it, init
+  refuses to clobber. crap4ts inherits the same behavior via `AdapterMeta`
+  and writes the same canonical `crap.toml`.
 
-  The generated config is self-documenting (inline comments explain
-  each option) and round-trips through `load_file_config` without
-  errors. Auto-detect rules pick `src/` then `crates/` then fall
-  back to `src` with a hint comment.
+  The generated config is self-documenting (inline comments explain each
+  option) and round-trips through `load_file_config` without errors. It
+  sets `threshold` live and leaves `preset` as a commented alternative,
+  so a freshly generated config has no top-level `preset` key.
 
-  # ── Non-interactive (CI path) ──────────────────────────────────────
+  # ── Deterministic annotated dump ───────────────────────────────────
 
   @wired
-  Scenario: --non-interactive writes a default config in an empty directory
-    Given an empty project directory
+  Scenario: init emits the fixed annotated dump, ignoring project layout
+    Given a project directory with a "crates" subdirectory
     When the operator runs `crap4rs init --non-interactive`
     Then a file named "crap.toml" exists in the project directory
-    And the config file contains 'preset = "default"'
-    And the config file contains 'src = "src"'
+    And the config file contains "exhaustive annotated config reference"
+    And the config file contains 'src = ["crates/core/src", "crates/cli/src"]'
+    And the config file contains 'threshold = 15.0'
     And the exit code is 0
 
   @wired
-  Scenario: --non-interactive auto-detects single-crate src layout
-    Given a project directory with a "src" subdirectory
-    When the operator runs `crap4rs init --non-interactive`
-    Then the config file contains 'src = "src"'
-    And the config file does not contain "adjust if your sources live elsewhere"
+  Scenario: stdin is ignored — there is no interactive prompt to answer
+    Given an empty project directory
+    When the operator runs `crap4rs init` with stdin "s\n"
+    Then the config file contains 'threshold = 15.0'
+    And the config file does not contain 'preset = "strict"'
+    And the config file does not contain 'preset = "lenient"'
     And the exit code is 0
 
   @wired
-  Scenario: --non-interactive auto-detects workspace crates layout
-    Given a project directory with a "crates" subdirectory but no "src" subdirectory
-    When the operator runs `crap4rs init --non-interactive`
-    Then the config file contains 'src = "crates"'
-    And the config file does not contain "adjust if your sources live elsewhere"
-    And the exit code is 0
-
-  @wired
-  Scenario: --non-interactive falls back to src and includes a hint comment when no layout matches
+  Scenario: generated config lists common exclude patterns live (not commented out)
     Given an empty project directory
     When the operator runs `crap4rs init --non-interactive`
-    Then the config file contains 'src = "src"'
-    And the config file contains "adjust if your sources live elsewhere"
-
-  @wired
-  Scenario: generated config includes commented-out common exclude patterns
-    Given an empty project directory
-    When the operator runs `crap4rs init --non-interactive`
-    Then the config file contains '# exclude = ['
-    And the config file contains "tests/**"
+    Then the config file contains 'exclude = ["tests/**"'
     And the config file contains "benches/**"
     And the config file contains "examples/**"
+    And the config file does not contain "# exclude = ["
 
   @wired
-  Scenario: generated config includes header comments explaining each option
+  Scenario: generated config documents every section with header comments
     Given an empty project directory
     When the operator runs `crap4rs init --non-interactive`
     Then the config file contains "# crap.toml"
-    And the config file contains "Threshold preset"
-    And the config file contains "strict (8)"
-    And the config file contains "default (15)"
-    And the config file contains "lenient (25)"
+    And the config file contains "exhaustive annotated config reference"
+    And the config file contains "[language.rust]"
+    And the config file contains "[language.typescript]"
+    And the config file contains "[output]"
+    And the config file contains "title ="
 
   @wired
-  Scenario: generated config round-trips through the loader
+  Scenario: generated config round-trips through the loader with threshold live and no preset
     Given an empty project directory
     When the operator runs `crap4rs init --non-interactive`
     Then the generated config file loads without error
-    And the loaded config has preset "default"
-    And the loaded config has src "src"
+    And the config file contains 'threshold = 15.0'
+    And the loaded config has no top-level preset
 
   # ── Collision handling ────────────────────────────────────────────
 
@@ -89,7 +81,7 @@ Feature: crap4rs init subcommand
     Given a project directory with an existing "crap.toml" containing 'preset = "lenient"'
     When the operator runs `crap4rs init --non-interactive --force`
     Then the exit code is 0
-    And the config file contains 'preset = "default"'
+    And the config file contains 'threshold = 15.0'
     And the config file does not contain 'preset = "lenient"'
 
   # Cross-adapter parity for `crap4ts init` is exercised by the
@@ -110,29 +102,3 @@ Feature: crap4rs init subcommand
     When the operator runs `crap4rs init --help`
     Then stdout contains "--non-interactive"
     And stdout contains "--force"
-
-  # ── Interactive path (stdin-driven prompt) ─────────────────────────
-  #
-  # The prompt reads a single line from stdin and maps the first char
-  # to `ThresholdPreset` (s|S → Strict, l|L → Lenient, else → Default).
-  # The harness pipes input via `Command::stdin(Stdio::piped())`; no
-  # pty crate needed since the handler does no `isatty()` branching.
-  # CI users pass `--non-interactive` to skip the prompt.
-
-  @wired
-  Scenario: interactive prompt accepts "s" for strict
-    Given an empty project directory
-    When the operator runs `crap4rs init` with stdin "s\n"
-    Then the config file contains 'preset = "strict"'
-
-  @wired
-  Scenario: interactive prompt accepts "l" for lenient
-    Given an empty project directory
-    When the operator runs `crap4rs init` with stdin "l\n"
-    Then the config file contains 'preset = "lenient"'
-
-  @wired
-  Scenario: interactive prompt defaults to "default" on empty input
-    Given an empty project directory
-    When the operator runs `crap4rs init` with stdin "\n"
-    Then the config file contains 'preset = "default"'


### PR DESCRIPTION
## Summary

Closes the BDD self-honesty decay surfaced during #280: four `@wired` cucumber harnesses (`cli_init`, `cli_ergonomics`, `github_annotations`, `multi_lang_html`) were absent from CI's gated cucumber step, so their `@wired` claims went unenforced — and `cli_init`'s 14 scenarios had silently decayed against the #347 init rewrite (8 failing + 2 "zombie" false-greens that passed only by substring-matching comment lines, validating features that no longer exist).

## What changed

- **`cli_init.feature` rewritten to the #347 contract** (14 → 9 scenarios, all `@wired`). #347 (`2c3a82d`) replaced init's auto-detect + interactive prompt with a single deterministic annotated `crap.toml` dump; the spec had been frozen at #345. Scenarios for the removed features are **deleted** (not archived as dead specs); the two zombie false-greens — L34 matched a `# (src = "crates")` comment, L134 matched a commented `# preset = "default"` — are rewritten to assert real behavior. The round-trip scenario now **parses** the generated TOML to prove `preset` is absent (a substring check can't — `preset` appears on commented lines).
- **Harness pruned** (`cli_init_cucumber.rs`): removed the 3 step defs orphaned by the deletions (`given_dir_with_subdir_but_not`, `then_loaded_preset`, `then_loaded_src`); added a parsing-based `the loaded config has no top-level preset` step.
- **CI now gates all 4 harnesses** (`ci.yml`): appended `--test {cli_init,cli_ergonomics,github_annotations,multi_lang_html}_cucumber` to the gated cucumber step. A durable comment documents that the step **order is load-bearing** for `multi_lang_html` — it resolves the `crap-render` binary (a crap-core bin; `CARGO_BIN_EXE_crap-render` is unset for crap4rs-package tests) from the shared target built by the preceding `nextest --workspace --all-targets` step; reordering would silently break it.

No `src/` changes — `init.rs` is the intended #347 behavior. This is test + CI hygiene only.

## Verification

- `cargo nextest run --workspace --all-targets` (1322 tests) + the full 12-harness cucumber line green, run **in CI order** so the crap-render build-ordering is exercised.
- Per-harness `@wired`: `cli_init` 9/9, `cli_ergonomics` 7/7, `github_annotations` 17/17, `multi_lang_html` 11/11.
- `bdd-tracked-lint.py` (Rule 1+2), `mutants-skip-lint.py`, `cargo fmt --check`, clippy (1.96, `-D warnings`), MSRV (1.93), `actionlint` — all green.

Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test coverage for the `crap4rs init` command to validate deterministic configuration generation regardless of project layout.

* **Chores**
  * Updated CI workflow test configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->