### PR TITLE
ci(deps): bump sticky-pull-request-comment to v3.0.4 across both pins

### DIFF
--- a/.github/actions/scorecard/action.yml
+++ b/.github/actions/scorecard/action.yml
@@ -2127,7 +2127,7 @@ runs:
         && inputs.comment-mode == 'sticky'
         && github.event_name == 'pull_request'
         && steps.fork-handoff.outputs.dir == ''
-      uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+      uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
       with:
         header: ${{ inputs.comment-header }}
         message: ${{ steps.compose.outputs.message }}

--- a/.github/workflows/pages-publish-fork.yml
+++ b/.github/workflows/pages-publish-fork.yml
@@ -208,7 +208,7 @@ jobs:
       # the publish step composed (handoff body + hosted link).
       - name: Post production sticky with hosted link
         if: steps.publish.outputs.pr_number != ''
-        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         with:
           header: crap-scorecard-production
           number: ${{ steps.publish.outputs.pr_number }}


### PR DESCRIPTION
## Summary

Bumps `marocchino/sticky-pull-request-comment` **2.9.4 → 3.0.4** in **both** references so the repo runs one consistent major version of the action:

| File | before | after |
|---|---|---|
| `.github/workflows/pages-publish-fork.yml:211` | `…405 # v2.9.4` | `0ea0beb…231c0 # v3.0.4` |
| `.github/actions/scorecard/action.yml:2130` | `…405 # v2.9.4` | `0ea0beb…231c0 # v3.0.4` |

SHA verified via `gh api repos/marocchino/sticky-pull-request-comment/commits/v3.0.4` → `0ea0beb66eb9baf113663a64ec522f60e49231c0`.

## Why this PR instead of #423

Dependabot's #423 bumped **only** the workflow ref and left the composite action (`.github/actions/scorecard/action.yml`) at v2.9.4 — even though `dependabot.yml`'s own header says it tracks `.github/actions/*/action.yml`. No separate PR exists for the composite-action pin, so it would have **decayed silently**, defeating the supply-chain freshness loop. This consolidates both into one atomic, consistent major bump. **Supersedes #423** (will be closed in favor of this).

## Breaking-change review (major bump)

v3.0.0's only breaking change is the runtime: `using: node20` → `using: node24` (supported on GitHub runners). The v3.0.4 `action.yml` retains every input we use — `header`, `number`, `path`, `message` — unchanged; v3.0.3 even *adds* `number_force` additively. No call-site changes needed.

## Out of scope

The `@v2` reference in `.github/actions/scorecard/README.md:810` is a generic consumer usage example (not a SHA-pinned maintained ref), left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions dependencies to enhance CI/CD system reliability and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->