### PR TITLE
ci(pages): #384 — external-consumer reference recipe + orphan-branch robustness

### DIFF
--- a/.github/actions/scorecard/README.md
+++ b/.github/actions/scorecard/README.md
@@ -515,6 +515,45 @@ sticky comment — one click, no download. Pair it with `baseline:` to
 host a per-PR report whose Delta tab diffs the PR branch against a
 published baseline.
 
+> **Copyable reference recipe.** A complete, ready-to-adapt workflow
+> for this — the per-PR publish job, the degrade-not-fail baseline
+> fetch, the same-repo `pages-publish` gate, and a companion cleanup
+> job — lives at
+> [`examples/hosted-pr-report.yml`](./examples/hosted-pr-report.yml).
+> Copy it into your repo's `.github/workflows/`, replace the
+> `OWNER/REPO` + `OWNER.github.io/REPO` placeholders, and pin the
+> action self-ref to a release SHA. The snippet below is the minimal
+> shape; the example file is the full setup.
+
+### Prerequisite: enable GitHub Pages on the branch (one-time)
+
+This is the prerequisite the section originally omitted. Two things
+must be true before the hosted link resolves, and they happen in this
+order:
+
+1. **The Pages branch must exist.** You do **not** need to pre-create
+   it: when `pages-branch` (default `gh-pages`) does not exist yet, the
+   action creates it as an **orphan branch** on its first publish —
+   empty tree, plus a `.nojekyll` marker so Pages serves the raw HTML
+   without Jekyll processing. (If you prefer, you can pre-create the
+   branch by hand instead; the action's first run is then a normal
+   additive publish.)
+
+2. **Pages must be enabled on that branch.** Creating the branch does
+   **not** make GitHub serve it. After the first run creates `gh-pages`
+   (or after you pre-create it), turn Pages on:
+   **Settings → Pages → Build and deployment → Deploy from a branch →
+   Branch: `gh-pages` → `/ (root)` → Save.**
+
+So the clean first-time ordering is: **first run creates `gh-pages` →
+you enable Pages on it → the link resolves from the next run** (or
+pre-create + enable, then run, so the very first run's link resolves).
+On that very first PR, the sticky link will **404 until Pages is
+enabled and has built once** — the "publish before post" guarantee
+(below) means the file was *pushed*, not that Pages is *serving* it
+yet. That candor is the point: the push succeeding is necessary but
+not sufficient for the link to be live.
+
 ```yaml
 jobs:
   scorecard:
@@ -548,27 +587,41 @@ page that was never written. The sticky link (`📊 [Open report](…)`)
 is emitted only when `pages-publish: true`; with it off the action's
 body is byte-identical to the artifact-link / no-link behavior.
 
-**`contents: write` and fork PRs.** The publish is a plain `git push`
-to the Pages branch from within the caller's job, authorized by the
-job's `GITHUB_TOKEN` — so the caller must grant `contents: write`.
-GitHub issues a **read-only** `GITHUB_TOKEN` for fork-triggered
-`pull_request` events regardless of the `permissions:` block, so the
-push would 403 on a fork. Gate `pages-publish` to same-repo events
-(as above); on a fork PR the action falls back to the existing
-artifact-link / no-link path and the card stays green. Full fork-PR
-publishing (a `workflow_run` topology that publishes in a privileged
-context) is a separate, later deliverable.
+**`contents: write` and the same-repo-only fork limitation.** The
+publish is a plain `git push` to the Pages branch from within the
+caller's job, authorized by the job's `GITHUB_TOKEN` — so the caller
+must grant `contents: write`. GitHub issues a **read-only**
+`GITHUB_TOKEN` for fork-triggered `pull_request` events regardless of
+the `permissions:` block, so the push would 403 on a fork. **Hosted
+per-PR reports therefore publish for same-repo PRs only.** Gate
+`pages-publish` to same-repo events (as above); on a fork PR the
+action falls back to the existing artifact-link / no-link path — the
+scorecard summary still posts, the card stays green, and the only
+thing missing is the hosted link. Full fork-PR hosted reports (a
+privileged `workflow_run` topology that publishes the fork's rendered
+artifact from the base repo's context) are tracked as a separate
+follow-up in crap-rs#386.
 
 **Existing Pages content is preserved.** The publish copies the
 report into `<pages-deploy-path>/index.html`; it does not wipe the
 branch tree. A root `index.html`, `.nojekyll`, a `baselines/`
 directory, and other PRs' deploy paths all survive untouched.
 
+**Cleanup on PR close.** Per-PR directories would otherwise accumulate
+on the branch forever. crap-rs ships a companion teardown workflow
+([`pages-cleanup.yml`](../../workflows/pages-cleanup.yml)) that removes
+`pr-<N>/` from the Pages branch when a PR closes (merged or not). Copy
+it alongside the publish workflow — it is a dedicated `pull_request:
+types: [closed]` workflow so PR close runs one tiny git operation
+rather than your whole build. It also tolerates a not-yet-created Pages
+branch (a fresh repo that never published): the clone-or-no-op exits
+clean rather than red-X'ing the close.
+
 **Concurrency.** If more than one job in your workflows can push to
-the Pages branch (e.g. a per-PR publish and a push-to-main publish),
-give them a shared `concurrency: { group: <pages-group>,
-cancel-in-progress: false }` so their pushes serialize and can't
-collide on the branch tip.
+the Pages branch (e.g. a per-PR publish, a push-to-main publish, and
+the cleanup-on-close), give them all a shared `concurrency: { group:
+<pages-group>, cancel-in-progress: false }` so their pushes serialize
+and can't collide on the branch tip.
 
 ## Patterns
 

--- a/.github/actions/scorecard/action.yml
+++ b/.github/actions/scorecard/action.yml
@@ -334,7 +334,14 @@ inputs:
     description: |
       The Pages branch to publish to. Default `gh-pages` (the
       deploy-from-branch convention). Consulted only when
-      `pages-publish: true`.
+      `pages-publish: true`. When the branch does not exist yet (a
+      fresh consumer repo's first publish), the action creates it as an
+      orphan branch (empty tree + a `.nojekyll` marker) so the first run
+      does not fatally fail — the consumer does NOT need to pre-create
+      the branch. Creating the branch does not, by itself, make GitHub
+      Pages serve it: the consumer must still enable Pages on this branch
+      (Settings → Pages → Deploy from a branch) for the hosted link to
+      resolve. See the action README's "Hosted per-PR report" section.
     required: false
     default: 'gh-pages'
 
@@ -1734,10 +1741,40 @@ runs:
         # (not the workflow checkout) keeps the push self-contained and
         # works even though the caller's checkout sets
         # persist-credentials: false. The token is in the URL via the
-        # env var, never echoed.
-        git clone --branch "$PAGES_BRANCH" --single-branch --depth 1 \
-          "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
-          gh-pages-pr-pub
+        # env var, never echoed. REMOTE_URL is built here in the script
+        # from the two env vars (token + repo) so the secret never flows
+        # through `${{ }}` interpolation and the two clone forms below
+        # share one definition.
+        REMOTE_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+        # Branch-exists path (the steady state for any repo that has
+        # published before — e.g. crap-rs, where gh-pages already exists):
+        # the --branch clone succeeds and the orphan block is NEVER
+        # entered, so the publish flow below is byte-identical to before
+        # this fallback existed (no regression).
+        #
+        # First-run path (a fresh consumer repo whose gh-pages does not
+        # exist yet): the --branch clone fails, so we clone the default
+        # branch instead and create gh-pages as an ORPHAN (no history,
+        # empty tree). The trailing `git push HEAD:$PAGES_BRANCH` below
+        # creates the branch on the remote. We seed `.nojekyll` so Pages
+        # serves the raw HTML without Jekyll processing (a gh-pages branch
+        # missing it can mis-serve files whose names Jekyll treats
+        # specially) AND stage it here — the main-flow `git add` further
+        # down stages only the report's index.html, so without this
+        # explicit add the orphan branch would ship without `.nojekyll`.
+        # `git add` keeps it in the index across the `cd ..` round-trip,
+        # so the existing commit picks up both files.
+        if ! git clone --branch "$PAGES_BRANCH" --single-branch --depth 1 \
+          "$REMOTE_URL" gh-pages-pr-pub 2>/dev/null; then
+          echo "Pages branch '$PAGES_BRANCH' not found — creating it (orphan)."
+          git clone --depth 1 "$REMOTE_URL" gh-pages-pr-pub
+          cd gh-pages-pr-pub
+          git checkout --orphan "$PAGES_BRANCH"
+          git rm -rf . >/dev/null 2>&1 || true
+          : > .nojekyll
+          git add .nojekyll
+          cd ..
+        fi
         # Copy the report to <deploy-path>/index.html. mkdir -p creates
         # the per-PR directory; existing Pages content outside it
         # (root index.html, .nojekyll, baselines/, other PR dirs) is

--- a/.github/actions/scorecard/action.yml
+++ b/.github/actions/scorecard/action.yml
@@ -1743,8 +1743,11 @@ runs:
         # persist-credentials: false. The token is in the URL via the
         # env var, never echoed. REMOTE_URL is built here in the script
         # from the two env vars (token + repo) so the secret never flows
-        # through `${{ }}` interpolation and the two clone forms below
-        # share one definition.
+        # through workflow-expression interpolation and the two clone forms
+        # below share one definition. (Do not write a literal GitHub
+        # expression here: GitHub scans run-block text — including bash
+        # comments — for expressions, so an empty/invalid one fails the
+        # action manifest load.)
         REMOTE_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
         # Branch-exists path (the steady state for any repo that has
         # published before — e.g. crap-rs, where gh-pages already exists):

--- a/.github/actions/scorecard/examples/hosted-pr-report.yml
+++ b/.github/actions/scorecard/examples/hosted-pr-report.yml
@@ -1,0 +1,214 @@
+# ============================================================================
+# COPYABLE REFERENCE RECIPE — hosted per-PR CRAP report on GitHub Pages
+# ============================================================================
+#
+# Copy this file into YOUR repo at `.github/workflows/hosted-pr-report.yml`
+# and replace the placeholders:
+#
+#   * OWNER/REPO            → your repo slug (e.g. acme/widgets)
+#   * OWNER.github.io/REPO  → your Pages base URL (project Pages). For a
+#                             USER/org Pages site or a custom domain the URL
+#                             differs — set `pages-url` to whatever serves the
+#                             gh-pages branch in YOUR setup.
+#   * @<pin-to-a-release-sha> on the scorecard action self-ref → a 40-char
+#                             commit SHA of a crap-rs release (resolve with
+#                             `gh api repos/breezy-bays-labs/crap-rs/commits/<tag> --jq .sha`).
+#
+# This is a TEMPLATE, not a live workflow — it lives under
+# `.github/actions/scorecard/examples/` (NOT `.github/workflows/`) so it does
+# not actually run in the crap-rs repo. crap-rs's own production wiring lives
+# in `.github/workflows/ci.yml` (job `scorecard-production`); this file is that
+# wiring generalized for a third-party consumer.
+#
+# WHAT IT GIVES YOU
+#   * A sticky PR comment with the CRAP scorecard.
+#   * A clickable LIVE hosted report on GitHub Pages at `…/pr-<N>/`, whose
+#     Delta tab diffs the PR branch against your published `main` baseline.
+#   * Automatic teardown of `pr-<N>/` when the PR closes.
+#
+# PREREQUISITE — enable GitHub Pages (one-time, manual)
+#   The action AUTO-CREATES the `gh-pages` branch on its first publish, so you
+#   do NOT need to pre-create it. BUT creating the branch does not make GitHub
+#   serve it. After the first run creates `gh-pages` (or before, if you
+#   pre-create it yourself), enable Pages on that branch:
+#       Settings → Pages → Build and deployment → Deploy from a branch →
+#       Branch: gh-pages → / (root) → Save
+#   The hosted link 404s until Pages is enabled AND has built once. The
+#   "publish before post" ordering guarantees the file was PUSHED, not that
+#   Pages is serving it yet — so on the very first PR the sticky link may 404
+#   for a few minutes (or until you enable Pages). Subsequent runs resolve.
+#
+# SAME-REPO ONLY (fork limitation)
+#   Fork PRs get a read-only GITHUB_TOKEN regardless of `permissions:`, so the
+#   gh-pages push would 403. `pages-publish` below is gated to same-repo PRs;
+#   on a fork PR the action degrades to summary-only (no hosted link), never a
+#   red X and never a dead link. Full fork-PR hosted reports (a privileged
+#   `workflow_run` topology) are tracked as a separate follow-up in crap-rs#386.
+# ============================================================================
+
+name: Hosted PR report
+
+on:
+  pull_request:
+    branches: [main]
+
+# Least-privilege default: read-only at the workflow level. The publish job
+# below elevates only itself.
+permissions:
+  contents: read
+
+jobs:
+  hosted-pr-report:
+    name: Hosted per-PR CRAP report → gh-pages
+    runs-on: ubuntu-latest
+    permissions:
+      # contents: write — the action's publish step pushes the rendered HTML
+      # to the gh-pages branch using THIS job's GITHUB_TOKEN.
+      # pull-requests: write — for the sticky scorecard comment.
+      contents: write
+      pull-requests: write
+    # Serialize every job that can push to gh-pages onto one named group so
+    # their pushes can't collide on the branch tip. Concurrency group names
+    # are repo-global, so the cleanup workflow (below) and any push-to-main
+    # publisher you run must share THIS group name. cancel-in-progress: false
+    # so an in-flight publish is queued behind — never aborted mid-push.
+    concurrency:
+      group: gh-pages-publish
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # The action publishes via a SEPARATE tokened clone of gh-pages,
+          # never this checkout's persisted credentials — keep them off the
+          # runner's .git/config (artipacked hardening).
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # tracks @stable branch
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      # ----------------------------------------------------------------------
+      # Build coverage. Adjust to your project's coverage tool. The example
+      # uses cargo-llvm-cov (LCOV) — the Rust adapter input. If you already
+      # produce the LCOV in an upstream job, download it via
+      # actions/download-artifact instead (see crap-rs ci.yml for that shape):
+      #   - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      #     with: { name: lcov }
+      # ----------------------------------------------------------------------
+      - name: Build coverage (LCOV)
+        run: |
+          set -euo pipefail
+          cargo install cargo-llvm-cov --locked
+          cargo llvm-cov --workspace --lcov --output-path lcov.info
+
+      # ----------------------------------------------------------------------
+      # Fetch the main baseline so the Delta tab renders. DEGRADE, NEVER FAIL:
+      # before your first push-to-main publish there is no baseline yet, and a
+      # missing baseline must render analysis-only — never red the PR. The
+      # whole fetch+show+size chain is inside the `if`, so `set -e` cannot
+      # propagate a failure; a non-zero anywhere takes the else branch and the
+      # step exits 0 with an empty baseline path.
+      #
+      # This reads gh-pages:baselines/main.json — the baseline a push-to-main
+      # publisher writes. Wire that publisher separately (mirror crap-rs's
+      # `publish-production-report` job in ci.yml: on push to main, render
+      # `--format html:report.html,json:envelope.json`, copy report.html to the
+      # Pages root index.html and envelope.json to baselines/main.json).
+      # ----------------------------------------------------------------------
+      - name: Fetch main baseline (degrade-not-fail)
+        id: baseline
+        run: |
+          set -euo pipefail
+          if git fetch origin gh-pages --depth 1 \
+            && git show FETCH_HEAD:baselines/main.json > baseline.json 2>/dev/null \
+            && [ -s baseline.json ]; then
+            echo "path=baseline.json" >> "$GITHUB_OUTPUT"
+            echo "Fetched main baseline — Delta tab will render."
+          else
+            echo "::warning::No non-empty gh-pages:baselines/main.json yet; rendering WITHOUT a Delta tab (expected before the first push-to-main publish)."
+            echo "path=" >> "$GITHUB_OUTPUT"
+            rm -f baseline.json
+          fi
+
+      # ----------------------------------------------------------------------
+      # The scorecard action. Renders HTML, publishes it to gh-pages:pr-<N>/
+      # for SAME-REPO PRs, and links the live page from the sticky comment.
+      # ----------------------------------------------------------------------
+      - uses: breezy-bays-labs/crap-rs/.github/actions/scorecard@<pin-to-a-release-sha> # SHA-pin to a crap-rs release commit
+        with:
+          languages: rust
+          coverage: lcov.info
+          # Baseline path (or empty) from the degrade-not-fail fetch above.
+          # When set, the action forwards --baseline and the HTML gains a Delta
+          # tab (PR vs main). run-mode is LEFT UNSET on purpose: run-mode:
+          # delta/both would HARD-ERROR on an empty baseline and fail the PR,
+          # violating degrade-not-fail. With run-mode empty the action forwards
+          # --baseline only when non-empty and renders analysis-only otherwise.
+          baseline: ${{ steps.baseline.outputs.path }}
+          # html-report: true is REQUIRED by pages-publish — there must be a
+          # rendered report to host. The Delta tab activates automatically when
+          # a baseline is present; no extra toggle.
+          html-report: true
+          # Publish the hosted per-PR report for SAME-REPO PRs only. A fork
+          # PR's token is read-only (the push would 403), so this resolves
+          # false on forks and the action degrades to summary-only (no link).
+          pages-publish: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
+          pages-deploy-path: pr-${{ github.event.number }}
+          # Full public URL the report is reachable at. The action does NOT
+          # derive this from pages-deploy-path — set it to YOUR Pages base URL
+          # (project Pages shown; user/org Pages and custom domains differ).
+          pages-url: https://OWNER.github.io/REPO/pr-${{ github.event.number }}/
+          gate-mode: gate-on-analysis
+          comment-mode: sticky
+          comment-header: crap-scorecard
+
+  # ==========================================================================
+  # COMPANION CLEANUP — remove pr-<N>/ from gh-pages when the PR closes.
+  # ==========================================================================
+  # This is a generalized inline copy of crap-rs's
+  # `.github/workflows/pages-cleanup.yml`. You can either copy that file
+  # wholesale into your own `.github/workflows/` (recommended — it is a
+  # self-contained dedicated workflow) OR keep this block. NOTE: cleanup must
+  # trigger on `pull_request: types: [closed]`, which is a DIFFERENT trigger
+  # than this file's top-level `on:` — so if you keep it here, change the
+  # top-level `on:` to include closed, or (cleaner) split cleanup into its own
+  # file. The dedicated-file approach avoids re-running the whole build on
+  # every PR close. See pages-cleanup.yml for the full, self-contained shape.
+  #
+  # cleanup-pr-report:
+  #   name: Remove closed PR's report from gh-pages
+  #   runs-on: ubuntu-latest
+  #   if: github.event.action == 'closed'
+  #   permissions:
+  #     contents: write
+  #   concurrency:
+  #     group: gh-pages-publish        # SAME group as the publish job above
+  #     cancel-in-progress: false
+  #   steps:
+  #     - name: Remove pr-<N> from gh-pages
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #         PR_NUMBER: ${{ github.event.number }}
+  #       run: |
+  #         set -euo pipefail
+  #         # Missing-branch tolerance: a fresh repo that never published has
+  #         # no gh-pages branch — treat the clone failure as nothing-to-clean.
+  #         if ! git clone --branch gh-pages --single-branch --depth 1 \
+  #           "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+  #           gh-pages-cleanup 2>/dev/null; then
+  #           echo "No gh-pages branch yet — nothing to clean (no-op)."
+  #           exit 0
+  #         fi
+  #         cd gh-pages-cleanup
+  #         if [ -d "pr-${PR_NUMBER}" ]; then
+  #           git rm -r "pr-${PR_NUMBER}"
+  #           if [ -z "$(git status --porcelain)" ]; then
+  #             echo "Nothing staged — no-op."; exit 0
+  #           fi
+  #           git \
+  #             -c user.name="github-actions[bot]" \
+  #             -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+  #             commit -m "ci(pages): remove per-PR report for closed PR #${PR_NUMBER}"
+  #           git push origin HEAD:gh-pages
+  #         else
+  #           echo "No pr-${PR_NUMBER}/ on gh-pages — nothing to clean (no-op)."
+  #           exit 0
+  #         fi

--- a/.github/workflows/pages-cleanup.yml
+++ b/.github/workflows/pages-cleanup.yml
@@ -68,9 +68,21 @@ jobs:
           # still CLONE a public repo; the only operation a fork token
           # can't do is PUSH — and on a fork PR the no-op exit below
           # happens BEFORE any push is reached (see the fork-safe note).
-          git clone --branch gh-pages --single-branch --depth 1 \
+          #
+          # Missing-branch tolerance (consumer robustness): a fresh
+          # consumer repo that has never published a per-PR report has no
+          # gh-pages branch, so the --branch clone would fail fatally and
+          # red-X this cleanup for a PR that never created anything to
+          # clean. Treat a clone failure as "nothing to clean" and exit 0
+          # — there is no per-PR directory to remove when the branch
+          # itself does not exist. (For crap-rs gh-pages always exists, so
+          # this path is never taken here; it benefits fresh consumers.)
+          if ! git clone --branch gh-pages --single-branch --depth 1 \
             "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
-            gh-pages-cleanup
+            gh-pages-cleanup 2>/dev/null; then
+            echo "No gh-pages branch yet — nothing to clean (no-op)."
+            exit 0
+          fi
           cd gh-pages-cleanup
           # Fork-safe / degrade-not-fail by construction: Wave 1 publishes
           # `pr-<N>/` for SAME-REPO PRs only, so a closed fork PR never


### PR DESCRIPTION
## Summary

Wave 2b of the hosted per-PR HTML scorecard reports epic (#377). Turns the
hosted-report capability into something a **fresh external consumer repo** can
adopt: action/cleanup robustness for an out-of-repo first run, a copyable
reference recipe, and the prerequisite docs Wave 1 shipped without. Fork-PR
publishing is **out of scope** here (tracked separately in #386); this wave
only documents the same-repo-only limitation.

## Deliverables

**A — action robustness: orphan-branch auto-create.** The "Publish HTML to
GitHub Pages" step in `.github/actions/scorecard/action.yml` did
`git clone --branch "$PAGES_BRANCH" …`, which fatally failed when the Pages
branch did not exist yet (a fresh consumer's first run). The clone is now
wrapped so that, on failure, it clones the default branch and creates the Pages
branch as an **orphan** (empty tree + a staged `.nojekyll` so Pages serves raw
HTML without Jekyll). The trailing `git push HEAD:$PAGES_BRANCH` creates the
branch on the remote. The `pages-branch` input description documents the
auto-create behavior.

**B — cleanup robustness.** `.github/workflows/pages-cleanup.yml`'s clone now
tolerates a missing gh-pages branch: a clone failure (a fresh consumer that
never published) takes a no-op `exit 0` instead of a red X.

**C — copyable reference recipe + docs.**
- New example workflow `.github/actions/scorecard/examples/hosted-pr-report.yml`
  (deliberately under `examples/`, NOT `.github/workflows/`, so it does not run
  in this repo). It is crap-rs's own `scorecard-production` wiring generalized:
  coverage build, degrade-not-fail baseline fetch, the action call with
  `html-report: true` + same-repo-gated `pages-publish` + `pages-deploy-path` +
  `pages-url`, shared `concurrency: gh-pages-publish`, `persist-credentials:
  false`, SHA-pinned `uses:`, and `permissions: { contents: write,
  pull-requests: write }`. A generalized cleanup companion is included inline
  (commented) with a pointer to the dedicated `pages-cleanup.yml`.
- README "Hosted per-PR report" section: backfills the Wave 1 prerequisite gap,
  reframed for orphan-branch behavior; links the example file; sharpens the
  same-repo-only fork limitation pointing at #386.

## Orphan-branch + Pages-enablement ordering

The action auto-creates `gh-pages` on first publish, so a consumer does **not**
need to pre-create it. BUT creating the branch does not make GitHub serve it —
the consumer must enable Pages on the branch (Settings → Pages → Deploy from a
branch → `gh-pages` → `/ (root)`). Clean first-time ordering: **first run
creates `gh-pages` → enable Pages on it → the link resolves from the next run**
(or pre-create + enable, then run). On the very first PR the sticky link will
**404 until Pages is enabled and has built once** — "publish before post"
guarantees the file was *pushed*, not that Pages is *serving* it yet. The
README states this candidly.

## Same-repo-only fork limitation → #386

A fork PR's `GITHUB_TOKEN` is read-only regardless of `permissions:`, so the
gh-pages push would 403. Hosted per-PR reports therefore publish for same-repo
PRs only; `pages-publish` is gated to same-repo events and a fork PR degrades to
summary-only (no link, never a red X, never a dead link). Full fork-PR hosted
reports (a privileged `workflow_run` topology) are tracked in #386.

## No-regression argument

The orphan block is entered **only** when the initial `git clone --branch`
fails. On crap-rs, gh-pages already exists, so the `--branch` clone succeeds and
the orphan code is never reached → the same-repo publish path is byte-identical
to before this change. Local simulation confirmed this: run 1 against a remote
with no gh-pages took the orphan path and landed both `.nojekyll` and
`pr-42/index.html`; run 2 (branch now present) took the normal clone path
(orphan block NOT entered), added `pr-99/`, and preserved `.nojekyll` + the
run-1 directory.

## Verification note

The orphan-branch + Pages-enablement behavior is for a **fresh consumer repo**
and cannot be dogfooded on crap-rs (gh-pages already exists + Pages already
enabled here). The robustness/recipe is verified by **local simulation + static
lint**, not by a crap-rs runtime path:
- Orphan-branch creation (Deliverable A) simulated against a bare git remote —
  both `.nojekyll` and the per-PR report land on first run; the normal clone
  path and prior content are preserved on the second run.
- Cleanup tolerance (Deliverable B) verified by structural equivalence rather
  than a live `file://` clone (the local sandbox blocked the clone after several
  attempts): the orphan-path simulation already proved `git clone --branch
  gh-pages` exits non-zero on a missing branch, and the cleanup wraps that same
  failing clone in `if ! …; then echo no-op; exit 0`.
- `actionlint` on `ci.yml`, `pages-cleanup.yml`, and the example file → exit 0.
- `pipx run 'zizmor>=1.5,<2' .github/` → no new findings (zizmor does not
  collect the `examples/` file, so the placeholder action self-ref creates no
  `unpinned-uses` finding; the four `${{ }}` parse warnings on action.yml are
  pre-existing on origin/main).
- `git diff --name-only origin/main` → exactly the four intended files; `ci.yml`
  is untouched.

Closes #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/breezy-bays-labs/crap-rs/pull/387">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->