### PR TITLE
feat(ci): #386 — fork-PR hosted reports via workflow_run (lift same-repo-only limit)

### DIFF
--- a/.github/actions/scorecard/action.yml
+++ b/.github/actions/scorecard/action.yml
@@ -2021,10 +2021,11 @@ runs:
     # and every consumer that does not opt in.
     - name: Stage fork Pages handoff
       id: fork-handoff
+      # html-report / comment-mode are NOT gated here — they are validated
+      # in-script below so an opted-in-but-misconfigured caller fails fast
+      # with an actionable error instead of a silently-skipped step.
       if: >-
         inputs.fork-handoff == 'true'
-        && inputs.html-report == 'true'
-        && inputs.comment-mode == 'sticky'
         && github.event_name == 'pull_request'
         && github.event.pull_request.head.repo.full_name != github.repository
         && (steps.lang.outputs.language == 'rust' || steps.lang.outputs.language == 'typescript' || steps.lang.outputs.language == 'multi')
@@ -2032,6 +2033,9 @@ runs:
       env:
         IS_MULTI: ${{ steps.presets.outputs.is_multi }}
         LANGUAGE: ${{ steps.lang.outputs.language }}
+        # Prerequisites validated in-script (fail-fast — see the if: note).
+        HTML_REPORT: ${{ inputs.html-report }}
+        COMMENT_MODE: ${{ inputs.comment-mode }}
         # Candidate report paths written by the render steps above — the
         # same resolution the inline `Publish HTML to GitHub Pages` step
         # uses, so the hosted artifact is the exact report a same-repo PR
@@ -2049,6 +2053,13 @@ runs:
         HANDOFF_DIR: ${{ runner.temp }}/crap-scorecard-pages-handoff
       run: |
         set -euo pipefail
+        # fork-handoff only makes sense with a report to host and a sticky
+        # to (re)post. Fail fast on a misconfigured opt-in rather than
+        # silently staging nothing (which would also skip the sticky).
+        if [ "$HTML_REPORT" != "true" ] || [ "$COMMENT_MODE" != "sticky" ]; then
+          echo "::error::fork-handoff: true requires html-report: true and comment-mode: sticky (got html-report='${HTML_REPORT}', comment-mode='${COMMENT_MODE}')."
+          exit 1
+        fi
         if [ "$IS_MULTI" = "true" ]; then
           REPORT_HTML="$UNIFIED_PATH"
         elif [ "$LANGUAGE" = "rust" ]; then
@@ -2089,13 +2100,10 @@ runs:
         echo "dir=$HANDOFF_DIR" >> "$GITHUB_OUTPUT"
 
     - name: Upload fork Pages handoff
-      if: >-
-        inputs.fork-handoff == 'true'
-        && inputs.html-report == 'true'
-        && inputs.comment-mode == 'sticky'
-        && github.event_name == 'pull_request'
-        && github.event.pull_request.head.repo.full_name != github.repository
-        && (steps.lang.outputs.language == 'rust' || steps.lang.outputs.language == 'typescript' || steps.lang.outputs.language == 'multi')
+      # Upload exactly when the staging step produced a bundle (single
+      # source of truth — no duplicated gate). A skipped staging step
+      # leaves `dir` empty; a failed one already fails the job.
+      if: steps.fork-handoff.outputs.dir != ''
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         # Suffix mirrors the per-language report uploads so a matrix
@@ -2107,17 +2115,18 @@ runs:
         if-no-files-found: error
 
     - name: Post sticky PR comment
-      # The trailing fork-handoff clause SKIPS the post on a fork PR that
-      # opted into the handoff: a fork's read-only token would 403 here
-      # and red the job. The privileged `workflow_run` consumer posts the
-      # sticky instead (from the trusted context, with the hosted link).
-      # On same-repo PRs and for every consumer that does not opt in, the
-      # clause is true and posting is byte-identical to before.
+      # The `dir == ''` clause SKIPS the post exactly when the handoff
+      # staging step ran (a fork PR that opted into fork-handoff): a fork's
+      # read-only token would 403 here and red the job, so the privileged
+      # `workflow_run` consumer posts the sticky instead (from the trusted
+      # context, with the hosted link). When no handoff was staged
+      # (same-repo PR, or any consumer that did not opt in), `dir` is empty
+      # and posting is byte-identical to before.
       if: >-
         (steps.lang.outputs.language == 'rust' || steps.lang.outputs.language == 'typescript' || steps.lang.outputs.language == 'multi')
         && inputs.comment-mode == 'sticky'
         && github.event_name == 'pull_request'
-        && (inputs.fork-handoff != 'true' || github.event.pull_request.head.repo.full_name == github.repository)
+        && steps.fork-handoff.outputs.dir == ''
       uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
       with:
         header: ${{ inputs.comment-header }}

--- a/.github/actions/scorecard/action.yml
+++ b/.github/actions/scorecard/action.yml
@@ -364,6 +364,29 @@ inputs:
       resolve. See the action README's "Hosted per-PR report" section.
     required: false
     default: 'gh-pages'
+  fork-handoff:
+    description: |
+      Opt into the fork-PR hosted-report handoff (advanced pattern). When
+      `true` AND the run is a fork PR with `html-report: true` and
+      `comment-mode: sticky`, the action stages a self-contained handoff
+      bundle (the rendered `report.html`, the PR number, and the composed
+      sticky body) and uploads it as the `crap-scorecard-pages-handoff`
+      artifact, and SKIPS posting the sticky comment (a fork PR's
+      `GITHUB_TOKEN` is read-only, so the post would 403 and red the job).
+
+      A separate privileged `workflow_run` workflow in the BASE repo then
+      consumes that artifact to publish the report to Pages and post the
+      sticky from the trusted context — see `docs/pages-fork-reports.md`.
+      This input is only the PRODUCER half of that two-workflow pattern;
+      without the companion workflow the uploaded artifact is simply
+      unused (harmless).
+
+      Has NO effect on same-repo PRs or push events — those publish inline
+      via `pages-publish`. Default `false`: additive only, byte-identical
+      output for every existing consumer. Empty string is treated as
+      `false`.
+    required: false
+    default: 'false'
 
 outputs:
   markdown:
@@ -1981,8 +2004,120 @@ runs:
           echo "__CRAP_SCORECARD_STICKY_EOF__"
         } >> "$GITHUB_OUTPUT"
 
+    # Fork-PR hosted-report handoff (crap-rs#386, opt-in via
+    # `fork-handoff: true`). A fork PR's GITHUB_TOKEN is read-only, so it
+    # can neither push to gh-pages nor post a comment — the inline
+    # `pages-publish` path and the `Post sticky PR comment` step below
+    # both no-op on forks. Instead, this step stages a self-contained
+    # bundle a SEPARATE privileged `workflow_run` workflow (running in the
+    # trusted BASE-repo context) will publish: the rendered report, the PR
+    # number, and the already-composed sticky body. The body MUST travel
+    # in the artifact because the privileged consumer cannot re-derive it
+    # without running this PR's untrusted code (the pwn-request the
+    # workflow_run topology exists to avoid). See docs/pages-fork-reports.md.
+    #
+    # Gated on a fork PR with html-report + sticky mode; a no-op (and
+    # byte-identical to before this input) for same-repo PRs, push events,
+    # and every consumer that does not opt in.
+    - name: Stage fork Pages handoff
+      id: fork-handoff
+      if: >-
+        inputs.fork-handoff == 'true'
+        && inputs.html-report == 'true'
+        && inputs.comment-mode == 'sticky'
+        && github.event_name == 'pull_request'
+        && github.event.pull_request.head.repo.full_name != github.repository
+        && (steps.lang.outputs.language == 'rust' || steps.lang.outputs.language == 'typescript' || steps.lang.outputs.language == 'multi')
+      shell: bash
+      env:
+        IS_MULTI: ${{ steps.presets.outputs.is_multi }}
+        LANGUAGE: ${{ steps.lang.outputs.language }}
+        # Candidate report paths written by the render steps above — the
+        # same resolution the inline `Publish HTML to GitHub Pages` step
+        # uses, so the hosted artifact is the exact report a same-repo PR
+        # would have published.
+        UNIFIED_PATH: ${{ steps.render-unified.outputs.unified_path }}
+        HTML_PATH_RUST: ${{ steps.run.outputs.html_path_rust }}
+        HTML_PATH_TYPESCRIPT: ${{ steps.run.outputs.html_path_typescript }}
+        # Caller preamble, prepended above the scorecard exactly as the
+        # `Compose sticky message` step does (crap-rs#336).
+        COMMENT_PREAMBLE: ${{ inputs.comment-preamble }}
+        # PR number flows through env (never interpolated into the script)
+        # per the repo's template-injection rule; the privileged consumer
+        # re-validates it as numeric before it touches a filesystem path.
+        PR_NUMBER: ${{ github.event.number }}
+        HANDOFF_DIR: ${{ runner.temp }}/crap-scorecard-pages-handoff
+      run: |
+        set -euo pipefail
+        if [ "$IS_MULTI" = "true" ]; then
+          REPORT_HTML="$UNIFIED_PATH"
+        elif [ "$LANGUAGE" = "rust" ]; then
+          REPORT_HTML="$HTML_PATH_RUST"
+        else
+          REPORT_HTML="$HTML_PATH_TYPESCRIPT"
+        fi
+        # Empty-file guard (AGENTS.md release-envelope rule): a silent
+        # render failure surfaces here as a named error rather than as an
+        # empty page published behind a live link by the privileged half.
+        if [ -z "$REPORT_HTML" ] || [ ! -s "$REPORT_HTML" ]; then
+          echo "::error::fork-handoff: the rendered HTML report ('${REPORT_HTML:-<unset>}') is missing or empty; refusing to stage an empty hosted report."
+          exit 1
+        fi
+        mkdir -p "$HANDOFF_DIR"
+        cp "$REPORT_HTML" "$HANDOFF_DIR/report.html"
+        printf '%s\n' "$PR_NUMBER" > "$HANDOFF_DIR/pr_number"
+        # Compose the handoff sticky body = preamble + raw scorecard, with
+        # NO report link. On a fork the inline compose step appends the
+        # artifact-DOWNLOAD link (the HTML artifact URL is populated), but
+        # the privileged consumer publishes a hosted page and must link
+        # THAT instead — so the handoff body is link-free and the consumer
+        # appends the hosted link after it publishes. The preamble +
+        # raw-scorecard selection mirrors the `Compose sticky message`
+        # step minus its link block.
+        sticky="$HANDOFF_DIR/sticky.md"
+        : > "$sticky"
+        if [ -n "$COMMENT_PREAMBLE" ]; then
+          printf '%s\n\n' "$COMMENT_PREAMBLE" >> "$sticky"
+        fi
+        if [ "$IS_MULTI" = "true" ]; then
+          cat "$RUNNER_TEMP/scorecard-combined.md" >> "$sticky"
+        elif [ "$LANGUAGE" = "rust" ]; then
+          cat "$RUNNER_TEMP/crap4rs-scorecard.md" >> "$sticky"
+        else
+          cat "$RUNNER_TEMP/crap4ts-scorecard.md" >> "$sticky"
+        fi
+        echo "dir=$HANDOFF_DIR" >> "$GITHUB_OUTPUT"
+
+    - name: Upload fork Pages handoff
+      if: >-
+        inputs.fork-handoff == 'true'
+        && inputs.html-report == 'true'
+        && inputs.comment-mode == 'sticky'
+        && github.event_name == 'pull_request'
+        && github.event.pull_request.head.repo.full_name != github.repository
+        && (steps.lang.outputs.language == 'rust' || steps.lang.outputs.language == 'typescript' || steps.lang.outputs.language == 'multi')
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        # Suffix mirrors the per-language report uploads so a matrix
+        # producer never collides on artifact names. crap-rs's single
+        # ubuntu-latest producer resolves to `-Linux`; the privileged
+        # consumer downloads that exact name.
+        name: crap-scorecard-pages-handoff${{ inputs.html-artifact-name-suffix == '' && format('-{0}', runner.os) || inputs.html-artifact-name-suffix }}
+        path: ${{ steps.fork-handoff.outputs.dir }}
+        if-no-files-found: error
+
     - name: Post sticky PR comment
-      if: (steps.lang.outputs.language == 'rust' || steps.lang.outputs.language == 'typescript' || steps.lang.outputs.language == 'multi') && inputs.comment-mode == 'sticky' && github.event_name == 'pull_request'
+      # The trailing fork-handoff clause SKIPS the post on a fork PR that
+      # opted into the handoff: a fork's read-only token would 403 here
+      # and red the job. The privileged `workflow_run` consumer posts the
+      # sticky instead (from the trusted context, with the hosted link).
+      # On same-repo PRs and for every consumer that does not opt in, the
+      # clause is true and posting is byte-identical to before.
+      if: >-
+        (steps.lang.outputs.language == 'rust' || steps.lang.outputs.language == 'typescript' || steps.lang.outputs.language == 'multi')
+        && inputs.comment-mode == 'sticky'
+        && github.event_name == 'pull_request'
+        && (inputs.fork-handoff != 'true' || github.event.pull_request.head.repo.full_name == github.repository)
       uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
       with:
         header: ${{ inputs.comment-header }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -764,19 +764,21 @@ jobs:
             rm -f baseline.json
           fi
 
-      - name: Note fork-PR Pages degradation
+      - name: Note fork-PR Pages handoff
         # On a fork PR the GITHUB_TOKEN is read-only regardless of the
-        # job's permissions: block, so the gh-pages push would 403. The
-        # pages-publish input below is computed false for fork PRs, so
-        # the action degrades to summary-only (no hosted link) — never a
-        # red X, never a dead link. Surface that decision in the log so a
-        # reviewer on a fork PR knows the missing link is by design.
-        # Full fork-PR publishing (a privileged workflow_run topology) is
-        # a later, separate deliverable of this epic.
+        # job's permissions: block, so neither the inline gh-pages push
+        # (pages-publish, computed false on forks below) nor the action's
+        # sticky-comment post can run here. Instead `fork-handoff: true`
+        # makes the action stage a handoff artifact, and the separate
+        # privileged `Pages publish (fork PRs)` workflow (workflow_run, in
+        # the trusted BASE context) publishes the report and posts the
+        # sticky AFTER this run completes. Surface that in the log so a
+        # reviewer on a fork PR knows the hosted link arrives shortly via
+        # the companion workflow, not inline. See docs/pages-fork-reports.md.
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
         run: |
           set -euo pipefail
-          echo "::notice::Fork PR detected — the hosted per-PR report link is omitted because a fork's GITHUB_TOKEN is read-only and cannot publish to GitHub Pages. The scorecard summary is unaffected. Full fork-PR hosted reports are a planned follow-up."
+          echo "::notice::Fork PR detected — the hosted report link is not posted inline (a fork's GITHUB_TOKEN is read-only). The 'Pages publish (fork PRs)' workflow publishes the report and posts the production sticky from the trusted base context once this CI run completes."
 
       - name: Production scorecard (gate-on-analysis)
         uses: ./.github/actions/scorecard
@@ -828,6 +830,13 @@ jobs:
           pages-publish: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
           pages-deploy-path: pr-${{ github.event.number }}
           pages-url: https://breezy-bays-labs.github.io/crap-rs/pr-${{ github.event.number }}/
+          # Fork-PR counterpart to pages-publish (crap-rs#386). On a fork
+          # PR the action stages a handoff artifact instead of publishing
+          # inline (a fork token can't push or comment); the privileged
+          # `pages-publish-fork.yml` workflow_run consumer publishes the
+          # report + posts the sticky from the trusted base context. A
+          # no-op on same-repo PRs and push events.
+          fork-handoff: true
           gate-mode: gate-on-analysis
           comment-mode: sticky
           comment-header: crap-scorecard-production

--- a/.github/workflows/pages-cleanup.yml
+++ b/.github/workflows/pages-cleanup.yml
@@ -2,9 +2,10 @@
 # epic. When a PR against main closes (merged OR not), this removes that
 # PR's report directory (`pr-<N>/`) from the gh-pages branch so per-PR
 # reports don't accumulate forever on the Pages branch as PRs come and
-# go. Wave 1 (the per-PR publish step in
-# `.github/actions/scorecard/action.yml`) creates `pr-<N>/`; this is the
-# matching teardown.
+# go. `pr-<N>/` is created either inline by the per-PR publish step in
+# `.github/actions/scorecard/action.yml` (same-repo PRs) or by the
+# privileged `pages-publish-fork.yml` workflow (fork PRs, crap-rs#386);
+# this is the matching teardown for both.
 #
 # DEDICATED workflow, deliberately NOT folded into ci.yml: adding
 # `closed` to ci.yml's `pull_request:` types would run the entire CI
@@ -13,7 +14,18 @@
 name: Pages cleanup
 
 on:
-  pull_request:
+  # pull_request_target runs privileged in the BASE context, which is what
+  # lets this cleanup push a deletion to gh-pages even when a FORK PR
+  # closes — a fork's plain `pull_request` token is read-only and could
+  # not push (crap-rs#386, once fork PRs publish `pr-<N>/` dirs that need
+  # tearing down). It is safe here because this job checks out NO code
+  # (neither base nor fork) and uses exactly ONE input — the PR number —
+  # which it validates as a positive integer before using it as a
+  # filesystem path. With no checkout-and-run of head code, the
+  # pull_request_target "pwn request" footgun does not apply; the trigger
+  # only supplies the privileged token the metadata-only deletion needs.
+  # See docs/pages-fork-reports.md.
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
     types: [closed]
     branches: [main]
 
@@ -62,12 +74,21 @@ jobs:
           PR_NUMBER: ${{ github.event.number }}
         run: |
           set -euo pipefail
+          # Defense-in-depth: PR_NUMBER is GitHub's own integer, but it
+          # becomes a filesystem path (pr-<N>/) below, so validate it as a
+          # run of digits before use — the same path-traversal guard the
+          # fork-publish workflow applies to its artifact-sourced number.
+          case "$PR_NUMBER" in
+            ''|*[!0-9]*)
+              echo "::error::Pages cleanup: PR number ('${PR_NUMBER}') is not a positive integer; refusing to operate on a derived path."
+              exit 1
+              ;;
+          esac
           # Shallow tokened clone of gh-pages. $GITHUB_REPOSITORY is the
-          # BASE repo even on a fork-PR close, so this always targets the
-          # canonical gh-pages branch. A read-only token (fork PR) can
-          # still CLONE a public repo; the only operation a fork token
-          # can't do is PUSH — and on a fork PR the no-op exit below
-          # happens BEFORE any push is reached (see the fork-safe note).
+          # BASE repo on every close (fork or not), so this always targets
+          # the canonical gh-pages branch — and under pull_request_target
+          # the token is read-write on fork closes too, so the deletion
+          # push below succeeds regardless of where the PR originated.
           #
           # Missing-branch tolerance (consumer robustness): a fresh
           # consumer repo that has never published a per-PR report has no
@@ -84,15 +105,14 @@ jobs:
             exit 0
           fi
           cd gh-pages-cleanup
-          # Fork-safe / degrade-not-fail by construction: Wave 1 publishes
-          # `pr-<N>/` for SAME-REPO PRs only, so a closed fork PR never
-          # created the directory → the else-branch no-ops and exits 0
-          # BEFORE any push (which a read-only fork token couldn't do
-          # anyway). The same absent-dir no-op covers a re-run, an
-          # already-clean state, or a same-repo PR that simply never
-          # published. No same-repo `if:` gate is needed — the dir-
-          # existence check is the whole fork-safety story, and skipping
-          # the gate keeps the workflow shape simplest.
+          # Dir-existence check is the whole story: remove `pr-<N>/` if it
+          # exists, no-op otherwise. Under pull_request_target the job has
+          # a write token on BOTH same-repo and fork closes, so a fork PR's
+          # `pr-<N>/` (published by the privileged fork workflow,
+          # crap-rs#386) is torn down here exactly like a same-repo one.
+          # The absent-dir no-op still covers a re-run, an already-clean
+          # state, a PR that never published, and any close whose report
+          # was never created — no same-repo `if:` gate needed.
           if [ -d "pr-${PR_NUMBER}" ]; then
             git rm -r "pr-${PR_NUMBER}"
             # No-op guard: if nothing is actually staged (e.g. the dir was

--- a/.github/workflows/pages-publish-fork.yml
+++ b/.github/workflows/pages-publish-fork.yml
@@ -1,0 +1,215 @@
+# Pages publish (fork PRs) — the privileged half of the fork-PR
+# hosted-report handoff (crap-rs#386, epic #377). This lifts the
+# same-repo-only limitation: a fork PR's GITHUB_TOKEN is read-only, so
+# the fork's own CI run can neither push to gh-pages nor post a comment.
+#
+# THE TRUST MODEL (why this is a separate `workflow_run` workflow):
+# The fork's CI run executes untrusted code, so GitHub denies it
+# privilege. This workflow runs AFTER that run completes, from the BASE
+# repository's trusted context, with a read-write token — but it NEVER
+# checks out or executes the fork's code. The only thing that crosses the
+# trust boundary is the `crap-scorecard-pages-handoff` ARTIFACT the fork
+# run uploaded (the rendered report, the PR number, the scorecard body).
+# This workflow downloads that artifact and treats every byte of it as
+# untrusted input. The PR number gets TWO guards before use: (1) it must
+# be a run of digits (path-traversal defense — it becomes a `pr-<N>/`
+# path); and (2) it is bound to this run's identity — PR N's head SHA and
+# head repo, read from the trusted GitHub API, must equal the
+# workflow_run payload's head_sha + head_repository. A fork controls its
+# whole run, so a numeric-but-arbitrary number could otherwise spoof a
+# maintainer's PR; guard 2 rejects any number whose PR this run did not
+# actually produce. The decoupling prevents code execution (the "pwn
+# request"); the two guards prevent injection AND identity-spoofing
+# through the data channel. All three halves matter.
+#
+# This is an ADVANCED OPT-IN pattern — see docs/pages-fork-reports.md for
+# the full walkthrough and the consumer checklist. Same-repo PRs do NOT
+# use this path: they publish inline in ci.yml's `scorecard-production`
+# job (which has a write token), and the fork-only gate below keeps this
+# workflow from double-publishing them.
+name: Pages publish (fork PRs)
+
+on:
+  # `workflow_run` runs privileged in the base context. It is safe here
+  # because this workflow never checks out or runs the head (fork) code —
+  # it consumes ONLY the uploaded artifact and validates everything it
+  # reads from it (see the trust-model header above).
+  workflow_run: # zizmor: ignore[dangerous-triggers]
+    workflows: [CI]
+    types: [completed]
+
+# Least-privilege default: read-only at the workflow level. The single
+# job below elevates only what it needs.
+permissions:
+  contents: read
+
+jobs:
+  publish-fork-report:
+    name: Publish fork PR report to gh-pages
+    runs-on: ubuntu-latest
+    # Act ONLY on a fork PR whose CI run succeeded:
+    #   * event == 'pull_request'  — ignore push-to-main (Wave 0 owns that).
+    #   * conclusion == 'success'  — a failed/cancelled run staged no valid
+    #                                handoff.
+    #   * head_repository != repository — FORK only. Same-repo PRs already
+    #                                published inline in scorecard-production;
+    #                                this gate is the dedup that stops a
+    #                                double-publish.
+    if: >-
+      github.event.workflow_run.event == 'pull_request'
+      && github.event.workflow_run.conclusion == 'success'
+      && github.event.workflow_run.head_repository.full_name != github.event.workflow_run.repository.full_name
+    permissions:
+      # actions: read   — download the triggering run's artifact (a
+      #                    cross-run download needs run-id + a token with
+      #                    actions:read).
+      # contents: write — push the report to the gh-pages branch.
+      # pull-requests: write — post the production sticky on the fork PR.
+      actions: read
+      contents: write
+      pull-requests: write
+    # Shared gh-pages publish lock (epic #377). Same named group as the
+    # inline per-PR publish, the push-to-main publish, and the cleanup, so
+    # no two gh-pages pushes collide on the branch tip. cancel-in-progress
+    # is false so an in-flight push is never aborted mid-operation.
+    concurrency:
+      group: gh-pages-publish
+      cancel-in-progress: false
+    steps:
+      # Best-effort download of the fork run's handoff. continue-on-error
+      # so a run that produced no handoff (e.g. a docs-only fork PR that
+      # skipped the scorecard job) does not red this workflow — the next
+      # step no-ops cleanly when the files are absent. The fixed `-Linux`
+      # suffix matches the producer: scorecard-production runs on
+      # ubuntu-latest with no html-artifact-name-suffix, so the action's
+      # `runner.os` suffix resolves to `-Linux`.
+      - name: Download fork handoff artifact
+        id: download
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: crap-scorecard-pages-handoff-Linux
+          path: handoff
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate handoff and publish report
+        id: publish
+        env:
+          # Token in env (never interpolated into the script); the publish
+          # is a plain git push, so secrets.GITHUB_TOKEN is correct here (a
+          # workflow job, not a composite action). $GITHUB_REPOSITORY is a
+          # default env var = the BASE repo, which is where we publish.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # gh CLI token for the identity cross-check below.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # TRUSTED head identity from the workflow_run payload (not from
+          # the artifact). Used to bind the artifact's claimed PR number to
+          # the run that actually produced it — see the cross-check below.
+          RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          RUN_HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
+        run: |
+          set -euo pipefail
+          # No handoff (best-effort download missed, or the fork PR
+          # produced no scorecard report) → nothing to publish. Exit 0:
+          # a missing report is not a failure of THIS workflow. All three
+          # files are written atomically by the producer, so guarding all
+          # three keeps the no-op contract total.
+          if [ ! -s handoff/report.html ] || [ ! -s handoff/pr_number ] || [ ! -s handoff/sticky.md ]; then
+            echo "::notice::No fork Pages handoff for this run — nothing to publish (the PR likely produced no scorecard report). Skipping."
+            exit 0
+          fi
+          # SECURITY (guard 1 of 2 — path traversal). The PR number came
+          # from an UNTRUSTED run's artifact and is about to become a
+          # filesystem path (pr-<N>/). Reject anything that is not a run of
+          # digits BEFORE it touches a path: a value like `../../evil` would
+          # otherwise be a path-traversal write into the gh-pages tree.
+          PR_NUMBER="$(tr -d '[:space:]' < handoff/pr_number)"
+          case "$PR_NUMBER" in
+            ''|*[!0-9]*)
+              echo "::error::fork Pages publish: PR number from handoff ('${PR_NUMBER}') is not a positive integer; refusing to proceed (path-traversal guard)."
+              exit 1
+              ;;
+          esac
+          # SECURITY (guard 2 of 2 — identity binding). A numeric PR number
+          # is still attacker-controlled: a malicious fork controls its
+          # whole pull_request run (including the action source), so it
+          # could write ANY valid integer — e.g. a maintainer's PR — to
+          # spoof that PR's sticky and overwrite its gh-pages dir.
+          # `workflow_run.pull_requests` is empty for fork PRs, so we cannot
+          # read the real number from the event; instead we bind the
+          # CLAIMED number to the TRUSTED run payload: PR N's head commit
+          # and head repo must equal this run's head_sha + head_repository.
+          # A fork cannot forge another PR's head SHA, so a mismatched claim
+          # is rejected here, before any publish or comment.
+          # A failed/empty API response (404, network, etc.) leaves the
+          # claimed_* vars empty → mismatch → clean rejection below, rather
+          # than a jq parse error killing the step under `set -e`.
+          pr_json="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" 2>/dev/null || true)"
+          claimed_head_sha="$(printf '%s' "$pr_json" | jq -r '.head.sha // ""' 2>/dev/null || true)"
+          claimed_head_repo="$(printf '%s' "$pr_json" | jq -r '.head.repo.full_name // ""' 2>/dev/null || true)"
+          if [ "$claimed_head_sha" != "$RUN_HEAD_SHA" ] || [ "$claimed_head_repo" != "$RUN_HEAD_REPO" ]; then
+            echo "::error::fork Pages publish: handoff PR #${PR_NUMBER} does not match the triggering run's head (PR head ${claimed_head_sha:-<none>} on ${claimed_head_repo:-<none>}; run head ${RUN_HEAD_SHA} on ${RUN_HEAD_REPO}). Refusing to publish/comment on a PR this run did not produce."
+            exit 1
+          fi
+          DEPLOY_PATH="pr-${PR_NUMBER}"
+          # Derive the default project-Pages URL from the base repo. Owner
+          # is lowercased (the github.io subdomain is case-folded); the repo
+          # path segment is preserved. Consumers on a custom domain adjust
+          # this one line — see docs/pages-fork-reports.md.
+          OWNER="$(printf '%s' "${GITHUB_REPOSITORY%%/*}" | tr '[:upper:]' '[:lower:]')"
+          REPO="${GITHUB_REPOSITORY##*/}"
+          PAGES_URL="https://${OWNER}.github.io/${REPO}/${DEPLOY_PATH}/"
+          # Publish: shallow tokened clone of gh-pages, drop the report at
+          # pr-<N>/index.html, commit + push. Same self-contained plain-git
+          # mechanism the inline publish and the cleanup use (no third-party
+          # action — supply-chain conventions). REMOTE_URL is built from the
+          # two env vars so the token never flows through a workflow
+          # expression. Existing Pages content outside pr-<N>/ is preserved
+          # (we copy in, we do not wipe the tree).
+          REMOTE_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          if ! git clone --branch gh-pages --single-branch --depth 1 "$REMOTE_URL" gh-pages-fork-pub 2>/dev/null; then
+            echo "::error::gh-pages branch not found. Publish a main report first (the push-to-main job seeds gh-pages) before fork PR reports can be hosted."
+            exit 1
+          fi
+          mkdir -p "gh-pages-fork-pub/${DEPLOY_PATH}"
+          cp handoff/report.html "gh-pages-fork-pub/${DEPLOY_PATH}/index.html"
+          # Compose the final sticky body: the link-free handoff body + the
+          # hosted Pages link. The producer deliberately left the report
+          # link OFF (on a fork it would otherwise be the artifact-download
+          # link), so we append the HOSTED url here. Wrapped in <...> per
+          # GFM so the link renders regardless of URL punctuation.
+          cp handoff/sticky.md handoff/sticky-final.md
+          printf '\n\n📊 [Open report](<%s>)\n' "$PAGES_URL" >> handoff/sticky-final.md
+          cd gh-pages-fork-pub
+          # No-op guard: skip an empty commit on an identical re-run. The
+          # sticky is still (re)posted below — marocchino update is
+          # idempotent — so a re-run refreshes the comment either way.
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "gh-pages already up to date for ${DEPLOY_PATH} — nothing to push."
+          else
+            git add "${DEPLOY_PATH}/index.html"
+            git \
+              -c user.name="github-actions[bot]" \
+              -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+              commit -m "ci(pages): publish fork PR #${PR_NUMBER} CRAP report to ${DEPLOY_PATH}"
+            git push origin HEAD:gh-pages
+            echo "Published fork PR #${PR_NUMBER} report to ${DEPLOY_PATH}."
+          fi
+          # Signal the sticky step to run (only set on a valid publish, so
+          # the no-handoff early-exit above leaves it empty → sticky skips).
+          echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+
+      # Post the production sticky from the trusted context. The fork run
+      # could not (read-only token), so this CREATES the sticky (and
+      # updates it on re-run — marocchino keys off the header marker).
+      # `number` targets the PR explicitly since workflow_run has no PR
+      # context; it is the integer validated above. `path` reads the body
+      # the publish step composed (handoff body + hosted link).
+      - name: Post production sticky with hosted link
+        if: steps.publish.outputs.pr_number != ''
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        with:
+          header: crap-scorecard-production
+          number: ${{ steps.publish.outputs.pr_number }}
+          path: handoff/sticky-final.md

--- a/docs/pages-fork-reports.md
+++ b/docs/pages-fork-reports.md
@@ -1,0 +1,146 @@
+# Hosted CRAP reports for fork PRs
+
+The hosted per-PR report recipe (epic #377) publishes a clickable HTML
+scorecard to GitHub Pages for every pull request and links it from the
+production sticky comment. By default this works for **same-repo PRs
+only**: a fork PR's `GITHUB_TOKEN` is read-only, so the fork's own CI run
+can neither push to `gh-pages` nor post a comment. Such PRs degrade to a
+summary-only sticky with no hosted link.
+
+This document describes the **opt-in, advanced** pattern that lifts that
+limit so fork PRs get hosted reports too. It is intentionally separate
+from the canonical recipe because it relies on a privileged workflow
+topology that must be understood before it is copied.
+
+> **You almost certainly do not need this for a repo that never receives
+> fork PRs.** The same-repo recipe is the safe default. Enable this only
+> when external contributors open PRs from forks and you want them to get
+> the same hosted-report experience.
+
+## Why fork PRs are different
+
+CI has to run untrusted code (the PR's diff) but sometimes needs
+privilege (push to `gh-pages`, post a comment). Handing a privileged
+token to untrusted code is how secrets get exfiltrated, so GitHub
+withholds privilege from fork PR runs: a `pull_request` event from a fork
+gets a **read-only** token and **no secrets**, and the `permissions:`
+block cannot elevate above that ceiling. The workflow file that runs is
+the **PR head's** version (attacker-controlled), so a read-only token is
+the only safe option.
+
+GitHub's Security Lab calls the class of bug where this protection is
+bypassed a **"pwn request."** The pattern below is structured
+specifically to avoid it.
+
+## The topology
+
+Three pieces cooperate. Two trust zones never share a token.
+
+```
+  Fork PR run (pull_request)            Privileged run (workflow_run)
+  ────────────────────────────         ──────────────────────────────
+  token: read-only, no secrets         token: read-write, secrets
+  YAML:  PR head (untrusted)           YAML:  base branch (trusted)
+  sees fork code: yes (it IS it)       sees fork code: NEVER
+  ───────────────────────────────────────────────────────────────────
+  build + render report                download the artifact
+  upload handoff ARTIFACT  ───────►    VALIDATE everything in it
+  (report.html, pr_number, body)       publish to gh-pages pr-<N>/
+  skip the (doomed) sticky post        post the production sticky
+```
+
+One artifact crosses the boundary, in one direction, and the privileged
+side treats it as hostile input. The decoupling prevents code execution;
+the validation prevents injection through the data channel. **Both halves
+matter** — a `workflow_run` job that blindly trusts its downloaded
+artifact is still exploitable.
+
+### 1. Producer — the scorecard action (`fork-handoff: true`)
+
+The `scorecard` composite action's `fork-handoff` input (default
+`false`) is the producer half. On a fork PR with `html-report: true` and
+`comment-mode: sticky`, it:
+
+- stages a self-contained handoff bundle: the rendered `report.html`, the
+  PR number, and the composed (link-free) sticky body;
+- uploads it as the `crap-scorecard-pages-handoff` artifact;
+- **skips** posting the sticky comment (a fork's read-only token would
+  403 and red the job).
+
+The sticky body is staged **without** a report link on purpose: the
+privileged consumer appends the hosted Pages URL, not the
+artifact-download URL the inline path would otherwise emit.
+
+This input is a no-op for same-repo PRs, push events, and every consumer
+that does not set it — output is byte-identical to before it existed.
+
+### 2. Privileged consumer — `pages-publish-fork.yml`
+
+A `workflow_run` workflow that fires after CI completes, runs in the base
+repo's trusted context, and:
+
+- gates to **fork PRs whose CI succeeded** (`workflow_run.event ==
+  'pull_request'`, `conclusion == 'success'`, and `head_repository !=
+  repository`) — the fork gate is also the dedup that stops it
+  double-publishing same-repo PRs;
+- downloads the handoff artifact from the triggering run (best-effort —
+  a fork PR that produced no report is a clean no-op);
+- **guards the PR number twice** before using it: (1) it must be a run of
+  digits — a value like `../../evil` would otherwise be a path-traversal
+  write into `gh-pages` when it becomes `pr-<N>/`; and (2) it is **bound to
+  the triggering run's identity** — PR N's head SHA and head repo (read
+  from the trusted GitHub API) must equal the `workflow_run` payload's
+  `head_sha` + `head_repository`. A fork controls its entire run, so a
+  numeric-but-arbitrary number could otherwise spoof a maintainer's PR
+  (post the production sticky there, overwrite its `gh-pages` dir); guard
+  2 rejects any PR this run did not actually produce;
+- publishes `report.html` to `gh-pages` at `pr-<N>/index.html`;
+- posts the production sticky from the trusted context, with the hosted
+  link appended.
+
+It **never checks out or runs the fork's code.** Its only inputs are the
+artifact's contents, each validated before use.
+
+### 3. Cleanup — `pages-cleanup.yml` (`pull_request_target`)
+
+When a PR closes, the cleanup workflow removes `pr-<N>/` from `gh-pages`.
+For fork closes to push the deletion it needs a write token, so the
+cleanup triggers on `pull_request_target` rather than `pull_request`.
+
+This is the **safe** use of `pull_request_target`: the cleanup job checks
+out no code (base or fork) and uses exactly one input — the PR number,
+validated numeric — to delete a directory. The "pwn request" footgun
+applies only when you check out *and run* head code under this trigger;
+a metadata-only job does not.
+
+## Enabling it on your own repo
+
+1. Have the same-repo hosted-report recipe working first (GitHub Pages
+   enabled on `gh-pages`, the push-to-main job seeding the root report and
+   baseline). Fork reports publish into the same branch and depend on it
+   existing.
+2. In your PR scorecard job, set `fork-handoff: true` on the `scorecard`
+   action (alongside `html-report: true` and `comment-mode: sticky`). Keep
+   `pages-publish` gated to same-repo PRs — the two are complementary.
+3. Copy `pages-publish-fork.yml` into `.github/workflows/`. Confirm its
+   `on.workflow_run.workflows` value matches your CI workflow's `name:`.
+4. Switch `pages-cleanup.yml` from `pull_request:` to
+   `pull_request_target:` (the numeric PR-number guard is already in
+   place).
+5. If you serve Pages from a **custom domain** or a user/organization
+   site (not the default `https://<owner>.github.io/<repo>/`), adjust the
+   one `PAGES_URL` line in `pages-publish-fork.yml`.
+
+## Security invariants (do not regress)
+
+- The privileged workflow **never** runs `actions/checkout` of the PR
+  head, and never executes any fork-supplied script.
+- Every value read from the handoff artifact is treated as untrusted. The
+  PR number is validated `^[0-9]+$` (path-traversal) **and** bound to the
+  triggering run's head SHA + head repo via the trusted GitHub API
+  (identity-spoofing) before it is used as a path or a comment target.
+  Both guards are load-bearing; do not drop either.
+- Tokens flow through `env:`, never interpolated into a `run:` script
+  (template-injection hygiene).
+- The fork gate (`head_repository != repository`) is what prevents
+  double-publishing same-repo PRs; do not loosen it.

--- a/docs/pages-fork-reports.md
+++ b/docs/pages-fork-reports.md
@@ -79,10 +79,10 @@ that does not set it — output is byte-identical to before it existed.
 A `workflow_run` workflow that fires after CI completes, runs in the base
 repo's trusted context, and:
 
-- gates to **fork PRs whose CI succeeded** (`workflow_run.event ==
-  'pull_request'`, `conclusion == 'success'`, and `head_repository !=
-  repository`) — the fork gate is also the dedup that stops it
-  double-publishing same-repo PRs;
+- gates to **fork PRs whose CI succeeded** — on the `github.event.workflow_run`
+  payload: `event == 'pull_request'`, `conclusion == 'success'`, and
+  `head_repository.full_name != repository.full_name` (the fork gate is
+  also the dedup that stops it double-publishing same-repo PRs);
 - downloads the handoff artifact from the triggering run (best-effort —
   a fork PR that produced no report is a clean no-op);
 - **guards the PR number twice** before using it: (1) it must be a run of


### PR DESCRIPTION
## Summary

Lifts the same-repo-only limit on hosted per-PR CRAP reports (epic #377): fork PRs now get a hosted Pages report + the production sticky link, published from the trusted base context via a privileged `workflow_run` topology.

A fork PR's `GITHUB_TOKEN` is read-only, so the fork's own CI run can neither push to `gh-pages` nor post a comment. The fix splits the work across the trust boundary:

- **Producer** (`scorecard` action, opt-in `fork-handoff: true`): on a fork PR, stage a self-contained handoff artifact (rendered `report.html`, PR number, link-free sticky body) and skip the doomed sticky post. Default `false` → byte-identical for every existing consumer.
- **Privileged consumer** (`pages-publish-fork.yml`, new): `workflow_run` after CI completes, runs in the base context, downloads the artifact, validates it, publishes to `gh-pages pr-<N>/`, and posts the sticky with the hosted link. **Never checks out or runs fork code.**
- **Cleanup** (`pages-cleanup.yml`): `pull_request` → `pull_request_target` so fork closes get a write token to delete `pr-<N>/` (safe variety — no checkout, metadata-only).
- **Docs** (`docs/pages-fork-reports.md`): the trust model + consumer enablement checklist.

## Security model

The artifact is the only thing that crosses the trust boundary, and the privileged side treats every byte as hostile:

- **No code execution** — the privileged workflow has zero `actions/checkout`; it consumes only the artifact + posts a comment.
- **Two guards on the PR number** — (1) `^[0-9]+$` (path-traversal: it becomes `pr-<N>/`), and (2) **identity binding** — PR N's head SHA + head repo (from the trusted API) must equal the `workflow_run` payload's `head_sha` + `head_repository`. A fork controls its whole run and could otherwise write an arbitrary integer to spoof a maintainer's PR; guard 2 rejects any PR this run did not produce (`workflow_run.pull_requests` is empty for fork PRs, hence the API cross-check rather than the event).
- **Fork-only gate** (`head_repository != repository`) is also the dedup that stops double-publishing same-repo PRs.
- Tokens via `env:`, never interpolated into `run:`. `pull_request_target`/`workflow_run` carry inline `# zizmor: ignore[dangerous-triggers]` with the safety rationale.

## Verification

- `actionlint` (incl. shellcheck on run blocks) clean; `yq` parse clean; no `${{ }}` in any `run:` block (composite-action manifest trap); byte-identical-default confirmed.
- Adversarial engineering review pass (found + fixed the identity-binding gap above).
- **End-to-end is merge-and-observe**: a same-repo PR (this one) runs the head workflow but by definition can't exercise the *fork* path. The fork publish + sticky can only be proven by an actual fork PR after merge. The guards, gates, and no-op paths are statically validated; the live fork flow is not.

Closes #386


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/breezy-bays-labs/crap-rs/pull/399">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->