### PR TITLE
feat(core+cli): #278 — configurable missing-coverage policy (pessimistic|optimistic|skip)

### DIFF
--- a/crap.example.toml
+++ b/crap.example.toml
@@ -15,6 +15,11 @@ threshold = 15.0
 # or `"cyclomatic"`.
 metric = "cognitive"
 
+# How to score a function whose source file is entirely absent from
+# the coverage data: `"pessimistic"` (default — 0% covered),
+# `"optimistic"` (100% covered), or `"skip"` (omit from the report).
+missing_coverage_policy = "optimistic"
+
 # Source root(s) the analyzer walks. Accepts a single string
 # (`src = "crates"`) or an array (`src = ["crate-a", "crate-b"]`).
 # A single root stays src-relative; multiple roots are keyed

--- a/crap.schema.json
+++ b/crap.schema.json
@@ -28,6 +28,13 @@
         "null"
       ]
     },
+    "missing_coverage_policy": {
+      "description": "How to score a function whose source file is entirely absent from\nthe coverage data: `\"pessimistic\"` (default — 0% covered),\n`\"optimistic\"` (100% covered), or `\"skip\"` (omit from the report).",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "output": {
       "description": "Output-shaping settings (`[output]`): annotation cap, scorecard\ntitle, and subtitle.",
       "$ref": "#/$defs/OutputSchema"

--- a/crates/crap-core/src/adapters/baseline.rs
+++ b/crates/crap-core/src/adapters/baseline.rs
@@ -16,7 +16,7 @@
 //! column-keyed). Future schema bumps will need an explicit
 //! migration path.
 
-use crate::domain::types::{AnalysisDiagnostics, AnalysisResult};
+use crate::domain::types::{AnalysisDiagnostics, AnalysisResult, MissingCoveragePolicy};
 use crate::ports::ParseDiagnostic;
 use serde::Deserialize;
 use std::fs::File;
@@ -55,6 +55,13 @@ struct BaselineEnvelope<P: ParseDiagnostic> {
     result: AnalysisResult,
     #[serde(default)]
     diagnostics: Option<AnalysisDiagnostics<P>>,
+    /// Policy the baseline was generated under. Absent on envelopes
+    /// emitted before the field existed, and on any pessimistic run
+    /// (the emitter elides the default) — both deserialize to
+    /// `Pessimistic` via `Default`, the load-bearing "absent ⇒
+    /// pessimistic" convention the delta mismatch warning relies on.
+    #[serde(default)]
+    missing_coverage_policy: MissingCoveragePolicy,
 }
 
 /// What the loader returns to callers. The fields are all the metadata
@@ -69,6 +76,10 @@ pub struct BaselineSnapshot<P: ParseDiagnostic> {
     pub tool_version: String,
     pub timestamp: String,
     pub diagnostics: Option<AnalysisDiagnostics<P>>,
+    /// Policy the baseline was generated under (`Pessimistic` when the
+    /// envelope omits the key). The delta path compares this to the
+    /// current run's policy and warns on a mismatch.
+    pub missing_coverage_policy: MissingCoveragePolicy,
 }
 
 /// Errors raised while loading a baseline envelope.
@@ -147,6 +158,7 @@ pub fn load<P: ParseDiagnostic>(path: &Path) -> Result<BaselineSnapshot<P>, Base
         tool_version: envelope.tool_version,
         timestamp: envelope.timestamp,
         diagnostics: envelope.diagnostics,
+        missing_coverage_policy: envelope.missing_coverage_policy,
     })
 }
 
@@ -217,6 +229,44 @@ mod tests {
         assert_eq!(snapshot.result.functions.len(), 0);
         assert!(snapshot.result.passed);
         assert!(snapshot.diagnostics.is_none());
+    }
+
+    #[test]
+    fn load_envelope_without_policy_defaults_to_pessimistic() {
+        // The "absent ⇒ pessimistic" convention the delta mismatch warning
+        // relies on: a baseline that omits the key (pre-field envelopes and
+        // every pessimistic run, which elides the default) loads as
+        // Pessimistic.
+        let file = write_envelope(minimal_envelope_json());
+        let snapshot = load_test(file.path()).expect("load minimal envelope");
+        assert_eq!(
+            snapshot.missing_coverage_policy,
+            MissingCoveragePolicy::Pessimistic
+        );
+    }
+
+    #[test]
+    fn load_envelope_with_policy_round_trips() {
+        let json = r#"{
+            "schema_version": 2,
+            "missing_coverage_policy": "optimistic",
+            "result": {
+                "functions": [],
+                "summary": {
+                    "total_functions": 0, "total_files": 0, "exceeding_threshold": 0,
+                    "average_crap": 0.0, "median_crap": 0.0,
+                    "max_crap": null, "worst_function": null,
+                    "distribution": { "low": 0, "acceptable": 0, "moderate": 0, "high": 0 }
+                },
+                "passed": true
+            }
+        }"#;
+        let file = write_envelope(json);
+        let snapshot = load_test(file.path()).expect("load envelope with policy");
+        assert_eq!(
+            snapshot.missing_coverage_policy,
+            MissingCoveragePolicy::Optimistic
+        );
     }
 
     #[test]

--- a/crates/crap-core/src/adapters/config.rs
+++ b/crates/crap-core/src/adapters/config.rs
@@ -15,7 +15,7 @@ use serde::Deserialize;
 use crate::cli::AdapterMeta;
 
 use crate::domain::threshold::{ThresholdOverride, ThresholdPreset, is_valid_threshold};
-use crate::domain::types::ComplexityMetric;
+use crate::domain::types::{ComplexityMetric, MissingCoveragePolicy};
 use crate::domain::view::{CoverageRange, CoverageRangeError, GroupKey, SortKey};
 
 // ── Parsed config types (re-exported from domain) ──────────────────
@@ -75,6 +75,10 @@ pub struct ConfigSchema {
     /// Complexity metric: `"cognitive"` (default for the Rust adapter)
     /// or `"cyclomatic"`.
     pub metric: Option<String>,
+    /// How to score a function whose source file is entirely absent from
+    /// the coverage data: `"pessimistic"` (default — 0% covered),
+    /// `"optimistic"` (100% covered), or `"skip"` (omit from the report).
+    pub missing_coverage_policy: Option<String>,
     /// Source root(s) the analyzer walks. Accepts a single string
     /// (`src = "crates"`) or an array (`src = ["crate-a", "crate-b"]`).
     /// A single root stays src-relative; multiple roots are keyed
@@ -268,6 +272,11 @@ pub enum ConfigError {
     /// An unrecognized `metric` string.
     #[error("unknown metric: {value}\n  valid values: cognitive, cyclomatic")]
     UnknownMetric { value: String },
+    /// An unrecognized `missing_coverage_policy` string.
+    #[error(
+        "unknown missing_coverage_policy: {value}\n  valid values: pessimistic, optimistic, skip"
+    )]
+    UnknownMissingCoveragePolicy { value: String },
     /// An unrecognized view-preset `sort` string. `preset` names the
     /// `[views.<name>]` block.
     #[error(
@@ -445,6 +454,11 @@ fn parse_config(content: &str) -> Result<FileConfig, ConfigError> {
     validate_raw_config(&raw)?;
 
     let metric = raw.metric.as_deref().map(parse_metric).transpose()?;
+    let missing_coverage_policy = raw
+        .missing_coverage_policy
+        .as_deref()
+        .map(parse_missing_coverage_policy)
+        .transpose()?;
     let preset = raw.preset.as_deref().map(parse_preset).transpose()?;
 
     let overrides = parse_overrides(raw.overrides);
@@ -455,6 +469,7 @@ fn parse_config(content: &str) -> Result<FileConfig, ConfigError> {
         threshold: raw.threshold,
         preset,
         metric,
+        missing_coverage_policy,
         src: raw.src.map(SrcSpec::into_paths).unwrap_or_default(),
         exclude: raw.exclude,
         overrides,
@@ -702,6 +717,17 @@ fn parse_metric(s: &str) -> Result<ComplexityMetric, ConfigError> {
     }
 }
 
+fn parse_missing_coverage_policy(s: &str) -> Result<MissingCoveragePolicy, ConfigError> {
+    match s {
+        "pessimistic" => Ok(MissingCoveragePolicy::Pessimistic),
+        "optimistic" => Ok(MissingCoveragePolicy::Optimistic),
+        "skip" => Ok(MissingCoveragePolicy::Skip),
+        other => Err(ConfigError::UnknownMissingCoveragePolicy {
+            value: other.to_string(),
+        }),
+    }
+}
+
 // ── JSON Schema artifact ───────────────────────────────────────────
 
 /// Render the committed JSON Schema for [`ConfigSchema`] as pretty JSON.
@@ -787,6 +813,7 @@ pub fn render_example_config(meta: &AdapterMeta) -> String {
         threshold,
         preset,
         metric,
+        missing_coverage_policy,
         src,
         exclude,
         overrides,
@@ -810,7 +837,14 @@ pub fn render_example_config(meta: &AdapterMeta) -> String {
     root.set_implicit(false);
 
     emit_header_banner(root, meta);
-    emit_top_scalars(root, threshold, metric, src, exclude);
+    emit_top_scalars(
+        root,
+        threshold,
+        metric,
+        missing_coverage_policy,
+        src,
+        exclude,
+    );
     emit_overrides_block(root, overrides);
     emit_views_block(root, views);
     emit_language_block(root, language);
@@ -840,6 +874,7 @@ fn emit_top_scalars(
     root: &mut toml_edit::Table,
     threshold: Option<f64>,
     metric: Option<String>,
+    missing_coverage_policy: Option<String>,
     src: Option<SrcSpec>,
     exclude: Option<Vec<String>>,
 ) {
@@ -859,6 +894,17 @@ fn emit_top_scalars(
 
     root.insert("metric", value(metric.expect("metric set")));
     comment_key(root, "metric", field_doc::<ConfigSchema>("metric"), true);
+
+    root.insert(
+        "missing_coverage_policy",
+        value(missing_coverage_policy.expect("missing_coverage_policy set")),
+    );
+    comment_key(
+        root,
+        "missing_coverage_policy",
+        field_doc::<ConfigSchema>("missing_coverage_policy"),
+        true,
+    );
 
     // src: emit the multi-root array form (the exhaustive shape).
     let mut src_arr = Array::new();
@@ -1182,6 +1228,7 @@ fn exhaustive_example(meta: &AdapterMeta) -> ConfigSchema {
         threshold: Some(15.0),
         preset: None,
         metric: Some("cognitive".to_string()),
+        missing_coverage_policy: Some("optimistic".to_string()),
         src: Some(SrcSpec::Many(vec![
             "crates/core/src".to_string(),
             "crates/cli/src".to_string(),
@@ -1264,6 +1311,30 @@ mod tests {
             ConfigError::UnknownMetric { value } => assert_eq!(value, "halstead"),
             other => panic!("expected UnknownMetric, got: {other:?}"),
         }
+    }
+
+    #[test]
+    fn parse_config_returns_typed_unknown_missing_coverage_policy() {
+        let err = parse_config("missing_coverage_policy = \"halt\"\n").unwrap_err();
+        match err {
+            ConfigError::UnknownMissingCoveragePolicy { value } => assert_eq!(value, "halt"),
+            other => panic!("expected UnknownMissingCoveragePolicy, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_config_parses_missing_coverage_policy() {
+        let config = parse_config("missing_coverage_policy = \"skip\"\n").unwrap();
+        assert_eq!(
+            config.missing_coverage_policy,
+            Some(MissingCoveragePolicy::Skip)
+        );
+    }
+
+    #[test]
+    fn parse_config_missing_coverage_policy_absent_is_none() {
+        let config = parse_config("threshold = 10.0\n").unwrap();
+        assert_eq!(config.missing_coverage_policy, None);
     }
 
     #[test]

--- a/crates/crap-core/src/adapters/reporters/json.rs
+++ b/crates/crap-core/src/adapters/reporters/json.rs
@@ -9,6 +9,7 @@
 use crate::domain::delta::{DeltaSummary, DeltaView, DeltaViewSpec, FunctionChange};
 use crate::domain::types::{
     AnalysisDiagnostics, AnalysisResult, AnalysisSummary, ComplexityMetric, FunctionVerdict,
+    MissingCoveragePolicy,
 };
 use crate::domain::view::{AnalysisView, GroupedView, ViewSpec};
 use crate::ports::ParseDiagnostic;
@@ -24,6 +25,11 @@ use serde::Serialize;
 pub struct JsonConfig<'a, P: ParseDiagnostic> {
     pub tool_version: String,
     pub metric: ComplexityMetric,
+    /// Resolved missing-coverage policy for this run. Recorded in the
+    /// envelope (unless `Pessimistic`) so a baseline captures the policy
+    /// it was generated under and a later delta run can warn on a
+    /// mismatch.
+    pub missing_coverage_policy: MissingCoveragePolicy,
     pub threshold: f64,
     pub timestamp: String,
     /// When present, diagnostics are included in the JSON output (--verbose).
@@ -86,6 +92,22 @@ struct JsonEnvelope<'a, P: ParseDiagnostic> {
     delta: Option<DeltaWire<'a, P>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     diagnostics: Option<&'a AnalysisDiagnostics<P>>,
+    /// Missing-coverage policy. Elided when `Pessimistic` (the default)
+    /// so every existing pessimistic-run envelope stays byte-identical;
+    /// emitted as `"optimistic"` / `"skip"` otherwise. A reader treats an
+    /// absent key as `Pessimistic` (see `baseline::BaselineEnvelope`).
+    /// Additive — does not bump `schema_version` (the default case is
+    /// unchanged).
+    #[serde(skip_serializing_if = "is_pessimistic")]
+    missing_coverage_policy: MissingCoveragePolicy,
+}
+
+/// `skip_serializing_if` predicate: elide the envelope's
+/// `missing_coverage_policy` key when it carries the default, so a
+/// pessimistic run's envelope is byte-identical to before the field
+/// existed.
+fn is_pessimistic(policy: &MissingCoveragePolicy) -> bool {
+    *policy == MissingCoveragePolicy::Pessimistic
 }
 
 /// On-the-wire delta representation. Mirrors the `delta` envelope key
@@ -194,6 +216,7 @@ pub fn format_json<P: ParseDiagnostic>(
         view: ViewWire::from_view(view, config.minimal_view),
         delta: delta_wire,
         diagnostics: config.diagnostics,
+        missing_coverage_policy: config.missing_coverage_policy,
     };
     serde_json::to_string_pretty(&envelope)
 }
@@ -216,6 +239,7 @@ mod tests {
         JsonConfig {
             tool_version: "0.1.0".to_string(),
             metric: ComplexityMetric::Cognitive,
+            missing_coverage_policy: MissingCoveragePolicy::Pessimistic,
             threshold: 8.0,
             timestamp: "2026-03-28T12:00:00Z".to_string(),
             diagnostics: None,
@@ -257,6 +281,38 @@ mod tests {
         assert!(r.get("functions").is_some());
         assert!(r.get("summary").is_some());
         assert!(r.get("passed").is_some());
+    }
+
+    #[test]
+    fn missing_coverage_policy_elided_when_pessimistic() {
+        // The default policy keeps the envelope byte-identical to before
+        // the field existed — the key is absent entirely.
+        let result = make_empty_result();
+        let v = parse_json(&result, &default_config());
+        assert!(
+            v.get("missing_coverage_policy").is_none(),
+            "pessimistic policy must elide the envelope key"
+        );
+    }
+
+    #[test]
+    fn missing_coverage_policy_emitted_when_non_default() {
+        let result = make_empty_result();
+        for (policy, wire) in [
+            (MissingCoveragePolicy::Optimistic, "optimistic"),
+            (MissingCoveragePolicy::Skip, "skip"),
+        ] {
+            let config = JsonConfig {
+                missing_coverage_policy: policy,
+                ..default_config()
+            };
+            let v = parse_json(&result, &config);
+            assert_eq!(
+                v.get("missing_coverage_policy").and_then(|x| x.as_str()),
+                Some(wire),
+                "non-default policy must serialize its wire token"
+            );
+        }
     }
 
     #[test]
@@ -603,6 +659,7 @@ mod proptests {
         (1.0..100.0f64,).prop_map(|(threshold,)| JsonConfig {
             tool_version: "0.1.0".to_string(),
             metric: ComplexityMetric::Cognitive,
+            missing_coverage_policy: MissingCoveragePolicy::Pessimistic,
             threshold,
             timestamp: "2026-01-01T00:00:00Z".to_string(),
             diagnostics: None,

--- a/crates/crap-core/src/cli/mod.rs
+++ b/crates/crap-core/src/cli/mod.rs
@@ -24,7 +24,7 @@ use crate::adapters::reporters::json::DeltaContext;
 use crate::core::{AnalysisOutput, AnalyzeOptions};
 use crate::domain::delta::{self, AnalysisDelta, DeltaView};
 use crate::domain::threshold::{ThresholdConfig, ThresholdPreset, is_valid_threshold};
-use crate::domain::types::{AnalysisDiagnostics, ComplexityMetric};
+use crate::domain::types::{AnalysisDiagnostics, ComplexityMetric, MissingCoveragePolicy};
 use crate::domain::view::{self, GroupKey, SortKey};
 use crate::ports::{ComplexityPort, CoveragePort, ParseDiagnostic};
 
@@ -48,6 +48,28 @@ impl From<MetricArg> for ComplexityMetric {
         match arg {
             MetricArg::Cognitive => ComplexityMetric::Cognitive,
             MetricArg::Cyclomatic => ComplexityMetric::Cyclomatic,
+        }
+    }
+}
+
+/// How to score a function whose source file is absent from the coverage
+/// data. Clap-side wrapper that keeps `clap::ValueEnum` out of the domain.
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum MissingCoveragePolicyArg {
+    /// Score as 0% covered (CRAP = c² + c) — the default, never hides risk
+    Pessimistic,
+    /// Score as 100% covered (CRAP = c) — for scoped local test slices
+    Optimistic,
+    /// Omit such functions from the report entirely
+    Skip,
+}
+
+impl From<MissingCoveragePolicyArg> for MissingCoveragePolicy {
+    fn from(arg: MissingCoveragePolicyArg) -> Self {
+        match arg {
+            MissingCoveragePolicyArg::Pessimistic => MissingCoveragePolicy::Pessimistic,
+            MissingCoveragePolicyArg::Optimistic => MissingCoveragePolicy::Optimistic,
+            MissingCoveragePolicyArg::Skip => MissingCoveragePolicy::Skip,
         }
     }
 }
@@ -307,6 +329,11 @@ pub struct InputArgs {
     /// Complexity metric to use
     #[arg(long, value_enum)]
     pub metric: Option<MetricArg>,
+
+    /// How to score functions whose file is absent from the coverage data
+    /// [default: pessimistic]
+    #[arg(long, value_enum)]
+    pub missing_coverage_policy: Option<MissingCoveragePolicyArg>,
 
     /// Path to config file (default: auto-discover the adapter's config TOML)
     #[arg(long, value_name = "FILE", value_hint = ValueHint::FilePath)]
@@ -1110,6 +1137,10 @@ struct EffectiveInputs {
     /// byte-identical back-compat case (crap-rs#336).
     src: Vec<PathBuf>,
     metric: ComplexityMetric,
+    /// Resolved policy for functions whose file is absent from coverage.
+    /// CLI flag wins over the top-level config key; defaults to
+    /// `Pessimistic`. Top-level only — no per-language overlay.
+    missing_coverage_policy: MissingCoveragePolicy,
     threshold_config: ThresholdConfig,
     threshold: f64,
     exclude: Vec<String>,
@@ -1183,6 +1214,16 @@ fn merge_effective_inputs(
         .or_else(|| lang.and_then(|l| l.metric))
         .or_else(|| file_config.as_ref().and_then(|c| c.metric))
         .unwrap_or(meta.default_metric);
+    // CLI flag wins over the top-level config key, then the domain
+    // default (`Pessimistic`). Top-level only — no per-language overlay,
+    // since the policy governs the whole run's treatment of files absent
+    // from coverage.
+    let missing_coverage_policy = cli
+        .input
+        .missing_coverage_policy
+        .map(Into::into)
+        .or_else(|| file_config.as_ref().and_then(|c| c.missing_coverage_policy))
+        .unwrap_or_default();
     let (threshold_config, threshold) = merge_threshold(cli, file_config, lang, metric);
     let exclude = merge_exclude(cli, file_config, lang, meta);
     let annotation_limit = cli
@@ -1199,6 +1240,7 @@ fn merge_effective_inputs(
     EffectiveInputs {
         src,
         metric,
+        missing_coverage_policy,
         threshold_config,
         threshold,
         exclude,
@@ -1366,6 +1408,7 @@ fn build_analyze_options(
         coverage: coverage.to_path_buf(),
         threshold_config: inputs.threshold_config.clone(),
         metric: inputs.metric,
+        missing_coverage_policy: inputs.missing_coverage_policy,
         exclude: inputs.exclude.clone(),
         respect_gitignore: !cli.filter.no_gitignore,
         diff_ref: cli.filter.diff.clone(),
@@ -3418,6 +3461,7 @@ mod tests {
         EffectiveInputs {
             src: roots,
             metric: ComplexityMetric::Cognitive,
+            missing_coverage_policy: MissingCoveragePolicy::Pessimistic,
             threshold_config: crate::domain::threshold::ThresholdConfig::default(),
             threshold: 15.0,
             exclude: Vec::new(),
@@ -3554,6 +3598,55 @@ mod tests {
         });
         let inputs = merge_effective_inputs(&cli, &file_config, &fake_meta());
         assert!(matches!(inputs.metric, ComplexityMetric::Cyclomatic));
+    }
+
+    #[test]
+    fn merge_effective_inputs_default_missing_coverage_policy_is_pessimistic() {
+        // No CLI flag, no config key → the domain default (Pessimistic),
+        // which preserves the historic 0%-coverage behavior.
+        let cli = parse(&["--coverage", "lcov.info"]).unwrap();
+        let inputs = merge_effective_inputs(&cli, &None, &fake_meta());
+        assert!(matches!(
+            inputs.missing_coverage_policy,
+            MissingCoveragePolicy::Pessimistic
+        ));
+    }
+
+    #[test]
+    fn merge_effective_inputs_config_sets_missing_coverage_policy() {
+        // Config key flows through when no CLI flag overrides it.
+        let cli = parse(&["--coverage", "lcov.info"]).unwrap();
+        let file_config = Some(FileConfig {
+            missing_coverage_policy: Some(MissingCoveragePolicy::Optimistic),
+            ..FileConfig::default()
+        });
+        let inputs = merge_effective_inputs(&cli, &file_config, &fake_meta());
+        assert!(matches!(
+            inputs.missing_coverage_policy,
+            MissingCoveragePolicy::Optimistic
+        ));
+    }
+
+    #[test]
+    fn merge_effective_inputs_cli_missing_coverage_policy_overrides_config() {
+        // CLI flag wins over the config key (the cascade is CLI > config
+        // > default, same as every other knob).
+        let cli = parse(&[
+            "--coverage",
+            "lcov.info",
+            "--missing-coverage-policy",
+            "skip",
+        ])
+        .unwrap();
+        let file_config = Some(FileConfig {
+            missing_coverage_policy: Some(MissingCoveragePolicy::Optimistic),
+            ..FileConfig::default()
+        });
+        let inputs = merge_effective_inputs(&cli, &file_config, &fake_meta());
+        assert!(matches!(
+            inputs.missing_coverage_policy,
+            MissingCoveragePolicy::Skip
+        ));
     }
 
     #[test]

--- a/crates/crap-core/src/cli/mod.rs
+++ b/crates/crap-core/src/cli/mod.rs
@@ -1528,7 +1528,7 @@ where
     // envelope and compute the AnalysisDelta. None when --baseline is
     // absent — the JSON envelope omits the `delta` block entirely so
     // existing consumers see byte-identical output.
-    let delta_state = load_delta_state(cli, &analysis.result)?;
+    let delta_state = load_delta_state(cli, &analysis.result, options.missing_coverage_policy)?;
 
     Ok(PipelinePrep {
         inputs,
@@ -1557,6 +1557,7 @@ fn format_as_json<P: ParseDiagnostic>(
     let config = reporters::json::JsonConfig {
         tool_version: meta.tool_version.to_string(),
         metric: inputs.metric,
+        missing_coverage_policy: inputs.missing_coverage_policy,
         threshold: inputs.threshold,
         timestamp: now_unix_epoch(),
         diagnostics: cli.display.verbose.then_some(&analysis.diagnostics),
@@ -1756,15 +1757,40 @@ struct DeltaState<P: ParseDiagnostic> {
 fn load_delta_state<P: ParseDiagnostic>(
     cli: &Cli,
     current: &crate::domain::types::AnalysisResult,
+    current_policy: MissingCoveragePolicy,
 ) -> Result<Option<DeltaState<P>>> {
     let Some(path) = cli.input.baseline.as_ref() else {
         return Ok(None);
     };
     let snapshot = baseline::load::<P>(path).map_err(|e| anyhow::anyhow!("{e}"))?;
+    if let Some(msg) = policy_mismatch_warning(snapshot.missing_coverage_policy, current_policy) {
+        eprintln!("{msg}");
+    }
     // delta::compute consumes both — we own snapshot.result, clone the
     // current analysis so the surrounding pipeline keeps its handle.
     let delta = delta::compute(snapshot.result.clone(), current.clone());
     Ok(Some(DeltaState { snapshot, delta }))
+}
+
+/// The warning text when the baseline and the current run used different
+/// missing-coverage policies, or `None` when they match. The delta
+/// compares two analyses that scored coverage-absent functions under
+/// different rules, so the per-function deltas can mislead: a
+/// `pessimistic` → `optimistic` switch makes every such function look
+/// like a large improvement, and a `pessimistic` → `skip` switch makes
+/// them look *deleted* (present in the baseline, absent now). Pure so the
+/// message is unit-testable; the caller emits it as a non-fatal stderr
+/// warning (the delta still computes).
+fn policy_mismatch_warning(
+    baseline: MissingCoveragePolicy,
+    current: MissingCoveragePolicy,
+) -> Option<String> {
+    (baseline != current).then(|| {
+        format!(
+            "warning: baseline used `missing_coverage_policy = {baseline}` but this run uses `{current}`; \
+             delta scores for functions absent from coverage may be misleading"
+        )
+    })
 }
 
 fn validate_display_flags(cli: &Cli) -> Result<()> {
@@ -3647,6 +3673,47 @@ mod tests {
             inputs.missing_coverage_policy,
             MissingCoveragePolicy::Skip
         ));
+    }
+
+    #[test]
+    fn policy_mismatch_warning_none_when_policies_match() {
+        assert!(
+            policy_mismatch_warning(
+                MissingCoveragePolicy::Pessimistic,
+                MissingCoveragePolicy::Pessimistic
+            )
+            .is_none()
+        );
+        assert!(
+            policy_mismatch_warning(MissingCoveragePolicy::Skip, MissingCoveragePolicy::Skip)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn policy_mismatch_warning_flags_pessimistic_baseline_vs_skip_current() {
+        // The phantom-deletion case: a pessimistic baseline scored
+        // coverage-absent functions at 0% (present in the baseline); a
+        // `skip` current run omits them, so the delta reads them as
+        // deletions. The warning must name both policies.
+        let msg = policy_mismatch_warning(
+            MissingCoveragePolicy::Pessimistic,
+            MissingCoveragePolicy::Skip,
+        )
+        .expect("mismatched policies must warn");
+        assert!(msg.contains("pessimistic"), "names the baseline policy");
+        assert!(msg.contains("skip"), "names the current policy");
+        assert!(msg.contains("misleading"), "flags the comparison risk");
+    }
+
+    #[test]
+    fn policy_mismatch_warning_flags_pessimistic_baseline_vs_optimistic_current() {
+        let msg = policy_mismatch_warning(
+            MissingCoveragePolicy::Pessimistic,
+            MissingCoveragePolicy::Optimistic,
+        )
+        .expect("mismatched policies must warn");
+        assert!(msg.contains("pessimistic") && msg.contains("optimistic"));
     }
 
     #[test]

--- a/crates/crap-core/src/core/mod.rs
+++ b/crates/crap-core/src/core/mod.rs
@@ -29,7 +29,7 @@ use crate::domain::summary::compute_summary;
 use crate::domain::threshold::ThresholdConfig;
 use crate::domain::types::{
     AnalysisDiagnostics, AnalysisResult, ComplexityMetric, CoverageMetric, FileChangeKind,
-    FunctionComplexity, FunctionVerdict, LineCoverage, ScoredFunction,
+    FunctionComplexity, FunctionVerdict, LineCoverage, MissingCoveragePolicy, ScoredFunction,
 };
 use crate::ports::{ComplexityPort, CoveragePort, DiffPort, ParseDiagnostic, ParseOutput};
 
@@ -80,6 +80,11 @@ pub struct AnalyzeOptions {
     /// computation is pure-domain and bounded — runs only on exceeding
     /// verdicts, so the cost scales with violations, not total functions.
     pub compute_diagnostics: bool,
+    /// How to score a function whose source file is entirely absent from
+    /// the coverage data (feature-gated file, untested file, or scoped
+    /// coverage run). The default is [`MissingCoveragePolicy::Pessimistic`]
+    /// — 0% coverage, the behavior that never hides risk.
+    pub missing_coverage_policy: MissingCoveragePolicy,
 }
 
 /// Full output from an analysis run, including both the scored results
@@ -136,6 +141,7 @@ impl Default for AnalyzeOptions {
             // parser-neutral diagnostic when nothing matches (#161).
             extensions: Vec::new(),
             compute_diagnostics: false,
+            missing_coverage_policy: MissingCoveragePolicy::default(),
         }
     }
 }
@@ -256,13 +262,26 @@ impl<'a, P: ParseDiagnostic> AnalysisContext<'a, P> {
             &all_complexities,
             &parse_output.coverage,
             parse_output.branches.as_ref(),
+            self.options.missing_coverage_policy,
         );
 
-        let functions_no_coverage = matched
+        // `functions_no_coverage` counts every extracted function whose
+        // file is absent from the coverage data. It is derived from
+        // `all_complexities`, not `matched`, so the count is correct under
+        // every policy: `Skip` drops such functions from `matched`, but
+        // they are still reported here. `functions_matched` counts the
+        // functions that did join coverage data (`matched` entries whose
+        // file is present). Because `match_functions` only ever omits
+        // no-coverage functions, the two counts partition every extracted
+        // function — the invariant the `debug_assert_eq!` below guards.
+        let functions_no_coverage = all_complexities
             .iter()
-            .filter(|(comp, _)| !parse_output.coverage.contains_key(&comp.identity.file_path))
+            .filter(|comp| !parse_output.coverage.contains_key(&comp.identity.file_path))
             .count();
-        let functions_matched = matched.len() - functions_no_coverage;
+        let functions_matched = matched
+            .iter()
+            .filter(|(comp, _)| parse_output.coverage.contains_key(&comp.identity.file_path))
+            .count();
 
         let resolver = ThresholdResolver::new(&self.options.threshold_config)?;
         let mut result = score_and_summarize(&matched, &resolver)?;
@@ -287,8 +306,8 @@ impl<'a, P: ParseDiagnostic> AnalysisContext<'a, P> {
 
         debug_assert_eq!(
             diagnostics.functions_matched + diagnostics.functions_no_coverage,
-            result.functions.len(),
-            "diagnostics counts must partition scored functions"
+            all_complexities.len(),
+            "matched-with-coverage and no-coverage counts must partition every extracted function",
         );
 
         Ok(AnalysisOutput {

--- a/crates/crap-core/src/domain/config.rs
+++ b/crates/crap-core/src/domain/config.rs
@@ -19,7 +19,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use super::threshold::{ThresholdOverride, ThresholdPreset};
-use super::types::ComplexityMetric;
+use super::types::{ComplexityMetric, MissingCoveragePolicy};
 use super::view::{GroupKey, SortKey};
 
 /// Parsed configuration from a TOML file.
@@ -39,6 +39,10 @@ pub struct FileConfig {
     pub threshold: Option<f64>,
     pub preset: Option<ThresholdPreset>,
     pub metric: Option<ComplexityMetric>,
+    /// How to score a function whose file is absent from the coverage
+    /// data. `None` defers to the CLI default
+    /// ([`MissingCoveragePolicy::Pessimistic`]).
+    pub missing_coverage_policy: Option<MissingCoveragePolicy>,
     /// Source roots the analyzer walks, in declaration order.
     ///
     /// Empty means "unset, defer to CLI / the `["src"]` default." A

--- a/crates/crap-core/src/domain/matching.rs
+++ b/crates/crap-core/src/domain/matching.rs
@@ -23,56 +23,59 @@ pub fn overlaps_any(span: &SourceSpan, changed_ranges: &[SourceSpan]) -> bool {
 
 /// Match complexity entries with coverage using line-range overlap.
 ///
-/// For each function in `complexities`, finds DA lines from `line_data`
-/// that fall within the function's span, then computes coverage ratio.
-/// If `branch_data` is provided, also computes branch coverage per function.
-///
-/// When a function's file is entirely absent from `line_data`,
-/// `missing_coverage_policy` decides the outcome: score it at 0%
-/// ([`Pessimistic`](MissingCoveragePolicy::Pessimistic)), score it at 100%
-/// ([`Optimistic`](MissingCoveragePolicy::Optimistic)), or omit it from the
-/// returned vec ([`Skip`](MissingCoveragePolicy::Skip)). A function whose
-/// file *is* present is matched the same way under every policy.
+/// Pairs each function in `complexities` with its computed
+/// [`FunctionCoverage`] via [`coverage_for_function`]. Functions the
+/// policy omits ([`Skip`](MissingCoveragePolicy::Skip) on a file absent
+/// from `line_data`) are filtered out, so the result may be shorter than
+/// `complexities`.
 pub fn match_functions(
     complexities: &[FunctionComplexity],
     line_data: &HashMap<String, Vec<LineCoverage>>,
     branch_data: Option<&HashMap<String, Vec<BranchCoverage>>>,
     missing_coverage_policy: MissingCoveragePolicy,
 ) -> Vec<(FunctionComplexity, FunctionCoverage)> {
-    let mut results = Vec::new();
+    complexities
+        .iter()
+        .filter_map(|comp| {
+            coverage_for_function(comp, line_data, branch_data, missing_coverage_policy)
+                .map(|coverage| (comp.clone(), coverage))
+        })
+        .collect()
+}
 
-    for comp in complexities {
-        let file_lines = match line_data.get(&comp.identity.file_path) {
-            Some(lines) => lines,
-            None => {
-                // File absent from coverage — score per the configured policy.
-                match missing_coverage_policy {
-                    MissingCoveragePolicy::Pessimistic => results.push((
-                        comp.clone(),
-                        zero_coverage(&comp.identity.file_path, comp.identity.span),
-                    )),
-                    MissingCoveragePolicy::Optimistic => results.push((
-                        comp.clone(),
-                        full_coverage(&comp.identity.file_path, comp.identity.span),
-                    )),
-                    MissingCoveragePolicy::Skip => {}
-                }
-                continue;
-            }
-        };
+/// Compute one function's coverage, or `None` when the policy omits it.
+///
+/// When the function's file is present in `line_data`, coverage is measured
+/// from the DA lines (and optional branch data) within its span. When the
+/// file is entirely absent, `missing_coverage_policy` decides: score it at
+/// 0% ([`Pessimistic`](MissingCoveragePolicy::Pessimistic)), score it at
+/// 100% ([`Optimistic`](MissingCoveragePolicy::Optimistic)), or drop it
+/// ([`Skip`](MissingCoveragePolicy::Skip) — the only case returning `None`).
+fn coverage_for_function(
+    comp: &FunctionComplexity,
+    line_data: &HashMap<String, Vec<LineCoverage>>,
+    branch_data: Option<&HashMap<String, Vec<BranchCoverage>>>,
+    missing_coverage_policy: MissingCoveragePolicy,
+) -> Option<FunctionCoverage> {
+    let file_path = &comp.identity.file_path;
+    let span = comp.identity.span;
 
-        let file_branches =
-            branch_data.and_then(|bd| bd.get(&comp.identity.file_path).map(|v| v.as_slice()));
-        let coverage = compute_function_coverage(
-            &comp.identity.file_path,
-            comp.identity.span,
-            file_lines,
-            file_branches,
-        );
-        results.push((comp.clone(), coverage));
+    match line_data.get(file_path) {
+        Some(file_lines) => {
+            let file_branches = branch_data.and_then(|bd| bd.get(file_path).map(|v| v.as_slice()));
+            Some(compute_function_coverage(
+                file_path,
+                span,
+                file_lines,
+                file_branches,
+            ))
+        }
+        None => match missing_coverage_policy {
+            MissingCoveragePolicy::Pessimistic => Some(zero_coverage(file_path, span)),
+            MissingCoveragePolicy::Optimistic => Some(full_coverage(file_path, span)),
+            MissingCoveragePolicy::Skip => None,
+        },
     }
-
-    results
 }
 
 /// Returns `true` if `line` falls within `span`'s inclusive `[start_line,

--- a/crates/crap-core/src/domain/matching.rs
+++ b/crates/crap-core/src/domain/matching.rs
@@ -6,7 +6,8 @@
 //! we bypass function name matching entirely.
 
 use super::types::{
-    BranchCoverage, CoverageRatio, FunctionComplexity, FunctionCoverage, LineCoverage, SourceSpan,
+    BranchCoverage, CoverageRatio, FunctionComplexity, FunctionCoverage, LineCoverage,
+    MissingCoveragePolicy, SourceSpan,
 };
 use std::collections::HashMap;
 
@@ -25,10 +26,18 @@ pub fn overlaps_any(span: &SourceSpan, changed_ranges: &[SourceSpan]) -> bool {
 /// For each function in `complexities`, finds DA lines from `line_data`
 /// that fall within the function's span, then computes coverage ratio.
 /// If `branch_data` is provided, also computes branch coverage per function.
+///
+/// When a function's file is entirely absent from `line_data`,
+/// `missing_coverage_policy` decides the outcome: score it at 0%
+/// ([`Pessimistic`](MissingCoveragePolicy::Pessimistic)), score it at 100%
+/// ([`Optimistic`](MissingCoveragePolicy::Optimistic)), or omit it from the
+/// returned vec ([`Skip`](MissingCoveragePolicy::Skip)). A function whose
+/// file *is* present is matched the same way under every policy.
 pub fn match_functions(
     complexities: &[FunctionComplexity],
     line_data: &HashMap<String, Vec<LineCoverage>>,
     branch_data: Option<&HashMap<String, Vec<BranchCoverage>>>,
+    missing_coverage_policy: MissingCoveragePolicy,
 ) -> Vec<(FunctionComplexity, FunctionCoverage)> {
     let mut results = Vec::new();
 
@@ -36,11 +45,18 @@ pub fn match_functions(
         let file_lines = match line_data.get(&comp.identity.file_path) {
             Some(lines) => lines,
             None => {
-                // No coverage data for this file — report as 0% coverage
-                results.push((
-                    comp.clone(),
-                    zero_coverage(&comp.identity.file_path, comp.identity.span),
-                ));
+                // File absent from coverage — score per the configured policy.
+                match missing_coverage_policy {
+                    MissingCoveragePolicy::Pessimistic => results.push((
+                        comp.clone(),
+                        zero_coverage(&comp.identity.file_path, comp.identity.span),
+                    )),
+                    MissingCoveragePolicy::Optimistic => results.push((
+                        comp.clone(),
+                        full_coverage(&comp.identity.file_path, comp.identity.span),
+                    )),
+                    MissingCoveragePolicy::Skip => {}
+                }
                 continue;
             }
         };
@@ -149,6 +165,24 @@ fn zero_coverage(file_path: &str, span: SourceSpan) -> FunctionCoverage {
     }
 }
 
+/// Coverage for a function whose file is missing from the coverage data,
+/// under the optimistic policy: no instrumentable lines were observed, so
+/// it is treated as 100% covered. This mirrors the "no instrumentable
+/// lines = trivially covered" rule in [`compute_function_coverage`], so
+/// the resulting CRAP score is the raw complexity `c`.
+fn full_coverage(file_path: &str, span: SourceSpan) -> FunctionCoverage {
+    FunctionCoverage {
+        file_path: file_path.to_string(),
+        span,
+        line_coverage: CoverageRatio {
+            covered: 0,
+            total: 0,
+            percent: 100.0,
+        },
+        branch_coverage: None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -190,7 +224,7 @@ mod tests {
     #[test]
     fn empty_complexities_returns_empty() {
         let line_data = make_line_data(&[("a.rs", &[(1, 5)])]);
-        let result = match_functions(&[], &line_data, None);
+        let result = match_functions(&[], &line_data, None, MissingCoveragePolicy::Pessimistic);
         assert!(result.is_empty());
     }
 
@@ -198,7 +232,7 @@ mod tests {
     fn no_coverage_data_for_file() {
         let comp = make_complexity("a.rs", "foo", 1, 10);
         let line_data = make_line_data(&[("b.rs", &[(1, 5)])]);
-        let result = match_functions(&[comp], &line_data, None);
+        let result = match_functions(&[comp], &line_data, None, MissingCoveragePolicy::Pessimistic);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].1.line_coverage.percent, 0.0);
         assert_eq!(result[0].1.line_coverage.covered, 0);
@@ -206,10 +240,66 @@ mod tests {
     }
 
     #[test]
+    fn optimistic_missing_file_is_full_coverage() {
+        let comp = make_complexity("a.rs", "foo", 1, 10);
+        let line_data = make_line_data(&[("b.rs", &[(1, 5)])]);
+        let result = match_functions(&[comp], &line_data, None, MissingCoveragePolicy::Optimistic);
+        // File absent from coverage → optimistic treats it as fully
+        // covered (0 instrumentable lines observed = trivially 100%),
+        // which scores CRAP = complexity.
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].1.line_coverage.percent, 100.0);
+        assert_eq!(result[0].1.line_coverage.covered, 0);
+        assert_eq!(result[0].1.line_coverage.total, 0);
+    }
+
+    #[test]
+    fn skip_missing_file_omits_function() {
+        let comp = make_complexity("a.rs", "foo", 1, 10);
+        let line_data = make_line_data(&[("b.rs", &[(1, 5)])]);
+        let result = match_functions(&[comp], &line_data, None, MissingCoveragePolicy::Skip);
+        // File absent from coverage → skip omits the function entirely.
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn skip_retains_covered_functions() {
+        // `a.rs` has coverage, `b.rs` does not. Under skip, only the
+        // covered function survives — skip never drops a matched function.
+        let covered = make_complexity("a.rs", "covered", 1, 3);
+        let missing = make_complexity("b.rs", "missing", 1, 3);
+        let line_data = make_line_data(&[("a.rs", &[(1, 1), (2, 1), (3, 1)])]);
+        let result = match_functions(
+            &[covered, missing],
+            &line_data,
+            None,
+            MissingCoveragePolicy::Skip,
+        );
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].0.identity.qualified_name, "covered");
+        assert_eq!(result[0].1.line_coverage.percent, 100.0);
+    }
+
+    #[test]
+    fn skip_all_missing_yields_empty() {
+        // Every file absent from coverage + skip → zero results, no panic.
+        let comp1 = make_complexity("a.rs", "foo", 1, 3);
+        let comp2 = make_complexity("b.rs", "bar", 1, 3);
+        let line_data = make_line_data(&[("c.rs", &[(1, 1)])]);
+        let result = match_functions(
+            &[comp1, comp2],
+            &line_data,
+            None,
+            MissingCoveragePolicy::Skip,
+        );
+        assert!(result.is_empty());
+    }
+
+    #[test]
     fn full_coverage() {
         let comp = make_complexity("a.rs", "foo", 1, 3);
         let line_data = make_line_data(&[("a.rs", &[(1, 1), (2, 3), (3, 7)])]);
-        let result = match_functions(&[comp], &line_data, None);
+        let result = match_functions(&[comp], &line_data, None, MissingCoveragePolicy::Pessimistic);
         assert_eq!(result[0].1.line_coverage.covered, 3);
         assert_eq!(result[0].1.line_coverage.total, 3);
         assert_eq!(result[0].1.line_coverage.percent, 100.0);
@@ -219,7 +309,7 @@ mod tests {
     fn zero_coverage_all_unhit() {
         let comp = make_complexity("a.rs", "foo", 1, 3);
         let line_data = make_line_data(&[("a.rs", &[(1, 0), (2, 0), (3, 0)])]);
-        let result = match_functions(&[comp], &line_data, None);
+        let result = match_functions(&[comp], &line_data, None, MissingCoveragePolicy::Pessimistic);
         assert_eq!(result[0].1.line_coverage.covered, 0);
         assert_eq!(result[0].1.line_coverage.total, 3);
         assert_eq!(result[0].1.line_coverage.percent, 0.0);
@@ -229,7 +319,7 @@ mod tests {
     fn partial_coverage() {
         let comp = make_complexity("a.rs", "foo", 1, 3);
         let line_data = make_line_data(&[("a.rs", &[(1, 1), (2, 0), (3, 5)])]);
-        let result = match_functions(&[comp], &line_data, None);
+        let result = match_functions(&[comp], &line_data, None, MissingCoveragePolicy::Pessimistic);
         assert_eq!(result[0].1.line_coverage.covered, 2);
         assert_eq!(result[0].1.line_coverage.total, 3);
         let pct = result[0].1.line_coverage.percent;
@@ -241,7 +331,7 @@ mod tests {
         let comp = make_complexity("a.rs", "foo", 3, 5);
         let line_data =
             make_line_data(&[("a.rs", &[(1, 1), (2, 1), (3, 1), (4, 0), (5, 1), (6, 1)])]);
-        let result = match_functions(&[comp], &line_data, None);
+        let result = match_functions(&[comp], &line_data, None, MissingCoveragePolicy::Pessimistic);
         // Only lines 3, 4, 5 should be counted
         assert_eq!(result[0].1.line_coverage.total, 3);
         assert_eq!(result[0].1.line_coverage.covered, 2); // lines 3 and 5
@@ -251,7 +341,7 @@ mod tests {
     fn boundary_inclusive_start() {
         let comp = make_complexity("a.rs", "foo", 5, 10);
         let line_data = make_line_data(&[("a.rs", &[(5, 3)])]);
-        let result = match_functions(&[comp], &line_data, None);
+        let result = match_functions(&[comp], &line_data, None, MissingCoveragePolicy::Pessimistic);
         assert_eq!(result[0].1.line_coverage.total, 1);
         assert_eq!(result[0].1.line_coverage.covered, 1);
     }
@@ -260,7 +350,7 @@ mod tests {
     fn boundary_inclusive_end() {
         let comp = make_complexity("a.rs", "foo", 5, 10);
         let line_data = make_line_data(&[("a.rs", &[(10, 2)])]);
-        let result = match_functions(&[comp], &line_data, None);
+        let result = match_functions(&[comp], &line_data, None, MissingCoveragePolicy::Pessimistic);
         assert_eq!(result[0].1.line_coverage.total, 1);
         assert_eq!(result[0].1.line_coverage.covered, 1);
     }
@@ -270,7 +360,7 @@ mod tests {
         let comp = make_complexity("a.rs", "foo", 5, 10);
         // No DA lines in the span at all
         let line_data = make_line_data(&[("a.rs", &[(1, 1), (20, 1)])]);
-        let result = match_functions(&[comp], &line_data, None);
+        let result = match_functions(&[comp], &line_data, None, MissingCoveragePolicy::Pessimistic);
         assert_eq!(result[0].1.line_coverage.total, 0);
         assert_eq!(result[0].1.line_coverage.percent, 100.0);
     }
@@ -281,7 +371,7 @@ mod tests {
         let comp2 = make_complexity("a.rs", "bar", 10, 15);
         let line_data =
             make_line_data(&[("a.rs", &[(1, 1), (2, 0), (3, 1), (10, 0), (11, 0), (12, 0)])]);
-        let result = match_functions(&[comp1, comp2], &line_data, None);
+        let result = match_functions(&[comp1, comp2], &line_data, None, MissingCoveragePolicy::Pessimistic);
 
         // foo: 2/3 covered
         assert_eq!(result[0].1.line_coverage.covered, 2);
@@ -300,7 +390,7 @@ mod tests {
             ("a.rs", &[(1, 5), (2, 5), (3, 5)]),
             ("b.rs", &[(1, 0), (2, 0)]),
         ]);
-        let result = match_functions(&[comp_a, comp_b], &line_data, None);
+        let result = match_functions(&[comp_a, comp_b], &line_data, None, MissingCoveragePolicy::Pessimistic);
 
         // a.rs: 3/3 = 100%
         assert_eq!(result[0].1.line_coverage.percent, 100.0);
@@ -334,7 +424,7 @@ mod tests {
         let line_data = make_line_data(&[("a.rs", &[(5, 1)])]);
         let branch_data =
             make_branch_data(&[("a.rs", &[(7, Some(3)), (10, Some(1)), (12, Some(0))])]);
-        let result = match_functions(&[comp], &line_data, Some(&branch_data));
+        let result = match_functions(&[comp], &line_data, Some(&branch_data), MissingCoveragePolicy::Pessimistic);
         let bc = result[0]
             .1
             .branch_coverage
@@ -349,7 +439,7 @@ mod tests {
         let line_data = make_line_data(&[("a.rs", &[(5, 1)])]);
         let branch_data =
             make_branch_data(&[("a.rs", &[(3, Some(1)), (10, Some(1)), (20, Some(1))])]);
-        let result = match_functions(&[comp], &line_data, Some(&branch_data));
+        let result = match_functions(&[comp], &line_data, Some(&branch_data), MissingCoveragePolicy::Pessimistic);
         let bc = result[0]
             .1
             .branch_coverage
@@ -363,7 +453,7 @@ mod tests {
         let comp = make_complexity("a.rs", "foo", 5, 15);
         let line_data = make_line_data(&[("a.rs", &[(5, 1)])]);
         let branch_data = make_branch_data(&[("a.rs", &[(5, Some(1)), (15, Some(1))])]);
-        let result = match_functions(&[comp], &line_data, Some(&branch_data));
+        let result = match_functions(&[comp], &line_data, Some(&branch_data), MissingCoveragePolicy::Pessimistic);
         let bc = result[0]
             .1
             .branch_coverage
@@ -378,7 +468,7 @@ mod tests {
         let comp = make_complexity("a.rs", "foo", 5, 15);
         let line_data = make_line_data(&[("a.rs", &[(5, 1)])]);
         let branch_data = make_branch_data(&[("a.rs", &[(7, Some(3)), (10, None), (12, Some(0))])]);
-        let result = match_functions(&[comp], &line_data, Some(&branch_data));
+        let result = match_functions(&[comp], &line_data, Some(&branch_data), MissingCoveragePolicy::Pessimistic);
         let bc = result[0]
             .1
             .branch_coverage
@@ -396,7 +486,7 @@ mod tests {
         let line_data = make_line_data(&[("a.rs", &[(5, 1)])]);
         // Branch data exists but outside span
         let branch_data = make_branch_data(&[("a.rs", &[(20, Some(1))])]);
-        let result = match_functions(&[comp], &line_data, Some(&branch_data));
+        let result = match_functions(&[comp], &line_data, Some(&branch_data), MissingCoveragePolicy::Pessimistic);
         assert!(result[0].1.branch_coverage.is_none());
     }
 
@@ -406,7 +496,7 @@ mod tests {
         let comp_b = make_complexity("b.rs", "bar", 1, 10);
         let line_data = make_line_data(&[("a.rs", &[(1, 1)]), ("b.rs", &[(1, 1)])]);
         let branch_data = make_branch_data(&[("a.rs", &[(5, Some(1))])]);
-        let result = match_functions(&[comp_a, comp_b], &line_data, Some(&branch_data));
+        let result = match_functions(&[comp_a, comp_b], &line_data, Some(&branch_data), MissingCoveragePolicy::Pessimistic);
         // a.rs has branch coverage
         let a_bc = result[0]
             .1
@@ -615,7 +705,7 @@ mod proptests {
             comp in arb_complexity("test.rs"),
             line_data in arb_line_data("test.rs"),
         ) {
-            let result = match_functions(&[comp], &line_data, None);
+            let result = match_functions(&[comp], &line_data, None, MissingCoveragePolicy::Pessimistic);
             for (_, cov) in &result {
                 let pct = cov.line_coverage.percent;
                 prop_assert!((0.0..=100.0).contains(&pct), "Coverage percent {pct} out of range");
@@ -627,7 +717,7 @@ mod proptests {
             comp in arb_complexity("test.rs"),
             line_data in arb_line_data("test.rs"),
         ) {
-            let result = match_functions(&[comp], &line_data, None);
+            let result = match_functions(&[comp], &line_data, None, MissingCoveragePolicy::Pessimistic);
             for (_, cov) in &result {
                 prop_assert!(
                     cov.line_coverage.covered <= cov.line_coverage.total,
@@ -672,7 +762,7 @@ mod proptests {
                 b_lines.iter().map(|&(l, h)| LineCoverage { line: l, hits: h }).collect(),
             );
 
-            let result = match_functions(&[comp_a, comp_b], &line_data, None);
+            let result = match_functions(&[comp_a, comp_b], &line_data, None, MissingCoveragePolicy::Pessimistic);
 
             // a.rs function should only have lines < 200
             let a_cov = &result[0].1;
@@ -716,7 +806,7 @@ mod proptests {
                 LineCoverage { line: end + 1, hits: 1 },   // after span (excluded)
             ]);
 
-            let result = match_functions(&[comp], &line_data, None);
+            let result = match_functions(&[comp], &line_data, None, MissingCoveragePolicy::Pessimistic);
             let cov = &result[0].1;
 
             if start > 1 {
@@ -732,7 +822,7 @@ mod proptests {
             line_data in arb_line_data("test.rs"),
             branch_data in arb_branch_data("test.rs"),
         ) {
-            let result = match_functions(&[comp], &line_data, Some(&branch_data));
+            let result = match_functions(&[comp], &line_data, Some(&branch_data), MissingCoveragePolicy::Pessimistic);
             for (_, cov) in &result {
                 if let Some(bc) = &cov.branch_coverage {
                     prop_assert!(bc.percent >= 0.0 && bc.percent <= 100.0,
@@ -747,7 +837,7 @@ mod proptests {
             line_data in arb_line_data("test.rs"),
             branch_data in arb_branch_data("test.rs"),
         ) {
-            let result = match_functions(&[comp], &line_data, Some(&branch_data));
+            let result = match_functions(&[comp], &line_data, Some(&branch_data), MissingCoveragePolicy::Pessimistic);
             for (_, cov) in &result {
                 if let Some(bc) = &cov.branch_coverage {
                     prop_assert!(bc.covered <= bc.total,
@@ -799,7 +889,7 @@ mod proptests {
                 b_branches.iter().map(|&(l, t)| BranchCoverage { line: l, taken: t }).collect(),
             );
 
-            let result = match_functions(&[comp_a, comp_b], &line_data, Some(&branch_data));
+            let result = match_functions(&[comp_a, comp_b], &line_data, Some(&branch_data), MissingCoveragePolicy::Pessimistic);
 
             // a.rs branch total should only count branches in [1, 100]
             if let Some(bc) = &result[0].1.branch_coverage {

--- a/crates/crap-core/src/domain/matching.rs
+++ b/crates/crap-core/src/domain/matching.rs
@@ -24,10 +24,11 @@ pub fn overlaps_any(span: &SourceSpan, changed_ranges: &[SourceSpan]) -> bool {
 /// Match complexity entries with coverage using line-range overlap.
 ///
 /// Pairs each function in `complexities` with its computed
-/// [`FunctionCoverage`] via [`coverage_for_function`]. Functions the
-/// policy omits ([`Skip`](MissingCoveragePolicy::Skip) on a file absent
-/// from `line_data`) are filtered out, so the result may be shorter than
-/// `complexities`.
+/// [`FunctionCoverage`] — line (and optional branch) coverage measured
+/// within the function's span, or the `missing_coverage_policy` outcome
+/// when the function's file is absent from `line_data`. Functions the
+/// policy omits ([`Skip`](MissingCoveragePolicy::Skip) on a missing file)
+/// are filtered out, so the result may be shorter than `complexities`.
 pub fn match_functions(
     complexities: &[FunctionComplexity],
     line_data: &HashMap<String, Vec<LineCoverage>>,

--- a/crates/crap-core/src/domain/matching.rs
+++ b/crates/crap-core/src/domain/matching.rs
@@ -232,7 +232,12 @@ mod tests {
     fn no_coverage_data_for_file() {
         let comp = make_complexity("a.rs", "foo", 1, 10);
         let line_data = make_line_data(&[("b.rs", &[(1, 5)])]);
-        let result = match_functions(&[comp], &line_data, None, MissingCoveragePolicy::Pessimistic);
+        let result = match_functions(
+            &[comp],
+            &line_data,
+            None,
+            MissingCoveragePolicy::Pessimistic,
+        );
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].1.line_coverage.percent, 0.0);
         assert_eq!(result[0].1.line_coverage.covered, 0);
@@ -299,7 +304,12 @@ mod tests {
     fn full_coverage() {
         let comp = make_complexity("a.rs", "foo", 1, 3);
         let line_data = make_line_data(&[("a.rs", &[(1, 1), (2, 3), (3, 7)])]);
-        let result = match_functions(&[comp], &line_data, None, MissingCoveragePolicy::Pessimistic);
+        let result = match_functions(
+            &[comp],
+            &line_data,
+            None,
+            MissingCoveragePolicy::Pessimistic,
+        );
         assert_eq!(result[0].1.line_coverage.covered, 3);
         assert_eq!(result[0].1.line_coverage.total, 3);
         assert_eq!(result[0].1.line_coverage.percent, 100.0);
@@ -309,7 +319,12 @@ mod tests {
     fn zero_coverage_all_unhit() {
         let comp = make_complexity("a.rs", "foo", 1, 3);
         let line_data = make_line_data(&[("a.rs", &[(1, 0), (2, 0), (3, 0)])]);
-        let result = match_functions(&[comp], &line_data, None, MissingCoveragePolicy::Pessimistic);
+        let result = match_functions(
+            &[comp],
+            &line_data,
+            None,
+            MissingCoveragePolicy::Pessimistic,
+        );
         assert_eq!(result[0].1.line_coverage.covered, 0);
         assert_eq!(result[0].1.line_coverage.total, 3);
         assert_eq!(result[0].1.line_coverage.percent, 0.0);
@@ -319,7 +334,12 @@ mod tests {
     fn partial_coverage() {
         let comp = make_complexity("a.rs", "foo", 1, 3);
         let line_data = make_line_data(&[("a.rs", &[(1, 1), (2, 0), (3, 5)])]);
-        let result = match_functions(&[comp], &line_data, None, MissingCoveragePolicy::Pessimistic);
+        let result = match_functions(
+            &[comp],
+            &line_data,
+            None,
+            MissingCoveragePolicy::Pessimistic,
+        );
         assert_eq!(result[0].1.line_coverage.covered, 2);
         assert_eq!(result[0].1.line_coverage.total, 3);
         let pct = result[0].1.line_coverage.percent;
@@ -331,7 +351,12 @@ mod tests {
         let comp = make_complexity("a.rs", "foo", 3, 5);
         let line_data =
             make_line_data(&[("a.rs", &[(1, 1), (2, 1), (3, 1), (4, 0), (5, 1), (6, 1)])]);
-        let result = match_functions(&[comp], &line_data, None, MissingCoveragePolicy::Pessimistic);
+        let result = match_functions(
+            &[comp],
+            &line_data,
+            None,
+            MissingCoveragePolicy::Pessimistic,
+        );
         // Only lines 3, 4, 5 should be counted
         assert_eq!(result[0].1.line_coverage.total, 3);
         assert_eq!(result[0].1.line_coverage.covered, 2); // lines 3 and 5
@@ -341,7 +366,12 @@ mod tests {
     fn boundary_inclusive_start() {
         let comp = make_complexity("a.rs", "foo", 5, 10);
         let line_data = make_line_data(&[("a.rs", &[(5, 3)])]);
-        let result = match_functions(&[comp], &line_data, None, MissingCoveragePolicy::Pessimistic);
+        let result = match_functions(
+            &[comp],
+            &line_data,
+            None,
+            MissingCoveragePolicy::Pessimistic,
+        );
         assert_eq!(result[0].1.line_coverage.total, 1);
         assert_eq!(result[0].1.line_coverage.covered, 1);
     }
@@ -350,7 +380,12 @@ mod tests {
     fn boundary_inclusive_end() {
         let comp = make_complexity("a.rs", "foo", 5, 10);
         let line_data = make_line_data(&[("a.rs", &[(10, 2)])]);
-        let result = match_functions(&[comp], &line_data, None, MissingCoveragePolicy::Pessimistic);
+        let result = match_functions(
+            &[comp],
+            &line_data,
+            None,
+            MissingCoveragePolicy::Pessimistic,
+        );
         assert_eq!(result[0].1.line_coverage.total, 1);
         assert_eq!(result[0].1.line_coverage.covered, 1);
     }
@@ -360,7 +395,12 @@ mod tests {
         let comp = make_complexity("a.rs", "foo", 5, 10);
         // No DA lines in the span at all
         let line_data = make_line_data(&[("a.rs", &[(1, 1), (20, 1)])]);
-        let result = match_functions(&[comp], &line_data, None, MissingCoveragePolicy::Pessimistic);
+        let result = match_functions(
+            &[comp],
+            &line_data,
+            None,
+            MissingCoveragePolicy::Pessimistic,
+        );
         assert_eq!(result[0].1.line_coverage.total, 0);
         assert_eq!(result[0].1.line_coverage.percent, 100.0);
     }
@@ -371,7 +411,12 @@ mod tests {
         let comp2 = make_complexity("a.rs", "bar", 10, 15);
         let line_data =
             make_line_data(&[("a.rs", &[(1, 1), (2, 0), (3, 1), (10, 0), (11, 0), (12, 0)])]);
-        let result = match_functions(&[comp1, comp2], &line_data, None, MissingCoveragePolicy::Pessimistic);
+        let result = match_functions(
+            &[comp1, comp2],
+            &line_data,
+            None,
+            MissingCoveragePolicy::Pessimistic,
+        );
 
         // foo: 2/3 covered
         assert_eq!(result[0].1.line_coverage.covered, 2);
@@ -390,7 +435,12 @@ mod tests {
             ("a.rs", &[(1, 5), (2, 5), (3, 5)]),
             ("b.rs", &[(1, 0), (2, 0)]),
         ]);
-        let result = match_functions(&[comp_a, comp_b], &line_data, None, MissingCoveragePolicy::Pessimistic);
+        let result = match_functions(
+            &[comp_a, comp_b],
+            &line_data,
+            None,
+            MissingCoveragePolicy::Pessimistic,
+        );
 
         // a.rs: 3/3 = 100%
         assert_eq!(result[0].1.line_coverage.percent, 100.0);
@@ -424,7 +474,12 @@ mod tests {
         let line_data = make_line_data(&[("a.rs", &[(5, 1)])]);
         let branch_data =
             make_branch_data(&[("a.rs", &[(7, Some(3)), (10, Some(1)), (12, Some(0))])]);
-        let result = match_functions(&[comp], &line_data, Some(&branch_data), MissingCoveragePolicy::Pessimistic);
+        let result = match_functions(
+            &[comp],
+            &line_data,
+            Some(&branch_data),
+            MissingCoveragePolicy::Pessimistic,
+        );
         let bc = result[0]
             .1
             .branch_coverage
@@ -439,7 +494,12 @@ mod tests {
         let line_data = make_line_data(&[("a.rs", &[(5, 1)])]);
         let branch_data =
             make_branch_data(&[("a.rs", &[(3, Some(1)), (10, Some(1)), (20, Some(1))])]);
-        let result = match_functions(&[comp], &line_data, Some(&branch_data), MissingCoveragePolicy::Pessimistic);
+        let result = match_functions(
+            &[comp],
+            &line_data,
+            Some(&branch_data),
+            MissingCoveragePolicy::Pessimistic,
+        );
         let bc = result[0]
             .1
             .branch_coverage
@@ -453,7 +513,12 @@ mod tests {
         let comp = make_complexity("a.rs", "foo", 5, 15);
         let line_data = make_line_data(&[("a.rs", &[(5, 1)])]);
         let branch_data = make_branch_data(&[("a.rs", &[(5, Some(1)), (15, Some(1))])]);
-        let result = match_functions(&[comp], &line_data, Some(&branch_data), MissingCoveragePolicy::Pessimistic);
+        let result = match_functions(
+            &[comp],
+            &line_data,
+            Some(&branch_data),
+            MissingCoveragePolicy::Pessimistic,
+        );
         let bc = result[0]
             .1
             .branch_coverage
@@ -468,7 +533,12 @@ mod tests {
         let comp = make_complexity("a.rs", "foo", 5, 15);
         let line_data = make_line_data(&[("a.rs", &[(5, 1)])]);
         let branch_data = make_branch_data(&[("a.rs", &[(7, Some(3)), (10, None), (12, Some(0))])]);
-        let result = match_functions(&[comp], &line_data, Some(&branch_data), MissingCoveragePolicy::Pessimistic);
+        let result = match_functions(
+            &[comp],
+            &line_data,
+            Some(&branch_data),
+            MissingCoveragePolicy::Pessimistic,
+        );
         let bc = result[0]
             .1
             .branch_coverage
@@ -486,7 +556,12 @@ mod tests {
         let line_data = make_line_data(&[("a.rs", &[(5, 1)])]);
         // Branch data exists but outside span
         let branch_data = make_branch_data(&[("a.rs", &[(20, Some(1))])]);
-        let result = match_functions(&[comp], &line_data, Some(&branch_data), MissingCoveragePolicy::Pessimistic);
+        let result = match_functions(
+            &[comp],
+            &line_data,
+            Some(&branch_data),
+            MissingCoveragePolicy::Pessimistic,
+        );
         assert!(result[0].1.branch_coverage.is_none());
     }
 
@@ -496,7 +571,12 @@ mod tests {
         let comp_b = make_complexity("b.rs", "bar", 1, 10);
         let line_data = make_line_data(&[("a.rs", &[(1, 1)]), ("b.rs", &[(1, 1)])]);
         let branch_data = make_branch_data(&[("a.rs", &[(5, Some(1))])]);
-        let result = match_functions(&[comp_a, comp_b], &line_data, Some(&branch_data), MissingCoveragePolicy::Pessimistic);
+        let result = match_functions(
+            &[comp_a, comp_b],
+            &line_data,
+            Some(&branch_data),
+            MissingCoveragePolicy::Pessimistic,
+        );
         // a.rs has branch coverage
         let a_bc = result[0]
             .1

--- a/crates/crap-core/src/domain/types.rs
+++ b/crates/crap-core/src/domain/types.rs
@@ -202,6 +202,56 @@ impl fmt::Display for ComplexityMetric {
     }
 }
 
+// ── Missing-Coverage Policy ──────────────────────────────────────────
+
+/// How to score a function whose source file is entirely absent from the
+/// coverage data.
+///
+/// A file can be missing from coverage for benign reasons — a `#[cfg(…)]`
+/// feature gate excluded from the coverage build, an untested file, or a
+/// scoped per-package coverage run. The policy decides what coverage such
+/// a function is assigned:
+///
+/// - [`Pessimistic`](Self::Pessimistic) treats it as 0% covered, so its
+///   CRAP score is `c² + c` (the historic behavior — the safe default
+///   that never hides risk).
+/// - [`Optimistic`](Self::Optimistic) treats it as 100% covered, so its
+///   CRAP score is `c` (the complexity alone) — appropriate when running
+///   a scoped test slice that legitimately omits some files.
+/// - [`Skip`](Self::Skip) omits the function from the result entirely; it
+///   appears in no summary, scorecard, or function list.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum MissingCoveragePolicy {
+    /// Score files missing from coverage as 0% covered (CRAP = `c² + c`).
+    #[default]
+    Pessimistic,
+    /// Score files missing from coverage as 100% covered (CRAP = `c`).
+    Optimistic,
+    /// Exclude functions in files missing from coverage from the result.
+    Skip,
+}
+
+impl MissingCoveragePolicy {
+    /// Canonical wire string — the single vocabulary shared by the CLI
+    /// flag value, the config key value, and the envelope token. Each arm
+    /// is held equal to this enum's serde (`rename_all = "lowercase"`)
+    /// representation by an integration test so the two never drift.
+    pub fn as_wire_str(&self) -> &'static str {
+        match self {
+            Self::Pessimistic => "pessimistic",
+            Self::Optimistic => "optimistic",
+            Self::Skip => "skip",
+        }
+    }
+}
+
+impl fmt::Display for MissingCoveragePolicy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_wire_str())
+    }
+}
+
 // ── Function Identity & Metrics ─────────────────────────────────────
 
 /// Identifies a function in the source code.

--- a/crates/crap-core/tests/as_wire_str_matches_serde.rs
+++ b/crates/crap-core/tests/as_wire_str_matches_serde.rs
@@ -13,7 +13,9 @@
 use crap_core::domain::delta::{ChangeKind, DeltaSortKey};
 use crap_core::domain::diagnostic::{Applicability, RootCause, SplitKind};
 use crap_core::domain::summary::CrapDeltaStatus;
-use crap_core::domain::types::{ComplexityMetric, ContributorKind, CoverageMetric, RiskLevel};
+use crap_core::domain::types::{
+    ComplexityMetric, ContributorKind, CoverageMetric, MissingCoveragePolicy, RiskLevel,
+};
 use crap_core::domain::view::{GroupKey, SortKey};
 use serde::Serialize;
 use serde_json::Value;
@@ -69,6 +71,17 @@ fn complexity_metric_wire_str_matches_serde() {
 #[test]
 fn coverage_metric_wire_str_matches_serde() {
     for v in [CoverageMetric::Line, CoverageMetric::Branch] {
+        assert_wire_str(v, v.as_wire_str());
+    }
+}
+
+#[test]
+fn missing_coverage_policy_wire_str_matches_serde() {
+    for v in [
+        MissingCoveragePolicy::Pessimistic,
+        MissingCoveragePolicy::Optimistic,
+        MissingCoveragePolicy::Skip,
+    ] {
         assert_wire_str(v, v.as_wire_str());
     }
 }

--- a/crates/crap4rs/README.md
+++ b/crates/crap4rs/README.md
@@ -62,6 +62,18 @@ The risk tiers themselves:
 
 The presets correspond to "gate at the next risk tier up." Override with `--threshold <N>` for a custom value, or define presets per-codebase in `crap.toml` (the canonical config name, written by `crap4rs init`). The legacy name `crap4rs.toml` is still discovered as a deprecated alias when no `crap.toml` is present.
 
+### Files missing from coverage
+
+When a source file is absent from the coverage report — a `#[cfg(feature = "…")]` module left out of the coverage build, an untested file, or a scoped per-package run — its functions are scored at 0% coverage by default, which inflates their CRAP (a complexity-`c` function jumps to `c² + c`). Choose how that case is handled with `--missing-coverage-policy` (or a `missing_coverage_policy` key in `crap.toml`):
+
+| Value | Behavior |
+|---|---|
+| `pessimistic` (default) | Score at 0% coverage — never hides risk. |
+| `optimistic` | Score at 100% coverage (CRAP = complexity) — for a scoped local test slice that legitimately omits some files. |
+| `skip` | Omit those functions from the report entirely. |
+
+The chosen policy is recorded in the JSON envelope (unless `pessimistic`), so a `--baseline` delta run warns when its policy differs from the baseline's.
+
 ## What it looks like
 
 ### Table (TTY default)

--- a/crates/crap4rs/src/lib.rs
+++ b/crates/crap4rs/src/lib.rs
@@ -43,7 +43,8 @@ pub mod domain {
             AnalysisResult, AnalysisSummary, BranchCoverage, ComplexityContributor,
             ComplexityMetric, ContributorKind, CoverageMetric, CoverageRatio, CrapError, CrapScore,
             Diagnostic, FileChangeKind, FunctionComplexity, FunctionCoverage, FunctionIdentity,
-            FunctionVerdict, LineCoverage, RiskDistribution, RiskLevel, ScoredFunction, SourceSpan,
+            FunctionVerdict, LineCoverage, MissingCoveragePolicy, RiskDistribution, RiskLevel,
+            ScoredFunction, SourceSpan,
         };
 
         /// v0.4 alias of [`crate::parse_diagnostic::LcovParseDiagnostic`].

--- a/crates/crap4rs/tests/analyze_integration.rs
+++ b/crates/crap4rs/tests/analyze_integration.rs
@@ -8,7 +8,7 @@ use crap4rs::adapters::coverage::LcovParser;
 use crap4rs::core::identity::IdentityBase;
 use crap4rs::core::{AnalyzeOptions, analyze};
 use crap4rs::domain::threshold::ThresholdConfig;
-use crap4rs::domain::types::ComplexityMetric;
+use crap4rs::domain::types::{ComplexityMetric, MissingCoveragePolicy};
 use std::path::{Path, PathBuf};
 
 /// Construct the LCOV/syn adapter pair rooted at `src`. Threaded
@@ -126,6 +126,87 @@ fn self_referential_with_cyclomatic() {
 
     // Should still find the same set of functions
     assert!(result.functions.len() > 10);
+}
+
+/// End-to-end snapshot of all three missing-coverage policies (AC #7):
+/// a single function whose file is absent from coverage scores three
+/// different ways. Complexity `c` is read from the result rather than
+/// hardcoded, so the CRAP assertions stay robust to the walker's exact
+/// cognitive count.
+#[test]
+fn missing_coverage_policy_changes_outputs_end_to_end() {
+    let tmp = tempfile::tempdir().unwrap();
+    let src = tmp.path().join("src");
+    std::fs::create_dir_all(&src).unwrap();
+    // Cognitive complexity > 1 so the 0%-vs-100% CRAP scores differ.
+    std::fs::write(
+        src.join("lib.rs"),
+        "pub fn classify(n: i32) -> &'static str {\n\
+         \x20   if n < 0 { \"neg\" } else if n == 0 { \"zero\" } else { \"pos\" }\n\
+         }\n",
+    )
+    .unwrap();
+    // LCOV covers an unrelated file, so `lib.rs` is absent from coverage
+    // and the policy decides its fate.
+    let lcov_path = tmp.path().join("lcov.info");
+    std::fs::write(&lcov_path, "SF:unrelated.rs\nDA:1,1\nend_of_record\n").unwrap();
+
+    let opts_for = |policy| AnalyzeOptions {
+        identity_base: IdentityBase::SrcRelative(src.clone()),
+        src: vec![src.clone()],
+        coverage: lcov_path.clone(),
+        threshold_config: ThresholdConfig {
+            global: 1000.0,
+            ..ThresholdConfig::default()
+        },
+        metric: ComplexityMetric::Cognitive,
+        exclude: Vec::new(),
+        respect_gitignore: false,
+        extensions: vec!["rs".to_string()],
+        missing_coverage_policy: policy,
+        ..AnalyzeOptions::default()
+    };
+
+    // Pessimistic: present, 0% coverage, CRAP = c² + c.
+    let (cx, cov) = adapters(&src);
+    let pess = analyze(&opts_for(MissingCoveragePolicy::Pessimistic), &cx, &cov)
+        .unwrap()
+        .result;
+    assert_eq!(pess.functions.len(), 1, "pessimistic keeps the function");
+    let f = &pess.functions[0].scored;
+    let c = f.complexity as f64;
+    assert!(c > 1.0, "fixture complexity must exceed 1, got {c}");
+    assert_eq!(f.coverage_percent, 0.0);
+    assert!(
+        (f.crap.value - (c * c + c)).abs() < 1e-9,
+        "pessimistic CRAP must be c²+c, got {} (c={c})",
+        f.crap.value
+    );
+
+    // Optimistic: present, 100% coverage, CRAP = c.
+    let (cx, cov) = adapters(&src);
+    let opt = analyze(&opts_for(MissingCoveragePolicy::Optimistic), &cx, &cov)
+        .unwrap()
+        .result;
+    assert_eq!(opt.functions.len(), 1, "optimistic keeps the function");
+    let f = &opt.functions[0].scored;
+    assert_eq!(f.coverage_percent, 100.0);
+    assert!(
+        (f.crap.value - c).abs() < 1e-9,
+        "optimistic CRAP must equal complexity {c}, got {}",
+        f.crap.value
+    );
+
+    // Skip: the function is omitted from the result entirely.
+    let (cx, cov) = adapters(&src);
+    let skip = analyze(&opts_for(MissingCoveragePolicy::Skip), &cx, &cov)
+        .unwrap()
+        .result;
+    assert!(
+        skip.functions.is_empty(),
+        "skip omits functions whose file is absent from coverage"
+    );
+    assert!(skip.passed, "an empty skip result still passes the gate");
 }
 
 #[test]

--- a/crates/crap4rs/tests/diff_integration.rs
+++ b/crates/crap4rs/tests/diff_integration.rs
@@ -8,7 +8,7 @@ use crap4rs::adapters::coverage::LcovParser;
 use crap4rs::core::identity::IdentityBase;
 use crap4rs::core::{AnalysisOutput, AnalyzeOptions, analyze};
 use crap4rs::domain::threshold::ThresholdConfig;
-use crap4rs::domain::types::ComplexityMetric;
+use crap4rs::domain::types::{ComplexityMetric, MissingCoveragePolicy};
 use std::path::Path;
 use std::process::Command;
 
@@ -602,6 +602,7 @@ fn json_envelope_contains_diff_ref() {
     let config = reporters::json::JsonConfig {
         tool_version: "0.1.0".to_string(),
         metric: ComplexityMetric::Cognitive,
+        missing_coverage_policy: MissingCoveragePolicy::Pessimistic,
         threshold: 30.0,
         timestamp: "2026-03-29T00:00:00Z".to_string(),
         diagnostics: None,
@@ -639,6 +640,7 @@ fn json_envelope_diff_ref_null_without_flag() {
     let config = reporters::json::JsonConfig {
         tool_version: "0.1.0".to_string(),
         metric: ComplexityMetric::Cognitive,
+        missing_coverage_policy: MissingCoveragePolicy::Pessimistic,
         threshold: 30.0,
         timestamp: "2026-03-29T00:00:00Z".to_string(),
         diagnostics: None,

--- a/crates/crap4rs/tests/json_reporter_cucumber.rs
+++ b/crates/crap4rs/tests/json_reporter_cucumber.rs
@@ -26,7 +26,7 @@ use cucumber::{World, given, then, when, writer};
 use serde_json::{Value, json};
 
 use crap4rs::adapters::reporters::{JsonConfig, format_json};
-use crap4rs::domain::types::{AnalysisResult, ComplexityMetric};
+use crap4rs::domain::types::{AnalysisResult, ComplexityMetric, MissingCoveragePolicy};
 use crap4rs::domain::view::{self, ViewSpec};
 
 /// State threaded through Given/When/Then steps. Each scenario starts
@@ -56,6 +56,7 @@ impl JsonWorld {
         let config = JsonConfig {
             tool_version: "0.1.0".to_string(),
             metric,
+            missing_coverage_policy: MissingCoveragePolicy::Pessimistic,
             threshold,
             timestamp: "2026-05-04T00:00:00Z".to_string(),
             diagnostics: None,

--- a/crates/crap4rs/tests/json_reporter_lcov_diagnostics.rs
+++ b/crates/crap4rs/tests/json_reporter_lcov_diagnostics.rs
@@ -15,7 +15,9 @@
 //! per-key assertions. Pure relocation — no behavior change.
 
 use crap4rs::adapters::reporters::{JsonConfig, format_json};
-use crap4rs::domain::types::{AnalysisDiagnostics, AnalysisResult, ComplexityMetric};
+use crap4rs::domain::types::{
+    AnalysisDiagnostics, AnalysisResult, ComplexityMetric, MissingCoveragePolicy,
+};
 use crap4rs::domain::view::{self, ViewSpec};
 
 fn make_empty_result() -> AnalysisResult {
@@ -65,6 +67,7 @@ fn diagnostics_included_when_present() {
     let config = JsonConfig {
         tool_version: "0.1.0".to_string(),
         metric: ComplexityMetric::Cognitive,
+        missing_coverage_policy: MissingCoveragePolicy::Pessimistic,
         threshold: 8.0,
         timestamp: "2026-03-28T12:00:00Z".to_string(),
         diagnostics: Some(&diag),

--- a/crates/crap4rs/tests/matching_integration.rs
+++ b/crates/crap4rs/tests/matching_integration.rs
@@ -7,6 +7,7 @@ use crap4rs::adapters::complexity::SynComplexityAdapter;
 use crap4rs::domain::matching::match_functions;
 use crap4rs::domain::types::ComplexityMetric;
 use crap4rs::domain::types::LineCoverage;
+use crap4rs::domain::types::MissingCoveragePolicy;
 use crap4rs::ports::ComplexityPort;
 use std::collections::HashMap;
 
@@ -40,7 +41,7 @@ fn simple_functions_fully_covered() {
         make_da_for_range(1, total_lines, true),
     );
 
-    let matched = match_functions(&fns, &line_data, None);
+    let matched = match_functions(&fns, &line_data, None, MissingCoveragePolicy::Pessimistic);
 
     assert_eq!(matched.len(), fns.len());
     for (comp, cov) in &matched {
@@ -84,7 +85,7 @@ fn impl_methods_matched_correctly() {
         ),
     );
 
-    let matched = match_functions(&fns, &line_data, None);
+    let matched = match_functions(&fns, &line_data, None, MissingCoveragePolicy::Pessimistic);
     assert_eq!(matched.len(), fns.len());
 
     // new should have coverage, others should have 0 total (no DA lines in their range)
@@ -110,7 +111,7 @@ fn function_with_no_coverage_file() {
     // Empty line data — no coverage for this file at all
     let line_data: HashMap<String, Vec<LineCoverage>> = HashMap::new();
 
-    let matched = match_functions(&fns, &line_data, None);
+    let matched = match_functions(&fns, &line_data, None, MissingCoveragePolicy::Pessimistic);
     assert_eq!(matched.len(), fns.len());
 
     for (_, cov) in &matched {
@@ -141,7 +142,7 @@ fn mixed_coverage_per_function() {
     let mut line_data = HashMap::new();
     line_data.insert("src/lib.rs".to_string(), da_lines);
 
-    let matched = match_functions(&fns, &line_data, None);
+    let matched = match_functions(&fns, &line_data, None, MissingCoveragePolicy::Pessimistic);
 
     // Every function should have some coverage data
     for (comp, cov) in &matched {


### PR DESCRIPTION
## Summary

Replaces the hardcoded pessimistic scoring for functions whose source file is **entirely absent from the coverage data** with a configurable `--missing-coverage-policy {pessimistic|optimistic|skip}` flag (and matching `missing_coverage_policy` config key). The default is `pessimistic` — byte-identical to today's behavior.

| Policy | Behavior |
|---|---|
| `pessimistic` (default) | score at 0% coverage (CRAP = c² + c) — never hides risk |
| `optimistic` | score at 100% coverage (CRAP = c) — for a scoped local test slice |
| `skip` | omit those functions from the report entirely |

The knob lives in `crap-core` (domain enum + CLI + matching), so **both adapters inherit it** through the shared `analyze` pipeline.

## What changed (commit-by-commit)

1. **domain + core mechanism** — `MissingCoveragePolicy` enum; `match_functions` takes the policy; `functions_no_coverage` is now derived from `all_complexities` (not the matched vec) so it stays accurate under `skip`, and the partition `debug_assert` re-anchors to `all_complexities` as a real check.
2. **CLI flag + config key** — `--missing-coverage-policy` (`Option<…>` so an unset flag never clobbers a config-set policy past `..Default`), `missing_coverage_policy` config key, cascade CLI > config > default. Regenerated `crap.example.toml` + `crap.schema.json`.
3. **envelope + baseline mismatch warn** — the JSON envelope records the policy, **elided when `pessimistic`** so every existing envelope (incl. the self-referential `wire_envelope_crap4rs` snapshot) stays byte-identical; the baseline loader reads it with `#[serde(default)]` (absent ⇒ pessimistic). A delta run **warns when its policy differs from the baseline's** — the `pessimistic` → `skip` case is the sharpest (those functions are present in the baseline, absent now, so the delta reads them as deletions).
4. **end-to-end 3-policy snapshot + docs** — a single function whose file is absent from coverage scores three ways through the real pipeline; crap4rs README documents the flag.
5. **refactor below strict-8** — the policy dispatch pushed `match_functions` to cognitive 8 (CRAP 8.0 at 100% cov — passing, but at the boundary). Extracted `coverage_for_function`; `match_functions` is now cognitive 1, the helper 4.

## AC coverage (#278)

- [x] `--missing-coverage-policy` flag + config key; default `pessimistic`
- [x] `optimistic` → 100% (CRAP = c); `skip` → omitted from summary/scorecard/list
- [x] `functions_no_coverage` accurate under all three policies
- [x] policy recorded in the wire envelope (baseline/delta coherence) + mismatch warning
- [x] tests for all three policy outputs (matching unit, envelope serialize, baseline round-trip, and an end-to-end snapshot)

## Verification

- `cargo fmt --check`, `cargo +1.96.0 clippy --workspace --all-targets -- -D warnings`, `cargo +1.93 check --workspace --all-targets` (MSRV) — all clean
- Full workspace: **1364 tests pass**; `scripts/mutants-skip-lint.py` + `scripts/bdd-tracked-lint.py` green
- **strict-8 self-gate** (the `scorecard-production` job): ran locally over the three prod crates with real `cargo llvm-cov` coverage — exit 0, zero functions over CRAP 8. The two touched functions land at CRAP 1.0 (`match_functions`) and 4.0 (`score_and_assemble`), with the new `coverage_for_function` at 4.0.

## Note on crap4ts

crap4ts inherits the knob for free via shared `crap-core`. Its Istanbul/V8 coverage is file-path-keyed the same way LCOV is, so a TS function whose file is absent from the coverage map is scored per the policy identically — but I did **not** separately exercise the TS path against a coverage-absent file in this PR; the parity is by construction (one shared `match_functions`), not separately validated end-to-end here.

Closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--missing-coverage-policy` CLI option to control how functions are scored when source files are absent from coverage data, with three modes: pessimistic (default, 0%), optimistic (100%), or skip (omit from report).
  * Added corresponding `missing_coverage_policy` configuration option in TOML files.
  * Policy selection is recorded in JSON envelopes for baseline comparisons; mismatched policies between runs trigger a warning.

* **Documentation**
  * Updated documentation with guidance on the new missing coverage policy option and its behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->