### PR TITLE
test(core): curate multi_root_src.feature — wire identity-resolution CLI contracts, keep in-process coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,7 @@ jobs:
           --test sarif_reporter_cucumber
           --test saved_view_presets_cucumber
           --test format_advice_cucumber
+          --test multi_root_cucumber
           --test github_annotations_cucumber
           --test multi_lang_html_cucumber
 

--- a/crates/crap4rs/Cargo.toml
+++ b/crates/crap4rs/Cargo.toml
@@ -141,6 +141,10 @@ name = "format_advice_cucumber"
 harness = false
 
 [[test]]
+name = "multi_root_cucumber"
+harness = false
+
+[[test]]
 name = "cli_init_cucumber"
 harness = false
 

--- a/crates/crap4rs/tests/features/multi_root_src.feature
+++ b/crates/crap4rs/tests/features/multi_root_src.feature
@@ -6,92 +6,54 @@ Feature: Multi-root source analysis — one scorecard across several source root
   unioned into one scorecard, joined against a single shared coverage
   file.
 
-  # Vocabulary used in scenarios:
-  #   "the operator"      — the human or script invoking crap4rs
-  #   "the JSON envelope" — terminal stdout when --format json
-  #   "the run identity base" — the path every function's `file_path`
-  #                         is relativized to. Single-root runs use the
-  #                         src root (back-compat); multi-root runs use
-  #                         the git toplevel so paths stay globally
-  #                         unique across roots.
-  #
-  # Design contract (see shaping.md L2/L3a + adr-multi-root-identity-base):
-  #   The identity base is decided ONCE from the root count and applied
-  #   to BOTH function identity and coverage-SF normalization. A run is
-  #   either single-root/src-relative OR multi-root/toplevel-relative —
-  #   the two regimes never mix within one run.
-  #
-  # Self-CRAP regression invariant: the multi-root code path must not
-  # introduce any crap-core/crap4rs/crap4ts function with CRAP above 15;
-  # the production scorecard gate enforces this.
+  This file pins the CLI-process contracts the running binary uniquely
+  captures: that `prepare_pipeline` resolves the run identity base from
+  the `--src` root COUNT (one root ⇒ src-relative, byte-compatible with
+  the pre-multi-root path; many roots ⇒ git-toplevel-relative so paths
+  stay globally unique), and that multi-root outside a git work tree is a
+  hard error rather than a silent basename strip. The union/dedup
+  invariant, the IdentityBase consumption, and the coverage-join
+  no-bleed contract are owned IN-PROCESS by `multi_root_integration.rs`
+  (it constructs `core::identity::IdentityBase` directly and calls
+  `analyze()` at the library boundary — the sole lib coverage of that
+  path, so it stays) plus the union proptest; the scorecard action's
+  comment-preamble / comment-header surfaces are owned at the CI layer
+  (`.github/actions/scorecard/action.yml` + the dogfood smoke jobs), not
+  by the binary. So those cases live there, not here (see `AGENTS.md`
+  § BDD hygiene). Step defs in `tests/multi_root_cucumber.rs`.
 
-  # ── union semantics ────────────────────────────────────────────────
+  # ── union semantics (end-to-end via the CLI) ───────────────────────
 
-  @unwired
+  @wired
   Scenario: Multiple --src roots union their functions into one report
-    # tracked: crap-rs#169 — behavior covered by proptest + multi_root_integration.rs; cucumber-harness wiring deferred to the BDD umbrella
-    When the operator runs `crap4rs --coverage lcov.info --src crate-a/src --src crate-b/src --format json`
-    Then the JSON envelope includes every function discovered under `crate-a/src`
-    And the JSON envelope includes every function discovered under `crate-b/src`
-    And the summary `total_functions` equals the count across both roots
+    Given a git work tree with source roots crate-a/src and crate-b/src
+    When the operator runs `crap4rs --coverage lcov.info --src crate-a/src --src crate-b/src --threshold 100 --no-gitignore --no-fail --format json`
+    Then view.shown has 4 functions
+    And view.shown contains a function keyed "crate-a/src/lib.rs"
+    And view.shown contains a function keyed "crate-b/src/lib.rs"
 
-  @unwired
-  Scenario: Union is order-independent and deduplicates overlapping roots
-    # tracked: crap-rs#169 — behavior covered by proptest + multi_root_integration.rs; cucumber-harness wiring deferred to the BDD umbrella
-    When the operator analyzes roots `[A, B]` and separately `[B, A]`
-    Then both runs report the identical function set
-    And a function discovered under two overlapping roots appears exactly once
+  # ── identity base resolved from the --src root count ────────────────
 
-  # ── identity base (the α' contract) ────────────────────────────────
+  @wired
+  Scenario: A single --src root yields src-relative identity (back-compat)
+    Given a git work tree with source roots crate-a/src and crate-b/src
+    When the operator runs `crap4rs --coverage lcov.info --src crate-a/src --threshold 100 --no-gitignore --no-fail --format json`
+    Then view.shown contains a function keyed "lib.rs"
+    And every view.shown function key is src-relative
 
-  @unwired
-  Scenario: A single --src root yields src-relative identity (byte-identical back-compat)
-    # tracked: crap-rs#169 — behavior covered by proptest + multi_root_integration.rs; cucumber-harness wiring deferred to the BDD umbrella
-    When the operator runs `crap4rs --coverage lcov.info --src crate-a/src --format json`
-    Then each function `file_path` is relative to `crate-a/src` (e.g. `lib.rs`)
-    And the JSON envelope is byte-identical to the pre-multi-root single-root output
+  @wired
+  Scenario: Multiple --src roots yield git-toplevel-relative identity with distinct keys
+    Given a git work tree with source roots crate-a/src and crate-b/src
+    When the operator runs `crap4rs --coverage lcov.info --src crate-a/src --src crate-b/src --threshold 100 --no-gitignore --no-fail --format json`
+    Then view.shown contains a function keyed "crate-a/src/adapters/mod.rs"
+    And view.shown contains a function keyed "crate-b/src/adapters/mod.rs"
 
-  @unwired
-  Scenario: Multiple --src roots yield git-toplevel-relative identity
-    # tracked: crap-rs#169 — behavior covered by proptest + multi_root_integration.rs; cucumber-harness wiring deferred to the BDD umbrella
-    When the operator runs `crap4rs --coverage lcov.info --src crate-a/src --src crate-b/src --format json`
-    Then each function `file_path` is relative to the git toplevel (e.g. `crate-a/src/lib.rs`)
-    And two same-named files in different roots have distinct `file_path` keys
+  # ── hard error: multi-root requires a resolvable git toplevel ───────
 
-  # ── coverage join under multi-root (no collision, no bleed) ─────────
-
-  @unwired
-  Scenario: Same-named files in different roots do not bleed coverage
-    # tracked: crap-rs#169 — behavior covered by proptest + multi_root_integration.rs; cucumber-harness wiring deferred to the BDD umbrella
-    Given `crate-a/src/adapters/mod.rs` and `crate-b/src/adapters/mod.rs` both exist
-    And the shared coverage file covers both with different hit counts
-    When the operator analyzes both roots in one run
-    Then each `adapters/mod.rs` function is joined to its own root's coverage
-    And neither file's coverage is attributed to the other
-
-  @unwired
-  Scenario: Multi-root with an unresolvable git toplevel is a hard error
-    # tracked: crap-rs#169 — behavior covered by proptest + multi_root_integration.rs; cucumber-harness wiring deferred to the BDD umbrella
-    Given the operator runs outside any git working tree
-    When the operator passes more than one --src root
-    Then crap4rs exits with an actionable error naming the unresolvable toplevel
-    And it does NOT silently fall back to a basename strip
-
-  # ── scorecard action surfaces ──────────────────────────────────────
-
-  @unwired
-  Scenario: comment-preamble prepends caller markdown to the sticky comment
-    # tracked: crap-rs#169 — action-integration scenarios wire at the CI layer (BDD umbrella), not the cli harness
-    Given the scorecard action is invoked with a non-empty `comment-preamble`
-    When the action composes the sticky comment
-    Then the preamble markdown appears above the rendered scorecard body
-    And an empty `comment-preamble` produces a byte-identical comment to today
-
-  @unwired
-  Scenario: Production and examples scorecards post distinct, non-colliding comments
-    # tracked: crap-rs#169 — action-integration scenarios wire at the CI layer (BDD umbrella), not the cli harness
-    Given the production scorecard uses `comment-header: crap-scorecard-production`
-    And the examples scorecard uses `comment-header: crap-scorecard-quickstart-smoke`
-    When both run on the same pull request
-    Then two separate sticky comments are posted
-    And each carries its own preamble labeling production vs teaching sample
+  @wired
+  Scenario: Multi-root outside a git work tree is a hard error, not a basename strip
+    Given a non-git directory with source roots crate-a/src and crate-b/src
+    When the operator runs `crap4rs --coverage lcov.info --src crate-a/src --src crate-b/src --threshold 100 --no-gitignore --no-fail --format json`
+    Then the exit code is 2
+    And stderr contains "multi-root analysis requires a git work tree"
+    And stderr contains "not inside a git work tree"

--- a/crates/crap4rs/tests/multi_root_cucumber.rs
+++ b/crates/crap4rs/tests/multi_root_cucumber.rs
@@ -102,13 +102,18 @@ impl MultiRootWorld {
 }
 
 fn run_git(dir: &Path, args: &[&str]) {
-    let ok = Command::new("git")
+    let output = Command::new("git")
         .current_dir(dir)
         .args(args)
-        .status()
-        .unwrap_or_else(|e| panic!("failed to invoke git {args:?}: {e}"))
-        .success();
-    assert!(ok, "git {args:?} failed");
+        .output()
+        .unwrap_or_else(|e| panic!("failed to invoke git {args:?}: {e}"));
+    assert!(
+        output.status.success(),
+        "git {args:?} failed (exit {:?})\nstdout:\n{}\nstderr:\n{}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
 }
 
 /// Scaffold two crate-like roots that share a crate-internal relative path

--- a/crates/crap4rs/tests/multi_root_cucumber.rs
+++ b/crates/crap4rs/tests/multi_root_cucumber.rs
@@ -1,0 +1,248 @@
+//! Cucumber-rs runner for `@wired` scenarios in
+//! `tests/features/multi_root_src.feature` (issue #336 / repeatable `--src`).
+//!
+//! This harness pins the CLI-process contracts the running binary uniquely
+//! captures: that `prepare_pipeline` resolves the run identity base from the
+//! `--src` root COUNT (one root ⇒ src-relative, byte-compatible with the
+//! pre-multi-root path; many roots ⇒ git-toplevel-relative so same-named
+//! files in different roots stay distinct), and that multi-root outside a
+//! git work tree is a hard error rather than a silent basename strip.
+//!
+//! The union/dedup invariant, the `core::identity::IdentityBase`
+//! consumption, and the coverage-join no-bleed contract are owned IN-PROCESS
+//! by `multi_root_integration.rs` — it constructs `IdentityBase` directly
+//! and calls `analyze()` at the library boundary, the SOLE lib coverage of
+//! that path, so it stays (a `harness = false` cucumber runner is skipped by
+//! nextest and would contribute no coverage). The scorecard action's
+//! comment-preamble / comment-header surfaces are owned at the CI layer
+//! (`.github/actions/scorecard/action.yml` + the dogfood smoke jobs). So
+//! those cases live there, not here (see `AGENTS.md` § BDD hygiene).
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use cucumber::{World, given, then, when, writer};
+
+const BINARY: &str = env!("CARGO_BIN_EXE_crap4rs");
+
+/// Toplevel-relative LCOV covering both roots. Key assertions read the
+/// walker-derived `file_path`, which is independent of coverage overlap, so
+/// a single fixture serves the single-root scenario too (its src-relative
+/// keys simply don't join this toplevel-keyed coverage — irrelevant here).
+const LCOV: &str = "\
+SF:crate-a/src/lib.rs
+DA:1,1
+end_of_record
+SF:crate-b/src/lib.rs
+DA:1,1
+end_of_record
+SF:crate-a/src/adapters/mod.rs
+DA:1,1
+end_of_record
+SF:crate-b/src/adapters/mod.rs
+DA:1,0
+end_of_record
+";
+
+#[derive(Debug, Default, World)]
+struct MultiRootWorld {
+    project_dir: Option<PathBuf>,
+    _tempdir: Option<tempfile::TempDir>,
+    output: Option<Output>,
+}
+
+impl MultiRootWorld {
+    fn require_dir(&self) -> &Path {
+        self.project_dir
+            .as_deref()
+            .expect("scenario did not set up a project directory")
+    }
+
+    fn require_output(&self) -> &Output {
+        self.output
+            .as_ref()
+            .expect("scenario did not run the binary")
+    }
+
+    fn stdout(&self) -> String {
+        String::from_utf8_lossy(&self.require_output().stdout).into_owned()
+    }
+
+    fn stderr(&self) -> String {
+        String::from_utf8_lossy(&self.require_output().stderr).into_owned()
+    }
+
+    fn fail_context(&self) -> String {
+        let o = self.require_output();
+        format!(
+            "exit: {:?}\nstdout:\n{}\nstderr:\n{}",
+            o.status.code(),
+            self.stdout(),
+            self.stderr()
+        )
+    }
+
+    /// Every `view.shown[].scored.identity.file_path` key.
+    fn shown_keys(&self) -> Vec<String> {
+        let out = self.stdout();
+        let root: serde_json::Value = serde_json::from_str(&out)
+            .unwrap_or_else(|e| panic!("stdout was not valid JSON: {e}\n{}", self.fail_context()));
+        root["view"]["shown"]
+            .as_array()
+            .unwrap_or_else(|| panic!("view.shown is not an array\n{}", self.fail_context()))
+            .iter()
+            .map(|v| {
+                v["scored"]["identity"]["file_path"]
+                    .as_str()
+                    .expect("file_path is a string")
+                    .to_string()
+            })
+            .collect()
+    }
+}
+
+fn run_git(dir: &Path, args: &[&str]) {
+    let ok = Command::new("git")
+        .current_dir(dir)
+        .args(args)
+        .status()
+        .unwrap_or_else(|e| panic!("failed to invoke git {args:?}: {e}"))
+        .success();
+    assert!(ok, "git {args:?} failed");
+}
+
+/// Scaffold two crate-like roots that share a crate-internal relative path
+/// (`adapters/mod.rs`) plus distinct `lib.rs` files. `git` controls whether
+/// a git work tree is initialized (the hard-error scenario needs none).
+fn scaffold(git: bool) -> (PathBuf, tempfile::TempDir) {
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    let root = tmp.path().to_path_buf();
+    for (crate_name, lib_body, mod_body) in [
+        (
+            "crate-a",
+            "pub fn a_only(x: i32) -> i32 { if x > 0 { x } else { -x } }\n",
+            "pub fn shared_a() -> u8 { 1 }\n",
+        ),
+        (
+            "crate-b",
+            "pub fn b_only(y: i32) -> i32 { y * 2 }\n",
+            "pub fn shared_b() -> u8 { 2 }\n",
+        ),
+    ] {
+        let src = root.join(crate_name).join("src");
+        std::fs::create_dir_all(src.join("adapters")).expect("create src/adapters dir");
+        std::fs::write(src.join("lib.rs"), lib_body).expect("write lib.rs");
+        std::fs::write(src.join("adapters").join("mod.rs"), mod_body)
+            .expect("write adapters/mod.rs");
+    }
+    std::fs::write(root.join("lcov.info"), LCOV).expect("write lcov.info");
+    if git {
+        run_git(&root, &["init", "-q"]);
+        run_git(&root, &["config", "user.email", "t@t.t"]);
+        run_git(&root, &["config", "user.name", "t"]);
+    }
+    (root, tmp)
+}
+
+fn parse_args(cmd: &str) -> Vec<String> {
+    cmd.split_whitespace().skip(1).map(str::to_string).collect()
+}
+
+// ── Given steps ──────────────────────────────────────────────────────
+
+#[given("a git work tree with source roots crate-a/src and crate-b/src")]
+fn given_git(world: &mut MultiRootWorld) {
+    let (dir, tmp) = scaffold(true);
+    world.project_dir = Some(dir);
+    world._tempdir = Some(tmp);
+}
+
+#[given("a non-git directory with source roots crate-a/src and crate-b/src")]
+fn given_nongit(world: &mut MultiRootWorld) {
+    let (dir, tmp) = scaffold(false);
+    world.project_dir = Some(dir);
+    world._tempdir = Some(tmp);
+}
+
+// ── When step ────────────────────────────────────────────────────────
+
+#[when(regex = r#"^the operator runs `([^`]+)`$"#)]
+fn when_run(world: &mut MultiRootWorld, cmd: String) {
+    let args = parse_args(&cmd);
+    let output = Command::new(BINARY)
+        .current_dir(world.require_dir())
+        .args(&args)
+        .output()
+        .unwrap_or_else(|e| panic!("failed to invoke crap4rs binary at {BINARY:?}: {e}"));
+    world.output = Some(output);
+}
+
+// ── Then steps ───────────────────────────────────────────────────────
+
+#[then(regex = r"^view\.shown has (\d+) functions$")]
+fn then_shown_count(world: &mut MultiRootWorld, n: usize) {
+    let keys = world.shown_keys();
+    assert_eq!(
+        keys.len(),
+        n,
+        "expected {n} functions in view.shown, got {}: {keys:?}",
+        keys.len()
+    );
+}
+
+#[then(regex = r#"^view\.shown contains a function keyed "([^"]+)"$"#)]
+fn then_shown_contains_key(world: &mut MultiRootWorld, key: String) {
+    let keys = world.shown_keys();
+    assert!(
+        keys.contains(&key),
+        "view.shown has no function keyed {key:?}; keys: {keys:?}"
+    );
+}
+
+#[then("every view.shown function key is src-relative")]
+fn then_keys_src_relative(world: &mut MultiRootWorld) {
+    let keys = world.shown_keys();
+    assert!(!keys.is_empty(), "view.shown must not be empty");
+    for key in &keys {
+        assert!(
+            !key.starts_with("crate-"),
+            "single-root identity must be src-relative, but {key:?} carries a root prefix; keys: {keys:?}"
+        );
+    }
+}
+
+#[then(regex = r"^the exit code is (\d+)$")]
+fn then_exit_code(world: &mut MultiRootWorld, expected: i32) {
+    let actual = world
+        .require_output()
+        .status
+        .code()
+        .expect("process exited via signal");
+    assert_eq!(
+        actual,
+        expected,
+        "exit code mismatch — expected {expected}, got {actual}\n{}",
+        world.fail_context()
+    );
+}
+
+#[then(regex = r#"^stderr contains "([^"]+)"$"#)]
+fn then_stderr_contains(world: &mut MultiRootWorld, needle: String) {
+    assert!(
+        world.stderr().contains(&needle),
+        "stderr did not contain {needle:?}\n{}",
+        world.fail_context()
+    );
+}
+
+// ── Runner ──────────────────────────────────────────────────────────
+
+#[tokio::main]
+async fn main() {
+    MultiRootWorld::cucumber()
+        .with_writer(writer::Libtest::or_basic())
+        .filter_run_and_exit("tests/features/multi_root_src.feature", |_, _, scenario| {
+            scenario.tags.iter().any(|t| t == "wired")
+        })
+        .await;
+}

--- a/crates/crap4rs/tests/multi_root_cucumber.rs
+++ b/crates/crap4rs/tests/multi_root_cucumber.rs
@@ -210,8 +210,8 @@ fn then_keys_src_relative(world: &mut MultiRootWorld) {
     assert!(!keys.is_empty(), "view.shown must not be empty");
     for key in &keys {
         assert!(
-            !key.starts_with("crate-"),
-            "single-root identity must be src-relative, but {key:?} carries a root prefix; keys: {keys:?}"
+            !Path::new(key).is_absolute() && !key.starts_with("crate-"),
+            "single-root identity must be src-relative, but {key:?} is absolute or carries a root prefix; keys: {keys:?}"
         );
     }
 }


### PR DESCRIPTION
## Summary

Curated BDD pass, **group 13 of 14** (`multi_root_src`) — the final curate target. Wires the multi-root CLI-process contracts as cucumber while **keeping** `multi_root_integration.rs` as the in-process coverage layer (the diff_mode #415 shape).

- **WIRE 4** `@wired` CLI-process contracts in a new `multi_root_cucumber.rs` (git-fixture harness):
  - repeated `--src` unions both roots' functions into one report (`total` 4)
  - a single `--src` root yields **src-relative** identity keys (`lib.rs`) — byte-compatible back-compat
  - multiple `--src` roots yield **git-toplevel-relative** keys (`crate-a/src/lib.rs`) with distinct keys for same-named files
  - multi-root outside a git work tree is a **hard error** (exit 2, actionable message, never a silent basename strip)

  These pin what the binary uniquely captures: `prepare_pipeline` resolving the identity base from the `--src` root *count* + the hard-error path. The in-process integration constructs `IdentityBase` directly and never exercises that CLI resolution.

- **KEEP `multi_root_integration.rs`** — it constructs `core::identity::IdentityBase` directly and calls `analyze()` at the library boundary, the **sole lib coverage** of that path. A `harness = false` cucumber runner is nextest-skipped and contributes no coverage, so the integration stays. The two test different boundaries (CLI-process/`prepare_pipeline` vs library/`analyze`), not the same acceptance.

- **DELETE 4** scenarios owned elsewhere (no coverage loss):
  | Deleted | Owner |
  |---|---|
  | Union order-independence + dedup | `multi_root_integration::multi_root_union_is_order_independent` + the union proptest |
  | Same-named files don't bleed coverage | `multi_root_integration` (absolute + relative-SF no-bleed tests) |
  | comment-preamble prepends caller markdown | CI layer — `.github/actions/scorecard/action.yml` + dogfood smoke |
  | Production/examples scorecards post distinct comments | CI layer — `comment-header` in the scorecard jobs |

## Coverage safety

No test deleted, integration kept. Self-gate confirms unchanged:

```
Summary: 1681 functions | 0 above threshold (8) | PASS
```

## Gates (all green)

`cargo fmt --check` · `cargo +1.96.0 clippy --workspace --all-targets -D warnings` · `cargo nextest run --workspace --all-targets` (1339 passed — `multi_root_integration.rs` intact) · `cargo test --test multi_root_cucumber` (4 scenarios / 18 steps) · `bdd-tracked-lint.py` (217 scenarios, 3 deferred repo-wide) · `mutants-skip-lint.py` · `cargo +1.93 check` (MSRV) · `cargo doc -D warnings` · **strict-8 self-gate (0 above threshold)**.

This completes the curated BDD pass — 13 feature groups actioned; `github_annotations` is already at its honest ceiling (17 wired; the 2 remaining `@unwired` are genuine blocked deferrals — #283 needs syn-walker nested-module support, #284 is CLI-unreachable and owned by reporter units).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded integration test suite for multi-root source directory handling with updated behavior specifications.
  * Enhanced CI pipeline to include comprehensive multi-root functionality scenario coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->