### PR TITLE
test(crap4ts): #432 — Istanbul structured fuzz arm (Q4)

### DIFF
--- a/crates/crap4ts/tests/fuzz_istanbul/main.rs
+++ b/crates/crap4ts/tests/fuzz_istanbul/main.rs
@@ -1,37 +1,92 @@
 //! Q4 fuzz: panic-freedom of the Istanbul JSON coverage parser over arbitrary
-//! input (raw-bytes arm).
+//! input — a raw-bytes arm and a structured arm.
 //!
 //! Same stable, no-nightly model as `fuzz_syn_walker` / `fuzz_oxc_walker` (see
 //! those headers for the bolero-on-stable rationale and the explicit-corpus-
-//! replay workaround). `parse_str` is metric-agnostic, so this is a single
-//! fuzz target plus the deterministic corpus-replay regression test.
+//! replay workaround). All arms run as ordinary tests on the existing nextest
+//! lane.
 //!
-//! Robustness contract: `parse_str` must never PANIC (or abort) on arbitrary
-//! input. `Err` (e.g. a serde_json parse failure on non-JSON bytes, or a
+//! Robustness contract (every arm): `parse_str` must never PANIC (or abort) on
+//! its input. `Err` (a serde_json parse failure on non-JSON bytes, or a
 //! recursion-limit rejection on deeply nested input) is correct, expected
-//! behavior — only a panic/abort is a bug. The raw arm exercises the
-//! three-path parse cascade and the inherited (but never directly asserted)
-//! serde_json nesting-recursion guard on both the typed and `Value` seams.
+//! behavior — only a panic/abort is a bug.
+//!
+//! - **Raw-bytes arm** (`fuzz_istanbul_raw`): feeds arbitrary bytes through
+//!   `parse_str`. Exercises the three-path parse cascade and the inherited
+//!   serde_json nesting-recursion guard on both the typed and `Value` seams.
+//!   Most random inputs fail at the JSON parse gate (an `Err`), so this arm is
+//!   mostly a parser-robustness check.
+//! - **Structured arm** (`fuzz_istanbul_structured`): generates a
+//!   schema-shaped `HashMap<String, GenFile>` (mirroring the parser's
+//!   `IstanbulCoverageFile` deserialization shape), serializes it to JSON, and
+//!   feeds *that* to `parse_str`. Because the input parses, this arm reaches
+//!   PAST the JSON gate into the coverage-mapping logic the raw arm starves:
+//!   the `with_capacity` allocation, the `s`/`statementMap` join, the branch
+//!   fan-out, and path normalization. Generation uses bolero's native
+//!   `TypeGenerator` derive (no extra `arbitrary` dependency — the derive ships
+//!   in bolero's prelude and is the idiomatic generator for this fuzzer).
 //!
 //! Boundary-Rule note: the crap4ts Istanbul parser surface has ZERO existing
-//! property/fuzz tests (only example-based unit + cucumber coverage), so this
-//! target is purely additive — it does not duplicate any lower-level
-//! invariant. (The structured `#[derive(Arbitrary)]` arm that reaches the
-//! coverage-mapping / OOM / traversal logic past the JSON parse gate lands in
-//! the follow-up sub-issue.)
+//! property/fuzz tests (only example-based unit + cucumber coverage), so both
+//! arms are purely additive — they do not duplicate any lower-level invariant.
+
+use std::collections::HashMap;
+
+use serde::Serialize;
 
 use crap4ts::adapters::coverage::IstanbulCoverage;
 
-/// Drive one input through the Istanbul parser. The contract is
-/// panic-freedom: `Ok` and `Err` are both acceptable; only a panic/abort is a
-/// bug. The root is the crate dir (an absolute path, matching production where
-/// `--src` is canonicalized) so the prefix-strip / suffix-match path
-/// normalization is actually exercised rather than short-circuited by a
-/// relative root.
+fn parser() -> IstanbulCoverage {
+    // Root is the crate dir (an absolute path, matching production where
+    // `--src` is canonicalized) so the prefix-strip / suffix-match path
+    // normalization is actually exercised rather than short-circuited by a
+    // relative root.
+    IstanbulCoverage::new(std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")))
+}
+
+/// Drive raw bytes through the parser. `Ok`/`Err` both acceptable; only a
+/// panic/abort is a bug.
 fn drive(input: &[u8]) {
     let src = String::from_utf8_lossy(input);
-    let parser = IstanbulCoverage::new(std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")));
-    let _ = parser.parse_str(&src);
+    let _ = parser().parse_str(&src);
+}
+
+// ── Structured generation: wrapper types mirroring the parser's
+// `IstanbulCoverageFile` deserialization shape (camelCase on the wire), so a
+// generated value serializes to JSON that `parse_str` accepts and maps.
+// `serde`/`serde_json` are crap4ts `[dependencies]`, available to this test.
+
+#[derive(Debug, bolero::TypeGenerator, Serialize)]
+struct GenPosition {
+    line: u32,
+}
+
+#[derive(Debug, bolero::TypeGenerator, Serialize)]
+struct GenStatementLoc {
+    start: GenPosition,
+}
+
+#[derive(Debug, bolero::TypeGenerator, Serialize)]
+struct GenBranchLoc {
+    loc: GenStatementLoc,
+    line: Option<u32>,
+}
+
+#[derive(Debug, bolero::TypeGenerator, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct GenFile {
+    path: String,
+    s: HashMap<String, u64>,
+    statement_map: HashMap<String, GenStatementLoc>,
+    b: HashMap<String, Vec<u64>>,
+    branch_map: HashMap<String, GenBranchLoc>,
+}
+
+/// Serialize a generated Istanbul-shaped map and drive it through the parser.
+fn drive_structured(files: &HashMap<String, GenFile>) {
+    if let Ok(json) = serde_json::to_string(files) {
+        let _ = parser().parse_str(&json);
+    }
 }
 
 /// Deterministic per-PR regression net: replay every committed corpus seed and
@@ -74,4 +129,11 @@ fn replay_committed_corpus_and_crashes() {
 #[test]
 fn fuzz_istanbul_raw() {
     bolero::check!().for_each(|input: &[u8]| drive(input));
+}
+
+#[test]
+fn fuzz_istanbul_structured() {
+    bolero::check!()
+        .with_type::<HashMap<String, GenFile>>()
+        .for_each(drive_structured);
 }


### PR DESCRIPTION
## Summary
Adds a **structured** generation arm to the Istanbul fuzz target so iterations reach PAST the JSON parse gate into the coverage-mapping logic the raw arm (#431) starves: the `with_capacity` allocation, the `s`/`statementMap` join, branch fan-out, and path normalization. **Stacked on #431** (base = `feat/q4-fuzz-istanbul-raw`).

> Stack: #435→#436→#437→this. GitHub auto-retargets on each merge.

## ⚠️ Engineering choice — bolero `TypeGenerator`, not `arbitrary`
The sub-issue (#432) literally names "Arbitrary", but I used **bolero's native `TypeGenerator` derive** (ships in bolero's prelude) instead. Same structured-generation intent, but **zero extra dependencies** — no `arbitrary` catalog entry, no syn-transitive dev-dep, no bolero feature change — and it's the idiomatic generator for this fuzzer. `serde`/`serde_json` are crap4ts `[dependencies]`, already available to the integration test. Flagging for your final review; happy to switch to `arbitrary` if you'd prefer the literal approach.

## What's here
- Wrapper types (`GenFile`/`GenStatementLoc`/`GenBranchLoc`/`GenPosition`) mirroring the parser's `IstanbulCoverageFile` deserialize shape (camelCase serde), generated → serialized to JSON → fed to `parse_str`.
- `fuzz_istanbul_structured` target; 50k-iteration local FP-hunt clean (no panic/overflow in the mapping path).

## Gates (green locally, full stack tree)
fmt · clippy-1.96 -D warnings · nextest --workspace --all-targets (1348 passed) · MSRV 1.93 · doc -D warnings · bdd/mutants lints. **No production `src/` change** → scorecard-production unaffected (CI confirms).

Closes #432

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced fuzzing test suite for coverage file parsing with improved robustness checks and structured JSON-based testing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->