### PR TITLE
test(ci): #328 — Playwright DOM validation for the unified HTML smoke

### DIFF
--- a/.github/actions/scorecard/README.md
+++ b/.github/actions/scorecard/README.md
@@ -491,6 +491,26 @@ silently produce a mangled combined view. Keep `crap4rs` and
 `crap4ts` reasonably up-to-date; major version bumps are documented
 in each crate's CHANGELOG.
 
+#### Interactive validation (the canonical end-to-end surface)
+
+The unified HTML report's two-axis (Language × View) switcher is
+validated end-to-end on every PR by the quick-start smoke, at two
+levels:
+
+| Gate | Level | Asserts |
+|------|-------|---------|
+| `Gate (i)` | markup (grep) | ≥ 3 `<nav class="tabs">` View navs; Delta tabs enabled/disabled per the baseline-fetch outcome |
+| `Gate (j)` | behavior (Playwright) | the report's JavaScript actually works in a headless browser — Language buttons swap panels, View tabs swap tab-panels, the `#<lang>:<view>` hash router tracks state, and a disabled Delta tab is a visible-but-no-op with its explanatory tooltip |
+
+`Gate (j)` (crap-rs#328) is the **canonical end-to-end interactive
+validation surface**. It exists because grep-level checks and
+`Given`-based BDD scenarios can both pass while the rendered page is
+broken — PR #327's artifact once shipped with zero interactive markup.
+The Playwright harness and the exact assertions live in
+[`tests/e2e/README.md`](../../../tests/e2e/README.md); both gates run
+against the same on-disk `unified-html-path` the action surfaces, so
+there is no artifact re-download.
+
 ### Aggregator pattern — `comment-mode: none` + `html-report: true`
 
 The action still uploads both artifacts and surfaces their URLs as

--- a/.github/workflows/quick-start-smoke.yml
+++ b/.github/workflows/quick-start-smoke.yml
@@ -532,3 +532,29 @@ jobs:
             fi
             echo "unified HTML carries ${NAVS} View navs and ${DISABLED} disabled Delta tabs ok (bootstrap fallback)"
           fi
+
+      # Gate (j) — Playwright DOM validation of the unified HTML (crap-rs#328).
+      # Gate (i) above grep-asserts the interactive MARKUP is present; this
+      # loads the SAME rendered file in a headless browser and asserts the
+      # JAVASCRIPT actually works — Language buttons swap the visible panel,
+      # View tabs swap the visible tab-panel, and the URL hash tracks the
+      # two-axis `#<lang>:<view>` state. A grep can't catch a broken click
+      # handler or a regressed hash router; this can. (Origin: PR #327
+      # review found the rendered artifact had ZERO interactive nav markup
+      # despite the feature being "implemented" — the Given-based BDD
+      # scenarios passed anyway. This is the end-to-end net for that class.)
+      # Runs against steps.crap.outputs.unified-html-path — the same on-disk
+      # file Gate (i) checks, no artifact re-download. See tests/e2e/README.md.
+      - name: Set up Node for Playwright (crap-rs#328)
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0 # zizmor: ignore[cache-poisoning]
+        with:
+          node-version: '24'
+      - name: Gate (j) — Playwright DOM validation of unified HTML
+        env:
+          HTML_PATH: ${{ steps.crap.outputs.unified-html-path }}
+        run: |
+          set -euo pipefail
+          cd tests/e2e
+          npm ci
+          npx playwright install --with-deps chromium
+          node validate-unified-html.mjs "$HTML_PATH"

--- a/tests/e2e/.gitignore
+++ b/tests/e2e/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,63 @@
+# End-to-end DOM validation — unified HTML report
+
+`validate-unified-html.mjs` loads the rendered **unified multi-language
+HTML scorecard** in a headless Chromium (via Playwright) and asserts that
+its JavaScript interactivity actually works — not just that the markup is
+present. It is the mechanical end-to-end net for the class of bug PR #327
+surfaced: the rendered artifact once shipped with *zero* interactive nav
+markup despite the feature being "implemented", and the `Given`-based BDD
+scenarios passed anyway because nothing ever loaded the page.
+
+This complements — does not replace — the cheaper grep-level check
+(`Gate (i)` in `.github/workflows/quick-start-smoke.yml`), which asserts
+the interactive *markup* is present. This goes one level deeper and
+asserts the *behavior*.
+
+## What it asserts
+
+Against the report's two-axis (Language × View) switcher:
+
+- ≥ 3 `nav.tabs` View navs (Combined + one per language).
+- Default load resolves to `#combined:current` with the Combined panel active.
+- The active panel's Delta View tab is genuinely **visible** (catches the
+  "markup present but hidden" regression).
+- **Enabled-Delta** (a baseline was supplied): clicking the Delta tab
+  activates the Delta tab-panel and the hash view axis becomes `:delta`.
+- **Disabled-Delta** (no baseline): the tab carries the
+  `no baselines provided …` tooltip, and a click is a no-op (the view
+  stays Current — the handler's `disabled` guard holds).
+- Clicking a non-Combined Language button activates its panel, deactivates
+  Combined, and updates the hash language axis (`#<lang>:…`).
+
+Both Delta worlds are exercised because the smoke runs in `run-mode:
+both` (enabled Delta) when the baseline envelope fetch succeeds and
+`run-mode: full` (disabled Delta) on the bootstrap-window fallback.
+
+## How interactions are driven
+
+Clicks use `locator.dispatchEvent('click')` rather than Playwright's
+actionable `.click()`. The report's handlers listen for the `click`
+event, so dispatching it tests exactly the handler logic; and on a
+synthetic `file://` page Playwright's visibility/stability heuristics are
+flaky on CSS-transitioned tab buttons (and would refuse to click a
+`disabled` Delta tab — yet asserting the disabled tab is a no-op is the
+whole point). Visibility, the "hidden markup" regression class, is
+asserted explicitly with `isVisible()`.
+
+## Running locally
+
+```bash
+cd tests/e2e
+npm ci
+npx playwright install chromium
+# Render a unified HTML first (or extract one of the html_multi snapshots):
+node validate-unified-html.mjs /path/to/crap-scorecard-unified.html
+```
+
+Exit 0 on success; exit 1 with `::error::` annotations on any failure.
+
+## CI
+
+`Gate (j)` in `quick-start-smoke.yml` runs this against
+`steps.crap.outputs.unified-html-path` — the same on-disk file `Gate (i)`
+checks — so it self-verifies on every PR with no artifact re-download.

--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -1,0 +1,59 @@
+{
+  "name": "crap-rs-e2e-html",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "crap-rs-e2e-html",
+      "version": "0.0.0",
+      "dependencies": {
+        "playwright": "^1.50.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "crap-rs-e2e-html",
+  "version": "0.0.0",
+  "private": true,
+  "description": "End-to-end DOM validation of the crap-rs unified multi-language HTML report (crap-rs#328). Not published.",
+  "type": "module",
+  "scripts": {
+    "validate": "node validate-unified-html.mjs"
+  },
+  "dependencies": {
+    "playwright": "^1.50.0"
+  }
+}

--- a/tests/e2e/validate-unified-html.mjs
+++ b/tests/e2e/validate-unified-html.mjs
@@ -87,38 +87,46 @@ try {
   const activeDelta = page.locator(
     '.lang-panel[data-active] .tabs .tab[data-tab="delta"]',
   );
-  check((await activeDelta.count()) >= 1, "active panel exposes a Delta View tab");
-  check(await activeDelta.first().isVisible(), "Delta View tab is actually visible (not hidden markup)");
-  const deltaDisabled = (await activeDelta.first().getAttribute("disabled")) !== null;
-  if (!deltaDisabled) {
-    await activeDelta.first().dispatchEvent("click");
-    check(
-      (await page
-        .locator('.lang-panel[data-active] .tab-panel[data-tab="delta"][data-active]')
-        .count()) === 1,
-      "clicking the enabled Delta tab activates the Delta tab-panel",
-    );
-    check(
-      page.url().includes(":delta"),
-      `hash view axis reflects :delta after click; got ${page.url().split("#")[1] || "<none>"}`,
-    );
-    // Reset to a clean View before the Language assertion.
-    await page
-      .locator('.lang-panel[data-active] .tabs .tab[data-tab="current"]')
-      .dispatchEvent("click");
-  } else {
-    const title = (await activeDelta.first().getAttribute("title")) || "";
-    check(
-      title.includes("no baselines provided"),
-      `disabled Delta tab carries the no-baseline tooltip; got "${title}"`,
-    );
-    await activeDelta.first().dispatchEvent("click");
-    check(
-      (await page
-        .locator('.lang-panel[data-active] .tab-panel[data-tab="current"][data-active]')
-        .count()) === 1,
-      "clicking a disabled Delta tab is a no-op (stays on Current)",
-    );
+  // Resolve the count ONCE and guard every following operation on it. A
+  // bare `.first().getAttribute()`/`.dispatchEvent()` on an empty locator
+  // would auto-wait the full 30s timeout and throw an opaque TimeoutError
+  // instead of failing fast with the assertion below (gemini catch).
+  const deltaCount = await activeDelta.count();
+  check(deltaCount >= 1, "active panel exposes a Delta View tab");
+  if (deltaCount >= 1) {
+    const firstDelta = activeDelta.first();
+    check(await firstDelta.isVisible(), "Delta View tab is actually visible (not hidden markup)");
+    const deltaDisabled = (await firstDelta.getAttribute("disabled")) !== null;
+    if (!deltaDisabled) {
+      await firstDelta.dispatchEvent("click");
+      check(
+        (await page
+          .locator('.lang-panel[data-active] .tab-panel[data-tab="delta"][data-active]')
+          .count()) === 1,
+        "clicking the enabled Delta tab activates the Delta tab-panel",
+      );
+      check(
+        page.url().includes(":delta"),
+        `hash view axis reflects :delta after click; got ${page.url().split("#")[1] || "<none>"}`,
+      );
+      // Reset to a clean View before the Language assertion.
+      await page
+        .locator('.lang-panel[data-active] .tabs .tab[data-tab="current"]')
+        .dispatchEvent("click");
+    } else {
+      const title = (await firstDelta.getAttribute("title")) || "";
+      check(
+        title.includes("no baselines provided"),
+        `disabled Delta tab carries the no-baseline tooltip; got "${title}"`,
+      );
+      await firstDelta.dispatchEvent("click");
+      check(
+        (await page
+          .locator('.lang-panel[data-active] .tab-panel[data-tab="current"][data-active]')
+          .count()) === 1,
+        "clicking a disabled Delta tab is a no-op (stays on Current)",
+      );
+    }
   }
 
   // 4) Language axis: the first non-Combined Language button. Clicking it

--- a/tests/e2e/validate-unified-html.mjs
+++ b/tests/e2e/validate-unified-html.mjs
@@ -1,0 +1,161 @@
+// End-to-end DOM validation of the crap-rs unified multi-language HTML
+// report (crap-rs#328). The quick-start smoke already grep-asserts that
+// the interactive MARKUP is present (`<nav class="tabs">` count, disabled
+// Delta attributes). This goes one level deeper: it loads the rendered
+// report in a real headless browser and asserts the JAVASCRIPT actually
+// works — clicking a Language button swaps the visible panel, clicking a
+// View tab swaps the visible tab-panel, and the URL hash reflects the
+// two-axis `#<lang>:<view>` state. A grep can't catch a broken event
+// handler or a regressed hash router; this can. (Origin: PR #327 review
+// found the rendered artifact had ZERO interactive nav markup despite the
+// feature being "implemented" — the Given-based BDD scenarios passed
+// anyway. This is the mechanical end-to-end net for that class of bug.)
+//
+// Usage: node validate-unified-html.mjs <path-to-unified-html>
+// Exits 0 on success, 1 (with ::error:: annotations) on any failure.
+
+import { chromium } from "playwright";
+import { pathToFileURL } from "node:url";
+import { existsSync, statSync } from "node:fs";
+
+const htmlPath = process.argv[2];
+if (!htmlPath || !existsSync(htmlPath) || statSync(htmlPath).size === 0) {
+  console.error(
+    `::error::validate-unified-html: missing or empty HTML path: ${htmlPath || "<unset>"}`,
+  );
+  process.exit(1);
+}
+
+const failures = [];
+const check = (cond, msg) => {
+  if (cond) {
+    console.log(`  ok: ${msg}`);
+  } else {
+    failures.push(msg);
+    console.error(`::error::unified HTML interactivity: ${msg}`);
+  }
+};
+
+const browser = await chromium.launch();
+try {
+  const page = await browser.newPage();
+  // Surface page console errors (a thrown handler would otherwise be silent).
+  page.on("pageerror", (err) =>
+    failures.push(`page threw: ${err.message}`),
+  );
+  await page.goto(pathToFileURL(htmlPath).href);
+
+  // The inline boot script sets the default hash via history.replaceState
+  // on load; wait for it so we never race the router.
+  await page
+    .waitForFunction(() => location.hash === "#combined:current", null, {
+      timeout: 5000,
+    })
+    .catch(() => {
+      /* asserted explicitly below for a clear message */
+    });
+
+  // 1) At least 3 View-axis navs: Combined + one per language (rust, ts).
+  const navCount = await page.locator("nav.tabs").count();
+  check(navCount >= 3, `>=3 nav.tabs present (Combined + per-language); got ${navCount}`);
+
+  // 2) Default two-axis state on first load: #combined:current, with the
+  //    Combined language panel active.
+  check(
+    page.url().endsWith("#combined:current"),
+    `default hash is #combined:current; got ${page.url().split("#")[1] ? "#" + page.url().split("#")[1] : "<none>"}`,
+  );
+  check(
+    (await page.locator('.lang-panel[data-lang="combined"][data-active]').count()) === 1,
+    "Combined language panel is active on load",
+  );
+
+  // Interactions are driven with dispatchEvent('click'), which fires the
+  // exact `click` event the report's handlers listen for. We deliberately
+  // avoid Playwright's actionable .click(): on a synthetic file:// page its
+  // visibility/stability heuristics are flaky on these CSS-transitioned
+  // tab buttons, and they would ALSO refuse to click a `disabled` Delta
+  // tab — but asserting the disabled tab is a no-op is exactly what we
+  // need. Visibility (the "markup present but hidden" regression class
+  // from PR #327) is asserted explicitly via isVisible() instead.
+
+  // 3) View axis: the active panel's Delta tab. Two valid worlds:
+  //    - baseline present → Delta enabled → click switches the visible
+  //      tab-panel to delta and the hash view becomes :delta.
+  //    - no baseline      → Delta disabled → it carries the explanatory
+  //      tooltip and its handler guard makes a click a no-op (stays current).
+  const activeDelta = page.locator(
+    '.lang-panel[data-active] .tabs .tab[data-tab="delta"]',
+  );
+  check((await activeDelta.count()) >= 1, "active panel exposes a Delta View tab");
+  check(await activeDelta.first().isVisible(), "Delta View tab is actually visible (not hidden markup)");
+  const deltaDisabled = (await activeDelta.first().getAttribute("disabled")) !== null;
+  if (!deltaDisabled) {
+    await activeDelta.first().dispatchEvent("click");
+    check(
+      (await page
+        .locator('.lang-panel[data-active] .tab-panel[data-tab="delta"][data-active]')
+        .count()) === 1,
+      "clicking the enabled Delta tab activates the Delta tab-panel",
+    );
+    check(
+      page.url().includes(":delta"),
+      `hash view axis reflects :delta after click; got ${page.url().split("#")[1] || "<none>"}`,
+    );
+    // Reset to a clean View before the Language assertion.
+    await page
+      .locator('.lang-panel[data-active] .tabs .tab[data-tab="current"]')
+      .dispatchEvent("click");
+  } else {
+    const title = (await activeDelta.first().getAttribute("title")) || "";
+    check(
+      title.includes("no baselines provided"),
+      `disabled Delta tab carries the no-baseline tooltip; got "${title}"`,
+    );
+    await activeDelta.first().dispatchEvent("click");
+    check(
+      (await page
+        .locator('.lang-panel[data-active] .tab-panel[data-tab="current"][data-active]')
+        .count()) === 1,
+      "clicking a disabled Delta tab is a no-op (stays on Current)",
+    );
+  }
+
+  // 4) Language axis: the first non-Combined Language button. Clicking it
+  //    activates its panel, deactivates Combined, and updates the hash
+  //    language axis.
+  const otherLangKey = await page.evaluate(() => {
+    const btns = Array.from(
+      document.querySelectorAll("[data-multi-lang] .lang-nav [data-lang]"),
+    ).map((b) => b.dataset.lang);
+    return btns.find((k) => k && k !== "combined") || null;
+  });
+  check(otherLangKey !== null, "report exposes at least one non-Combined Language button");
+  if (otherLangKey) {
+    const langBtn = page.locator(
+      `[data-multi-lang] .lang-nav [data-lang="${otherLangKey}"]`,
+    );
+    check(await langBtn.isVisible(), `${otherLangKey} Language button is actually visible`);
+    await langBtn.dispatchEvent("click");
+    check(
+      (await page.locator(`.lang-panel[data-lang="${otherLangKey}"][data-active]`).count()) === 1,
+      `clicking the ${otherLangKey} Language button activates its panel`,
+    );
+    check(
+      (await page.locator('.lang-panel[data-lang="combined"][data-active]').count()) === 0,
+      "Combined panel deactivates after switching Language",
+    );
+    check(
+      page.url().includes(`#${otherLangKey}:`),
+      `hash language axis reflects #${otherLangKey}: after click; got ${page.url().split("#")[1] || "<none>"}`,
+    );
+  }
+} finally {
+  await browser.close();
+}
+
+if (failures.length > 0) {
+  console.error(`\nunified HTML interactive validation FAILED (${failures.length} issue(s))`);
+  process.exit(1);
+}
+console.log("\nunified HTML interactive validation passed");


### PR DESCRIPTION
## Summary

Adds **Gate (j)** to the quick-start smoke: Playwright DOM validation of the unified multi-language HTML report. The existing Gate (i) grep-asserts the interactive *markup* is present; this loads the **same** rendered file in a headless Chromium and asserts the *JavaScript behavior*:

- ≥ 3 `nav.tabs` View navs; default load resolves to `#combined:current` with the Combined panel active.
- The active panel's Delta tab is genuinely **visible** (catches "markup present but hidden").
- **Enabled Delta** (baseline present): clicking switches the Delta tab-panel and the hash becomes `:delta`.
- **Disabled Delta** (no baseline): the tab carries the `no baselines provided …` tooltip and a click is a no-op (Current stays active).
- Clicking a non-Combined Language button swaps the active panel, deactivates Combined, and updates the `#<lang>:` hash.

## Why

PR #327 review found the rendered artifact had **zero** interactive nav markup despite the feature being "implemented" — the `Given`-based BDD scenarios passed anyway because nothing ever loaded the page. A grep can't catch a broken click handler or a regressed hash router; a real browser can.

## Design notes

- **Standalone `tests/e2e` harness** (Playwright 1.60, pinned + lockfile; `node_modules` gitignored). No new fixture plumbing — runs against `steps.crap.outputs.unified-html-path`, the same on-disk file Gate (i) checks.
- **Self-verifying:** the smoke is `pull_request`-triggered, so Gate (j) runs against this PR's live-rendered examples HTML.
- Interactions use `dispatchEvent('click')` (fires the exact event the handlers listen for) rather than actionable `.click()`, which is flaky on synthetic `file://` pages and refuses to click `disabled` elements — yet asserting the disabled tab is a no-op is the point. Visibility is asserted separately via `isVisible()`.
- Verified locally against **both** rendered snapshot fixtures (enabled-Delta `with_baselines`, disabled-Delta plain) and the missing-file guard before pushing.

Docs: `tests/e2e/README.md` + a new "Interactive validation" section in the action README.

Closes #328


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/breezy-bays-labs/crap-rs/pull/402">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->