### PR TITLE
docs: adopt org Testing Strategy — crap4rs testing overlay

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -4,15 +4,41 @@ paths:
   - "**/*test*"
 ---
 
-# Testing
+# Testing — crap4rs overlay
 
-When working with tests:
+crap4rs's thin overlay on the org **Testing Strategy**
+(`~/Github/ops/standards/testing-strategy.md`; meta-principles are always
+injected via `~/.claude/rules/testing-framework.md`). The canonical doc says
+*which level and why*; this file says *which tool*. Apply the **Boundary
+Rule**: test each behavior once, at the lowest level that fully captures it;
+a `.feature` scenario earns its place only if it is a product-level
+**contract** (a CLI flag's observable effect, an output format's shape, a
+gate's pass/fail, config discovery/precedence, an end-to-end result).
+Parser/matching/formula edge cases are implementation details — they belong
+in unit/property/fuzz, not the `.feature` corpus.
 
-1. **TDD** — write tests before implementation for domain and adapter code.
-2. **Test runner** — `cargo nextest run` preferred, `cargo test` as fallback.
-3. **Fixtures** — test fixtures live in `tests/fixtures/`. Use real `.rs` files for complexity and real LCOV files for coverage.
-4. **Golden-file tests** — use `insta` for snapshot testing of analysis output (JSON format).
-5. **Property tests** — use `proptest` for CRAP formula invariants. Reference values from crap4ts.
-6. **No mocking adapters in integration tests** — use the real adapter with fixture files. Only mock I/O boundaries.
-7. **Assert behavior, not implementation** — test `qualified_name` and `complexity` values, not internal AST traversal details.
-8. **Self-referential test** — crap4rs should be able to analyze its own source code as an integration test.
+## crap4rs tools by level
+
+| Level | Tool | Notes |
+|-------|------|-------|
+| Unit | `cargo nextest` | domain + adapter `#[test]` |
+| Property | `proptest` | CRAP formula, LCOV parser, line-range matching, walker invariants. Regression files in `proptest-regressions/` are **committed**, never gitignored |
+| **Fuzz (Q4)** | `cargo-fuzz` / `bolero` — **planned** | the LCOV/Istanbul parsers ingest untrusted input; no fuzz target yet |
+| Integration | `cargo nextest` shelling the built binary against real fixtures | real `.rs` for complexity, real LCOV for coverage; no adapter mocking |
+| Acceptance (BDD) | `cucumber-rs` | `tests/features/*.feature` + `*_cucumber.rs`; hygiene enforced by `bdd-tracked-lint.py` — see AGENTS.md "BDD hygiene" |
+| E2E / smoke | the composite scorecard action; Playwright DOM validation of the unified HTML | CI-only |
+| Coverage | `cargo llvm-cov` | |
+| Risk (CRAP) | `crap4rs` self-gate — strict-8 `scorecard-production` | dogfoods its own analyzer |
+| Mutation | `cargo-mutants` | dual-file surface (`view.rs` per-PR, walker per-merge) + `mutants-skip-lint.py` guard-the-guard |
+| Fitness functions | `clippy -D warnings`, the four-layer `ast-purity` job, `deny.toml`, dependency direction | |
+| Performance | — *(aspirational)* | no benchmarks yet |
+
+## crap4rs rules
+
+1. **TDD** — tests before implementation for domain + adapter code.
+2. **Domain purity** — `domain/`/`ports/` import no external crates and do no I/O.
+3. **Fixtures over mocks** — real `.rs` + real LCOV; only mock I/O boundaries.
+4. **Golden-file** — `insta` for wire/report snapshots; `cargo insta accept` only after verifying the drift is span/coverage-only.
+5. **Assert behavior, not implementation** — `qualified_name`/`complexity` values, not AST-traversal internals.
+6. **Self-referential** — crap4rs analyzes its own source as an integration test.
+7. **Boundary Rule** — keep `.feature` for product contracts; push engine internals down to unit/property/fuzz.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 ## Repo Context
 
 - Architecture: hexagonal (ports & adapters) — `domain/` → `ports/` → `adapters/` → `core/` → `cli/`. Never import "inward."
-- Testing: `cargo nextest run` for tests, `cargo clippy -- -D warnings` for lints, `cargo fmt --check` for formatting. Quick verify: all three chained.
+- Testing: `cargo nextest run` for tests, `cargo clippy -- -D warnings` for lints, `cargo fmt --check` for formatting. Quick verify: all three chained. The org **Testing Strategy** (`~/Github/ops/standards/testing-strategy.md` — the three axes, the Boundary Rule, the quadrants, the five-leg health dashboard) is canonical; crap4rs's per-level tool-map + the Boundary Rule are in `.claude/rules/testing.md`.
 - Property tests use `proptest` — regression files in `proptest-regressions/` are committed to git, never gitignored.
 - Safety: do not push directly to `main`, always branch + PR. Do not modify `.github/workflows/*` unless the task clearly requires CI changes.
 - The `domain/` and `ports/` layers stay language-agnostic (no `syn`/`oxc`, no LCOV/Istanbul types) — they live in the shared `crap-core` library that every adapter links (`crap4rs` via `syn`, `crap4ts` via `oxc`); `crap-core` also ships the `crap-render` binary. Purity is enforced by the four-layer `ast-purity` CI job + `deny.toml`; the only allowed proc-macro-chain derives are `serde`, `thiserror`, and `askama` (the `Template` derive backing the HTML/markdown reporters).


### PR DESCRIPTION
Propagates the new org **Testing Strategy** (`ops/standards/testing-strategy.md`, published today) into crap4rs as a thin per-project overlay.

- **`.claude/rules/testing.md`** — now a per-level **tool-map** (unit→`nextest`, property→`proptest`, fuzz→`cargo-fuzz`/`bolero` *planned*, integration, acceptance→`cucumber-rs`, E2E→action+Playwright, coverage→`llvm-cov`, risk→`crap4rs` self-gate, mutation→`cargo-mutants`, fitness→`clippy`/`ast-purity`/`deny.toml`, perf *aspirational*) plus the **Boundary Rule**: keep `.feature` for product contracts; push parser/matching/formula edge cases down to unit/property/fuzz.
- **`AGENTS.md`** — pointer to the canonical doc.

Doc-only; no code or CI behavior changes. Sets up the curated BDD pass (apply the Boundary Rule to the corpus) + the Q4 fuzz epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/breezy-bays-labs/crap-rs/pull/403">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated testing guidance with a clearer, structured overview of the test strategy and the recommended tools for each testing level.
  * Added a boundary rule that separates product-facing scenarios from lower-level implementation checks.
  * Refined repo testing instructions to point to the canonical strategy reference while keeping the existing command flow intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->