### PR TITLE
feat(core): #275 — markdown sticky-comment marker + breakdown collapsibles

### DIFF
--- a/crates/crap-core/CHANGELOG.md
+++ b/crates/crap-core/CHANGELOG.md
@@ -10,6 +10,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `format_markdown` always emits a hidden
+    `<!-- {tool_name}:scorecard -->` HTML comment as the first output
+    line — a per-adapter dedupe anchor for sticky-PR-comment tooling
+    (it precedes a configured `[output] title`, and the scorecard
+    action's heading-offset rewrite leaves it untouched). Breakdown
+    contributor bullets are wrapped per function row in a
+    `<details><summary>Show breakdown</summary>` collapsible, with the
+    blank line GFM needs to render the bullets as a list inside the
+    HTML block. (crap-rs#275)
+
 ### Changed
 
 - Config-file auto-discovery now **walks upward**: when no explicit

--- a/crates/crap-core/src/adapters/reporters/markdown.rs
+++ b/crates/crap-core/src/adapters/reporters/markdown.rs
@@ -23,9 +23,17 @@ use askama::Template;
 /// threshold, otherwise the worst by CRAP). Designed to fit comfortably
 /// in a PR comment — bounded output regardless of codebase size.
 ///
+/// The first output line is always a hidden HTML comment marker,
+/// `<!-- {tool_name}:scorecard -->` — invisible in rendered GFM, but a
+/// stable dedupe anchor for sticky-PR-comment tooling. It carries the
+/// calling adapter's `tool_name`, so each adapter's scorecard can
+/// sticky to its own comment on the same PR.
+///
 /// `breakdown` injects an indented bullet list of complexity
 /// contributors under each exceeding function in the spotlight (or
-/// the full table when `full_table` is set). `explain` adds a trailing
+/// the full table when `full_table` is set), wrapped in a
+/// `<details><summary>Show breakdown</summary>` collapsible so the
+/// default PR-comment view stays compact. `explain` adds a trailing
 /// legend describing increment semantics (only meaningful when
 /// `breakdown` is set).
 ///
@@ -602,11 +610,14 @@ mod tests {
             None,
         );
         // The configured title is the prominent headline — it takes the
-        // `#` H1, and the tool/version line demotes to `##` attribution
-        // (prominence consistent with the table + html reporters).
+        // `#` H1 (right after the hidden dedupe marker), and the
+        // tool/version line demotes to `##` attribution (prominence
+        // consistent with the table + html reporters).
         assert!(
-            out.starts_with("# Acme Coverage Report\n"),
-            "expected the title as the H1 headline at the top; got:\n{out}",
+            out.starts_with(&format!(
+                "<!-- {TEST_TOOL_NAME}:scorecard -->\n\n# Acme Coverage Report\n"
+            )),
+            "expected the title as the H1 headline beneath the marker; got:\n{out}",
         );
         assert!(out.contains(&format!(
             "## {TEST_TOOL_NAME} v{TEST_TOOL_VERSION} — CRAP Score Analysis"
@@ -627,7 +638,9 @@ mod tests {
             Some("nightly build"),
         );
         assert!(
-            out.starts_with("# Acme Coverage Report\n\nnightly build\n"),
+            out.starts_with(&format!(
+                "<!-- {TEST_TOOL_NAME}:scorecard -->\n\n# Acme Coverage Report\n\nnightly build\n"
+            )),
             "expected the subtitle on its own paragraph beneath the title; got:\n{out}",
         );
     }
@@ -641,8 +654,10 @@ mod tests {
         // demote it). Exercises the template's `{%- else -%}` branch's
         // inner subtitle arm.
         assert!(
-            out.starts_with("nightly build\n\n# "),
-            "expected the subtitle above the tool H1; got:\n{out}",
+            out.starts_with(&format!(
+                "<!-- {TEST_TOOL_NAME}:scorecard -->\n\nnightly build\n\n# "
+            )),
+            "expected the subtitle above the tool H1 (beneath the marker); got:\n{out}",
         );
         assert!(out.contains(&format!(
             "# {TEST_TOOL_NAME} v{TEST_TOOL_VERSION} — CRAP Score Analysis"
@@ -662,9 +677,160 @@ mod tests {
         );
         assert!(
             default.starts_with(&format!(
-                "# {TEST_TOOL_NAME} v{TEST_TOOL_VERSION} — CRAP Score Analysis"
+                "<!-- {TEST_TOOL_NAME}:scorecard -->\n\n# {TEST_TOOL_NAME} v{TEST_TOOL_VERSION} — CRAP Score Analysis"
             )),
-            "default header must lead with the tool/version H1, no empty line above",
+            "default header must lead with the marker, a blank line, then \
+             the tool/version H1 — no extra line drift",
+        );
+    }
+
+    // ── sticky-comment marker + breakdown collapsibles ──────────────
+
+    #[test]
+    fn markdown_leads_with_hidden_sticky_marker() {
+        let result = make_multi_function_result();
+        let out = md(&make_view_default(&result));
+        assert!(
+            out.starts_with(&format!(
+                "<!-- {TEST_TOOL_NAME}:scorecard -->\n\n# {TEST_TOOL_NAME}"
+            )),
+            "expected the hidden dedupe marker as the first line, a blank \
+             line, then the tool H1; got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn marker_carries_the_adapter_tool_name() {
+        // Distinct per adapter so crap4rs and crap4ts can sticky to
+        // separate comments on the same PR.
+        let result = make_multi_function_result();
+        let mut meta = test_meta();
+        meta.tool_name = "other-adapter";
+        let out = format_markdown(
+            &make_view_default(&result),
+            None,
+            8.0,
+            false,
+            false,
+            false,
+            10,
+            &meta,
+            ComplexityMetric::Cognitive,
+            None,
+            None,
+        );
+        assert!(
+            out.starts_with("<!-- other-adapter:scorecard -->\n"),
+            "expected the marker to carry the calling adapter's tool_name; got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn marker_precedes_configured_title() {
+        // The marker is a machine dedupe anchor — it must stay the first
+        // line even when a configured title takes the H1 headline.
+        let result = make_multi_function_result();
+        let out = md_labeled(
+            &make_view_default(&result),
+            Some("Acme Coverage Report"),
+            None,
+        );
+        assert!(
+            out.starts_with(&format!(
+                "<!-- {TEST_TOOL_NAME}:scorecard -->\n\n# Acme Coverage Report\n"
+            )),
+            "expected marker first, then the configured title H1; got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn marker_present_on_empty_analysis() {
+        let result = make_empty_result();
+        let out = md(&make_view_default(&result));
+        assert!(
+            out.starts_with(&format!("<!-- {TEST_TOOL_NAME}:scorecard -->\n")),
+            "the dedupe marker must lead even an empty analysis; got:\n{out}"
+        );
+        assert!(out.contains("No functions analyzed"));
+    }
+
+    #[test]
+    fn breakdown_bullets_collapse_into_details() {
+        use crate::domain::types::{AnalysisResult, ComplexityContributor, ContributorKind};
+        let verdict = make_verdict_with_contributors(
+            make_verdict(
+                "risky_fn",
+                "src/lib.rs",
+                5,
+                30.0,
+                45.0,
+                RiskLevel::High,
+                8.0,
+            ),
+            vec![
+                ComplexityContributor {
+                    kind: ContributorKind::IfBranch,
+                    line: 12,
+                    column: None,
+                    increment: 1,
+                    end_line: 12,
+                    nesting_depth: 0,
+                },
+                ComplexityContributor {
+                    kind: ContributorKind::Match,
+                    line: 18,
+                    column: None,
+                    increment: 2,
+                    end_line: 18,
+                    nesting_depth: 1,
+                },
+            ],
+        );
+        let result = AnalysisResult {
+            functions: vec![verdict.clone()],
+            summary: crate::domain::summary::compute_summary(std::slice::from_ref(&verdict)),
+            passed: false,
+        };
+        let out = format_markdown(
+            &make_view_default(&result),
+            None,
+            8.0,
+            true,
+            false,
+            true,
+            10,
+            &test_meta(),
+            ComplexityMetric::Cognitive,
+            None,
+            None,
+        );
+        let open = out
+            .find("<details><summary>Show breakdown</summary>")
+            .unwrap_or_else(|| panic!("missing <details> wrapper in:\n{out}"));
+        let close = out
+            .find("</details>")
+            .unwrap_or_else(|| panic!("missing </details> in:\n{out}"));
+        assert!(open < close, "malformed details block in:\n{out}");
+        let inner = &out[open..close];
+        assert!(
+            inner.contains("L12 if-branch +1") && inner.contains("L18 match +2"),
+            "contributor bullets must sit inside the collapsible; got:\n{out}"
+        );
+        // GFM only renders markdown inside an HTML block after a blank
+        // line — the bullets must not butt up against the <summary> tag.
+        assert!(
+            out.contains("</summary>\n\n"),
+            "expected a blank line after </summary> so the bullet list renders; got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn no_details_block_without_breakdown() {
+        let result = make_multi_function_result();
+        let out = md(&make_view_default(&result));
+        assert!(
+            !out.contains("<details>"),
+            "no collapsible should render when breakdown is inactive; got:\n{out}"
         );
     }
 

--- a/crates/crap-core/src/adapters/reporters/snapshots/crap_core__adapters__reporters__markdown__tests__full_markdown_breakdown_snapshot.snap
+++ b/crates/crap-core/src/adapters/reporters/snapshots/crap_core__adapters__reporters__markdown__tests__full_markdown_breakdown_snapshot.snap
@@ -2,6 +2,8 @@
 source: crates/crap-core/src/adapters/reporters/markdown.rs
 expression: out
 ---
+<!-- test-adapter:scorecard -->
+
 # test-adapter v0.4.0 — CRAP Score Analysis
 
 ## Summary
@@ -21,7 +23,11 @@ expression: out
 | File | Function | CC | Cov% | CRAP | Risk |
 |------|----------|----|------|------|------|
 | src/lib.rs | risky_fn | 5 | 30.0 | 45.00 | high |
+<details><summary>Show breakdown</summary>
+
   - L5 if-branch +1
   - L10 for-loop +2
+
+</details>
 
 _Legend: +1 = base structural increment. +N (nested) = +1 base plus +(N-1) from active nesting depth (if/else, match arms, while/for/loop, let-else diverging branches, closures)._

--- a/crates/crap-core/src/adapters/reporters/snapshots/crap_core__adapters__reporters__markdown__tests__full_markdown_snapshot.snap
+++ b/crates/crap-core/src/adapters/reporters/snapshots/crap_core__adapters__reporters__markdown__tests__full_markdown_snapshot.snap
@@ -2,6 +2,8 @@
 source: crates/crap-core/src/adapters/reporters/markdown.rs
 expression: out
 ---
+<!-- test-adapter:scorecard -->
+
 # test-adapter v0.4.0 — CRAP Score Analysis
 
 ## Summary

--- a/crates/crap-core/src/adapters/reporters/snapshots/crap_core__adapters__reporters__markdown__tests__full_markdown_with_delta_snapshot.snap
+++ b/crates/crap-core/src/adapters/reporters/snapshots/crap_core__adapters__reporters__markdown__tests__full_markdown_with_delta_snapshot.snap
@@ -2,6 +2,8 @@
 source: crates/crap-core/src/adapters/reporters/markdown.rs
 expression: out
 ---
+<!-- test-adapter:scorecard -->
+
 # test-adapter v0.4.0 — CRAP Score Analysis
 
 ## Summary

--- a/crates/crap-core/src/adapters/reporters/snapshots/crap_core__adapters__reporters__markdown__tests__grouped_markdown_snapshot.snap
+++ b/crates/crap-core/src/adapters/reporters/snapshots/crap_core__adapters__reporters__markdown__tests__grouped_markdown_snapshot.snap
@@ -2,6 +2,8 @@
 source: crates/crap-core/src/adapters/reporters/markdown.rs
 expression: out
 ---
+<!-- test-adapter:scorecard -->
+
 # test-adapter v0.4.0 — CRAP Score Analysis
 
 ## Summary

--- a/crates/crap-core/templates/markdown_report.txt
+++ b/crates/crap-core/templates/markdown_report.txt
@@ -23,8 +23,18 @@
    pre-#352 render (existing snapshots untouched). The fixed heading
    offset the scorecard composite action applies (`# `→`#### `, `## `→
    `##### `) is content-agnostic, so the title/tool levels nest cleanly
-   under the action's `### Rust (crap4rs)` wrapper either way. -#}
-{%- if let Some(title) = title -%}
+   under the action's `### Rust (crap4rs)` wrapper either way.
+
+   The hidden `<!-- {tool_name}:scorecard -->` first line is a
+   machine-readable dedupe anchor for sticky-PR-comment actions —
+   invisible in rendered GFM, distinct per adapter so crap4rs and
+   crap4ts can sticky to separate comments on the same PR, and immune
+   to the action's heading-offset sed (which only rewrites `#`-prefixed
+   lines). It leads the output even when a configured title takes the
+   H1. -#}
+<!-- {{ tool_name }}:scorecard -->
+
+{% if let Some(title) = title -%}
 # {{ title }}
 {% if let Some(subtitle) = subtitle %}
 {{ subtitle }}
@@ -69,9 +79,14 @@ No functions analyzed.
 |------|----------|----|------|------|------|
 {% for row in rows -%}
 | {{ row.file }} | {{ row.function }} | {{ row.cc }} | {{ row.cov }} | {{ row.crap }} | {{ row.risk }} |
+{% if !row.breakdown_bullets.is_empty() -%}
+<details><summary>Show breakdown</summary>
+
 {% for bullet in row.breakdown_bullets -%}
 {{ bullet }}
-{% endfor -%}
+{% endfor %}
+</details>
+{% endif -%}
 {% endfor -%}
 {%- if legend.is_some() %}
 {{ legend.as_ref().unwrap() }}
@@ -83,9 +98,14 @@ No functions analyzed.
 |------|----------|----|------|------|------|
 {% for row in rows -%}
 | {{ row.file }} | {{ row.function }} | {{ row.cc }} | {{ row.cov }} | {{ row.crap }} | {{ row.risk }} |
+{% if !row.breakdown_bullets.is_empty() -%}
+<details><summary>Show breakdown</summary>
+
 {% for bullet in row.breakdown_bullets -%}
 {{ bullet }}
-{% endfor -%}
+{% endfor %}
+</details>
+{% endif -%}
 {% endfor -%}
 {%- if legend.is_some() %}
 {{ legend.as_ref().unwrap() }}

--- a/crates/crap4rs/CHANGELOG.md
+++ b/crates/crap4rs/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `--format markdown` output now leads with a hidden
+    `<!-- crap4rs:scorecard -->` HTML comment — invisible in rendered
+    GFM, but a stable dedupe anchor sticky-PR-comment tooling can match
+    on to update its existing comment instead of posting a new one per
+    push. The marker carries the adapter name, so a Rust scorecard and
+    a TypeScript scorecard can sticky to separate comments on the same
+    PR. With `--breakdown`, each exceeding function's
+    complexity-contributor bullets now render inside a collapsed
+    `<details>` block, keeping the default PR-comment view compact.
+    (crap-rs#275)
+
 ### Changed
 
 - Config auto-discovery now walks **upward** from the `--src` anchor

--- a/crates/crap4rs/README.md
+++ b/crates/crap4rs/README.md
@@ -96,7 +96,11 @@ Functions: 988 · Above threshold: 0 · Worst CRAP: 13.00 · Distribution: 951 l
 
 ### Markdown (`--format markdown`) — PR-comment ready
 
+The first output line is always a hidden HTML comment, `<!-- crap4rs:scorecard -->` — invisible when rendered, but a stable anchor that sticky-PR-comment tooling can match on to find and update its own comment instead of posting a new one on every push. The marker carries the adapter name, so a Rust and a TypeScript scorecard can sticky to separate comments on the same PR. (A multi-language combined comment contains both adapters' markers, so match accordingly if you post combined output.) With `--breakdown`, each exceeding function's complexity-contributor bullets are wrapped in a collapsed `<details>` block to keep the default comment view compact.
+
 ```markdown
+<!-- crap4rs:scorecard -->
+
 # crap4rs v0.5.0 — CRAP Score Analysis
 
 **Result:** PASS · **Functions:** 988 · **Above threshold (15):** 0

--- a/crates/crap4rs/tests/delta_integration.rs
+++ b/crates/crap4rs/tests/delta_integration.rs
@@ -194,6 +194,14 @@ fn markdown_format_renders_scorecard_section() {
         ],
     );
     let stdout = stdout_str(&output);
+    // Pins the literal adapter marker end-to-end: the reporter unit
+    // tests exercise the template with a synthetic tool_name only, so
+    // without this a package rename would silently rotate the dedupe
+    // anchor that third-party sticky-comment tooling matches on.
+    assert!(
+        stdout.starts_with("<!-- crap4rs:scorecard -->\n"),
+        "markdown output must lead with the crap4rs sticky-comment marker"
+    );
     assert!(stdout.contains("## CRAP Scorecard"));
     assert!(stdout.contains("- **Delta status:**"));
     assert!(stdout.contains("- **Changes:**"));

--- a/crates/crap4ts/README.md
+++ b/crates/crap4ts/README.md
@@ -93,7 +93,11 @@ Functions: 142 · Above threshold: 1 · Worst CRAP: 17.06 · Distribution: 98 lo
 
 ### Markdown (`--format markdown`) — PR-comment ready
 
+The first output line is always a hidden HTML comment, `<!-- crap4ts:scorecard -->` — invisible when rendered, but a stable anchor that sticky-PR-comment tooling can match on to find and update its own comment instead of posting a new one on every push. The marker carries the adapter name, so a Rust and a TypeScript scorecard can sticky to separate comments on the same PR. (A multi-language combined comment contains both adapters' markers, so match accordingly if you post combined output.) With `--breakdown`, each exceeding function's complexity-contributor bullets are wrapped in a collapsed `<details>` block to keep the default comment view compact.
+
 ```markdown
+<!-- crap4ts:scorecard -->
+
 # crap4ts v2.0.0-rc.2 — CRAP Score Analysis
 
 **Result:** FAIL · **Functions:** 142 · **Above threshold (15):** 1

--- a/crates/crap4ts/tests/end_to_end_smoke.rs
+++ b/crates/crap4ts/tests/end_to_end_smoke.rs
@@ -171,9 +171,10 @@ fn markdown_reporter_emits_crap4ts_title_header() {
     );
     let stdout = String::from_utf8_lossy(&out.stdout);
     assert!(
-        stdout.starts_with("# crap4ts v"),
-        "markdown body should start with `# crap4ts v…`; got first line:\n{}",
-        stdout.lines().next().unwrap_or("(empty)")
+        stdout.starts_with("<!-- crap4ts:scorecard -->\n\n# crap4ts v"),
+        "markdown body should lead with the sticky-comment dedupe marker, \
+         then the `# crap4ts v…` H1; got first lines:\n{}",
+        stdout.lines().take(3).collect::<Vec<_>>().join("\n")
     );
     assert!(
         stdout.contains("— CRAP Score Analysis"),

--- a/packages/crap4ts/CHANGELOG.md
+++ b/packages/crap4ts/CHANGELOG.md
@@ -13,6 +13,17 @@ shared-core development.
 
 ## [Unreleased]
 
+### Added
+
+- The markdown reporter (`--format markdown`) emits a hidden
+    `<!-- crap4ts:scorecard -->` HTML comment as its first line. Sticky
+    PR-comment actions can use it as a dedupe anchor to find and update
+    their existing TypeScript-scorecard comment; because the anchor is
+    adapter-named, it never collides with a crap4rs comment on the same
+    PR. Contributor breakdown bullets (`--breakdown`) are now wrapped
+    in a collapsed `<details>` block so long TS scorecards stay
+    scannable in the PR timeline. (crap-rs#275)
+
 ### Changed
 
 - Config auto-discovery now walks **upward** from the `--src` anchor


### PR DESCRIPTION
## Summary

The markdown reporter now leads every output with a hidden HTML comment marker, `<!-- {tool_name}:scorecard -->`, and wraps breakdown contributor bullets in a collapsed `<details>` block — so third-party sticky-PR-comment actions can dedupe by marker without callers remembering a unique header string, and `--breakdown` scorecards stay scannable in the PR timeline.

Closes #275

## AC verification

- **Marker shape** `<!-- crap4rs:scorecard -->` / `<!-- crap4ts:scorecard -->` — per-adapter distinct via `AdapterMeta.tool_name`; leads the output even when a configured `[output] title` takes the H1, and on empty analyses. Pinned at three levels: reporter unit tests (synthetic tool name), crap4rs `delta_integration` (literal `crap4rs` marker end-to-end), crap4ts `end_to_end_smoke` (literal `crap4ts` marker end-to-end) — so a future package rename cannot silently rotate the anchor.
- **Collapsibles** — breakdown bullets per function row render inside `<details><summary>Show breakdown</summary>` + the blank line GFM requires to render markdown inside an HTML block (asserted explicitly). Rows without bullets are **byte-identical** to the previous render (verified with `cmp` against a main-built binary: `tail -n +3` of the new output matches main exactly in plain and no-exceeder breakdown modes).
- **Backward compatibility** — the composite action's heading-offset sed only rewrites `#`-prefixed lines (marker passes through verbatim, verified empirically); `comment-header` sticky dedup unchanged; the trailing-newline heredoc contract preserved. The `comment-preamble` prepends above the marker in the composed sticky body — immaterial, since sticky tooling substring-matches the whole body.
- **Snapshots** — 4 markdown insta snapshots regenerated; 3 are exactly +2 lines (marker + blank), the breakdown snapshot additionally gains the `<details>` wrapper.

## Notes

- Discovery questions resolved per AC: marker carries adapter name only (no baseline-scope hint); collapsibles wrap breakdown bullets only (no full-table toggle).
- A multi-language combined sticky comment contains both adapters' markers mid-document — called out in the README so external consumers match accordingly.
- READMEs (both adapters) + CHANGELOGs (per-adapter reworded entries + crap-core implementing entry) updated.

## Gates

fmt, clippy 1.96 `-D warnings`, full nextest (1427/1427), all 5 cucumber harnesses, MSRV 1.93 check, `RUSTDOCFLAGS=-D warnings cargo doc`, bdd-tracked-lint, mutants-skip-lint, strict-8 self-gate (1657 fns, 0 above 8), live release-binary output verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/breezy-bays-labs/crap-rs/pull/395">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->