### PR TITLE
ci(pages): #378 — publish production report + baseline envelope to gh-pages on push:main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -753,6 +753,111 @@ jobs:
             `crap-examples` (an intentionally bad teaching sample), not
             production.
 
+  publish-production-report:
+    # ----------------------------------------------------------------
+    # Hosted-reports walking skeleton (crap-rs#378, epic #377). On
+    # push to main ONLY, render the production CRAP HTML report and
+    # publish it to the GitHub Pages root, plus write the production
+    # analysis envelope to gh-pages:/baselines/main.json — the baseline
+    # every future per-PR report will diff against. Main report only;
+    # per-PR / delta wiring is a later wave.
+    #
+    # This is REPORT-ONLY, never a gate: the threshold gate is owned by
+    # `scorecard-production` (gate-on-analysis) on the PR. This job only
+    # `needs: [coverage]` and so runs even if a strict-8 regression
+    # reached main — exactly when the hosted report matters most — so
+    # the render uses `--no-fail` (the same flag the composite action
+    # uses to capture truth into its envelope) to keep the analyzer's
+    # threshold exit code from skipping the publish.
+    #
+    # The analysis half mirrors `scorecard-production` byte-for-byte:
+    # same pinned actions, same `lcov` artifact, and the published
+    # crap4rs predates the repeatable-`--src` this repo's `crap.toml`
+    # needs, so the report MUST run THIS commit's freshly built binary.
+    # Analysis knobs (`src` / `threshold` / `metric`) are NOT passed —
+    # the repo-root `crap.toml` owns them via auto-discovery, identical
+    # to `scorecard-production`.
+    # ----------------------------------------------------------------
+    name: Publish production report → gh-pages
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    needs: [coverage]
+    permissions:
+      # Elevate ONLY here: contents: write to push the rendered report
+      # and baseline envelope to the gh-pages branch. The top-level
+      # workflow default stays contents: read.
+      contents: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # The publish step uses a separate tokened clone of gh-pages,
+          # never this checkout's persisted credentials — keep them off
+          # the runner's .git/config (artipacked audit).
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # tracks @stable branch
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: lcov
+
+      - name: Build crap4rs from source
+        # The published crap4rs lacks the repeatable `--src` this repo's
+        # crap.toml needs (3 prod crate roots) — same rationale as
+        # scorecard-production's "Build PR binary" step.
+        run: cargo build --release --package crap4rs
+
+      - name: Render production HTML report + baseline envelope
+        # No analysis flags — crap.toml owns src/threshold/metric via
+        # auto-discovery from the repo root. Multi-format fan-out writes
+        # both shapes in one pass: HTML is the hosted report, JSON is
+        # the baseline envelope. No `--baseline`: main IS the baseline,
+        # so the root report has no delta tab (correct for Wave 0).
+        # `--no-fail` makes this report-only — a threshold violation on
+        # main must not skip publication (gating is scorecard-production).
+        run: |
+          set -euo pipefail
+          ./target/release/crap4rs \
+            --coverage lcov.info \
+            --no-fail \
+            --format html:report.html,json:envelope.json
+          # Empty-file guard (AGENTS.md release-envelope rule): a silent
+          # render failure surfaces here, not as an opaque downstream
+          # parse error on the published asset.
+          [ -s report.html ] || { echo "::error::render produced an empty report.html"; exit 1; }
+          [ -s envelope.json ] || { echo "::error::render produced an empty envelope.json"; exit 1; }
+
+      - name: Publish to gh-pages
+        # Plain git push (no third-party action — supply-chain
+        # conventions). A separate shallow tokened clone of gh-pages
+        # avoids relying on the main checkout's (deliberately absent)
+        # persisted credentials. Existing gh-pages content — notably
+        # `.nojekyll` — is preserved because we copy files in rather
+        # than wiping the tree. The no-op guard skips an empty commit;
+        # in practice the envelope's embedded timestamp changes every
+        # run, so it is a safety net, not a deduplicator.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git clone --branch gh-pages --single-branch --depth 1 \
+            "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            gh-pages-pub
+          # Root report → Pages index.html; envelope → baselines/main.json.
+          cp report.html gh-pages-pub/index.html
+          mkdir -p gh-pages-pub/baselines
+          cp envelope.json gh-pages-pub/baselines/main.json
+          cd gh-pages-pub
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "gh-pages already up to date — nothing to publish"
+            exit 0
+          fi
+          git add index.html baselines/main.json
+          git \
+            -c user.name="github-actions[bot]" \
+            -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+            commit -m "ci(pages): publish production report + baseline envelope (${GITHUB_SHA})"
+          git push origin HEAD:gh-pages
+
   scorecard-smoke-ts:
     # Sibling of `scorecard-smoke-rust` for the TypeScript dispatch
     # path. Build crap4ts from the PR, stage it on PATH (the only


### PR DESCRIPTION
## Summary

Wave 0 walking skeleton for the hosted-reports epic (#377). Adds a new `publish-production-report` job to `ci.yml` that, **on push to `main` only**, renders the production CRAP HTML report and publishes it to the GitHub Pages root, plus writes the production analysis **envelope** to `gh-pages:/baselines/main.json` — the baseline every future per-PR report will diff against.

Closes #378

Main report only. No per-PR / delta logic (those are later waves). The root report has no `--baseline` (main IS the baseline → no delta tab), which is correct for Wave 0.

## The job

- `if: github.event_name == 'push'` — runs ONLY on push-to-main, never on PRs.
- `needs: [coverage]` — consumes the existing `lcov` artifact.
- `permissions: contents: write` — scoped to this job only; the top-level workflow default stays `contents: read`.
- **Analysis half mirrors `scorecard-production` byte-for-byte**: same SHA-pinned actions (`actions/checkout` v6.0.2, `dtolnay/rust-toolchain` @stable, `Swatinem/rust-cache` v2, `actions/download-artifact` v8.0.1), from-source `cargo build --release --package crap4rs` (the published binary lacks the repeatable `--src` this repo's `crap.toml` needs), and **no analysis flags** so `crap.toml` owns src/threshold/metric via auto-discovery.
- **Render is REPORT-ONLY** (`--no-fail`): gating stays with `scorecard-production` (gate-on-analysis on the PR). Since this job only `needs: [coverage]`, it must still publish — and write the baseline — even if a strict-8 regression ever reaches main. `--no-fail` is the same flag the composite scorecard action uses internally to capture truth into its envelope.
- **Render command**: `crap4rs --coverage lcov.info --no-fail --format html:report.html,json:envelope.json` — one analysis pass, two outputs.
- **Publish** is a plain `git push` (no third-party action — supply-chain conventions) via a separate shallow tokened clone of `gh-pages` using `GITHUB_TOKEN` injected into the remote URL. The main checkout keeps `persist-credentials: false`. `.nojekyll` is preserved by copying files *in* (no tree wipe); a no-op guard skips empty commits; `contents: write` scoped to this job.

## Local render-validation (done)

Generated a fresh workspace `lcov.info` (`cargo llvm-cov nextest --workspace --exclude crap-examples`) and ran the **exact CI render command** with the freshly built binary:

- `report.html` — **1.27 MB**, self-contained (CSS inlined via `<style>`, zero external script/link refs), valid `<!doctype html>`.
- `envelope.json` — **2.55 MB**, well-formed JSON; 1628 functions; coverage joined (1620/1628 nonzero, 0–100%); `diff_ref: null` (no baseline → no delta tab); `threshold: 8.0` + `metric: cognitive` confirming `crap.toml` auto-discovery drove the run.
- Exit code **0** with `--no-fail` even when a forced `--threshold 1` violation was injected (verified the report-only behavior).
- Simulated the publish step against a local `gh-pages` clone: `.nojekyll` (0 bytes) preserved, `index.html` overwritten with the report, `baselines/main.json` created, `git add` captures both, no-op guard fires correctly.

## Static workflow validation (done)

- `actionlint .github/workflows/ci.yml` → **EXIT 0** (1.7.11).
- `pipx run 'zizmor>=1.5,<2' .github/` (the exact constraint the `zizmor` CI job uses) → **No findings to report** (EXIT 0; the 1 ignored / 31 suppressed are pre-existing inline suppressions, none from this job).
- `git diff --name-only origin/main` → only `.github/workflows/ci.yml`.

## Verification note

**A `push:main` job cannot be fully verified pre-merge** — it triggers on push to `main`, so it first runs on the first merge to main after this lands. The hosted report will then render at https://breezy-bays-labs.github.io/crap-rs/ and the baseline envelope at `/baselines/main.json`. The optional pre-merge validation path is a synthetic-push drill on a throwaway branch with a transient `push: ['**']` trigger — **I did not run that drill** (out of scope for this PR; noted as the available path).

The `gh-pages` push will not re-trigger CI: `on.push.branches` is `[main]` only (gh-pages pushes don't match), and `GITHUB_TOKEN`-authored pushes don't spawn workflow runs anyway (belt and suspenders).

## Risks / decisions

- **Exit-code gating (the one real correctness risk)**: the raw `crap4rs` binary exits 1 on threshold violations; without `--no-fail`, the render would die exactly when a regression reaches main, and the baseline envelope would never get written. Resolved with `--no-fail` (the action's own report-only mechanism) — not a blanket `|| true`, which would also mask genuine crashes.
- **No-op guard**: the envelope embeds a top-level `timestamp`, so `baselines/main.json` changes every run and the guard essentially never fires — it's a safety net, not a deduplicator (intentional for Wave 0; comment in the YAML says so).
- **Template-injection surface**: the publish step uses only `${{ secrets.GITHUB_TOKEN }}` in step `env:` and runner-provided `$GITHUB_REPOSITORY` / `$GITHUB_SHA` (shell-quoted) — no `${{ github.event.* }}` interpolation in `run:` blocks. zizmor confirms clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/breezy-bays-labs/crap-rs/pull/380">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated production report generation and continuous deployment workflow. The pipeline now executes automatically on every push to the main branch, generating comprehensive metrics reports and baseline envelopes, validating outputs for data completeness, and publishing results to the project documentation portal for enhanced stakeholder visibility and continuous performance metrics analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->