### PR TITLE
test(crap4rs): #434 — property tests for the LCOV path-normalization seam

### DIFF
--- a/crates/crap4rs/src/adapters/coverage/mod.rs
+++ b/crates/crap4rs/src/adapters/coverage/mod.rs
@@ -1011,6 +1011,66 @@ mod proptests {
             let _ = parser.parse_str(&lcov);
         }
 
+        // ── crap-rs#434 — Boundary-Rule deferral accountability ──
+        // The LCOV parser is excluded from the Q4 fuzz epic because its `.*`
+        // panic-freedom is already proptested above (`no_panic_on_arbitrary_*`).
+        // Its one residual signal — the I/O-bearing `normalize_path` /
+        // `suffix_match_under` path handling — belongs at the property level,
+        // not fuzz. These two cover that seam over its input domain,
+        // complementing the example-based traversal unit tests.
+
+        // `normalize_path` never panics on arbitrary SF-path input under an
+        // arbitrary root (adversarial `..`, mixed separators, unicode, long
+        // suffixes all included).
+        #[test]
+        fn normalize_path_never_panics(
+            path in ".*",
+            root in "[A-Za-z0-9_/.-]{0,30}",
+        ) {
+            let parser = LcovParser::new(PathBuf::from(root));
+            let _ = parser.normalize_path(&path);
+        }
+
+        // Traversal guard (structural): when `suffix_match_under` resolves a
+        // real file, the returned suffix never contains a `..` component and
+        // always re-anchors *under* the root — even when the input path is
+        // prefixed with `..`/junk segments. A real tempdir file keeps the
+        // `Some` branch non-vacuous.
+        #[test]
+        fn suffix_match_under_is_rooted_and_parentdir_free(
+            junk in prop::collection::vec(r"\.\.|[a-z]{1,5}", 0..4),
+        ) {
+            use std::io::Write;
+            let dir = tempfile::tempdir().unwrap();
+            let root = dir.path();
+            let leaf_dir = root.join("pkg");
+            std::fs::create_dir_all(&leaf_dir).unwrap();
+            std::fs::File::create(leaf_dir.join("leaf.rs"))
+                .unwrap()
+                .write_all(b"fn x() {}")
+                .unwrap();
+
+            let mut p = root.to_path_buf();
+            for seg in &junk {
+                p.push(seg);
+            }
+            p.push("pkg");
+            p.push("leaf.rs");
+
+            if let Some(suffix) = suffix_match_under(root, &p) {
+                prop_assert!(
+                    !Path::new(&suffix)
+                        .components()
+                        .any(|c| c == std::path::Component::ParentDir),
+                    "suffix_match_under returned a `..`-bearing suffix: {suffix}"
+                );
+                prop_assert!(
+                    root.join(&suffix).is_file(),
+                    "suffix {suffix} does not re-anchor to a real file under root"
+                );
+            }
+        }
+
         #[test]
         fn no_cross_file_leakage(
             a_lines in prop::collection::vec((1..100usize, 0..10u64), 1..5),

--- a/crates/crap4rs/src/adapters/coverage/mod.rs
+++ b/crates/crap4rs/src/adapters/coverage/mod.rs
@@ -1041,14 +1041,24 @@ mod proptests {
             junk in prop::collection::vec(r"\.\.|[a-z]{1,5}", 0..4),
         ) {
             use std::io::Write;
-            let dir = tempfile::tempdir().unwrap();
+            use std::sync::OnceLock;
+
+            // Initialize the tempdir + real file ONCE for the whole test run
+            // (the test only reads it), not per proptest case — avoids 256×
+            // dir-create/file-write I/O. The tempdir-qualified absolute path
+            // also keeps execution CWD-independent for parallel test safety.
+            static TEST_DIR: OnceLock<tempfile::TempDir> = OnceLock::new();
+            let dir = TEST_DIR.get_or_init(|| {
+                let d = tempfile::tempdir().unwrap();
+                let leaf_dir = d.path().join("pkg");
+                std::fs::create_dir_all(&leaf_dir).unwrap();
+                std::fs::File::create(leaf_dir.join("leaf.rs"))
+                    .unwrap()
+                    .write_all(b"fn x() {}")
+                    .unwrap();
+                d
+            });
             let root = dir.path();
-            let leaf_dir = root.join("pkg");
-            std::fs::create_dir_all(&leaf_dir).unwrap();
-            std::fs::File::create(leaf_dir.join("leaf.rs"))
-                .unwrap()
-                .write_all(b"fn x() {}")
-                .unwrap();
 
             let mut p = root.to_path_buf();
             for seg in &junk {
@@ -1057,18 +1067,26 @@ mod proptests {
             p.push("pkg");
             p.push("leaf.rs");
 
-            if let Some(suffix) = suffix_match_under(root, &p) {
-                prop_assert!(
-                    !Path::new(&suffix)
-                        .components()
-                        .any(|c| c == std::path::Component::ParentDir),
-                    "suffix_match_under returned a `..`-bearing suffix: {suffix}"
-                );
-                prop_assert!(
-                    root.join(&suffix).is_file(),
-                    "suffix {suffix} does not re-anchor to a real file under root"
-                );
-            }
+            // Non-vacuous: the real `pkg/leaf.rs` leaf guarantees a match, so
+            // assert presence FIRST — otherwise a regression of
+            // `suffix_match_under` to always-`None` would let this test pass
+            // silently. Then validate the guard on the resolved suffix.
+            let suffix = suffix_match_under(root, &p);
+            prop_assert!(
+                suffix.is_some(),
+                "suffix_match_under returned None despite a real pkg/leaf.rs leaf"
+            );
+            let suffix = suffix.unwrap();
+            prop_assert!(
+                !Path::new(&suffix)
+                    .components()
+                    .any(|c| c == std::path::Component::ParentDir),
+                "suffix_match_under returned a `..`-bearing suffix: {suffix}"
+            );
+            prop_assert!(
+                root.join(&suffix).is_file(),
+                "suffix {suffix} does not re-anchor to a real file under root"
+            );
         }
 
         #[test]


### PR DESCRIPTION
## Summary
Boundary-Rule deferral accountability for excluding the LCOV parser from the Q4 fuzz epic (#428). The LCOV parser's `.*` panic-freedom is **already** proptested, so fuzzing it would duplicate a proven invariant. Its one residual signal — the I/O-bearing `normalize_path` / `suffix_match_under` path handling — belongs at the **property** level, not fuzz. **Independent of the fuzz stack** (branches off `main`, no bolero).

## What's here
Two proptests in the existing inline `mod proptests` (crap4rs `adapters/coverage/mod.rs`):
- `normalize_path_never_panics` — panic-freedom over arbitrary SF-path input under an arbitrary root (adversarial `..`, mixed separators, unicode, long suffixes).
- `suffix_match_under_is_rooted_and_parentdir_free` — the structural traversal guard: when a real file resolves, the returned suffix has no `..` component and always re-anchors under the root. A real tempdir file + `..`/junk-prefixed input keeps the `Some` branch non-vacuous.

Complements the existing example-based traversal unit tests (`parentdir_sf_path_does_not_take_fast_path_is_file_probe`, etc.).

## Gates (all green locally)
fmt · clippy-1.96 -D warnings · nextest --workspace --all-targets (incl. both new proptests) · MSRV 1.93 · doc -D warnings · mutants-skip lint · **strict-8 self-gate: 1681 fns, 0 above threshold, PASS**. No new deps (proptest + tempfile already dev-deps). The `proptest!` block is at the file's end and its macro body isn't walked as individual functions → self-CRAP set + `wire_envelope_crap4rs` snapshot unchanged.

Closes #434

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive property-based unit tests to expand testing coverage of path-handling functionality. These new tests validate system stability across diverse input scenarios, including edge cases and unexpected inputs, strengthening code robustness and helping prevent potential failures in various operating conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->