### PR TITLE
feat(core): #397 — breakdown collapsible on sticky scorecards (rendered below the table)

### DIFF
--- a/.github/actions/scorecard/action.yml
+++ b/.github/actions/scorecard/action.yml
@@ -248,6 +248,26 @@ inputs:
       values outside the range are rejected by the adapter's CLI parser.
     required: false
     default: ''
+  breakdown:
+    description: |
+      When `true`, the analyzer is invoked with `--breakdown` for the
+      MARKDOWN scorecard, so the per-line complexity-contributor
+      breakdown of every ABOVE-THRESHOLD function renders in a single
+      collapsed `<details>` block below the scorecard table (crap-rs#275,
+      crap-rs#397). Lets a reviewer expand WHY a function scored its
+      complexity without leaving the PR timeline, while the table stays
+      scannable by default. Functions within the threshold carry no
+      breakdown, so on an all-green scorecard the collapsible is absent.
+
+      Scoped to the markdown invocation only — the JSON / HTML /
+      scorecard-row passes are unaffected. The flag is forwarded ONLY
+      when `true`, so the analyzer's own default owns the no-opt-in
+      case (the same conditional-forward / never-materialize-the-tool-
+      default contract `annotations` / `html-report` follow). Default
+      `false` keeps the markdown byte-identical for callers who don't
+      opt in; empty string is treated as `false`.
+    required: false
+    default: 'false'
   html-report:
     description: |
       When `true`, the action additionally renders the scorecard as
@@ -1047,6 +1067,10 @@ runs:
         # passing `''` behave identically — same convention as the
         # other empty-default inputs (threshold / gate-mode / etc.).
         HTML_REPORT: ${{ inputs.html-report }}
+        # crap-rs#397: forwarded as `--breakdown` to the per-language
+        # markdown invocation only. Empty string is treated as `false`
+        # (same empty-default convention as HTML_REPORT above).
+        BREAKDOWN: ${{ inputs.breakdown }}
       run: |
         set -euo pipefail
         # Per-language loop. Single-language mode iterates once over
@@ -1168,7 +1192,19 @@ runs:
           # dominated by adapter install upstream. Tracked in
           # https://github.com/breezy-bays-labs/crap-rs/issues/100.
           "$BIN" "${common[@]}" --format json --no-fail > "$envelope"
-          "$BIN" "${common[@]}" --format markdown --no-fail > "$markdown_file"
+
+          # crap-rs#397: the markdown scorecard gets `--breakdown` when
+          # the caller opted in, so each row's complexity-contributor
+          # breakdown renders as a collapsed `<details>` (crap-rs#275).
+          # Built from a markdown-scoped copy of `${common[@]}` so the
+          # flag never leaks into the JSON / HTML / scorecard-row passes
+          # (which reuse `${common[@]}` directly). Forwarded ONLY when
+          # `true` — the analyzer owns the default otherwise.
+          markdown_cmd=("$BIN" "${common[@]}" --format markdown --no-fail)
+          if [ "$BREAKDOWN" = "true" ]; then
+            markdown_cmd+=(--breakdown)
+          fi
+          "${markdown_cmd[@]}" > "$markdown_file"
 
           # PR γ (#294): optional HTML render. Same `${common[@]}`
           # invocation shape as the json + markdown calls above

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -831,6 +831,13 @@ jobs:
           gate-mode: gate-on-analysis
           comment-mode: sticky
           comment-header: crap-scorecard-production
+          # Surface the complexity-contributor breakdown of any
+          # above-threshold function as a collapsed `<details>` below the
+          # sticky scorecard table (crap-rs#397). This gate is normally
+          # green (0 above threshold), so the collapsible is a no-op
+          # then; it pays off when the gate FAILS, explaining WHY the
+          # offending function tripped the threshold right in the sticky.
+          breakdown: true
           comment-preamble: |
             **Production CRAP scorecard** — gates `crap-core`, `crap4rs`,
             and `crap4ts` source. This is real production code held to the

--- a/.github/workflows/quick-start-smoke.yml
+++ b/.github/workflows/quick-start-smoke.yml
@@ -254,6 +254,14 @@ jobs:
           gate-mode: report-only
           comment-mode: sticky
           comment-header: 'crap-scorecard-quickstart-smoke'
+          # Surface the complexity-contributor breakdown of every
+          # above-threshold function as a collapsed `<details>` below the
+          # scorecard table (crap-rs#397). The examples corpus is the
+          # richer demo surface — it scores poorly by design, so both
+          # per-language sections have above-threshold functions whose
+          # breakdowns render here (and on this PR's own sticky, since the
+          # smoke is pull_request-triggered).
+          breakdown: true
           comment-preamble: |
             **Examples dogfood — intentionally spans risk bands; not
             production code.** This scorecard analyzes `crap-examples`, a

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Run `crap4rs --help` for the canonical full reference. Grouped here as in `--hel
 | `--color <COLOR>` | `auto` | `auto`, `always`, or `never`. |
 | `-v`, `--verbose` | — | Show parse diagnostics and matching statistics. |
 | `-q`, `--quiet` | — | Suppress report output, only set exit code. |
-| `--breakdown` | — | Show per-contributor complexity breakdown for failing functions in table output. |
+| `--breakdown` | — | Show the per-contributor complexity breakdown for each above-threshold function. In `table` output it prints inline beneath each row; in `markdown` output the breakdowns collect into one collapsed `<details>` block below the table. |
 | `--explain` | — | With `--breakdown`, explain nested cognitive increments in table output. |
 | `--md-full-table` | — | Append the full per-function table to markdown output (default markdown is a compact top-N summary). |
 | `--md-top <N>` | `10` | Number of rows in the markdown top-N table. |

--- a/crates/crap-core/CHANGELOG.md
+++ b/crates/crap-core/CHANGELOG.md
@@ -16,11 +16,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `<!-- {tool_name}:scorecard -->` HTML comment as the first output
     line — a per-adapter dedupe anchor for sticky-PR-comment tooling
     (it precedes a configured `[output] title`, and the scorecard
-    action's heading-offset rewrite leaves it untouched). Breakdown
-    contributor bullets are wrapped per function row in a
-    `<details><summary>Show breakdown</summary>` collapsible, with the
-    blank line GFM needs to render the bullets as a list inside the
-    HTML block. (crap-rs#275)
+    action's heading-offset rewrite leaves it untouched). When
+    `--breakdown` is active, the per-line complexity contributors of the
+    above-threshold functions collect into one
+    `<details><summary>Show breakdown</summary>` collapsible rendered
+    BELOW the scorecard table, each function keyed by a markdown code
+    span. The collapsible sits below the table (rather than interleaved
+    between rows) because a `<details>` HTML block terminates a GFM
+    table — an inline block would drop every row after the first to
+    literal "pipe-text". Verified against GitHub's own `/markdown`
+    renderer. (crap-rs#275, crap-rs#397)
 
 ### Changed
 

--- a/crates/crap-core/src/adapters/reporters/markdown.rs
+++ b/crates/crap-core/src/adapters/reporters/markdown.rs
@@ -175,11 +175,17 @@ enum BodySection {
     },
     FullTable {
         rows: Vec<FunctionRow>,
+        /// Per-function complexity breakdowns, rendered in one
+        /// collapsible BELOW the table (crap-rs#397). Empty unless
+        /// `--breakdown` is active and at least one shown function
+        /// exceeds the threshold with contributors.
+        breakdowns: Vec<FunctionBreakdown>,
         legend: Option<&'static str>,
     },
     Spotlight {
         header: String,
         rows: Vec<FunctionRow>,
+        breakdowns: Vec<FunctionBreakdown>,
         legend: Option<&'static str>,
         footnote: Option<&'static str>,
     },
@@ -204,7 +210,31 @@ struct FunctionRow {
     cov: String,
     crap: String,
     risk: String,
-    breakdown_bullets: Vec<String>,
+}
+
+/// One function's complexity-contributor breakdown, rendered inside the
+/// single collapsible below the table (crap-rs#397). `function` and
+/// `file` are passed through `code_span_safe` (not pipe-escaped like the
+/// table cells) because the template renders them as markdown code
+/// spans: inside backticks GFM renders `<`/`>` literally, so a TS
+/// `<arrow>` survives where a bare table cell drops it — but a literal
+/// backtick or newline would break the span, so those are neutralized.
+struct FunctionBreakdown {
+    function: String,
+    file: String,
+    bullets: Vec<String>,
+}
+
+/// Make an identity string safe to drop inside a markdown code span.
+/// Code spans are how the breakdown header renders `<`/`>` literally
+/// (a TS `<arrow>`), but a literal backtick closes the span early and a
+/// newline breaks the line. Neither occurs in a Rust path, but a
+/// TypeScript string-literal module/property name reaches
+/// `qualified_name` verbatim (e.g. `module "a`b" { … }`), so collapse
+/// both: backtick → `'`, CR/LF → space (mirroring `escape_cell`'s
+/// newline handling).
+fn code_span_safe(s: &str) -> String {
+    s.replace(['\n', '\r'], " ").replace('`', "'")
 }
 
 fn summary_data(view: &AnalysisView<'_>, threshold: f64) -> SummaryData {
@@ -265,12 +295,9 @@ fn grouped_rows(grouped: &crate::domain::view::GroupedView) -> Vec<GroupedRow> {
 }
 
 fn full_table_section(view: &AnalysisView<'_>, breakdown: bool, explain: bool) -> BodySection {
-    let rows: Vec<FunctionRow> = view
-        .shown
-        .iter()
-        .map(|v| function_row(v, breakdown))
-        .collect();
+    let rows: Vec<FunctionRow> = view.shown.iter().map(|v| function_row(v)).collect();
     BodySection::FullTable {
+        breakdowns: function_breakdowns(view.shown.iter().copied(), breakdown),
         rows,
         legend: legend_if_needed(view, breakdown, explain),
     }
@@ -291,9 +318,13 @@ fn spotlight_section(
             return BodySection::None;
         }
         let header = format!("## Top {} worst by CRAP", worst.len());
-        let rows: Vec<FunctionRow> = worst.iter().map(|v| function_row(v, breakdown)).collect();
+        let rows: Vec<FunctionRow> = worst.iter().map(|v| function_row(v)).collect();
         return BodySection::Spotlight {
             header,
+            // No function exceeds here, so `function_breakdowns`
+            // resolves to empty (breakdowns gate on `exceeds`); the
+            // collapsible never renders in the all-clear case.
+            breakdowns: function_breakdowns(worst.iter().copied(), breakdown),
             rows,
             legend: legend_if_needed(view, breakdown, explain),
             footnote: Some("\n_All functions are within threshold._"),
@@ -316,21 +347,18 @@ fn spotlight_section(
             format_threshold(view, threshold),
         )
     };
-    let rows: Vec<FunctionRow> = shown_failures
-        .iter()
-        .map(|v| function_row(v, breakdown))
-        .collect();
+    let rows: Vec<FunctionRow> = shown_failures.iter().map(|v| function_row(v)).collect();
     BodySection::Spotlight {
         header,
+        breakdowns: function_breakdowns(shown_failures.iter().copied(), breakdown),
         rows,
         legend: legend_if_needed(view, breakdown, explain),
         footnote: None,
     }
 }
 
-fn function_row(verdict: &FunctionVerdict, breakdown: bool) -> FunctionRow {
+fn function_row(verdict: &FunctionVerdict) -> FunctionRow {
     let s = &verdict.scored;
-    let bullets = breakdown_bullets(verdict, breakdown);
     FunctionRow {
         file: escape_cell(&s.identity.file_path),
         function: escape_cell(&s.identity.qualified_name),
@@ -338,8 +366,31 @@ fn function_row(verdict: &FunctionVerdict, breakdown: bool) -> FunctionRow {
         cov: format!("{:.1}", s.coverage_percent),
         crap: format!("{:.2}", s.crap.value),
         risk: s.crap.risk_level.to_string(),
-        breakdown_bullets: bullets,
     }
+}
+
+/// Build the per-function breakdown list rendered in the single
+/// collapsible below the table (crap-rs#397). Iterates the SAME verdict
+/// slice the table rows came from (so order + membership match the
+/// table) and keeps only functions whose `breakdown_bullets` are
+/// non-empty — i.e. `--breakdown` is active AND the function exceeds the
+/// threshold AND it has contributors. Returns empty otherwise, so the
+/// template omits the collapsible entirely.
+fn function_breakdowns<'a, I>(verdicts: I, breakdown: bool) -> Vec<FunctionBreakdown>
+where
+    I: IntoIterator<Item = &'a FunctionVerdict>,
+{
+    verdicts
+        .into_iter()
+        .filter_map(|v| {
+            let bullets = breakdown_bullets(v, breakdown);
+            (!bullets.is_empty()).then(|| FunctionBreakdown {
+                function: code_span_safe(&v.scored.identity.qualified_name),
+                file: code_span_safe(&v.scored.identity.file_path),
+                bullets,
+            })
+        })
+        .collect()
 }
 
 fn breakdown_bullets(verdict: &FunctionVerdict, breakdown: bool) -> Vec<String> {
@@ -831,6 +882,169 @@ mod tests {
         assert!(
             !out.contains("<details>"),
             "no collapsible should render when breakdown is inactive; got:\n{out}"
+        );
+    }
+
+    /// Regression for crap-rs#397. #275 emitted a `<details>` block
+    /// directly after each table row; in GFM a `<details>` is an HTML
+    /// block that TERMINATES the table, so every row after the first
+    /// rendered as literal pipe-text ("pipe soup") — verified against
+    /// GitHub's own `/markdown` renderer. The single-function fixtures
+    /// the other breakdown tests use could never catch it. The
+    /// breakdowns now sit in ONE collapsible BELOW the whole table so
+    /// the table stays contiguous.
+    #[test]
+    fn multi_row_breakdown_keeps_table_contiguous() {
+        use crate::domain::types::{AnalysisResult, ComplexityContributor, ContributorKind};
+        let contributors = || {
+            vec![
+                ComplexityContributor {
+                    kind: ContributorKind::IfBranch,
+                    line: 12,
+                    column: None,
+                    increment: 1,
+                    end_line: 12,
+                    nesting_depth: 0,
+                },
+                ComplexityContributor {
+                    kind: ContributorKind::Match,
+                    line: 18,
+                    column: None,
+                    increment: 2,
+                    end_line: 18,
+                    nesting_depth: 1,
+                },
+            ]
+        };
+        let functions = vec![
+            make_verdict_with_contributors(
+                make_verdict("alpha_fn", "src/a.rs", 9, 40.0, 30.0, RiskLevel::High, 8.0),
+                contributors(),
+            ),
+            make_verdict_with_contributors(
+                make_verdict("beta_fn", "src/b.rs", 7, 50.0, 20.0, RiskLevel::High, 8.0),
+                contributors(),
+            ),
+        ];
+        let result = AnalysisResult {
+            summary: crate::domain::summary::compute_summary(&functions),
+            functions,
+            passed: false,
+        };
+        // Spotlight arm (full_table = false) — the shape the scorecard
+        // action renders on its sticky comments.
+        let out = format_markdown(
+            &make_view_default(&result),
+            None,
+            8.0,
+            true,
+            false,
+            false,
+            10,
+            &test_meta(),
+            ComplexityMetric::Cognitive,
+            None,
+            None,
+        );
+
+        // The whole table must precede the first collapsible: both data
+        // rows live in the region above `<details>`. Under the #275 bug
+        // `beta_fn` landed AFTER alpha's `<details>` and rendered as
+        // pipe soup — so it would be absent from this region.
+        let details_at = out
+            .find("<details>")
+            .unwrap_or_else(|| panic!("missing <details>; got:\n{out}"));
+        let table_region = &out[..details_at];
+        assert!(
+            table_region.contains("alpha_fn") && table_region.contains("beta_fn"),
+            "both rows must sit in the contiguous table above the collapsible; got:\n{out}"
+        );
+
+        // Exactly ONE collapsible wraps every breakdown (not one per row).
+        assert_eq!(
+            out.matches("<details>").count(),
+            1,
+            "expected a single breakdown collapsible below the table; got:\n{out}"
+        );
+
+        // GFM needs a blank line between the table and the HTML block,
+        // and after `</summary>`, or the table/list silently fail to
+        // render. A table row ends with `|`; assert the blank line
+        // separates it from `<details>`, and the blank after summary.
+        assert!(
+            out.contains("|\n\n<details><summary>Show breakdown</summary>\n\n"),
+            "need a blank line before <details> and after </summary> for GFM; got:\n{out}"
+        );
+
+        // Each function's breakdown sits inside the wrapper, keyed by a
+        // code span so names with angle brackets (e.g. a TS `<arrow>`)
+        // render literally instead of being eaten as an HTML tag.
+        let open = out
+            .find("<details><summary>Show breakdown</summary>")
+            .unwrap();
+        let close = out.find("</details>").unwrap();
+        let inner = &out[open..close];
+        assert!(
+            inner.contains("`alpha_fn`") && inner.contains("`beta_fn`"),
+            "both function headers must sit inside the collapsible as code spans; got:\n{out}"
+        );
+        assert!(
+            inner.contains("L12 if-branch +1") && inner.contains("L18 match +2"),
+            "contributor bullets must sit inside the collapsible; got:\n{out}"
+        );
+    }
+
+    /// A backtick in an identity string (reachable from crap4ts, which
+    /// maps a string-literal module/property name verbatim into
+    /// `qualified_name`) must NOT leak into the markdown code span, where
+    /// it would close the span early and garble the breakdown header.
+    /// `code_span_safe` neutralizes it to an apostrophe.
+    #[test]
+    fn backtick_in_name_does_not_break_the_code_span() {
+        use crate::domain::types::{AnalysisResult, ComplexityContributor, ContributorKind};
+        let verdict = make_verdict_with_contributors(
+            make_verdict("ns`weird.fn", "src/a`b.ts", 9, 30.0, 30.0, RiskLevel::High, 8.0),
+            vec![ComplexityContributor {
+                kind: ContributorKind::IfBranch,
+                line: 12,
+                column: None,
+                increment: 1,
+                end_line: 12,
+                nesting_depth: 0,
+            }],
+        );
+        let result = AnalysisResult {
+            summary: crate::domain::summary::compute_summary(std::slice::from_ref(&verdict)),
+            functions: vec![verdict],
+            passed: false,
+        };
+        let out = format_markdown(
+            &make_view_default(&result),
+            None,
+            8.0,
+            true,
+            false,
+            false,
+            10,
+            &test_meta(),
+            ComplexityMetric::Cognitive,
+            None,
+            None,
+        );
+        let open = out
+            .find("<details><summary>Show breakdown</summary>")
+            .unwrap();
+        let close = out.find("</details>").unwrap();
+        let inner = &out[open..close];
+        // The header renders as a balanced code span with the backtick
+        // neutralized — never the raw backtick that would break it.
+        assert!(
+            inner.contains("`ns'weird.fn` — `src/a'b.ts`"),
+            "backtick must be neutralized inside the code-span header; got:\n{out}"
+        );
+        assert!(
+            !inner.contains("ns`weird"),
+            "raw backtick must not leak into the code span; got:\n{out}"
         );
     }
 

--- a/crates/crap-core/src/adapters/reporters/markdown.rs
+++ b/crates/crap-core/src/adapters/reporters/markdown.rs
@@ -29,13 +29,13 @@ use askama::Template;
 /// calling adapter's `tool_name`, so each adapter's scorecard can
 /// sticky to its own comment on the same PR.
 ///
-/// `breakdown` injects an indented bullet list of complexity
-/// contributors under each exceeding function in the spotlight (or
-/// the full table when `full_table` is set), wrapped in a
-/// `<details><summary>Show breakdown</summary>` collapsible so the
-/// default PR-comment view stays compact. `explain` adds a trailing
-/// legend describing increment semantics (only meaningful when
-/// `breakdown` is set).
+/// `breakdown` collects the per-line complexity contributors of every
+/// above-threshold function into one `<details><summary>Show
+/// breakdown</summary>` collapsible rendered BELOW the table (spotlight
+/// or full table) so the default PR-comment view stays compact and the
+/// GFM table stays intact — an inline `<details>` would terminate it.
+/// `explain` adds a trailing legend describing increment semantics
+/// (only meaningful when `breakdown` is set).
 ///
 /// `full_table` switches the body to the legacy row-per-function table
 /// rendered after the summary — useful when piping into a longer
@@ -1003,7 +1003,15 @@ mod tests {
     fn backtick_in_name_does_not_break_the_code_span() {
         use crate::domain::types::{AnalysisResult, ComplexityContributor, ContributorKind};
         let verdict = make_verdict_with_contributors(
-            make_verdict("ns`weird.fn", "src/a`b.ts", 9, 30.0, 30.0, RiskLevel::High, 8.0),
+            make_verdict(
+                "ns`weird.fn",
+                "src/a`b.ts",
+                9,
+                30.0,
+                30.0,
+                RiskLevel::High,
+                8.0,
+            ),
             vec![ComplexityContributor {
                 kind: ContributorKind::IfBranch,
                 line: 12,

--- a/crates/crap-core/src/adapters/reporters/snapshots/crap_core__adapters__reporters__markdown__tests__full_markdown_breakdown_snapshot.snap
+++ b/crates/crap-core/src/adapters/reporters/snapshots/crap_core__adapters__reporters__markdown__tests__full_markdown_breakdown_snapshot.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/crap-core/src/adapters/reporters/markdown.rs
+assertion_line: 1155
 expression: out
 ---
 <!-- test-adapter:scorecard -->
@@ -23,7 +24,10 @@ expression: out
 | File | Function | CC | Cov% | CRAP | Risk |
 |------|----------|----|------|------|------|
 | src/lib.rs | risky_fn | 5 | 30.0 | 45.00 | high |
+
 <details><summary>Show breakdown</summary>
+
+`risky_fn` — `src/lib.rs`
 
   - L5 if-branch +1
   - L10 for-loop +2

--- a/crates/crap-core/templates/markdown_report.txt
+++ b/crates/crap-core/templates/markdown_report.txt
@@ -72,41 +72,49 @@ No functions analyzed.
 {% for row in rows -%}
 | {{ row.file_path }} | {{ row.function_count }} | {{ row.exceeding_count }} | {{ row.average_crap }} | {{ row.worst_crap }} | {{ row.worst_fn }} |
 {% endfor -%}
-{%- when BodySection::FullTable with { rows, legend } %}
+{%- when BodySection::FullTable with { rows, breakdowns, legend } %}
 ## All functions
 
 | File | Function | CC | Cov% | CRAP | Risk |
 |------|----------|----|------|------|------|
 {% for row in rows -%}
 | {{ row.file }} | {{ row.function }} | {{ row.cc }} | {{ row.cov }} | {{ row.crap }} | {{ row.risk }} |
-{% if !row.breakdown_bullets.is_empty() -%}
+{% endfor -%}
+{%- if !breakdowns.is_empty() %}
 <details><summary>Show breakdown</summary>
 
-{% for bullet in row.breakdown_bullets -%}
+{% for b in breakdowns -%}
+`{{ b.function }}` — `{{ b.file }}`
+
+{% for bullet in b.bullets -%}
 {{ bullet }}
 {% endfor %}
+{% endfor -%}
 </details>
 {% endif -%}
-{% endfor -%}
 {%- if legend.is_some() %}
 {{ legend.as_ref().unwrap() }}
 {%- endif -%}
-{%- when BodySection::Spotlight with { header, rows, legend, footnote } %}
+{%- when BodySection::Spotlight with { header, rows, breakdowns, legend, footnote } %}
 {{ header }}
 
 | File | Function | CC | Cov% | CRAP | Risk |
 |------|----------|----|------|------|------|
 {% for row in rows -%}
 | {{ row.file }} | {{ row.function }} | {{ row.cc }} | {{ row.cov }} | {{ row.crap }} | {{ row.risk }} |
-{% if !row.breakdown_bullets.is_empty() -%}
+{% endfor -%}
+{%- if !breakdowns.is_empty() %}
 <details><summary>Show breakdown</summary>
 
-{% for bullet in row.breakdown_bullets -%}
+{% for b in breakdowns -%}
+`{{ b.function }}` — `{{ b.file }}`
+
+{% for bullet in b.bullets -%}
 {{ bullet }}
 {% endfor %}
+{% endfor -%}
 </details>
 {% endif -%}
-{% endfor -%}
 {%- if legend.is_some() %}
 {{ legend.as_ref().unwrap() }}
 {%- endif -%}

--- a/crates/crap4rs/CHANGELOG.md
+++ b/crates/crap4rs/CHANGELOG.md
@@ -15,10 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     on to update its existing comment instead of posting a new one per
     push. The marker carries the adapter name, so a Rust scorecard and
     a TypeScript scorecard can sticky to separate comments on the same
-    PR. With `--breakdown`, each exceeding function's
-    complexity-contributor bullets now render inside a collapsed
-    `<details>` block, keeping the default PR-comment view compact.
-    (crap-rs#275)
+    PR. With `--breakdown`, the complexity-contributor bullets of the
+    above-threshold functions render inside one collapsed
+    `<details>` block below the scorecard table, keeping the default
+    PR-comment view compact while keeping the markdown table itself
+    intact (a `<details>` placed between table rows would terminate the
+    GFM table). (crap-rs#275, crap-rs#397)
 
 ### Changed
 

--- a/crates/crap4rs/README.md
+++ b/crates/crap4rs/README.md
@@ -96,7 +96,7 @@ Functions: 988 · Above threshold: 0 · Worst CRAP: 13.00 · Distribution: 951 l
 
 ### Markdown (`--format markdown`) — PR-comment ready
 
-The first output line is always a hidden HTML comment, `<!-- crap4rs:scorecard -->` — invisible when rendered, but a stable anchor that sticky-PR-comment tooling can match on to find and update its own comment instead of posting a new one on every push. The marker carries the adapter name, so a Rust and a TypeScript scorecard can sticky to separate comments on the same PR. (A multi-language combined comment contains both adapters' markers, so match accordingly if you post combined output.) With `--breakdown`, each exceeding function's complexity-contributor bullets are wrapped in a collapsed `<details>` block to keep the default comment view compact.
+The first output line is always a hidden HTML comment, `<!-- crap4rs:scorecard -->` — invisible when rendered, but a stable anchor that sticky-PR-comment tooling can match on to find and update its own comment instead of posting a new one on every push. The marker carries the adapter name, so a Rust and a TypeScript scorecard can sticky to separate comments on the same PR. (A multi-language combined comment contains both adapters' markers, so match accordingly if you post combined output.) With `--breakdown`, the complexity-contributor bullets of the above-threshold functions collect into one collapsed `<details>` block below the scorecard table — below the table rather than between rows, since a `<details>` placed inside a markdown table terminates it.
 
 ```markdown
 <!-- crap4rs:scorecard -->

--- a/crates/crap4ts/README.md
+++ b/crates/crap4ts/README.md
@@ -93,7 +93,7 @@ Functions: 142 · Above threshold: 1 · Worst CRAP: 17.06 · Distribution: 98 lo
 
 ### Markdown (`--format markdown`) — PR-comment ready
 
-The first output line is always a hidden HTML comment, `<!-- crap4ts:scorecard -->` — invisible when rendered, but a stable anchor that sticky-PR-comment tooling can match on to find and update its own comment instead of posting a new one on every push. The marker carries the adapter name, so a Rust and a TypeScript scorecard can sticky to separate comments on the same PR. (A multi-language combined comment contains both adapters' markers, so match accordingly if you post combined output.) With `--breakdown`, each exceeding function's complexity-contributor bullets are wrapped in a collapsed `<details>` block to keep the default comment view compact.
+The first output line is always a hidden HTML comment, `<!-- crap4ts:scorecard -->` — invisible when rendered, but a stable anchor that sticky-PR-comment tooling can match on to find and update its own comment instead of posting a new one on every push. The marker carries the adapter name, so a Rust and a TypeScript scorecard can sticky to separate comments on the same PR. (A multi-language combined comment contains both adapters' markers, so match accordingly if you post combined output.) With `--breakdown`, the complexity-contributor bullets of the above-threshold functions collect into one collapsed `<details>` block below the scorecard table — below the table rather than between rows, since a `<details>` placed inside a markdown table terminates it.
 
 ```markdown
 <!-- crap4ts:scorecard -->

--- a/packages/crap4ts/CHANGELOG.md
+++ b/packages/crap4ts/CHANGELOG.md
@@ -20,9 +20,12 @@ shared-core development.
     PR-comment actions can use it as a dedupe anchor to find and update
     their existing TypeScript-scorecard comment; because the anchor is
     adapter-named, it never collides with a crap4rs comment on the same
-    PR. Contributor breakdown bullets (`--breakdown`) are now wrapped
-    in a collapsed `<details>` block so long TS scorecards stay
-    scannable in the PR timeline. (crap-rs#275)
+    PR. With `--breakdown`, the contributor bullets of the
+    above-threshold functions collect into one collapsed `<details>`
+    block below the scorecard table so long TS scorecards stay scannable
+    in the PR timeline — below the table rather than between rows,
+    because an inline `<details>` would break the GFM table.
+    (crap-rs#275, crap-rs#397)
 
 ### Changed
 


### PR DESCRIPTION
## Summary

Makes the `--breakdown` complexity collapsible appear — and render
correctly — on our sticky PR scorecards. #275 (merged as #395) shipped
the collapsible in the markdown reporter, but no CI surface passed
`--breakdown`, so it was invisible on every sticky comment.

Wiring it on surfaced a **latent GFM bug in #275**: the breakdown
`<details>` was emitted *inline between table rows*, and a `<details>`
is a GFM HTML block that **terminates a markdown table** — so with more
than one above-threshold function, every row after the first rendered
as literal "pipe-text". Confirmed against GitHub's own `/markdown`
renderer, not a spec reading. The single-function reporter fixtures
could never catch it.

So this PR is two things: the **render fix** in `crap-core` (the
load-bearing part) and the **CI wiring** that makes it visible.

Closes #397

## What changed

**Reporter fix (`crap-core`)** — both the `FullTable` and `Spotlight`
markdown arms now render the table complete first, then collect every
above-threshold function's contributors into **one** collapsible below
it:

```markdown
| File | Function | CC | Cov% | CRAP | Risk |
|------|----------|----|------|------|------|
| string_utils.rs | slugify | 16 | 67.7 | 24.59 | moderate |
| config_merger.rs | merge_configs | 13 | 75.0 | 15.64 | moderate |

<details><summary>Show breakdown</summary>

`slugify` — `string_utils.rs`

  - L19 if-branch +1
  …
</details>
```

- Each function is keyed by a markdown **code span**, which renders
  `<`/`>` literally — so a TS `<arrow>` survives where a bare table cell
  drops it (`<td></td>`). `code_span_safe` neutralizes a literal
  backtick or newline, reachable from crap4ts (a string-literal
  module/property name maps verbatim into the qualified name).
- The block ends with one trailing newline so the following content (a
  legend, or the appended delta's `## CRAP Scorecard` heading) keeps its
  GFM blank-line separator.
- **Breakdown-off output is byte-identical** — the unchanged
  no-breakdown snapshot proves it.

**CI wiring** — a `breakdown:` input on the composite scorecard action
(boolean, default `false`), appended as `--breakdown` to the
markdown-only invocation, only when `true` (conditional-forward /
never-materialize-the-default, like `annotations` / `html-report`).
Enabled on both sticky-posting jobs: the production gate (`ci.yml`) and
the multi-language examples dogfood (`quick-start-smoke.yml`).

## See it on this PR

Both sticky jobs are `pull_request`-triggered, so this PR dogfoods
itself — the **quickstart-smoke** sticky (examples corpus, which has
above-threshold functions by design) will render the collapsible live.
The **production** gate is normally green (0 above threshold 8), where
the collapsible is a no-op; it pays off when the gate *fails*,
explaining the offending function inline.

## Verification

Rendered the real binary output through GitHub's `/markdown` API at
every step — table intact, exactly one `<details>`, zero pipe-soup rows,
`## CRAP Scorecard` renders as `<h2>` after the collapsible. New
regression tests `multi_row_breakdown_keeps_table_contiguous` (RED
against the old inline template) and
`backtick_in_name_does_not_break_the_code_span`.

## Gates

fmt, clippy `-D warnings`, full nextest (1429), 5 cucumber harnesses,
MSRV 1.93 check, `RUSTDOCFLAGS=-D warnings cargo doc`, bdd-tracked-lint,
mutants-skip-lint, actionlint, strict-8 self-gate (1661 fns, 0 above 8).
Diff touches no `*/src` adapter sources beyond `crap-core` → wire-envelope
self-snapshot + scorecard-row/RiskLevel canaries unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/breezy-bays-labs/crap-rs/pull/398">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->