### PR TITLE
refactor(core): #389 — unify the JSON envelope wire schema into one owned source of truth

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,12 @@ napi-build = "2"
 
 # ── Serialization ──
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+# float_roundtrip: serde_json's default fast float parser may lose the
+# last ulp on read (e.g. coverage_percent 90.79017890334245 parsing back
+# as ...44), which would make the wire envelope's serialize→deserialize
+# round-trip lossy. The exact parser keeps the wire contract bit-exact;
+# the round-trip proptest in crap-core's adapters::wire pins it.
+serde_json = { version = "1", features = ["float_roundtrip"] }
 
 # ── Terminal output ──
 comfy-table = { version = "7", features = ["custom_styling"] }

--- a/crates/crap-core/proptest-regressions/adapters/wire.txt
+++ b/crates/crap-core/proptest-regressions/adapters/wire.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc e227b24216724bb963ce94334bd7e9cf1d499e39c4f51f1a5936b3d003d637bb # shrinks to result = AnalysisResult { functions: [FunctionVerdict { scored: ScoredFunction { identity: FunctionIdentity { file_path: "src/a.rs", qualified_name: "a", span: SourceSpan { start_line: 1, end_line: 10, start_column: 0, end_column: 0 } }, complexity: 1, complexity_metric: Cognitive, coverage_percent: 90.79017890334245, branch_coverage_percent: None, crap: CrapScore { value: 1.0, risk_level: Low }, contributors: [] }, threshold: 1.0, exceeds: false, diagnostic: None }], summary: AnalysisSummary { total_functions: 1, total_files: 1, exceeding_threshold: 0, average_crap: 1.0, median_crap: 1.0, max_crap: Some(CrapScore { value: 1.0, risk_level: Low }), worst_function: Some(FunctionIdentity { file_path: "src/a.rs", qualified_name: "a", span: SourceSpan { start_line: 1, end_line: 10, start_column: 0, end_column: 0 } }), distribution: RiskDistribution { low: 1, acceptable: 0, moderate: 0, high: 0 }, max_complexity: 1, average_complexity: 1.0, median_complexity: 1.0, min_coverage: 90.79017890334245, average_coverage: 90.79017890334245, median_coverage: 90.79017890334245 }, passed: true }, threshold = 1.0, epsilon = 0.0

--- a/crates/crap-core/src/adapters/baseline.rs
+++ b/crates/crap-core/src/adapters/baseline.rs
@@ -3,66 +3,34 @@
 //! envelope metadata (tool_version, timestamp) needed for delta
 //! reporting.
 //!
-//! The on-the-wire JSON envelope (see `adapters::reporters::json`)
-//! includes far more than `result`: `view`, `diagnostics`, `delta` (in
-//! the future), etc. The baseline loader ignores everything except
-//! `schema_version`, `result`, `tool_version`, `timestamp`, and
-//! optionally `diagnostics` so that consumers can produce baseline
-//! envelopes that contain extra fields without breaking us.
+//! The envelope is parsed as the canonical
+//! [`wire::Envelope`](crate::adapters::wire::Envelope) — the same type
+//! the JSON reporter serializes — so the writer and this reader cannot
+//! drift apart. The loader then projects the subset delta
+//! reporting needs into [`BaselineSnapshot`]. The wire type's read
+//! contract is permissive (only `schema_version` and `result` are
+//! required; unknown fields are ignored), so consumers can produce
+//! baseline envelopes that carry extra fields — or only the analysis
+//! itself — without breaking us.
 //!
-//! Schema version validation: `schema_version` 1 and 2 are both
-//! accepted (the current emit version is 2; v1 baselines remain
+//! Schema version validation: every version in
+//! [`SUPPORTED_SCHEMA_VERSIONS`] is accepted (v1 baselines remain
 //! loadable because delta matching is identity-keyed, not
 //! column-keyed). Future schema bumps will need an explicit
 //! migration path.
 
+use crate::adapters::wire::Envelope;
 use crate::domain::types::{AnalysisDiagnostics, AnalysisResult, MissingCoveragePolicy};
 use crate::ports::ParseDiagnostic;
-use serde::Deserialize;
 use std::fs::File;
 use std::io::{BufReader, ErrorKind};
 use std::path::Path;
 
-/// Currently-emitted envelope schema version. Lockstep with
-/// `adapters::reporters::json::JsonEnvelope::schema_version`.
-pub const CURRENT_SCHEMA_VERSION: u32 = 2;
-
-/// Envelope schema versions accepted by the baseline loader. v1 stays
-/// loadable across the v0.3.x → v0.4.x boundary so users can keep their
-/// committed baseline JSON; the column-convention shift in v2 doesn't
-/// affect delta calculations (identity-keyed matching).
-pub const SUPPORTED_SCHEMA_VERSIONS: &[u32] = &[1, 2];
-
-/// On-disk shape we read. Mirrors the relevant subset of
-/// `JsonEnvelope`. `serde(default)` on optional fields keeps us
-/// forward-compatible with envelopes that omit fields we don't need.
-///
-/// `P: ParseDiagnostic` carries the adapter-specific parse-diagnostic
-/// type through `AnalysisDiagnostics<P>`. crap4rs concretizes to
-/// `LcovParseDiagnostic` via the v0.4 shim alias.
-/// `serde(bound = "")` suppresses the auto-generated `P: Serialize` /
-/// `P: Deserialize<'de>` bounds — `P: ParseDiagnostic` already provides
-/// `Serialize + DeserializeOwned`, and the auto-bounds conflict with
-/// the owned-deserialize requirement.
-#[derive(Debug, Deserialize)]
-#[serde(bound = "")]
-struct BaselineEnvelope<P: ParseDiagnostic> {
-    schema_version: u32,
-    #[serde(default)]
-    tool_version: String,
-    #[serde(default)]
-    timestamp: String,
-    result: AnalysisResult,
-    #[serde(default)]
-    diagnostics: Option<AnalysisDiagnostics<P>>,
-    /// Policy the baseline was generated under. Absent on envelopes
-    /// emitted before the field existed, and on any pessimistic run
-    /// (the emitter elides the default) — both deserialize to
-    /// `Pessimistic` via `Default`, the load-bearing "absent ⇒
-    /// pessimistic" convention the delta mismatch warning relies on.
-    #[serde(default)]
-    missing_coverage_policy: MissingCoveragePolicy,
-}
+// Re-exported from the canonical wire module (where the writer also
+// reads them) so the long-standing
+// `crap_core::adapters::baseline::{CURRENT_SCHEMA_VERSION,
+// SUPPORTED_SCHEMA_VERSIONS}` import paths keep compiling.
+pub use crate::adapters::wire::{CURRENT_SCHEMA_VERSION, SUPPORTED_SCHEMA_VERSIONS};
 
 /// What the loader returns to callers. The fields are all the metadata
 /// the delta envelope's `delta.baseline_*` keys ultimately surface.
@@ -140,7 +108,7 @@ pub fn load<P: ParseDiagnostic>(path: &Path) -> Result<BaselineSnapshot<P>, Base
         },
     })?;
 
-    let envelope: BaselineEnvelope<P> =
+    let envelope: Envelope<P> =
         serde_json::from_reader(BufReader::new(file)).map_err(|source| BaselineError::Parse {
             path: path_str.clone(),
             source,

--- a/crates/crap-core/src/adapters/mod.rs
+++ b/crates/crap-core/src/adapters/mod.rs
@@ -1,7 +1,10 @@
 //! Language-agnostic adapters — IO and presentation layers that make
 //! no assumptions about the source language being analyzed.
 //!
-//! Four families live here:
+//! Five families live here:
+//! - **`wire`**: the canonical JSON envelope schema — one owned
+//!   `Serialize + Deserialize` type shared by the JSON reporter (write)
+//!   and every envelope reader (the baseline loader, `crap-render`).
 //! - **`baseline`**: loads a previously-emitted JSON envelope from disk
 //!   so delta reporting can compare the current run against a prior one.
 //! - **`config`**: parses the adapter's TOML configuration (threshold
@@ -22,3 +25,4 @@ pub mod baseline;
 pub mod config;
 pub mod diff;
 pub mod reporters;
+pub mod wire;

--- a/crates/crap-core/src/adapters/reporters/json.rs
+++ b/crates/crap-core/src/adapters/reporters/json.rs
@@ -3,17 +3,19 @@
 //!
 //! The envelope carries both the unshapeable underlying analysis
 //! (`result`) and the View metadata (`view`) describing how the
-//! reported rows were filtered, sorted, and truncated. `view.full` is
-//! `#[serde(skip)]` so the analysis is emitted exactly once.
+//! reported rows were filtered, sorted, and truncated. The wire schema
+//! itself is the canonical [`wire::Envelope`]; this module's job is
+//! presentation assembly — projecting the borrowed view / delta state
+//! into the owned envelope at emit time. The clone this implies trades
+//! the previous zero-copy serialization for a single schema type shared
+//! with every envelope reader; for a fire-and-exit CLI about to
+//! pretty-print the same data, the cost is negligible.
 
-use crate::domain::delta::{DeltaSummary, DeltaView, DeltaViewSpec, FunctionChange};
-use crate::domain::types::{
-    AnalysisDiagnostics, AnalysisResult, AnalysisSummary, ComplexityMetric, FunctionVerdict,
-    MissingCoveragePolicy,
-};
-use crate::domain::view::{AnalysisView, GroupedView, ViewSpec};
+use crate::adapters::wire::{self, DeltaBlock, Envelope, ViewBlock};
+use crate::domain::delta::DeltaView;
+use crate::domain::types::{AnalysisDiagnostics, ComplexityMetric, MissingCoveragePolicy};
+use crate::domain::view::AnalysisView;
 use crate::ports::ParseDiagnostic;
-use serde::Serialize;
 
 /// Configuration for the JSON envelope metadata.
 ///
@@ -67,150 +69,33 @@ pub struct DeltaContext<'a, P: ParseDiagnostic> {
     pub baseline_diagnostics: Option<&'a AnalysisDiagnostics<P>>,
 }
 
-/// JSON envelope. Field order is **load-bearing** —
-/// `tests/features/cli_ergonomics.feature:243-246` asserts the
-/// declaration order is exactly:
-///   schema_version, tool_version, language, timestamp, metric,
-///   threshold, diff_ref, result, view
-/// Per ADR D2 the schema is additive across minor versions; the
-/// `schema_version` bump from 1 → 2 in 0.4.0 reflects the
-/// `ComplexityContributor.column` 0-based → 1-based convention shift.
-/// Older v1 baselines remain loadable for delta reporting (matching
-/// is identity-keyed, not column-keyed).
-#[derive(Serialize)]
-#[serde(bound = "")]
-struct JsonEnvelope<'a, P: ParseDiagnostic> {
-    schema_version: u32,
-    tool_version: &'a str,
-    language: &'static str,
-    timestamp: &'a str,
-    metric: &'a ComplexityMetric,
-    threshold: f64,
-    diff_ref: Option<&'a str>,
-    result: &'a AnalysisResult,
-    view: ViewWire<'a>,
-    /// Delta block. Present iff `--baseline` was passed; absent (key
-    /// elided) otherwise so existing consumers see byte-identical
-    /// output for the no-delta case. Additive — does not itself bump
-    /// `schema_version` (ADR D2).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    delta: Option<DeltaWire<'a, P>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    diagnostics: Option<&'a AnalysisDiagnostics<P>>,
-    /// Missing-coverage policy. Elided when `Pessimistic` (the default)
-    /// so every existing pessimistic-run envelope stays byte-identical;
-    /// emitted as `"optimistic"` / `"skip"` otherwise. A reader treats an
-    /// absent key as `Pessimistic` (see `baseline::BaselineEnvelope`).
-    /// Additive — does not bump `schema_version` (the default case is
-    /// unchanged).
-    #[serde(skip_serializing_if = "is_pessimistic")]
-    missing_coverage_policy: MissingCoveragePolicy,
-    /// Effective threshold-border epsilon (`--threshold-epsilon` /
-    /// `[delta] epsilon`) this run was configured with. Carried on the
-    /// envelope — even on a baseline-less run that computes no delta — so a
-    /// downstream consumer that recomputes the delta from result envelopes
-    /// (`crap-render`) applies the same band the gate would (crap-rs#379).
-    /// Additive: does NOT bump `schema_version`, and is elided when `0.0`
-    /// (the suppression-off default) so every existing envelope stays
-    /// byte-identical. Declared last to preserve the load-bearing order of
-    /// the leading keys asserted by `cli_ergonomics.feature`.
-    #[serde(skip_serializing_if = "is_zero_epsilon")]
-    epsilon: f64,
-}
-
-/// `skip_serializing_if` predicate: elide the envelope's
-/// `missing_coverage_policy` key when it carries the default, so a
-/// pessimistic run's envelope is byte-identical to before the field
-/// existed.
-fn is_pessimistic(policy: &MissingCoveragePolicy) -> bool {
-    *policy == MissingCoveragePolicy::Pessimistic
-}
-
-/// `skip_serializing_if` predicate: elide the envelope's `epsilon` key when
-/// it is `0.0` (suppression off — the default), so every existing envelope
-/// stays byte-identical. `0.0 == -0.0` in IEEE-754, and the resolved epsilon
-/// is always a finite value `>= 0.0` (validated at the CLI / config
-/// boundary), so `== 0.0` is the exact "off" test.
-fn is_zero_epsilon(epsilon: &f64) -> bool {
-    *epsilon == 0.0
-}
-
-/// On-the-wire delta representation. Mirrors the `delta` envelope key
-/// shape documented in ADR D7 §DeltaView.
-#[derive(Serialize)]
-#[serde(bound = "")]
-struct DeltaWire<'a, P: ParseDiagnostic> {
-    /// Aggregate counts over the *unshaped* change set. The gate
-    /// keystone — shaping never alters this.
-    summary: &'a DeltaSummary,
-    /// Echoes the resolved [`DeltaViewSpec`] so consumers can
-    /// reconstruct what filters / sort / limit produced `shown`.
-    spec: &'a DeltaViewSpec,
-    /// Post-filter, pre-truncate count. With `truncated`, lets
-    /// consumers render "Showing X of Y".
-    eligible_count: usize,
-    truncated: bool,
-    /// Reserved for a future `--baseline-ref <label>` flag (F2 follow-up).
-    /// Always `null` today.
-    baseline_ref: Option<&'a str>,
-    baseline_tool_version: &'a str,
-    baseline_timestamp: &'a str,
-    /// Per-change list, post-filter / sort / truncate. References
-    /// (the borrows hold for the envelope's lifetime via the View).
-    shown: Vec<&'a FunctionChange>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    baseline_diagnostics: Option<&'a AnalysisDiagnostics<P>>,
-}
-
-impl<'a, P: ParseDiagnostic> DeltaWire<'a, P> {
-    fn from_context(ctx: &'a DeltaContext<'a, P>) -> Self {
-        DeltaWire {
-            summary: &ctx.view.full.summary,
-            spec: &ctx.view.spec,
-            eligible_count: ctx.view.eligible_count,
-            truncated: ctx.view.truncated,
-            baseline_ref: None,
-            baseline_tool_version: ctx.baseline_tool_version,
-            baseline_timestamp: ctx.baseline_timestamp,
-            shown: ctx.view.shown.clone(),
-            baseline_diagnostics: ctx.baseline_diagnostics,
-        }
+/// Project the borrowed row view into the owned wire block.
+///
+/// A minimal view elides the per-row `shown` list; every other view key
+/// remains for scope context.
+fn view_block(view: &AnalysisView<'_>, minimal: bool) -> ViewBlock {
+    ViewBlock {
+        spec: view.spec.clone(),
+        eligible_count: view.eligible_count,
+        truncated: view.truncated,
+        shown: (!minimal).then(|| view.shown.iter().map(|v| (*v).clone()).collect()),
+        shown_summary: view.shown_summary.clone(),
+        grouped: view.grouped.clone(),
     }
 }
 
-/// On-the-wire view representation. Mirrors `AnalysisView`'s serialized
-/// shape exactly when `shown` is `Some`, so the default JSON output is
-/// byte-identical to the prior `view: &AnalysisView` serialization.
-/// `--minimal-view` sets `shown = None`, which `skip_serializing_if`
-/// elides — every other key remains for scope context.
-#[derive(Serialize)]
-struct ViewWire<'a> {
-    spec: &'a ViewSpec,
-    eligible_count: usize,
-    truncated: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    shown: Option<&'a [&'a FunctionVerdict]>,
-    shown_summary: &'a AnalysisSummary,
-    /// Per-key aggregation block. Always serialized (emits `null`
-    /// when grouping is inactive) so consumers can distinguish
-    /// "default invocation" from "schema doesn't carry grouping".
-    grouped: Option<&'a GroupedView>,
-}
-
-impl<'a> ViewWire<'a> {
-    fn from_view(view: &'a AnalysisView<'a>, minimal: bool) -> Self {
-        ViewWire {
-            spec: &view.spec,
-            eligible_count: view.eligible_count,
-            truncated: view.truncated,
-            shown: if minimal {
-                None
-            } else {
-                Some(view.shown.as_slice())
-            },
-            shown_summary: &view.shown_summary,
-            grouped: view.grouped.as_ref(),
-        }
+/// Project the borrowed delta context into the owned wire block.
+fn delta_block<P: ParseDiagnostic>(ctx: &DeltaContext<'_, P>) -> DeltaBlock<P> {
+    DeltaBlock {
+        summary: ctx.view.full.summary,
+        spec: ctx.view.spec.clone(),
+        eligible_count: ctx.view.eligible_count,
+        truncated: ctx.view.truncated,
+        baseline_ref: None,
+        baseline_tool_version: ctx.baseline_tool_version.to_string(),
+        baseline_timestamp: ctx.baseline_timestamp.to_string(),
+        shown: ctx.view.shown.iter().map(|c| (*c).clone()).collect(),
+        baseline_diagnostics: ctx.baseline_diagnostics.cloned(),
     }
 }
 
@@ -227,20 +112,18 @@ pub fn format_json<P: ParseDiagnostic>(
     view: &AnalysisView<'_>,
     config: &JsonConfig<'_, P>,
 ) -> Result<String, serde_json::Error> {
-    let delta_wire: Option<DeltaWire<P>> = config.delta.as_ref().map(DeltaWire::from_context);
-
-    let envelope = JsonEnvelope {
-        schema_version: 2,
-        tool_version: &config.tool_version,
-        language: "rust",
-        timestamp: &config.timestamp,
-        metric: &config.metric,
+    let envelope = Envelope {
+        schema_version: wire::CURRENT_SCHEMA_VERSION,
+        tool_version: config.tool_version.clone(),
+        language: "rust".to_string(),
+        timestamp: config.timestamp.clone(),
+        metric: config.metric,
         threshold: config.threshold,
-        diff_ref: config.diff_ref,
-        result: view.full,
-        view: ViewWire::from_view(view, config.minimal_view),
-        delta: delta_wire,
-        diagnostics: config.diagnostics,
+        diff_ref: config.diff_ref.map(str::to_string),
+        result: view.full.clone(),
+        view: view_block(view, config.minimal_view),
+        delta: config.delta.as_ref().map(delta_block),
+        diagnostics: config.diagnostics.cloned(),
         missing_coverage_policy: config.missing_coverage_policy,
         epsilon: config.epsilon,
     };
@@ -251,7 +134,7 @@ pub fn format_json<P: ParseDiagnostic>(
 mod tests {
     use super::*;
     use crate::adapters::reporters::test_fixtures::*;
-    use crate::domain::types::{ComplexityMetric, RiskLevel};
+    use crate::domain::types::{AnalysisResult, ComplexityMetric, RiskLevel};
     use crate::test_strategies::DummyParseDiagnostic;
 
     /// Concrete `P` for in-module tests — the JSON reporter's behavior

--- a/crates/crap-core/src/adapters/wire.rs
+++ b/crates/crap-core/src/adapters/wire.rs
@@ -237,7 +237,7 @@ pub struct DeltaBlock<P: ParseDiagnostic> {
 /// the [`AnalysisDiagnostics`] block around the entries keeps its
 /// shared concrete shape (the count fields every adapter's writer
 /// emits).
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct RawParseDiagnostic(pub serde_json::Value);
 

--- a/crates/crap-core/src/adapters/wire.rs
+++ b/crates/crap-core/src/adapters/wire.rs
@@ -1,0 +1,567 @@
+//! Canonical JSON wire envelope — the single owned schema shared by the
+//! writer (the JSON reporter) and every reader (the baseline loader and
+//! the `crap-render` binary).
+//!
+//! ## One type, both directions
+//!
+//! [`Envelope`] derives both `Serialize` and `Deserialize`, so the wire
+//! contract has exactly one source of truth: a field added to the writer
+//! is readable by construction, and a field the readers expect must
+//! exist on the writer. The previous split — a borrow-based
+//! `Serialize`-only writer struct mirrored by hand-maintained partial
+//! reader structs — let the two sides drift silently (a new writer field
+//! would `serde(default)` to nothing on the read side instead of failing
+//! to compile). The cost of unification is that the writer clones the
+//! analysis into the owned envelope at emit time, trading the previous
+//! zero-copy serialization for the single schema; for a fire-and-exit
+//! CLI about to pretty-print the same data, the clone is negligible.
+//!
+//! ## Data vs presentation
+//!
+//! The envelope carries two kinds of fields with different round-trip
+//! contracts:
+//!
+//! - **Data** — `schema_version` through `result`, plus `diagnostics`,
+//!   `missing_coverage_policy`, and `epsilon`. This is the analysis and
+//!   the parameters that shaped it. Data fields round-trip: what the
+//!   writer emits, a reader gets back, guarded by this module's tests.
+//! - **Presentation** — [`ViewBlock`] (`view`) and [`DeltaBlock`]
+//!   (`delta`). These describe how rows were filtered / sorted /
+//!   truncated for display, and what changed vs a baseline. They are
+//!   derived from the data and recomputable from it, so they are
+//!   **write-only**: serialized for external consumers, but
+//!   `skip_deserializing` on the read side (a parsed envelope carries
+//!   defaults). In particular, a consumer that needs a delta recomputes
+//!   it from two `result` blocks (as `crap-render` does) rather than
+//!   trusting a pre-computed block whose inputs it cannot see.
+//!
+//! ## Read contract
+//!
+//! Only `schema_version` and `result` are required on read; every other
+//! field defaults when absent. This is the baseline loader's documented
+//! permissive contract (consumers may hand-produce baseline envelopes
+//! carrying only what they have), now uniform across all readers.
+//!
+//! ## Adapter-agnostic reading
+//!
+//! `Envelope` is generic over `P: ParseDiagnostic` because
+//! `diagnostics` carries adapter-specific parse-diagnostic shapes. A
+//! reader that must accept envelopes from *any* adapter (such as
+//! `crap-render`, which composes Rust and TypeScript envelopes into one
+//! report) instantiates [`Envelope<RawParseDiagnostic>`]: the raw
+//! diagnostic preserves the per-entry diagnostic JSON faithfully
+//! without committing to a concrete adapter's type. The erasure covers
+//! the `parse_diagnostics` *entries* only — the surrounding
+//! [`AnalysisDiagnostics`] count fields are the shared concrete shape
+//! every adapter's writer emits.
+
+use crate::domain::delta::{DeltaSummary, DeltaViewSpec, FunctionChange};
+use crate::domain::types::{
+    AnalysisDiagnostics, AnalysisResult, AnalysisSummary, ComplexityMetric, FunctionVerdict,
+    MissingCoveragePolicy,
+};
+use crate::domain::view::{GroupedView, ViewSpec};
+use crate::ports::ParseDiagnostic;
+use serde::{Deserialize, Serialize};
+
+/// Envelope schema version stamped on every emitted envelope.
+///
+/// The writer stamps this constant and the readers validate against
+/// [`SUPPORTED_SCHEMA_VERSIONS`], so the emit version and the accepted
+/// range can never drift apart silently. The schema evolves additively
+/// across minor releases; the bump from 1 → 2 in 0.4.0 reflects the
+/// `ComplexityContributor.column` 0-based → 1-based convention shift.
+pub const CURRENT_SCHEMA_VERSION: u32 = 2;
+
+/// Envelope schema versions accepted by every reader.
+///
+/// v1 stays loadable across the v0.3.x → v0.4.x boundary so users can
+/// keep their committed baseline JSON; the column-convention shift in
+/// v2 doesn't affect delta calculations (identity-keyed matching).
+/// Future schema bumps will need an explicit migration path.
+pub const SUPPORTED_SCHEMA_VERSIONS: &[u32] = &[1, 2];
+
+/// The canonical JSON envelope — the single wire schema, used owned by
+/// the writer and deserialized whole by every reader.
+///
+/// Field declaration order is **load-bearing**: it is the wire key
+/// order, pinned end-to-end by the CLI ergonomics feature
+/// (`schema_version` through `view`) and at the type level by this
+/// module's key-order test. New fields are appended additively after
+/// `epsilon` and elided at their default so existing envelopes stay
+/// byte-identical; they do not bump [`CURRENT_SCHEMA_VERSION`].
+///
+/// See the module docs for the data-vs-presentation split and the
+/// permissive read contract (only `schema_version` and `result` are
+/// required; everything else defaults).
+///
+/// `serde(bound = "")` suppresses the auto-generated `P: Serialize` /
+/// `P: Deserialize<'de>` bounds — `P: ParseDiagnostic` already provides
+/// `Serialize + DeserializeOwned`, and the auto-bounds conflict with
+/// the owned-deserialize requirement.
+#[non_exhaustive]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(bound = "")]
+pub struct Envelope<P: ParseDiagnostic> {
+    pub schema_version: u32,
+    #[serde(default)]
+    pub tool_version: String,
+    /// Language tag of the emitting adapter. Note the JSON reporter
+    /// currently stamps `"rust"` for every adapter, so readers must not
+    /// treat this field as a usable identity signal yet; `crap-render`
+    /// pairs each envelope with a language key on the CLI instead.
+    #[serde(default)]
+    pub language: String,
+    #[serde(default)]
+    pub timestamp: String,
+    #[serde(default)]
+    pub metric: ComplexityMetric,
+    #[serde(default)]
+    pub threshold: f64,
+    /// Git ref used for diff filtering. Always emitted (`null` when no
+    /// diff filter was active) so consumers can distinguish "no diff
+    /// filter" from "schema doesn't carry the key".
+    #[serde(default)]
+    pub diff_ref: Option<String>,
+    /// The canonical analysis — the gate source of truth, and the block
+    /// a consumer recomputes deltas from.
+    pub result: AnalysisResult,
+    /// Presentation: how the reported rows were filtered, sorted, and
+    /// truncated. Write-only — see the module docs.
+    #[serde(skip_deserializing, default)]
+    pub view: ViewBlock,
+    /// Presentation: changes vs a baseline. Present iff the emitting
+    /// run compared against one; the key is elided otherwise so the
+    /// no-delta envelope stays byte-identical to pre-delta output.
+    /// Write-only — a consumer that needs a delta recomputes it from
+    /// two `result` blocks.
+    #[serde(skip_deserializing, default, skip_serializing_if = "Option::is_none")]
+    pub delta: Option<DeltaBlock<P>>,
+    /// Parse diagnostics from the coverage ingestion, included when the
+    /// emitting run was verbose. Adapter-specific shape; see
+    /// [`RawParseDiagnostic`] for adapter-agnostic reading.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub diagnostics: Option<AnalysisDiagnostics<P>>,
+    /// Missing-coverage policy the run was configured with. Elided when
+    /// `Pessimistic` (the default) so every pessimistic-run envelope
+    /// stays byte-identical to envelopes emitted before the field
+    /// existed; readers treat an absent key as `Pessimistic`.
+    #[serde(default, skip_serializing_if = "is_pessimistic")]
+    pub missing_coverage_policy: MissingCoveragePolicy,
+    /// Effective threshold-border epsilon the run was configured with.
+    /// Carried on the envelope — even on a baseline-less run that
+    /// computes no delta — so a consumer recomputing the delta from
+    /// `result` blocks applies the same border band the gate used.
+    /// Elided when `0.0` (suppression off, the default).
+    #[serde(default, skip_serializing_if = "is_zero_epsilon")]
+    pub epsilon: f64,
+}
+
+/// `skip_serializing_if` predicate: elide `missing_coverage_policy`
+/// when it carries the default, so a pessimistic run's envelope is
+/// byte-identical to before the field existed.
+fn is_pessimistic(policy: &MissingCoveragePolicy) -> bool {
+    *policy == MissingCoveragePolicy::Pessimistic
+}
+
+/// `skip_serializing_if` predicate: elide `epsilon` when it is `0.0`
+/// (suppression off — the default), so every existing envelope stays
+/// byte-identical. `0.0 == -0.0` in IEEE-754, and the resolved epsilon
+/// is always a finite value `>= 0.0` (validated at the CLI / config
+/// boundary), so `== 0.0` is the exact "off" test.
+fn is_zero_epsilon(epsilon: &f64) -> bool {
+    *epsilon == 0.0
+}
+
+/// On-the-wire view block: how the reported rows were shaped for
+/// display. Owned mirror of the row-view metadata; write-only
+/// presentation (see the module docs), so it derives `Serialize` and
+/// `Default` but deliberately not `Deserialize`.
+#[non_exhaustive]
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct ViewBlock {
+    /// Echoes the resolved view spec so consumers can reconstruct what
+    /// filters / sort / limit produced `shown`.
+    pub spec: ViewSpec,
+    /// Post-filter, pre-truncate count. With `truncated`, lets
+    /// consumers render "Showing X of Y".
+    pub eligible_count: usize,
+    pub truncated: bool,
+    /// Per-row list, post-filter / sort / truncate. `None` when the run
+    /// asked for a minimal view, which elides the key; every other view
+    /// key remains for scope context.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub shown: Option<Vec<FunctionVerdict>>,
+    pub shown_summary: AnalysisSummary,
+    /// Per-key aggregation block. Always serialized (emits `null` when
+    /// grouping is inactive) so consumers can distinguish "default
+    /// invocation" from "schema doesn't carry grouping".
+    pub grouped: Option<GroupedView>,
+}
+
+/// On-the-wire delta block: changes vs a baseline, shaped for display.
+/// Owned mirror of the delta-view metadata; write-only presentation
+/// (see the module docs).
+#[non_exhaustive]
+#[derive(Debug, Clone, Serialize)]
+#[serde(bound = "")]
+pub struct DeltaBlock<P: ParseDiagnostic> {
+    /// Aggregate counts over the *unshaped* change set. The gate
+    /// keystone — shaping never alters this.
+    pub summary: DeltaSummary,
+    /// Echoes the resolved delta-view spec so consumers can reconstruct
+    /// what filters / sort / limit produced `shown`.
+    pub spec: DeltaViewSpec,
+    /// Post-filter, pre-truncate count. With `truncated`, lets
+    /// consumers render "Showing X of Y".
+    pub eligible_count: usize,
+    pub truncated: bool,
+    /// Reserved for a future baseline-label flag. Always `null` today.
+    pub baseline_ref: Option<String>,
+    pub baseline_tool_version: String,
+    pub baseline_timestamp: String,
+    /// Per-change list, post-filter / sort / truncate.
+    pub shown: Vec<FunctionChange>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub baseline_diagnostics: Option<AnalysisDiagnostics<P>>,
+}
+
+/// Adapter-agnostic parse diagnostic: preserves a diagnostic entry's
+/// JSON faithfully without committing to a concrete adapter's
+/// diagnostic type.
+///
+/// A reader that must accept envelopes from *any* adapter instantiates
+/// [`Envelope<RawParseDiagnostic>`]; the transparent `serde_json::Value`
+/// representation round-trips diagnostic entries it does not understand
+/// instead of rejecting or distorting them. The erasure is per-entry:
+/// the [`AnalysisDiagnostics`] block around the entries keeps its
+/// shared concrete shape (the count fields every adapter's writer
+/// emits).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct RawParseDiagnostic(pub serde_json::Value);
+
+impl ParseDiagnostic for RawParseDiagnostic {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adapters::reporters::test_fixtures::make_single_function_result;
+    use crate::domain::types::RiskLevel;
+    use crate::test_strategies::DummyParseDiagnostic;
+
+    fn sample_diagnostics() -> AnalysisDiagnostics<DummyParseDiagnostic> {
+        AnalysisDiagnostics {
+            parse_diagnostics: vec![],
+            files_found: 10,
+            files_unparseable: 1,
+            functions_extracted: 42,
+            functions_matched: 40,
+            functions_no_coverage: 2,
+            files_analyzed: 8,
+            files_zero_coverage: 2,
+        }
+    }
+
+    /// A fully-populated envelope: every data field non-default, both
+    /// presentation blocks present, so a single fixture exercises every
+    /// serialization branch.
+    fn populated_envelope() -> Envelope<DummyParseDiagnostic> {
+        Envelope {
+            schema_version: CURRENT_SCHEMA_VERSION,
+            tool_version: "9.9.9".to_string(),
+            language: "rust".to_string(),
+            timestamp: "2026-06-09T12:00:00Z".to_string(),
+            metric: ComplexityMetric::Cyclomatic,
+            threshold: 11.5,
+            diff_ref: Some("main".to_string()),
+            result: make_single_function_result(
+                "compute_crap",
+                "src/domain/crap.rs",
+                5,
+                80.0,
+                5.16,
+                RiskLevel::Acceptable,
+                11.5,
+            ),
+            view: ViewBlock {
+                spec: ViewSpec::default(),
+                eligible_count: 1,
+                truncated: false,
+                shown: None,
+                shown_summary: AnalysisSummary::default(),
+                grouped: None,
+            },
+            delta: Some(DeltaBlock {
+                summary: DeltaSummary::default(),
+                spec: DeltaViewSpec::default(),
+                eligible_count: 0,
+                truncated: false,
+                baseline_ref: None,
+                baseline_tool_version: "0.0.9".to_string(),
+                baseline_timestamp: "2026-01-01T00:00:00Z".to_string(),
+                shown: vec![],
+                baseline_diagnostics: None,
+            }),
+            diagnostics: Some(sample_diagnostics()),
+            missing_coverage_policy: MissingCoveragePolicy::Optimistic,
+            epsilon: 0.25,
+        }
+    }
+
+    fn to_value<T: Serialize>(value: &T) -> serde_json::Value {
+        serde_json::to_value(value).expect("serializable")
+    }
+
+    #[test]
+    fn data_fields_round_trip_through_the_wire() {
+        let original = populated_envelope();
+        let json = serde_json::to_string_pretty(&original).expect("serialize");
+        let parsed: Envelope<DummyParseDiagnostic> =
+            serde_json::from_str(&json).expect("the writer's output must parse as the same type");
+
+        assert_eq!(parsed.schema_version, original.schema_version);
+        assert_eq!(parsed.tool_version, original.tool_version);
+        assert_eq!(parsed.language, original.language);
+        assert_eq!(parsed.timestamp, original.timestamp);
+        assert_eq!(parsed.metric, original.metric);
+        assert_eq!(parsed.threshold, original.threshold);
+        assert_eq!(parsed.diff_ref, original.diff_ref);
+        assert_eq!(to_value(&parsed.result), to_value(&original.result));
+        assert_eq!(
+            to_value(&parsed.diagnostics),
+            to_value(&original.diagnostics)
+        );
+        assert_eq!(
+            parsed.missing_coverage_policy,
+            original.missing_coverage_policy
+        );
+        assert_eq!(parsed.epsilon, original.epsilon);
+    }
+
+    #[test]
+    fn presentation_blocks_are_emitted_but_not_read_back() {
+        let original = populated_envelope();
+        let json = serde_json::to_string_pretty(&original).expect("serialize");
+
+        // Emitted: external consumers see both blocks on the wire.
+        assert!(json.contains("\n  \"view\""), "view block must be emitted");
+        assert!(
+            json.contains("\n  \"delta\""),
+            "delta block must be emitted"
+        );
+
+        // Not read back: a parsed envelope carries defaults — the blocks
+        // are derived presentation, recomputable from `result`.
+        let parsed: Envelope<DummyParseDiagnostic> = serde_json::from_str(&json).expect("parse");
+        assert_eq!(
+            parsed.view.eligible_count, 0,
+            "view is write-only; reads as default"
+        );
+        assert!(parsed.delta.is_none(), "delta is write-only; reads as None");
+    }
+
+    #[test]
+    fn wire_key_order_matches_the_pinned_contract() {
+        // The leading key order (schema_version .. view) is asserted
+        // end-to-end by the CLI ergonomics feature; this pins the FULL
+        // order including the conditional tail keys, at the type level,
+        // so a field reorder fails here before it reaches a snapshot.
+        let json = serde_json::to_string_pretty(&populated_envelope()).expect("serialize");
+        let keys = [
+            "schema_version",
+            "tool_version",
+            "language",
+            "timestamp",
+            "metric",
+            "threshold",
+            "diff_ref",
+            "result",
+            "view",
+            "delta",
+            "diagnostics",
+            "missing_coverage_policy",
+            "epsilon",
+        ];
+        // Top-level keys sit at indent 2 in serde_json's pretty printer;
+        // anchoring on `\n  "<key>"` keeps nested same-name keys from
+        // shadowing the top-level position.
+        let positions: Vec<usize> = keys
+            .iter()
+            .map(|k| {
+                json.find(&format!("\n  \"{k}\""))
+                    .unwrap_or_else(|| panic!("missing top-level key {k} in:\n{json}"))
+            })
+            .collect();
+        for (pair, w) in keys.windows(2).zip(positions.windows(2)) {
+            assert!(
+                w[0] < w[1],
+                "wire key order: expected {} before {}, got positions {} and {}",
+                pair[0],
+                pair[1],
+                w[0],
+                w[1],
+            );
+        }
+    }
+
+    #[test]
+    fn elision_rules_keep_default_envelopes_lean() {
+        // Defaults elide the optional tail keys so an envelope emitted
+        // with no delta context, default policy, and epsilon off stays
+        // byte-identical to envelopes produced before those fields
+        // existed. `diff_ref` and `view` are NOT elided: consumers
+        // distinguish "no diff filter" (null) from "schema doesn't carry
+        // the key".
+        let envelope: Envelope<DummyParseDiagnostic> = Envelope {
+            schema_version: CURRENT_SCHEMA_VERSION,
+            tool_version: "0.1.0".to_string(),
+            language: "rust".to_string(),
+            timestamp: "2026-06-09T12:00:00Z".to_string(),
+            metric: ComplexityMetric::Cognitive,
+            threshold: 8.0,
+            diff_ref: None,
+            result: make_single_function_result(
+                "f",
+                "src/lib.rs",
+                1,
+                100.0,
+                1.0,
+                RiskLevel::Low,
+                8.0,
+            ),
+            view: ViewBlock::default(),
+            delta: None,
+            diagnostics: None,
+            missing_coverage_policy: MissingCoveragePolicy::Pessimistic,
+            epsilon: 0.0,
+        };
+        let v: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string_pretty(&envelope).expect("serialize"))
+                .expect("valid JSON");
+
+        assert!(v.get("delta").is_none(), "absent delta elides the key");
+        assert!(
+            v.get("diagnostics").is_none(),
+            "absent diagnostics elides the key"
+        );
+        assert!(
+            v.get("missing_coverage_policy").is_none(),
+            "default policy elides the key"
+        );
+        assert!(v.get("epsilon").is_none(), "epsilon 0.0 elides the key");
+        assert!(
+            v.get("diff_ref").is_some_and(serde_json::Value::is_null),
+            "diff_ref stays present as null"
+        );
+        assert!(v.get("view").is_some(), "view block is always emitted");
+    }
+
+    #[test]
+    fn read_contract_requires_only_schema_version_and_result() {
+        // The permissive read contract: consumers may hand-produce
+        // envelopes carrying only the analysis itself; all metadata
+        // defaults. This is the baseline loader's documented behavior,
+        // uniform across every reader of the canonical type.
+        let json = r#"{
+            "schema_version": 2,
+            "result": {
+                "functions": [],
+                "summary": {
+                    "total_functions": 0, "total_files": 0, "exceeding_threshold": 0,
+                    "average_crap": 0.0, "median_crap": 0.0,
+                    "max_crap": null, "worst_function": null,
+                    "distribution": { "low": 0, "acceptable": 0, "moderate": 0, "high": 0 }
+                },
+                "passed": true
+            }
+        }"#;
+        let parsed: Envelope<DummyParseDiagnostic> =
+            serde_json::from_str(json).expect("schema_version + result suffice");
+        assert_eq!(parsed.schema_version, 2);
+        assert_eq!(parsed.tool_version, "");
+        assert_eq!(parsed.language, "");
+        assert_eq!(parsed.timestamp, "");
+        assert_eq!(parsed.metric, ComplexityMetric::Cognitive);
+        assert_eq!(parsed.threshold, 0.0);
+        assert_eq!(parsed.diff_ref, None);
+        assert!(parsed.result.passed);
+        assert!(parsed.diagnostics.is_none());
+        assert_eq!(
+            parsed.missing_coverage_policy,
+            MissingCoveragePolicy::Pessimistic
+        );
+        assert_eq!(parsed.epsilon, 0.0);
+    }
+
+    #[test]
+    fn raw_parse_diagnostic_carries_any_adapter_shape_faithfully() {
+        // The erased diagnostic must accept arbitrary adapter-specific
+        // entries AND re-serialize them unchanged, so an
+        // adapter-agnostic reader neither rejects nor distorts
+        // diagnostics it does not understand.
+        let json = r#"{
+            "parse_diagnostics": [
+                {"kind":"MalformedRecord","line":42,"detail":"bad DA"},
+                {"kind":"UnknownPrefix","line":7}
+            ],
+            "files_found": 5, "files_unparseable": 1,
+            "functions_extracted": 10, "functions_matched": 8,
+            "functions_no_coverage": 2, "files_analyzed": 5, "files_zero_coverage": 0
+        }"#;
+        let diag: AnalysisDiagnostics<RawParseDiagnostic> =
+            serde_json::from_str(json).expect("erased diagnostics must deserialize");
+        assert_eq!(diag.parse_diagnostics.len(), 2);
+        let original: serde_json::Value = serde_json::from_str(json).expect("valid JSON");
+        assert_eq!(
+            to_value(&diag),
+            original,
+            "re-serialization must be value-identical to the input"
+        );
+    }
+}
+
+#[cfg(test)]
+mod proptests {
+    use super::*;
+    use crate::test_strategies::{DummyParseDiagnostic, arb_analysis_result};
+    use proptest::prelude::*;
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(256))]
+
+        /// The data contract round-trips for ANY analysis: with default
+        /// (write-only) presentation blocks, serialize → parse →
+        /// re-serialize is value-identical, so a writer/reader
+        /// divergence on any data field fails here.
+        #[test]
+        fn prop_envelope_data_round_trips(
+            result in arb_analysis_result(),
+            threshold in 1.0..100.0f64,
+            epsilon in prop_oneof![Just(0.0f64), 0.001..2.0f64],
+        ) {
+            let envelope: Envelope<DummyParseDiagnostic> = Envelope {
+                schema_version: CURRENT_SCHEMA_VERSION,
+                tool_version: "0.1.0".to_string(),
+                language: "rust".to_string(),
+                timestamp: "2026-01-01T00:00:00Z".to_string(),
+                metric: ComplexityMetric::Cognitive,
+                threshold,
+                diff_ref: None,
+                result,
+                view: ViewBlock::default(),
+                delta: None,
+                diagnostics: None,
+                missing_coverage_policy: MissingCoveragePolicy::Pessimistic,
+                epsilon,
+            };
+            let json = serde_json::to_string_pretty(&envelope).expect("serialize");
+            let parsed: Envelope<DummyParseDiagnostic> =
+                serde_json::from_str(&json).expect("parse");
+            prop_assert_eq!(
+                serde_json::to_value(&envelope).expect("to_value"),
+                serde_json::to_value(&parsed).expect("to_value")
+            );
+        }
+    }
+}

--- a/crates/crap-core/src/bin/crap-render.rs
+++ b/crates/crap-core/src/bin/crap-render.rs
@@ -32,11 +32,11 @@
 //!
 //! ## Schema-version validation
 //!
-//! Each envelope's `schema_version` is validated on parse. The
-//! renderer accepts `schema_version ∈ {1, 2}` (mirrors the baseline
-//! loader's accepted range in `adapters::baseline`). Out-of-range
-//! values fail fast with an actionable error message naming the
-//! envelope path and the offending value.
+//! Each envelope's `schema_version` is validated on parse against the
+//! shared `adapters::wire::SUPPORTED_SCHEMA_VERSIONS` (the same range
+//! every envelope reader accepts). Out-of-range values fail fast with
+//! an actionable error message naming the envelope path and the
+//! offending value.
 //!
 //! ## Duplicate adapter guard
 //!
@@ -52,22 +52,14 @@ use std::process::ExitCode;
 
 use anyhow::{Context, Result, anyhow, bail};
 use clap::{ArgAction, Parser, ValueEnum};
-use serde::Deserialize;
 
 use crap_core::adapters::reporters::{HtmlMultiOptions, format_html_multi};
+use crap_core::adapters::wire::{Envelope, RawParseDiagnostic, SUPPORTED_SCHEMA_VERSIONS};
 use crap_core::core::compose::compose_multi_lang;
 use crap_core::domain::delta::{self, AnalysisDelta, DeltaViewSpec};
 use crap_core::domain::multi_lang::LanguageBlock;
 use crap_core::domain::types::{AnalysisResult, ComplexityMetric};
 use crap_core::domain::view::{self, ViewSpec};
-
-/// Schema versions this renderer accepts on input envelopes.
-///
-/// Mirrors the baseline loader's range
-/// (`adapters::baseline::SUPPORTED_SCHEMA_VERSIONS`); when production
-/// envelopes bump past this range, the renderer fails fast with an
-/// actionable error rather than producing a mangled combined view.
-const SUPPORTED_SCHEMA_VERSIONS: &[u32] = &[1, 2];
 
 #[derive(Parser, Debug)]
 #[command(
@@ -131,25 +123,6 @@ struct ParsedEnvelope {
     /// matches the gate that produced the envelope. `0.0` ⇒ band off.
     epsilon: f64,
     tool_version: String,
-}
-
-/// Minimal envelope shape for deserialization. Mirrors the relevant
-/// subset of `JsonEnvelope` in `crap-core::adapters::reporters::json`
-/// — we only read the fields the renderer needs.
-#[derive(Deserialize)]
-struct WireEnvelope {
-    schema_version: u32,
-    #[serde(default)]
-    tool_version: String,
-    metric: ComplexityMetric,
-    threshold: f64,
-    /// Effective threshold-border epsilon the emitting run was configured
-    /// with (crap-rs#379). `serde(default)` → `0.0` for envelopes that omit
-    /// it (every pre-#379 envelope, and any epsilon-off run), so the
-    /// recomputed delta stays byte-identical to the old behavior there.
-    #[serde(default)]
-    epsilon: f64,
-    result: AnalysisResult,
 }
 
 fn main() -> ExitCode {
@@ -330,9 +303,13 @@ fn parse_input_spec(spec: &str, kind: &str) -> Result<ParsedEnvelope> {
     // `from_reader` reads forward through the JSON document; on a
     // typical workspace this is functionally equivalent to slurping
     // but bounds peak memory in the high-input case.
+    //
+    // `RawParseDiagnostic` keeps the renderer adapter-agnostic: it
+    // accepts envelopes from any emitting adapter without committing to
+    // a concrete parse-diagnostic type.
     let file =
         File::open(&path).with_context(|| format!("opening envelope at {}", path.display()))?;
-    let envelope: WireEnvelope = serde_json::from_reader(BufReader::new(file))
+    let envelope: Envelope<RawParseDiagnostic> = serde_json::from_reader(BufReader::new(file))
         .with_context(|| format!("parsing JSON envelope at {}", path.display()))?;
 
     if !SUPPORTED_SCHEMA_VERSIONS.contains(&envelope.schema_version) {

--- a/crates/crap-core/tests/snapshots/wire_envelope_crap4rs__envelope.snap
+++ b/crates/crap-core/tests/snapshots/wire_envelope_crap4rs__envelope.snap
@@ -88,7 +88,7 @@ expression: pretty
               "nesting_depth": 1
             }
           ],
-          "coverage_percent": 94.73684210526316,
+          "coverage_percent": 94.73684210526315,
           "crap": {
             "risk_level": "low",
             "value": 4.0
@@ -121,7 +121,7 @@ expression: pretty
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 93.33333333333331,
+          "coverage_percent": 93.33333333333333,
           "crap": {
             "risk_level": "low",
             "value": 2.0
@@ -6214,7 +6214,7 @@ expression: pretty
     "passed": true,
     "summary": {
       "average_complexity": 1.5201793721973094,
-      "average_coverage": 95.49769207254388,
+      "average_coverage": 95.49769207254387,
       "average_crap": 1.5780269058295966,
       "distribution": {
         "acceptable": 0,
@@ -6758,7 +6758,7 @@ expression: pretty
               "nesting_depth": 1
             }
           ],
-          "coverage_percent": 94.73684210526316,
+          "coverage_percent": 94.73684210526315,
           "crap": {
             "risk_level": "low",
             "value": 4.0
@@ -7653,7 +7653,7 @@ expression: pretty
               "nesting_depth": 0
             }
           ],
-          "coverage_percent": 93.33333333333331,
+          "coverage_percent": 93.33333333333333,
           "crap": {
             "risk_level": "low",
             "value": 2.0
@@ -12459,7 +12459,7 @@ expression: pretty
     ],
     "shown_summary": {
       "average_complexity": 1.5201793721973094,
-      "average_coverage": 95.49769207254388,
+      "average_coverage": 95.49769207254387,
       "average_crap": 1.5780269058295966,
       "distribution": {
         "acceptable": 0,


### PR DESCRIPTION
## Summary

The analyzer JSON envelope was written once (`JsonEnvelope`, borrow-based `Serialize`-only) and read by two hand-maintained partial DTOs (`WireEnvelope` in crap-render, `BaselineEnvelope` in the baseline loader) plus two duplicated `SUPPORTED_SCHEMA_VERSIONS` constants — no compiler link guaranteed the sides agreed, which is the structural gap that let the epsilon parameter (#379) stay invisible to readers.

This PR replaces all of that with **one owned canonical `wire::Envelope<P>`** deriving `Serialize + Deserialize`, used by the JSON reporter (write) and both readers (deserialize + project). A field added to the writer is now readable by construction.

Closes #389

## Design

- **Data vs presentation, encoded in the type.** Data fields (`schema_version` … `result`, `diagnostics`, `missing_coverage_policy`, `epsilon`) round-trip and are guarded by a round-trip proptest. `view`/`delta` are **write-only presentation** (`#[serde(skip_deserializing)]`): serialized for external consumers, defaulted on read — consistent with the settled decision that crap-render *recomputes* deltas from two `result` blocks rather than consuming a pre-computed one.
- **AC1 narrowing (conscious):** the issue's literal AC asks for `DeltaBlock` to derive `Deserialize`. It deliberately does not — making the delta consumable would re-open the recompute-vs-consume decision purely to satisfy a test. The round-trip contract covers the surface readers actually consume (where the #379-class bug lived).
- **AC4 tradeoff recorded:** the writer now clones the analysis into the owned envelope at emit time, trading the previous zero-copy serialize for a single source of truth. Negligible for a fire-and-exit CLI about to pretty-print the same data; revisit only if measured hot.
- **Adapter-agnostic reading:** `RawParseDiagnostic(serde_json::Value)` lets crap-render instantiate `Envelope<RawParseDiagnostic>` and accept any emitter's diagnostic *entries* faithfully (the surrounding `AnalysisDiagnostics` count shape stays concrete — every adapter's writer emits it).
- **`SUPPORTED_SCHEMA_VERSIONS` / `CURRENT_SCHEMA_VERSION` defined once** in `wire`, re-exported from `baseline` so existing import paths (incl. crap4rs's shim) compile unchanged. The writer now stamps `CURRENT_SCHEMA_VERSION` instead of a literal — emit version and accepted range can't drift.

## The round-trip test caught a real wire imprecision

The proptest failed immediately: serde_json's default fast float parser loses the last ulp on read (`coverage_percent: 94.73684210526315` parsed back as `…16`). **Baseline loads have silently perturbed floats by 1 ulp until now.** Fixed by enabling serde_json's `float_roundtrip` feature — the wire now round-trips bit-exactly.

**Drift documented (wire_envelope_crap4rs snapshot):** the regen is *harness parse fidelity only* — the snapshot test re-prints binary stdout through a serde_json parse, and the exact parser now records the binary's true floats instead of 1-ulp-off artifacts. Binary stdout verified byte-identical against raw output (`94.73684210526315` / `93.33333333333333` / `95.49769207254387` are what the binary actually emits). **crap4ts canary: no drift.**

## Read-contract changes (named, per advisor review)

- **crap-render loosened:** it previously hard-required `metric`/`threshold` on input envelopes; it now inherits the permissive read (only `schema_version` + `result` required) that the baseline loader has always documented. Real emitters always write both fields; a hand-malformed envelope missing `threshold` renders a visible `inf×` ratio rather than erroring.
- **Both readers typed-stricter on previously-ignored fields:** junk-typed `metric`/`threshold` (e.g. a string `"8"`) in a baseline now fails parse instead of being skipped; crap-render now parses `diagnostics` when present. Fail-loud on malformed input; zero practical change for emitter-produced envelopes.

## Follow-up filed

#393 — metric-mismatch guard on both delta paths (warn + disabled Delta tab; decided semantics), with the missing-`metric`/`threshold` stderr note as a secondary AC. Deliberately not bolted on here — the last warn added to `parse_input_spec` pushed it over the strict-8 gate and was later reverted as a false-positive.

## Verification

- Full workspace `cargo nextest run --all-targets`: **1412/1412** (7 new wire-contract tests incl. a 256-case round-trip proptest; regression seed committed)
- `cargo fmt --check`, `cargo +1.96.0 clippy --workspace --all-targets -- -D warnings`, `cargo +1.93 check --workspace --all-targets` (MSRV), `RUSTDOCFLAGS="-D warnings" cargo doc`
- `bdd-tracked-lint` + `mutants-skip-lint` green
- **strict-8 production self-gate: PASS** (1642 functions, 0 above threshold 8, worst 8.0)
- Scorecard-row parity + RiskLevel cross-adapter canaries unchanged; `wire_envelope_crap4ts` snapshot unchanged

Net: −163 lines across the migrated files; the new module is mostly contract documentation and tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/breezy-bays-labs/crap-rs/pull/392">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced unified JSON envelope schema for improved compatibility between analysis writers and readers.

* **Improvements**
  * Enhanced float precision handling in JSON serialization to ensure accurate round-trip conversion.
  * Strengthened schema version validation with explicit support declaration for compatibility checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
