### PR TITLE
ci(pages): #381 — per-PR delta report on gh-pages + hosted link in the single scorecard sticky

### DIFF
--- a/.github/actions/scorecard/README.md
+++ b/.github/actions/scorecard/README.md
@@ -506,6 +506,70 @@ GitHub** (per the GH API contract on artifact download URLs), so the
 links are meant for human-followable surfaces (sticky comments,
 Check Run summaries) — not in-job `curl` retrieval.
 
+## Hosted per-PR report on GitHub Pages
+
+A workflow-artifact link makes the reviewer download a zip and open
+it locally. `pages-publish: true` instead pushes the rendered HTML to
+a GitHub Pages branch and links the **live hosted page** in the
+sticky comment — one click, no download. Pair it with `baseline:` to
+host a per-PR report whose Delta tab diffs the PR branch against a
+published baseline.
+
+```yaml
+jobs:
+  scorecard:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write       # required for the gh-pages push
+      pull-requests: write  # required for the sticky comment
+    steps:
+      - uses: actions/checkout@<sha>
+        with:
+          persist-credentials: false
+      # ... build coverage + (optionally) fetch a baseline ...
+      - uses: breezy-bays-labs/crap-rs/.github/actions/scorecard@<sha>
+        with:
+          coverage: lcov.info
+          baseline: baseline.json          # optional — enables the Delta tab
+          html-report: true                # required for pages-publish
+          comment-mode: sticky
+          # Publish ONLY on same-repo PRs — a fork PR's GITHUB_TOKEN is
+          # read-only and the push would 403. On a fork PR this resolves
+          # to false and the card degrades to summary-only (no link).
+          pages-publish: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
+          pages-deploy-path: pr-${{ github.event.number }}
+          pages-url: https://acme.github.io/my-repo/pr-${{ github.event.number }}/
+```
+
+**Publish before post (no dead links).** The publish step runs BEFORE
+the sticky comment is composed, under `set -euo pipefail`, so a push
+failure fails the whole job (red X) rather than posting a link to a
+page that was never written. The sticky link (`📊 [Open report](…)`)
+is emitted only when `pages-publish: true`; with it off the action's
+body is byte-identical to the artifact-link / no-link behavior.
+
+**`contents: write` and fork PRs.** The publish is a plain `git push`
+to the Pages branch from within the caller's job, authorized by the
+job's `GITHUB_TOKEN` — so the caller must grant `contents: write`.
+GitHub issues a **read-only** `GITHUB_TOKEN` for fork-triggered
+`pull_request` events regardless of the `permissions:` block, so the
+push would 403 on a fork. Gate `pages-publish` to same-repo events
+(as above); on a fork PR the action falls back to the existing
+artifact-link / no-link path and the card stays green. Full fork-PR
+publishing (a `workflow_run` topology that publishes in a privileged
+context) is a separate, later deliverable.
+
+**Existing Pages content is preserved.** The publish copies the
+report into `<pages-deploy-path>/index.html`; it does not wipe the
+branch tree. A root `index.html`, `.nojekyll`, a `baselines/`
+directory, and other PRs' deploy paths all survive untouched.
+
+**Concurrency.** If more than one job in your workflows can push to
+the Pages branch (e.g. a per-PR publish and a push-to-main publish),
+give them a shared `concurrency: { group: <pages-group>,
+cancel-in-progress: false }` so their pushes serialize and can't
+collide on the branch tip.
+
 ## Patterns
 
 The three standard integration shapes. Pattern 1 is what the [Quick
@@ -705,6 +769,10 @@ row; the aggregator owns the comment.
 | `annotation-limit` | `''` | Cap on emitted annotations when `annotations: true`. Empty defers to the adapter's default (10) or `[output] annotation_limit` from `config`. Range 1..=100 |
 | `html-report` | `false` | When `true`, render `<bin> --format html` as a workflow artifact and (sticky-only) append a download link to the comment body. Per-language in multi-language mode. See [HTML report](#html-report) |
 | `html-artifact-name-suffix` | `''` (→ `-${{ runner.os }}`) | Suffix appended to the HTML artifact name(s) to disambiguate matrix-strategy uploads. See [HTML report — Artifact naming + retention](#artifact-naming--retention) |
+| `pages-publish` | `false` | When `true`, publish the rendered HTML to a GitHub Pages branch and use the hosted URL as the sticky link (replacing the artifact-download link). Requires `html-report: true`, `pages-deploy-path`, `pages-url`, and the caller's job granting `contents: write`. Set `false` on fork PRs (read-only token can't push). See [Hosted per-PR report](#hosted-per-pr-report-on-github-pages) |
+| `pages-deploy-path` | `''` | Path within the Pages branch to deploy to (e.g. `pr-123`). Report is written to `<path>/index.html`; existing Pages content outside the path is preserved. Required when `pages-publish: true` |
+| `pages-url` | `''` | Public URL the deployed report is reachable at (e.g. `https://acme.github.io/my-repo/pr-123/`). Used verbatim as the sticky link. Required when `pages-publish: true` — the action does not derive it from `pages-deploy-path` |
+| `pages-branch` | `gh-pages` | The Pages branch to publish to. Consulted only when `pages-publish: true` |
 | `threshold-preset` | `''` | (preset) `strict` (8) \| `default` (15) \| `lenient` (25). Derives `threshold`; raw `threshold:` wins on conflict + warning. See [Presets](#presets) |
 | `run-mode` | `''` | (preset) `full` \| `delta` \| `both` — drives baseline expectations. `delta`/`both` require `baseline:` set. See [Presets](#presets) |
 | `gate-mode` | `''` | (preset) `report-only` \| `gate-on-analysis` \| `gate-on-delta` \| `gate-on-both`. Atomic `analysis-gate` + `delta-gate` pair; raw inputs win on conflict + warning. See [Presets](#presets) |

--- a/.github/actions/scorecard/action.yml
+++ b/.github/actions/scorecard/action.yml
@@ -281,6 +281,62 @@ inputs:
       Only consulted when `html-report: true`.
     required: false
     default: ''
+  pages-publish:
+    description: |
+      When `true`, publish the rendered HTML report to a GitHub Pages
+      branch and use the resulting hosted URL as the sticky-comment
+      report link (replacing the workflow-artifact download link). The
+      publish happens BEFORE the sticky comment is composed, so a push
+      failure fails the job (red X) rather than posting a dead link.
+
+      Requires `html-report: true` (there must be a rendered report to
+      publish) — the action errors if `pages-publish: true` is set
+      without it. Requires `pages-deploy-path` and `pages-url` to be
+      set. The CALLER's job must grant `contents: write` (the publish
+      is a plain `git push` to the Pages branch from within the caller's
+      job, using the job's `GITHUB_TOKEN`).
+
+      Set this `false` on fork PRs: a fork PR's `GITHUB_TOKEN` is
+      read-only regardless of the job's `permissions:` block, so the
+      push would 403. The caller is responsible for gating this input
+      to same-repo events (e.g. `github.event.pull_request.head.repo.
+      full_name == github.repository`); on a fork PR the action then
+      falls back to the existing artifact-link / no-link behavior.
+
+      Default `false` (additive only — no behavior change for existing
+      consumers). Empty string is treated as `false`.
+    required: false
+    default: 'false'
+  pages-deploy-path:
+    description: |
+      Path WITHIN the Pages branch to deploy the report to, e.g.
+      `pr-123`. The rendered HTML is written to
+      `<pages-deploy-path>/index.html`. Required (non-empty) when
+      `pages-publish: true`. Existing Pages content outside this path
+      (the root `index.html`, `.nojekyll`, `baselines/`, other PRs'
+      directories) is preserved — the publish copies files in, it does
+      not wipe the branch tree. Ignored when `pages-publish: false`.
+    required: false
+    default: ''
+  pages-url:
+    description: |
+      The public URL the deployed report is reachable at, e.g.
+      `https://acme.github.io/my-repo/pr-123/`. Used verbatim as the
+      sticky-comment report link (`📊 [Open report](<pages-url>)`).
+      Required (non-empty) when `pages-publish: true`. The action does
+      NOT derive this from `pages-deploy-path` — the caller passes the
+      full URL so the action stays agnostic to the consumer's Pages
+      base URL (custom domains, project vs user Pages, subpaths all
+      differ). Ignored when `pages-publish: false`.
+    required: false
+    default: ''
+  pages-branch:
+    description: |
+      The Pages branch to publish to. Default `gh-pages` (the
+      deploy-from-branch convention). Consulted only when
+      `pages-publish: true`.
+    required: false
+    default: 'gh-pages'
 
 outputs:
   markdown:
@@ -455,6 +511,13 @@ runs:
         # validation skips when `is_multi=false`.
         COVERAGE_TS: ${{ inputs.coverage-ts }}
         SRC_TS: ${{ inputs.src-ts }}
+        # Pages-publish inputs — validated below (the publish step
+        # itself runs later, after the HTML render). Empty defaults
+        # keep the validation inert for callers who never opt in.
+        PAGES_PUBLISH: ${{ inputs.pages-publish }}
+        PAGES_DEPLOY_PATH: ${{ inputs.pages-deploy-path }}
+        PAGES_URL: ${{ inputs.pages-url }}
+        HTML_REPORT: ${{ inputs.html-report }}
       run: |
         set -euo pipefail
         # ----------------------------------------------------------------
@@ -783,9 +846,49 @@ runs:
           fi
         fi
 
+        # ----------------------------------------------------------------
+        # 6. Pages-publish validation
+        # ----------------------------------------------------------------
+        # Fail fast (here, before any adapter dispatch) on a Pages-publish
+        # misconfiguration so the error names the cause in the same step
+        # that resolved it, rather than surfacing later as a dead link or
+        # an opaque `git push` failure.
+        #
+        # Accept only `""|true|false` for the boolean (free-form GHA
+        # input strings — a typo like `TRUE`/`yes` would otherwise read
+        # as "not true" and silently disable publishing, dropping the
+        # hosted link without warning). Then, when publishing is ON:
+        #   * require `html-report: true` — there must be a rendered
+        #     report to publish; otherwise the compose step would emit a
+        #     `pages-url` link pointing at a page that was never written
+        #     (the exact dead-link hazard the publish-before-post
+        #     ordering exists to prevent).
+        #   * require `pages-deploy-path` AND `pages-url` — the publish
+        #     step has no sane default for either; an empty deploy path
+        #     would write to the Pages root (clobbering the production
+        #     report), and an empty URL would compose a broken link.
+        case "$PAGES_PUBLISH" in
+          ""|true|false) ;;
+          *) echo "::error::unsupported pages-publish '$PAGES_PUBLISH'; expected 'true' or 'false' (or empty for the default 'false')"; exit 1 ;;
+        esac
+        if [ "$PAGES_PUBLISH" = "true" ]; then
+          if [ "$HTML_REPORT" != "true" ]; then
+            echo "::error::pages-publish: true requires html-report: true (there must be a rendered HTML report to publish). Set html-report: true or pages-publish: false."
+            exit 1
+          fi
+          pages_missing=""
+          [ -z "$PAGES_DEPLOY_PATH" ] && pages_missing="${pages_missing}pages-deploy-path "
+          [ -z "$PAGES_URL" ] && pages_missing="${pages_missing}pages-url "
+          if [ -n "$pages_missing" ]; then
+            echo "::error::pages-publish: true requires the following input(s): ${pages_missing}. pages-deploy-path is the path within the Pages branch (e.g. 'pr-123'); pages-url is the public URL the report is reachable at (used as the sticky link)."
+            exit 1
+          fi
+        fi
+        echo "pages_publish=$PAGES_PUBLISH" >> "$GITHUB_OUTPUT"
+
         # Surface a compact summary in the job log so the resolved
         # values are obvious to reviewers without scrolling.
-        echo "Resolved presets: threshold=$resolved_threshold analysis-gate=$resolved_analysis_gate delta-gate=$resolved_delta_gate single-language=${single_language:-<unset>} language-set=${language_set:-<unset>} is-multi=$is_multi run-mode=${RUN_MODE:-<unset>}"
+        echo "Resolved presets: threshold=$resolved_threshold analysis-gate=$resolved_analysis_gate delta-gate=$resolved_delta_gate single-language=${single_language:-<unset>} language-set=${language_set:-<unset>} is-multi=$is_multi run-mode=${RUN_MODE:-<unset>} pages-publish=$PAGES_PUBLISH"
 
     - name: Resolve language
       id: lang
@@ -1563,6 +1666,100 @@ runs:
         path: ${{ steps.render-unified.outputs.unified_path }}
         if-no-files-found: error
 
+    # Hosted per-PR report (crap-rs#377 epic, Wave 1): publish the
+    # rendered HTML to a GitHub Pages branch so the sticky comment can
+    # link a live hosted report instead of a download-a-zip artifact.
+    #
+    # Runs ONLY when `pages-publish: true` (validated in `Resolve
+    # presets` to also require html-report:true + a deploy path + a
+    # URL). Placed AFTER the HTML render (the file it copies was written
+    # by `Run analysis` / `Render unified HTML`) and BEFORE `Compose
+    # sticky message` (so the link the compose step emits is only ever
+    # produced when the publish already succeeded — "publish before
+    # post"). The PR's own report file is resolved here: the unified
+    # render in multi-language mode, else the single-language per-adapter
+    # render.
+    #
+    # `set -euo pipefail` makes a `git push` failure FAIL the job
+    # (non-zero exit) — the whole point of ordering this before the
+    # sticky step is that a failed publish reds the run rather than
+    # posting a dead link. On a fork PR the caller passes
+    # `pages-publish: false` (a fork token can't push), so this step is
+    # skipped entirely and the action falls back to the artifact/no-link
+    # path.
+    #
+    # Token: `github.token` (NOT `secrets.GITHUB_TOKEN`, which is
+    # unavailable in composite-action context). `github.token` carries
+    # the CALLER job's permissions, so the caller's `contents: write`
+    # grant is what authorizes the push. It is referenced only via the
+    # step `env:` block, never interpolated into the `run:` script
+    # (template-injection hygiene). `$GITHUB_REPOSITORY` is shell-quoted.
+    - name: Publish HTML to GitHub Pages
+      id: pages
+      if: steps.presets.outputs.pages_publish == 'true' && inputs.html-report == 'true'
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+        PAGES_BRANCH: ${{ inputs.pages-branch }}
+        PAGES_DEPLOY_PATH: ${{ inputs.pages-deploy-path }}
+        IS_MULTI: ${{ steps.presets.outputs.is_multi }}
+        LANGUAGE: ${{ steps.lang.outputs.language }}
+        # Candidate report paths written by the render steps above. In
+        # multi-language mode the unified render is canonical; in single-
+        # language mode the per-adapter render path applies.
+        UNIFIED_PATH: ${{ steps.render-unified.outputs.unified_path }}
+        HTML_PATH_RUST: ${{ steps.run.outputs.html_path_rust }}
+        HTML_PATH_TYPESCRIPT: ${{ steps.run.outputs.html_path_typescript }}
+      run: |
+        set -euo pipefail
+        # Resolve the single report file to publish — unified (multi)
+        # else the per-language render (single). One canonical "report
+        # to publish" var keeps the empty-file guard and copy below
+        # path-agnostic.
+        if [ "$IS_MULTI" = "true" ]; then
+          REPORT_HTML="$UNIFIED_PATH"
+        elif [ "$LANGUAGE" = "rust" ]; then
+          REPORT_HTML="$HTML_PATH_RUST"
+        else
+          REPORT_HTML="$HTML_PATH_TYPESCRIPT"
+        fi
+        # Empty-file guard (AGENTS.md release-envelope rule): a silent
+        # render failure surfaces here as a named error, not as a
+        # published empty page behind a live link.
+        if [ -z "$REPORT_HTML" ] || [ ! -s "$REPORT_HTML" ]; then
+          echo "::error::pages-publish: the rendered HTML report ('${REPORT_HTML:-<unset>}') is missing or empty; refusing to publish a dead/empty page."
+          exit 1
+        fi
+        # Shallow tokened clone of the Pages branch. A SEPARATE clone
+        # (not the workflow checkout) keeps the push self-contained and
+        # works even though the caller's checkout sets
+        # persist-credentials: false. The token is in the URL via the
+        # env var, never echoed.
+        git clone --branch "$PAGES_BRANCH" --single-branch --depth 1 \
+          "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+          gh-pages-pr-pub
+        # Copy the report to <deploy-path>/index.html. mkdir -p creates
+        # the per-PR directory; existing Pages content outside it
+        # (root index.html, .nojekyll, baselines/, other PR dirs) is
+        # preserved because we copy in rather than wiping the tree.
+        mkdir -p "gh-pages-pr-pub/${PAGES_DEPLOY_PATH}"
+        cp "$REPORT_HTML" "gh-pages-pr-pub/${PAGES_DEPLOY_PATH}/index.html"
+        cd gh-pages-pr-pub
+        # No-op guard: skip an empty commit when the report is unchanged
+        # (a re-run on the same SHA). In practice the envelope-embedded
+        # render reflects code/coverage that usually differs, so this is
+        # a safety net, not a deduplicator.
+        if [ -z "$(git status --porcelain)" ]; then
+          echo "gh-pages already up to date for ${PAGES_DEPLOY_PATH} — nothing to publish"
+          exit 0
+        fi
+        git add "${PAGES_DEPLOY_PATH}/index.html"
+        git \
+          -c user.name="github-actions[bot]" \
+          -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+          commit -m "ci(pages): publish per-PR CRAP report to ${PAGES_DEPLOY_PATH}"
+        git push origin "HEAD:${PAGES_BRANCH}"
+
     # PR γ (#294) + ζ (#315): compose the sticky-comment body by
     # appending the HTML-artifact download link(s) to the rendered
     # markdown when `html-report: true`. Runs unconditionally (no
@@ -1618,6 +1815,14 @@ runs:
         # multi-language mode only; empty in single-language mode
         # (per the step's `if:` gate).
         HTML_URL_UNIFIED: ${{ steps.upload-unified.outputs.artifact-url }}
+        # Hosted per-PR report (crap-rs#377, Wave 1): when the publish
+        # step ran (pages-publish:true), the sticky link is the hosted
+        # Pages URL instead of the artifact-download URL. The publish
+        # step runs BEFORE this one and fails the job on a push error,
+        # so reaching this step with PAGES_PUBLISH=true means the page
+        # is live — "publish succeeded" is implicit in control flow.
+        PAGES_PUBLISH: ${{ steps.presets.outputs.pages_publish }}
+        PAGES_URL: ${{ inputs.pages-url }}
       run: |
         set -euo pipefail
         composed_file="$RUNNER_TEMP/scorecard-sticky-message.md"
@@ -1649,7 +1854,16 @@ runs:
           # link renderable even if a future artifact-URL shape includes
           # parentheses or spaces (gemini catch on PR #312).
           link_block=""
-          if [ "$IS_MULTI" = "true" ]; then
+          if [ "$PAGES_PUBLISH" = "true" ]; then
+            # Hosted per-PR report (crap-rs#377, Wave 1): the link is the
+            # live Pages URL, not a download-a-zip artifact. The publish
+            # step already ran and would have failed the job on error, so
+            # the page is live; PAGES_URL was validated non-empty in
+            # `Resolve presets`. This branch is reached ONLY when the
+            # caller opted in, so the artifact-link branches below stay
+            # byte-identical for every existing consumer.
+            link_block="📊 [Open report](<$PAGES_URL>)"
+          elif [ "$IS_MULTI" = "true" ]; then
             # PR ζ (#315): in multi-language mode the unified artifact
             # is the canonical destination. Two deep-link anchors
             # (#rust / #typescript) let reviewers jump straight to a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -689,10 +689,24 @@ jobs:
     name: Scorecard — production crates (gated)
     runs-on: ubuntu-latest
     needs: [coverage]
+    # Shared gh-pages publish lock (epic #377, Wave 1). The per-PR
+    # publish here and the push-to-main publish in
+    # `publish-production-report` sit in DIFFERENT top-level concurrency
+    # groups (the workflow group is `ci-${{ github.ref }}`, so a PR run
+    # and a main run never share it). Without this job-level group, a
+    # merge-to-main publish and an in-flight PR publish could push to
+    # gh-pages concurrently and collide on the branch tip. A shared
+    # named group with cancel-in-progress: false serializes the two.
+    concurrency:
+      group: gh-pages-publish
+      cancel-in-progress: false
     permissions:
-      # contents: read for checkout; pull-requests: write for the
-      # distinct `crap-scorecard-production` sticky comment on PRs.
-      contents: read
+      # contents: write to push the per-PR HTML report to the gh-pages
+      # branch (epic #377, Wave 1 — the action's pages-publish step uses
+      # the job's GITHUB_TOKEN); pull-requests: write for the distinct
+      # `crap-scorecard-production` sticky comment on PRs. The top-level
+      # workflow default stays contents: read.
+      contents: write
       pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -721,6 +735,49 @@ jobs:
           install -m 0755 ./target/release/crap4rs "$HOME/.cargo/bin/crap4rs"
           crap4rs --version
 
+      - name: Fetch main baseline (degrade-not-fail)
+        id: baseline
+        # The per-PR Delta tab diffs this PR against the production
+        # baseline Wave 0 publishes to gh-pages:/baselines/main.json on
+        # every push to main. Fetch it via `git show` off a shallow
+        # `gh-pages` fetch — the branch tip avoids the Pages CDN's
+        # propagation lag, and a public-repo fetch needs no token.
+        #
+        # DEGRADE, NEVER FAIL (epic #377 AC): if the fetch fails OR the
+        # file is empty (first run before any main publish, a transient
+        # ref glitch, etc.), emit a `::warning::` and leave the baseline
+        # path empty. An empty `baseline:` makes the action render
+        # analysis-only (no Delta tab) — the PR must NEVER red over a
+        # missing baseline. The whole fetch+show+size-check chain is
+        # inside the `if` so `set -e` cannot propagate a failure: a
+        # non-zero anywhere takes the else branch and the step exits 0.
+        run: |
+          set -euo pipefail
+          if git fetch origin gh-pages --depth 1 \
+            && git show FETCH_HEAD:baselines/main.json > baseline.json 2>/dev/null \
+            && [ -s baseline.json ]; then
+            echo "path=baseline.json" >> "$GITHUB_OUTPUT"
+            echo "Fetched main baseline ($(wc -c < baseline.json) bytes) — Delta tab will render."
+          else
+            echo "::warning::Could not fetch a non-empty gh-pages:baselines/main.json; rendering the per-PR report WITHOUT a Delta tab (degrade-not-fail). This is expected before the first push-to-main publish."
+            echo "path=" >> "$GITHUB_OUTPUT"
+            rm -f baseline.json
+          fi
+
+      - name: Note fork-PR Pages degradation
+        # On a fork PR the GITHUB_TOKEN is read-only regardless of the
+        # job's permissions: block, so the gh-pages push would 403. The
+        # pages-publish input below is computed false for fork PRs, so
+        # the action degrades to summary-only (no hosted link) — never a
+        # red X, never a dead link. Surface that decision in the log so a
+        # reviewer on a fork PR knows the missing link is by design.
+        # Full fork-PR publishing (a privileged workflow_run topology) is
+        # a later, separate deliverable of this epic.
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+          set -euo pipefail
+          echo "::notice::Fork PR detected — the hosted per-PR report link is omitted because a fork's GITHUB_TOKEN is read-only and cannot publish to GitHub Pages. The scorecard summary is unaffected. Full fork-PR hosted reports are a planned follow-up."
+
       - name: Production scorecard (gate-on-analysis)
         uses: ./.github/actions/scorecard
         with:
@@ -743,6 +800,34 @@ jobs:
           # artifact); `gate-mode` / `comment-*` shape how the wrapper
           # gates and renders the PR comment.
           coverage: lcov.info
+          # Baseline path (or empty) from the degrade-not-fail fetch
+          # above. When set, the action forwards `--baseline` and the
+          # rendered HTML gains a Delta tab (PR vs main); when empty, the
+          # report is analysis-only. `run-mode` is deliberately LEFT
+          # UNSET: setting `run-mode: delta`/`both` would make the
+          # action HARD-ERROR when the baseline degrades to empty, which
+          # would fail the PR and violate degrade-not-fail. With run-mode
+          # empty the action forwards `--baseline` iff non-empty and
+          # silently runs analysis-only otherwise — exactly the degrade
+          # contract. gate-mode: gate-on-analysis below keeps the GATE
+          # whole-project (the baseline only feeds the Delta VIEW, never
+          # the gate), and an empty run-mode means no spurious
+          # baseline/run-mode warning is emitted.
+          baseline: ${{ steps.baseline.outputs.path }}
+          # Render HTML so there is a report to host (required by
+          # pages-publish). The Delta tab activates automatically when
+          # baseline is non-empty — no extra toggle.
+          html-report: true
+          # Publish the hosted per-PR report for SAME-REPO PRs only. A
+          # fork PR's token is read-only (the push would 403), so this
+          # resolves false on forks and the action degrades to
+          # summary-only (no link). On push:main this is also false (the
+          # expression is pull_request-only), so this job never
+          # double-publishes — Wave 0's `publish-production-report` owns
+          # the push:main root publish.
+          pages-publish: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
+          pages-deploy-path: pr-${{ github.event.number }}
+          pages-url: https://breezy-bays-labs.github.io/crap-rs/pr-${{ github.event.number }}/
           gate-mode: gate-on-analysis
           comment-mode: sticky
           comment-header: crap-scorecard-production
@@ -782,6 +867,15 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
     needs: [coverage]
+    # Shared gh-pages publish lock (epic #377, Wave 1). This push-to-main
+    # publish and the per-PR publish in `scorecard-production` are in
+    # different top-level concurrency groups (the workflow group is
+    # `ci-${{ github.ref }}`), so without a shared job-level group their
+    # gh-pages pushes could race and collide on the branch tip. The
+    # named group + cancel-in-progress: false serializes them.
+    concurrency:
+      group: gh-pages-publish
+      cancel-in-progress: false
     permissions:
       # Elevate ONLY here: contents: write to push the rendered report
       # and baseline envelope to the gh-pages branch. The top-level


### PR DESCRIPTION
## Summary

Wave 1 of the hosted-reports epic (#377). On a pull request, the **single** `crap-scorecard-production` sticky comment now carries a working link to a **hosted HTML report** with a **Delta tab** (PR branch vs the `baselines/main.json` baseline Wave 0 publishes). One card — no second/third sticky. The link comes FROM the shared composite action, and the report is published to GitHub Pages **before** the card is posted, so the link is never dead.

The capability lives in the shared composite action (`.github/actions/scorecard`) as additive, default-OFF inputs — so external consumers enable it with a flag, not a pile of copied YAML — and crap-rs's `ci.yml` is the reference recipe that dogfoods it.

## What changed

### Composite action — `.github/actions/scorecard/action.yml`
New additive, default-OFF inputs (existing consumers stay byte-identical):
- `pages-publish` (default `false`) — publish the rendered HTML to a Pages branch and use the hosted URL as the sticky link.
- `pages-deploy-path` (default `''`) — path within the branch (e.g. `pr-123`); report written to `<path>/index.html`.
- `pages-url` (default `''`) — public URL used verbatim as the sticky link.
- `pages-branch` (default `gh-pages`).

Behavior:
- `Resolve presets` validates the inputs (boolean shape; `pages-publish: true` requires `html-report: true` + `pages-deploy-path` + `pages-url`) so a misconfig fails fast instead of producing a dead link.
- New **"Publish HTML to GitHub Pages"** step runs only when `pages-publish == 'true'` AND html was rendered, placed AFTER the HTML render and BEFORE "Compose sticky message". It empty-file-guards the resolved report (unified in multi-language mode, else the per-language render), shallow-clones the Pages branch with a tokened URL, copies to `<deploy-path>/index.html`, commits as `github-actions[bot]`, and pushes. `set -euo pipefail` → a push failure fails the job (no dead link).
- "Compose sticky message" uses `pages-url` as the report link (`📊 [Open report](<url>)`) when `pages-publish: true` (the branch is gated **first**, leaving the existing artifact-link branches byte-identical when off).
- Token hygiene: `GITHUB_TOKEN: ${{ github.token }}` (composite actions have no `secrets` context) via `env:` only — never `run:` interpolation; `$GITHUB_REPOSITORY` shell-quoted; no `github.event.*` in run blocks.
- README documents the new inputs + a "Hosted per-PR report on GitHub Pages" section.

### CI wiring — `.github/workflows/ci.yml`, job `scorecard-production`
- Granted `contents: write` (kept `pull-requests: write`); top-level default stays `contents: read`.
- New **degrade-not-fail** baseline fetch step before the action call: `git fetch origin gh-pages --depth 1` + `git show FETCH_HEAD:baselines/main.json`. On any failure or empty file it emits a `::warning::` and leaves the baseline path empty (analysis-only, no Delta tab) — never reds the PR. The whole chain is inside an `if` so `set -e` can't propagate the failure.
- Passes `baseline:` (fetched path or empty), `html-report: true`, `pages-publish:` computed for same-repo PRs only (`github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository`), `pages-deploy-path: pr-${{ github.event.number }}`, `pages-url: https://breezy-bays-labs.github.io/crap-rs/pr-${{ github.event.number }}/`. `gate-mode: gate-on-analysis` unchanged.
- Fork PRs emit a `::notice::` explaining the omitted link (read-only token); the card stays green, summary-only.
- Shared `concurrency: { group: gh-pages-publish, cancel-in-progress: false }` added to BOTH `scorecard-production` AND Wave 0's `publish-production-report`, so concurrent gh-pages pushes (a merge-to-main publish vs a PR publish — different top-level groups) can't collide. Coexists with the top-level `ci-${{ github.ref }}` concurrency.

## Locked design
- **One card** — the link rides the existing `crap-scorecard-production` sticky; no new comment.
- **Publish before post** — the publish step is ordered before "Compose sticky message" and fails the job on a push error, so the link is only ever emitted when the page is live.
- **Fork degrade** — `pages-publish` is false on forks (read-only token); summary-only, never red, never a dead link. Full fork-PR publishing is the Wave 2 reference-recipe deliverable.
- **Baseline degrade** — a missing/empty baseline → analysis-only + `::warning::`, never a failed PR.
- **Shared concurrency** — one named gh-pages lock across both publishing jobs.

## The `gate-mode: gate-on-analysis` + `baseline:` finding
With `gate-mode: gate-on-analysis` and `baseline:` set, **`run-mode` is left UNSET** — and that is load-bearing, not stylistic:
- The action's `Resolve presets` only warns/errors on baseline when `run-mode` is non-empty (`run-mode: full` warns if a baseline is set; `delta`/`both` **hard-error** if a baseline is *missing*). With `run-mode` empty, neither path fires, so there is **no spurious warning**.
- More importantly, an empty `run-mode` means the action forwards `--baseline` iff the path is non-empty and silently runs analysis-only when it's empty — which is exactly the **degrade-not-fail** contract. Setting `run-mode: delta`/`both` would make `Resolve presets` `exit 1` when the baseline fetch degrades to empty, failing the PR and violating the AC. So "leave run-mode empty" is required, not optional.
- `gate-mode: gate-on-analysis` keeps the **gate** whole-project (analysis-gate=true, delta-gate=false); the baseline only feeds the Delta **view** in the hosted report, never the gate.

Verified empirically: rendering with `--baseline` produces the Delta tab (`data-tab="delta"` button + panel, 2 occurrences); rendering without it omits all `data-tab` markers entirely.

## Self-dogfood validation note
For same-repo PRs, GitHub runs the workflow from the PR HEAD branch — so **this PR's own CI run exercises the new wiring**: `scorecard-production` fetches the live baseline, renders this PR's delta report, publishes it to gh-pages `/pr-<this-PR-number>/`, and posts the sticky with the hosted link. The reviewer can validate end-to-end on the PR: check the single sticky comment and click **📊 Open report**, then open the **Delta** tab.

I confirmed the live baseline exists: `git fetch origin gh-pages --depth 1 && git show FETCH_HEAD:baselines/main.json` returns a valid 2.55 MB envelope (`schema_version: 2`, `tool_version: 0.6.0`, rust, cognitive, threshold 8.0) — so this PR's report will render a populated Delta tab, not degrade to analysis-only. gh-pages pushes don't retrigger CI (`on.push.branches` is `[main]` only).

## Validation results
1. `actionlint .github/workflows/ci.yml` → **exit 0** (and `actionlint` across all workflows → exit 0).
2. `pipx run 'zizmor>=1.5,<2' .github/` → **"No findings to report. Good job! (1 ignored, 31 suppressed)"**, exit 0 — no NEW findings.
3. **Delta-tab render proof** (local): built `crap4rs`, ran `cargo llvm-cov nextest --workspace --exclude crap-examples`, produced `baseline.json`, then rendered HTML **with** baseline (contains the `data-tab="delta"` tab button + panel) and **without** baseline (no `data-tab` markers at all). Marker found empirically by diffing the two renders.
4. **Publish-step logic** (local): copy/preservation/no-op/commit-author validated against a pre-populated gh-pages repo — writes `<deploy-path>/index.html` byte-identical to the rendered HTML (delta marker survives), preserves `.nojekyll` / root `index.html` / `baselines/`, no-op guard skips identical content, commit author is `github-actions[bot]`. The `git clone`+`git push` halves mirror Wave 0's already-proven `publish-production-report` step byte-for-byte (the sandbox blocked the local `file://` clone).
5. `git diff --name-only origin/main` → only `.github/workflows/ci.yml`, `.github/actions/scorecard/action.yml`, and the action README (intentional input docs). **Nothing under `crap4rs/src`** (the `wire_envelope_crap4rs` self-snapshot is untouched).
6. New `uses:` references: **none added** — all additions are `run:` steps and action inputs, so no new SHA pins to manage.

## Same-repo-only scope
This wave is **same-repo PRs only**. Fork PRs degrade to summary-only (no link). Full fork-PR hosted publishing — a `workflow_run`-triggered topology that publishes in a privileged context — is an explicit deliverable of the **Wave 2** external-consumer reference recipe, not this wave.

## Risks / decisions
- **Pages CDN lag:** deploy-from-branch rebuilds asynchronously, so the hosted link can briefly 404 between the push and the Pages rebuild. Inherent to deploy-from-branch; publish-before-post guarantees the *push* succeeded, not instant CDN availability.
- **Serialization on push:main:** the shared `gh-pages-publish` group makes `scorecard-production` and `publish-production-report` serialize on `push:main` even though `scorecard-production` does not publish on push events (its `pages-publish` expression is pull_request-only). This is per-spec (the group is required on both jobs), a minor latency cost, not a correctness issue.
- **Publish vs gate ordering:** the publish step runs before `Enforce gates`, so on a gate-*failing* PR the report still publishes and the link still posts, then the job reds — correct UX (a failing gate is exactly when the live report is most useful). A publish *failure* still reds before the sticky is composed, so there is never a dead link.

Closes #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/breezy-bays-labs/crap-rs/pull/382">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->