### PR TITLE
test(crap4rs): #429 — bolero fuzz harness + syn-walker target (Q4 walking skeleton)

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -23,7 +23,7 @@ in unit/property/fuzz, not the `.feature` corpus.
 |-------|------|-------|
 | Unit | `cargo nextest` | domain + adapter `#[test]` |
 | Property | `proptest` | CRAP formula, LCOV parser, line-range matching, walker invariants. Regression files in `proptest-regressions/` are **committed**, never gitignored |
-| **Fuzz (Q4)** | `cargo-fuzz` / `bolero` — **planned** | the LCOV/Istanbul parsers ingest untrusted input; no fuzz target yet |
+| **Fuzz (Q4)** | `bolero` (library) on **stable** via the nextest lane | `tests/fuzz_*/main.rs` `check!` targets run as ordinary tests (no nightly/sanitizer/`cargo-bolero` on the PR path): bounded-random discovery + an explicit replay test over the committed `corpus/`+`crashes/` seeds (the deterministic regression net — a crash + its fix land in the same PR, mirroring `proptest-regressions/`). In scope: syn walker, oxc walker, Istanbul parser. **LCOV deferred** — its `.*` panic-freedom is already proptested; residual `normalize_path` I/O seam tracked as a property-test follow-up. Deferred nightly `cargo bolero fuzz` cron adds coverage-guided libFuzzer+ASan depth (ADR-gated). See AGENTS.md + epic #428 |
 | Integration | `cargo nextest` shelling the built binary against real fixtures | real `.rs` for complexity, real LCOV for coverage; no adapter mocking |
 | Acceptance (BDD) | `cucumber-rs` | `tests/features/*.feature` + `*_cucumber.rs`; hygiene enforced by `bdd-tracked-lint.py` — see AGENTS.md "BDD hygiene" |
 | E2E / smoke | the composite scorecard action; Playwright DOM validation of the unified HTML | CI-only |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,13 @@ permissions:
 env:
   CARGO_TARGET_DIR: target
   CARGO_TERM_COLOR: always
+  # Determinism + speed knob for the bolero Q4 fuzz `check!` targets
+  # (`tests/fuzz_*`), which run on stable as ordinary tests in the
+  # `Test (*)` + `coverage` nextest lanes. Pins the bounded-random
+  # iteration count so PR runs are fast and reproducible in cost; the
+  # committed corpus/crashes seeds carry the deterministic regression
+  # weight (replayed explicitly by each target's replay test).
+  BOLERO_RANDOM_ITERATIONS: '1000'
   # Single source of truth for the smoke jobs' threshold input — both
   # `scorecard-smoke-rust` and `scorecard-smoke-ts` (and the preset
   # spot-check steps under `scorecard-smoke-rust`) consume this. The

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,6 +223,99 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "bolero"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ff44d278fc0062c95327087ed96b3d256906d1d8f579e534a3de8d6b386913a"
+dependencies = [
+ "bolero-afl",
+ "bolero-engine",
+ "bolero-generator",
+ "bolero-honggfuzz",
+ "bolero-kani",
+ "bolero-libfuzzer",
+ "cfg-if",
+ "rand",
+]
+
+[[package]]
+name = "bolero-afl"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9bf4cbd0bacf9356d3c7e5d9d088480f2076ba3c595c15ee9a6a378cdd7b297"
+dependencies = [
+ "bolero-engine",
+ "cc",
+]
+
+[[package]]
+name = "bolero-engine"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dca199170a7c92c669c1019f9219a316b66bcdcfa4b36cac5a460a4c1a851aba"
+dependencies = [
+ "anyhow",
+ "bolero-generator",
+ "lazy_static",
+ "pretty-hex",
+ "rand",
+ "rand_xoshiro",
+]
+
+[[package]]
+name = "bolero-generator"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98a5782f2650f80d533f58ec339c6dce4cc5428f9c2755894f98156f52af81f2"
+dependencies = [
+ "bolero-generator-derive",
+ "either",
+ "getrandom 0.3.4",
+ "rand_core",
+ "rand_xoshiro",
+]
+
+[[package]]
+name = "bolero-generator-derive"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a21a3b022507b9edd2050caf370d945e398c1a7c8455531220fa3968c45d29e"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "bolero-honggfuzz"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a118ef27295eddefadc6a99728ee698d1b18d2e80dc4777d21bee3385096ffd"
+dependencies = [
+ "bolero-engine",
+]
+
+[[package]]
+name = "bolero-kani"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852ea5784a9f3e68bfd302ca80b8b863bce140593eb5770fee6ab110899c28fc"
+dependencies = [
+ "bolero-engine",
+]
+
+[[package]]
+name = "bolero-libfuzzer"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "858dc57c11725c52662501fa79fdbc6f7050339a05ca1bf1e587add0fed40d62"
+dependencies = [
+ "bolero-engine",
+ "cc",
+]
+
+[[package]]
 name = "borrow-or-share"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -258,6 +351,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "cc"
+version = "1.2.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
 ]
 
 [[package]]
@@ -439,7 +542,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "toml",
- "toml_edit",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -457,6 +560,7 @@ version = "0.6.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "bolero",
  "clap",
  "clap_complete",
  "clap_complete_nushell",
@@ -758,6 +862,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fluent-uri"
@@ -1930,6 +2040,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pretty-hex"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a65843dfefbafd3c879c683306959a6de478443ffe9c9adf02f5976432402d7"
+
+[[package]]
 name = "pretty_assertions"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1947,6 +2063,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
+dependencies = [
+ "toml_edit 0.20.7",
 ]
 
 [[package]]
@@ -2038,6 +2163,15 @@ name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
 dependencies = [
  "rand_core",
 ]
@@ -2293,6 +2427,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2527,7 +2667,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -2537,6 +2677,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.20.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow 0.5.40",
 ]
 
 [[package]]
@@ -2836,6 +2987,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "0.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,15 @@ proptest = "1"
 pretty_assertions = "1"
 insta = { version = "1", features = ["json"] }
 tempfile = "3"
+# Q4 fuzzing (dev/test only). bolero `check!` targets are authored as
+# plain `#[test]` fns and run on STABLE via the existing
+# `cargo nextest run --workspace --all-targets` lane (bounded-random
+# discovery + an explicit committed-corpus replay test) — no nightly,
+# no sanitizer, no cargo-bolero binary on the PR path. Nightly is needed
+# ONLY for the optional coverage-guided `cargo bolero fuzz` cron lane.
+# bolero MSRV 1.66 << workspace floor 1.93. (`arbitrary`, for the
+# Istanbul structured fuzz arm, joins the catalog in its own sub-issue.)
+bolero = "0.13"
 # Schema round-trip validation for `--format scorecard-row` (issue #111).
 jsonschema = { version = "0.30", default-features = false }
 # BDD execution of `tests/features/*.feature` files (issue #115).

--- a/crates/crap4rs/Cargo.toml
+++ b/crates/crap4rs/Cargo.toml
@@ -94,6 +94,10 @@ jsonschema = { workspace = true }
 # harness; future siblings (crap4ts) consume their own bindings.
 cucumber = { workspace = true, features = ["libtest"] }
 tokio = { workspace = true }
+# Q4 fuzzing: `tests/fuzz_*.rs` bolero `check!` targets run on stable
+# via the existing nextest lane (corpus replay + bounded random). See
+# the workspace-deps catalog comment + AGENTS.md for the model.
+bolero = { workspace = true }
 # Cross-crate binary invocation for the multi-language BDD harness:
 # `multi_lang_html_cucumber.rs` runs the `crap-render` binary that
 # ships from crap-core (PR ζ #315). `env!("CARGO_BIN_EXE_*")` is only

--- a/crates/crap4rs/tests/fuzz_syn_walker/corpus/seed_basic
+++ b/crates/crap4rs/tests/fuzz_syn_walker/corpus/seed_basic
@@ -1,0 +1,18 @@
+fn f(x: i32) -> i32 {
+    if x > 0 {
+        match x {
+            1 => 1,
+            2 | 3 => x + 1,
+            _ => x * 2,
+        }
+    } else if x < -10 {
+        for i in 0..x.abs() {
+            if i % 2 == 0 && i > 3 {
+                return i;
+            }
+        }
+        0
+    } else {
+        -x
+    }
+}

--- a/crates/crap4rs/tests/fuzz_syn_walker/corpus/seed_deep_nesting
+++ b/crates/crap4rs/tests/fuzz_syn_walker/corpus/seed_deep_nesting
@@ -1,0 +1,29 @@
+fn deep(x: i32) -> i32 {
+    let _y = (((((((((((((((((((((((((1 + x)))))))))))))))))))))))));
+    if x == 0 {
+        0
+    } else if x == 1 {
+    } else if x == 2 {
+    } else if x == 3 {
+    } else if x == 4 {
+    } else if x == 5 {
+    } else if x == 6 {
+    } else if x == 7 {
+    } else if x == 8 {
+    } else if x == 9 {
+    } else if x == 10 {
+    } else if x == 11 {
+    } else if x == 12 {
+    } else if x == 13 {
+    } else if x == 14 {
+    } else if x == 15 {
+    } else if x == 16 {
+    } else if x == 17 {
+    } else if x == 18 {
+    } else if x == 19 {
+    } else if x == 20 {
+        x + 1
+    } else {
+        -1
+    }
+}

--- a/crates/crap4rs/tests/fuzz_syn_walker/main.rs
+++ b/crates/crap4rs/tests/fuzz_syn_walker/main.rs
@@ -56,7 +56,9 @@ fn drive_both(input: &[u8]) {
 /// crash regression through the walker. Runs on stable as an ordinary test.
 #[test]
 fn replay_committed_corpus_and_crashes() {
-    let base = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fuzz_syn_walker");
+    let base = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fuzz_syn_walker");
     let mut replayed = 0usize;
     for sub in ["corpus", "crashes"] {
         let dir = base.join(sub);

--- a/crates/crap4rs/tests/fuzz_syn_walker/main.rs
+++ b/crates/crap4rs/tests/fuzz_syn_walker/main.rs
@@ -1,0 +1,101 @@
+//! Q4 fuzz: panic-freedom of the syn complexity walker over arbitrary source.
+//!
+//! Two complementary layers, both running on **stable** under the existing
+//! `cargo nextest run --workspace --all-targets` lane — no nightly, no
+//! sanitizer, no `cargo-bolero` binary:
+//!
+//! 1. `replay_committed_corpus_and_crashes` — a deterministic regression net.
+//!    It reads every committed `tests/fuzz_syn_walker/{corpus,crashes}` seed
+//!    (via `CARGO_MANIFEST_DIR`, so the path is correct in a workspace) and
+//!    drives each through the walker for both metrics. This is what guarantees
+//!    a discovered-and-fixed crash STAYS fixed: the minimized input lands in
+//!    `crashes/` in the same PR as its fix and is replayed on every run
+//!    thereafter. (bolero's own `check!` corpus auto-discovery does NOT fire
+//!    under plain libtest/nextest — its `is_harnessed()` keys off the libtest
+//!    thread name and routes corpus lookup to an internal `__fuzz__` path used
+//!    only by the `cargo-bolero` CLI — so we replay the seeds explicitly.)
+//! 2. `fuzz_syn_walker_{cognitive,cyclomatic}` — bolero `check!` targets doing
+//!    bounded randomized generation (`BOLERO_RANDOM_ITERATIONS`, pinned in CI).
+//!    These are the discovery layer and escalate, unchanged, to coverage-guided
+//!    libFuzzer fuzzing under the optional nightly `cargo bolero fuzz` cron
+//!    lane (which DOES consume the on-disk corpus/crashes dirs).
+//!
+//! Robustness contract under test: the walker must never PANIC (or abort via
+//! stack overflow) on arbitrary input. Returning `Err` (e.g. a syn parse
+//! failure on non-Rust bytes) is correct, expected behavior — only a
+//! panic/abort is a bug. We therefore drive the `Result`-returning
+//! `ComplexityPort::extract` seam directly and discard the `Result`; we do NOT
+//! use the `extract_src` test helper, which `.unwrap()`s and would conflate a
+//! benign parse `Err` with a crash.
+//!
+//! Boundary-Rule note: this ADDS coverage the existing `proptest` suite cannot
+//! reach. `no_panic_on_fixture_files` (adapters/complexity/mod.rs) is
+//! fixture-vocabulary bounded; this target explores arbitrary bytes and the
+//! deep-nesting recursion regime (mutually-recursive cognitive/cyclomatic
+//! counters + syn's own recursive `full`-feature parse) that fixtures never
+//! exercise.
+
+use crap4rs::adapters::complexity::SynComplexityAdapter;
+use crap4rs::domain::types::ComplexityMetric;
+use crap4rs::ports::ComplexityPort;
+
+/// Drive one input through the walker for one metric. The contract is
+/// panic-freedom: `Ok` and `Err` are both acceptable outcomes; only a
+/// panic/abort is a bug.
+fn drive(input: &[u8], metric: ComplexityMetric) {
+    let src = String::from_utf8_lossy(input);
+    let _ = SynComplexityAdapter::new().extract(&src, "fuzz.rs", metric);
+}
+
+fn drive_both(input: &[u8]) {
+    drive(input, ComplexityMetric::Cognitive);
+    drive(input, ComplexityMetric::Cyclomatic);
+}
+
+/// Deterministic per-PR regression net: replay every committed corpus seed and
+/// crash regression through the walker. Runs on stable as an ordinary test.
+#[test]
+fn replay_committed_corpus_and_crashes() {
+    let base = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fuzz_syn_walker");
+    let mut replayed = 0usize;
+    for sub in ["corpus", "crashes"] {
+        let dir = base.join(sub);
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_file() {
+                continue;
+            }
+            // Skip dotfiles (.gitkeep) like bolero's own corpus loader does.
+            if path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.starts_with('.'))
+            {
+                continue;
+            }
+            let bytes = std::fs::read(&path)
+                .unwrap_or_else(|e| panic!("failed to read seed {}: {e}", path.display()));
+            drive_both(&bytes);
+            replayed += 1;
+        }
+    }
+    // The committed corpus is hand-seeded, so at least the basic + deep-nesting
+    // seeds must be present — a zero here means the seeds went missing.
+    assert!(
+        replayed >= 2,
+        "expected >= 2 committed corpus/crash seeds to replay, found {replayed}"
+    );
+}
+
+#[test]
+fn fuzz_syn_walker_cognitive() {
+    bolero::check!().for_each(|input: &[u8]| drive(input, ComplexityMetric::Cognitive));
+}
+
+#[test]
+fn fuzz_syn_walker_cyclomatic() {
+    bolero::check!().for_each(|input: &[u8]| drive(input, ComplexityMetric::Cyclomatic));
+}


### PR DESCRIPTION
## Summary
Walking skeleton for the Q4 fuzz epic (#428). Adds `bolero` (library) to the workspace catalog + crap4rs dev-deps plus the first fuzz target over the syn complexity walker. It runs on **stable** via the existing `cargo nextest run --workspace --all-targets` lane — **no nightly, no sanitizer, no cargo-bolero binary on the PR path**. Everything after this sub-issue is additive.

## What's here
- **`crates/crap4rs/tests/fuzz_syn_walker/main.rs`** — drives the `Result`-returning `ComplexityPort::extract` seam (NOT the `extract_src` test helper, which `.unwrap()`s and would conflate a benign parse `Err` with a crash) and asserts panic-freedom. Two layers:
  - `replay_committed_corpus_and_crashes` — deterministic per-PR regression net replaying the committed `corpus/`+`crashes/` seeds via `CARGO_MANIFEST_DIR`.
  - `fuzz_syn_walker_{cognitive,cyclomatic}` — bolero `check!` bounded-random discovery (`BOLERO_RANDOM_ITERATIONS` pinned in CI), escalating unchanged to the deferred nightly `cargo bolero fuzz` lane.
- Committed corpus seeds (a valid sample + a bounded deep-nesting case) + `crashes/.gitkeep`, mirroring the `proptest-regressions/` committed-to-git convention.
- `BOLERO_RANDOM_ITERATIONS` CI knob (workflow-level `env:`).
- Flips the `.claude/rules/testing.md` Fuzz-Q4 row to the live bolero/stable model.

## Substrate notes (verified, not assumed)
- **`bolero`'s own `check!` corpus auto-discovery does NOT fire under plain libtest/nextest** — its `is_harnessed()` keys off the libtest thread name and routes corpus lookup to an internal `__fuzz__` path used only by the `cargo-bolero` CLI. Proven empirically with a throwaway sentinel probe. Hence the explicit replay test for the per-PR regression guarantee. (The on-disk corpus/crashes dirs are still consumed by the deferred nightly cargo-bolero lane.)
- The directory layout (`tests/fuzz_syn_walker/main.rs`, not a flat `.rs`) is required so bolero/the replay resolve the corpus dir correctly in a workspace.
- The target calls the library directly (no `cargo_bin`/`CARGO_BIN_EXE_` shelling), so **no new `.cargo/mutants.toml --skip` token** is needed — `mutants-skip-lint` stays green.

## Boundary Rule
Adds coverage the existing `proptest` suite cannot reach: `no_panic_on_fixture_files` is fixture-vocabulary bounded; this target explores arbitrary bytes + the deep-nesting recursion regime (mutually-recursive cognitive/cyclomatic counters + syn's own recursive `full` parse).

## Gates (all green locally)
`cargo fmt` · `cargo +1.96.0 clippy --workspace --all-targets -D warnings` · `cargo nextest run --workspace --all-targets` (1342 passed, +3) · `cargo +1.93 check --workspace --all-targets` (MSRV; bolero MSRV 1.66) · `RUSTDOCFLAGS=-D warnings cargo doc` · bdd-tracked / bdd-mislevel / mutants-skip lints · **strict-8 self-gate: 1681 fns, 0 above threshold, PASS** (no `src/` change).

Closes #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)