### PR TITLE
test: #290 — vary github-annotations fixture nesting depth so CRAP scores are distinct

### DIFF
--- a/crates/crap4rs/tests/github_annotations_cucumber.rs
+++ b/crates/crap4rs/tests/github_annotations_cucumber.rs
@@ -11,10 +11,12 @@
 //! The two synthetic source templates cover the cardinality and
 //! risk-level invariants every scenario in this feature needs:
 //!
-//! * **EXCEEDS** — branchy uncovered fns. Each generated fn has cognitive
-//!   complexity ≥ 5 (three nested conditionals) and ~0% coverage, which
-//!   produces CRAP well above the default threshold of 8. A configurable
-//!   `n` controls how many such fns the fixture writes.
+//! * **EXCEEDS** — branchy uncovered fns. Nesting depth grows with the
+//!   fn index (3 nested conditionals for the first fn, one more per
+//!   subsequent fn), so every generated fn has a strictly distinct CRAP
+//!   score, the lowest of which (≈21.5 at ~0% body coverage) sits well
+//!   above the default threshold of 15. A configurable `n` controls how
+//!   many such fns the fixture writes.
 //! * **WITHIN** — trivial covered fns. CRAP ≤ 1, so no fn exceeds any
 //!   reasonable threshold.
 
@@ -73,15 +75,23 @@ impl GhaWorld {
     }
 }
 
-/// Build a branchy uncovered fn body that produces high CRAP. Three
-/// nested conditionals push cognitive complexity ≥ 5; coverage is 0%
-/// on the body lines (we only mark line 1 — the signature line — as
-/// covered in the LCOV stub).
-fn branchy_fn_body(name: &str) -> String {
-    format!(
-        "pub fn {name}(x: i32) -> i32 {{\n    \
-         if x > 0 {{ if x > 5 {{ if x > 10 {{ 1 }} else {{ 2 }} }} else {{ 3 }} }} else {{ 4 }}\n}}\n"
-    )
+/// Build a branchy uncovered fn body that produces high CRAP. `depth`
+/// nested conditionals (all on one source line, preserving the
+/// `BRANCHY_LINES` contract) push cognitive complexity up with each
+/// level, so two fns with different depths always score distinct CRAP
+/// values; coverage is 0% on the body lines (we only mark line 1 — the
+/// signature line — as covered in the LCOV stub). The minimum depth
+/// used by `write_project` is 3, which keeps every generated fn above
+/// the default threshold.
+fn branchy_fn_body(name: &str, depth: usize) -> String {
+    assert!(depth >= 1, "branchy_fn_body needs at least one conditional");
+    let mut expr = String::from("1");
+    for level in (0..depth).rev() {
+        let bound = level * 5;
+        let fallback = level + 2;
+        expr = format!("if x > {bound} {{ {expr} }} else {{ {fallback} }}");
+    }
+    format!("pub fn {name}(x: i32) -> i32 {{\n    {expr}\n}}\n")
 }
 
 /// Build a trivial single-expression fn — coverage 100%, complexity 1.
@@ -95,7 +105,11 @@ const BRANCHY_LINES: usize = 3;
 
 /// Write a synthetic project to `dir` containing `n_exceeding` branchy
 /// uncovered fns named `branchy_a`, `branchy_b`, …, plus `n_within`
-/// trivial covered fns.
+/// trivial covered fns. Nesting depth grows with the fn index
+/// (`branchy_a` shallowest, so source order is CRAP-ascending), which
+/// gives every exceeder a strictly distinct CRAP score — scenarios
+/// that assert sort order therefore genuinely exercise the reporter's
+/// descending sort instead of passing on ties.
 fn write_project(dir: &Path, n_exceeding: usize, n_within: usize) {
     let mut src = String::new();
     let mut lcov = String::from("SF:lib.rs\n");
@@ -103,7 +117,7 @@ fn write_project(dir: &Path, n_exceeding: usize, n_within: usize) {
 
     for i in 0..n_exceeding {
         let name = format!("branchy_{}", letter(i));
-        src.push_str(&branchy_fn_body(&name));
+        src.push_str(&branchy_fn_body(&name, 3 + i));
         let _ = writeln!(lcov, "DA:{},1", next_line);
         for _ in 1..BRANCHY_LINES {
             next_line += 1;
@@ -182,11 +196,12 @@ fn given_all_below(world: &mut GhaWorld) {
 
 #[given("exceeding functions across risk levels high, moderate, acceptable")]
 fn given_mixed_risk_exceeders(world: &mut GhaWorld) {
-    // The shaped fixtures all produce High-risk exceeders. The
-    // single-tier-warning contract is "every emitted line begins with
-    // `::warning`" regardless of which risk tier each exceeder lands in —
-    // a fixture that mixes risk tiers is equivalent to one that doesn't
-    // for this assertion (the reporter ignores `risk_level` entirely).
+    // The shaped fixture spans Moderate and High exceeders but not all
+    // three named tiers. The single-tier-warning contract is "every
+    // emitted line begins with `::warning`" regardless of which risk
+    // tier each exceeder lands in — a fixture that covers every tier is
+    // equivalent to one that doesn't for this assertion (the reporter
+    // ignores `risk_level` entirely).
     setup_with(world, 3, 0);
 }
 
@@ -518,10 +533,14 @@ fn then_sorted_crap_desc(world: &mut GhaWorld) {
         .map(extract_crap_score)
         .collect();
     assert!(scores.len() >= 2, "need ≥2 scores, got {scores:?}");
+    // The Given promises DISTINCT scores, so descending must be strict.
+    // A `>=` here would pass on an all-tied fixture without exercising
+    // the sort at all; strict `>` makes the fixture's distinctness
+    // self-enforcing.
     for w in scores.windows(2) {
         assert!(
-            w[0] >= w[1],
-            "scores not CRAP-DESC: {} < {} in {scores:?}",
+            w[0] > w[1],
+            "scores not strictly CRAP-DESC (tie or misorder): {} !> {} in {scores:?}",
             w[0],
             w[1]
         );


### PR DESCRIPTION
## Summary

The `given_five_exceeders` cucumber fixture generated five functions from the same 3-nested-if template and identical 1/3 LCOV coverage, so all five tied at CRAP 21.5 — the "Annotations are sorted by CRAP score descending" scenario passed on ties (`>=`) without exercising the sort. Surfaced by CodeRabbit on #288.

Closes #290

## What changed (AC path (a): fixture rework)

- `branchy_fn_body(name, depth)` — generates `depth` nested conditionals on a single source line (preserving the `BRANCHY_LINES = 3` contract that drives LCOV stanza generation). `write_project` passes `3 + index`, so every exceeder scores a strictly distinct CRAP value and source order is CRAP-**ascending** — the reporter's descending sort genuinely reverses its input.
- `then_sorted_crap_desc` is now **strict** (`>`): the Given promises distinct scores, and strictness makes the fixture's distinctness self-enforcing — a future tie regression fails the scenario instead of slipping through. The `--sort-by` scenario's separate Then keeps `>=` deliberately (its Given makes no distinctness promise).
- Stale comments fixed: the `given_mixed_risk_exceeders` note (claimed all-High when 21.5 is the Moderate band) and the module header (claimed "three nested conditionals / threshold 8"; the no-config default threshold is 15).

## AC verification

- Five strictly-distinct CRAP scores: live run confirms strictly increasing scores from 21.5 upward; the strict assertion enforces it permanently
- No regression in the sorted scenario's pass/fail signal: RED observed on the old fixture (`21.5 !> 21.5`), GREEN after
- Adjacent cardinality scenarios keep working: all 17 scenarios / 58 steps pass; minimum depth 3 keeps the lowest score (21.5) above the default threshold, and the exact-text truncation-notice assertion (`5 more functions exceed threshold`) reproduces byte-identical

## Gates

fmt, clippy 1.96 `-D warnings`, full nextest (1421), all 5 cucumber harnesses, MSRV 1.93 check, bdd-tracked-lint, mutants-skip-lint, strict-8 self-gate (1651 fns, 0 above 8 — test-only change). Feature file untouched; no tag transitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/breezy-bays-labs/crap-rs/pull/396">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->