### PR TITLE
refactor(crap-core): #260 — decompose matching.rs below cognitive-8

### DIFF
--- a/crates/crap-core/src/domain/matching.rs
+++ b/crates/crap-core/src/domain/matching.rs
@@ -59,23 +59,46 @@ pub fn match_functions(
     results
 }
 
+/// Returns `true` if `line` falls within `span`'s inclusive `[start_line,
+/// end_line]` range. The single point-in-span test both line- and
+/// branch-coverage counting share.
+fn line_within_span(span: SourceSpan, line: usize) -> bool {
+    line >= span.start_line && line <= span.end_line
+}
+
+/// Counts `(covered, total)` instrumentable lines whose line number falls
+/// within `span`. A line is covered when its hit count is nonzero.
+fn count_line_coverage(span: SourceSpan, file_lines: &[LineCoverage]) -> (usize, usize) {
+    let in_span = file_lines
+        .iter()
+        .filter(|line| line_within_span(span, line.line));
+
+    let total = in_span.clone().count();
+    let covered = in_span.filter(|line| line.hits > 0).count();
+    (covered, total)
+}
+
+/// Counts `(covered, total)` branch points within `span`. Only branches
+/// with a recorded `taken` count participate; a branch is covered when
+/// that count is nonzero.
+fn count_branch_coverage(span: SourceSpan, branches: &[BranchCoverage]) -> (usize, usize) {
+    let taken_in_span = branches
+        .iter()
+        .filter(|branch| line_within_span(span, branch.line))
+        .filter_map(|branch| branch.taken);
+
+    let total = taken_in_span.clone().count();
+    let covered = taken_in_span.filter(|&taken| taken > 0).count();
+    (covered, total)
+}
+
 fn compute_function_coverage(
     file_path: &str,
     span: SourceSpan,
     file_lines: &[LineCoverage],
     file_branches: Option<&[BranchCoverage]>,
 ) -> FunctionCoverage {
-    let mut total = 0usize;
-    let mut covered = 0usize;
-
-    for line in file_lines {
-        if line.line >= span.start_line && line.line <= span.end_line {
-            total += 1;
-            if line.hits > 0 {
-                covered += 1;
-            }
-        }
-    }
+    let (covered, total) = count_line_coverage(span, file_lines);
 
     let percent = if total > 0 {
         (covered as f64 / total as f64) * 100.0
@@ -99,20 +122,7 @@ fn compute_function_coverage(
 }
 
 fn compute_branch_coverage(span: SourceSpan, branches: &[BranchCoverage]) -> Option<CoverageRatio> {
-    let mut total = 0usize;
-    let mut covered = 0usize;
-
-    for branch in branches {
-        if branch.line >= span.start_line
-            && branch.line <= span.end_line
-            && let Some(taken) = branch.taken
-        {
-            total += 1;
-            if taken > 0 {
-                covered += 1;
-            }
-        }
-    }
+    let (covered, total) = count_branch_coverage(span, branches);
 
     if total == 0 {
         return None;


### PR DESCRIPTION
## Summary

CRAP-8 campaign slice: decomposes the two over-8 functions in `crates/crap-core/src/domain/matching.rs` (line-range coverage matching) below cognitive-8. Pure-complexity decomposition — these are ~100% covered, so cc is the lever.

## What changed

| Function | cognitive before → after | Decomposition |
|---|---|---|
| `compute_function_coverage` | 9 → **2** | thin ratio-builder over extracted counters |
| `compute_branch_coverage` | 10 → **2** | thin ratio-builder over extracted counters |

Three in-file private helpers (each cc ≤ 2):
- `line_within_span(span, line)` — the inclusive point-in-span test (`line >= start && line <= end`), shared by both counters.
- `count_line_coverage(span, file_lines)` — covered/total over `LineCoverage` in span (covered = hits > 0).
- `count_branch_coverage(span, branches)` — covered/total over `BranchCoverage` in span (`filter_map(taken)` drops `None` exactly as the original `if let Some(taken)`).

The `total == 0` fork is deliberately kept inline per parent (function → 100.0 trivially-covered; branch → `None`), since the empty-case semantics differ. Coverage math is **byte-identical** — the inclusive boundary check moved verbatim into the predicate.

## Domain purity preserved

`matching.rs` is in the purity-enforced `domain/` layer. No non-domain import added — production imports remain only `super::types::{...}` + `std::collections::HashMap` (verified). Helpers operate exclusively on existing domain types.

## Verification

- `cargo nextest run --workspace --all-targets` — 1322/1322 pass.
- **The line-range boundary-invariant proptests all pass** (the correctness net for this file): `boundary_precision`, `boundary_inclusive_start`/`_end`, `coverage_always_0_to_100`, `covered_lte_total`, `no_cross_file_leakage`, the `branch_*` variants, and both fork guards (`no_instrumentable_lines_100_pct`, `no_branch_points_gives_none`) — 40/40 matching tests green.
- Analyzer cc re-measurement: both targets cc2, all 3 helpers ≤ 2; highest production fn in the file is `match_functions` at 5 (unchanged); nothing above 8.
- `cargo fmt --check`, `cargo +1.96.0 clippy --workspace --all-targets -- -D warnings`, `cargo +1.93 check --workspace --all-targets` (MSRV) — all green.

Part of #260 (gate flip lands with the final slice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
