### PR TITLE
docs(crap-core): #260 — correct stale 15/25/40⇄8/16/30 threshold tiers to flat 8/15/25

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -339,11 +339,15 @@ then CRAP/threshold ratio desc within band).
 Two axes are deliberately kept distinct here, since #317's prose
 conflates them: `RiskLevel` **bands** are score-based, fixed in
 `classify_risk` (≤8 Low / ≤15 Acceptable / ≤25 Moderate / else High),
-metric-agnostic, and independent of `--threshold`; the per-adapter
-**calibrated thresholds** (cognitive 15/25/40 ⇄ cyclomatic 8/16/30)
-drive the `--threshold` GATE (`exceeds` / scorecard-row `status`),
-which is the separate axis the scorecard-row + default-gate canaries
-own. The RiskLevel canary pins the band axis only.
+metric-agnostic, and independent of `--threshold`; the
+**preset thresholds** (strict/default/lenient, flat `8/15/25` across
+both metrics today, routed through metric-keyed infrastructure so a
+future per-metric recalibration stays a one-line change) drive the
+`--threshold` GATE (`exceeds` / scorecard-row `status`), which is the
+separate axis the scorecard-row + default-gate canaries own. The
+RiskLevel canary pins the band axis only. The two axes share the same
+`8/15/25` numbers today but remain conceptually distinct: the band is
+score-based via `classify_risk`, the gate is `preset.threshold(metric)`.
 
 **Mechanical enforcement**:
 `crates/crap-core/tests/risk_level_cross_adapter.rs` (test fn

--- a/crates/crap-core/tests/risk_level_cross_adapter.rs
+++ b/crates/crap-core/tests/risk_level_cross_adapter.rs
@@ -44,20 +44,26 @@
 //! ## Why this is NOT "mapped against per-adapter thresholds"
 //!
 //! Issue #317's prose says to map the High/Moderate/Acceptable/Low
-//! buckets "against their respective per-adapter thresholds
-//! (cognitive 15/25/40 ⇄ cyclomatic 8/16/30)". Reading the substrate
-//! shows those two things are distinct and must not be conflated:
+//! buckets "against their respective per-adapter thresholds". (#317
+//! was written when the presets were metric-keyed to different numbers
+//! per metric; #281 later flattened them to `8/15/25` for both metrics,
+//! so there is no longer a per-metric threshold split — but the
+//! distinction below holds regardless of the numbers.) Reading the
+//! substrate shows the band and the gate are distinct and must not be
+//! conflated:
 //!
 //! * **`RiskLevel` bands are score-based and shared.** `classify_risk`
 //!   keys off the raw CRAP *score* (≤8 Low, ≤15 Acceptable, ≤25
 //!   Moderate, else
 //!   High) and is metric-agnostic — identical for both adapters,
 //!   independent of any `--threshold`.
-//! * **The per-adapter calibrated numbers drive the `--threshold`
+//! * **The preset threshold numbers drive the `--threshold`
 //!   GATE**, not the risk band. They decide `exceeds` /
 //!   scorecard-row `status` (Green/Yellow/Red), which is a *separate*
 //!   axis already locked by `scorecard_row_parity.rs` +
-//!   `default_gate_threshold.rs`.
+//!   `default_gate_threshold.rs`. (They happen to equal the band
+//!   numbers `8/15/25` today, but the gate is `preset.threshold(metric)`,
+//!   not `classify_risk`.)
 //!
 //! So the honest invariant — the one ζ's Combined-view ranking
 //! actually depends on (risk-level desc, then CRAP/threshold ratio


### PR DESCRIPTION
## Summary

Corrects stale threshold-tier numbers in two current-state descriptions. The strict/default/lenient presets were re-flattened to **8/15/25 across both metrics** in #281 ("align CRAP thresholds + risk tiers"), superseding #222's metric-keyed `8/16/30` (cyclomatic) ⇄ `15/25/40` (cognitive) calibration. Two docs still asserted the dead #222 numbers as live.

## What changed

- **`AGENTS.md`** (RiskLevel-consistency section): reworded "calibrated thresholds (cognitive 15/25/40 ⇄ cyclomatic 8/16/30)" to the actual flat `8/15/25`, noting the values route through metric-keyed infrastructure so a future per-metric recalibration stays a one-line change. The band-vs-gate distinction the section teaches is preserved.
- **`crates/crap-core/tests/risk_level_cross_adapter.rs`** (doc comment): #317's prose is kept as a *historical quote* but annotated that #281 flattened the numbers; the two-axes teaching point (score-based `RiskLevel` band via `classify_risk` vs the `preset.threshold(metric)` gate) is unchanged, now noting both equal `8/15/25` today.

Comment/doc-only — no behavior change; the canary still compiles and the invariant it pins is intact.

## Not touched (deliberate)

The crap4rs/crap4ts **CHANGELOG** entries that attribute #222's `8/16/30 / 15/25/40` calibration to #281 are release history (the Fixed entry contradicts #281's own "align to 8/15/25" entry one section above). Correcting release-history attribution is left for a separate maintainer decision rather than rewritten here.

Part of #260 (self-honesty cleanup surfaced during the CRAP-8 campaign).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified documentation around risk assessment and threshold behavior to better distinguish their respective roles in scoring and gating processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->