### PR TITLE
ci: defer nightly fuzz lane — disable schedule, drop crap4rs targets (tracked: #443)

### DIFF
--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -1,13 +1,30 @@
 name: fuzz-nightly
 
+# DEFERRED — NOT YET VALIDATED END-TO-END (tracked: crap-rs#443).
+#
 # Coverage-guided fuzzing of the Q4 bolero targets on a SCOPED nightly
-# toolchain — the repo's first and only nightly usage, deliberately confined
-# to this scheduled job and kept entirely OFF the per-PR path. The stable
-# `check!` targets in the `Test (*)` nextest lane carry the per-PR regression
-# net (bounded-random + committed-corpus replay); this lane adds the deeper,
-# coverage-guided libFuzzer + AddressSanitizer discovery that is nightly-only
-# (`-Zsanitizer`). See the ADR:
+# toolchain. The stable `check!` targets in the `Test (*)` nextest lane carry
+# the always-on per-PR regression net (bounded-random + committed-corpus
+# replay); this lane adds the deeper, coverage-guided libFuzzer +
+# AddressSanitizer discovery that is nightly-only (`-Zsanitizer`). See the ADR:
 #   ops/decisions/crap-rs/adr-first-nightly-fuzz-lane.md
+#
+# Why deferred (tracked: crap-rs#443):
+#   `cargo bolero test` has NO test-target scoping flag — its `<test>` arg is a
+#   libtest filter, not a `--test` selector. So `cargo bolero test --package
+#   crap4rs <target>` builds and runs the ENTIRE crap4rs test suite (every
+#   `harness=false` cucumber harness) under nightly + ASan + `--cfg fuzzing`,
+#   just to reach one fuzz target; crap4rs's cucumber harnesses shell the
+#   ASan-instrumented `crap4rs` binary and fail. crap4ts's targets are
+#   unaffected (its harnesses are library-level and never shell a bin), so the
+#   3 crap4ts targets remain below while the 2 crap4rs walker targets are
+#   dropped. Re-enabling them (and the weekly schedule) needs a dedicated fuzz
+#   member crate that holds only the fuzz `[[test]]` targets — the idiomatic
+#   cargo-fuzz pattern. crap-rs#443 tracks that work.
+#
+#   The lane is shelved, not worthless: on first fire it found a real
+#   upstream-oxc panic in the crap4ts walker (fixed in #442). It stays
+#   `workflow_dispatch`-only for now so re-validation blocks no PR.
 #
 # On a finding, `cargo bolero` writes the minimized crash to the target's
 # `crashes/` dir; this job then fails and uploads that dir as an artifact for
@@ -17,11 +34,9 @@ name: fuzz-nightly
 # write token) for least privilege.
 
 on:
-  schedule:
-    # Mondays 06:00 UTC — weekly, mirroring the per-merge cadence intent of
-    # the walker-mutants gate without taxing any PR.
-    - cron: '0 6 * * 1'
-  # Manual trigger for first-fire validation + on-demand deep fuzzing.
+  # Weekly schedule DISABLED while deferred (tracked: crap-rs#443) — the lane
+  # is dispatch-only until the dedicated fuzz crate lands and a full 5-target
+  # run is green. Re-add the `schedule:` block below when re-enabling.
   workflow_dispatch: {}
 
 # Least privilege: this lane never pushes. Read-only checkout token.
@@ -42,16 +57,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # `test` is the bolero target name (the `check!` fn, per `cargo bolero
+        # list`), NOT the test-binary/dir name. `dir` is the on-disk
+        # corpus/crashes directory (shared by the fn-targets in one file).
+        # crap4rs walker targets are deferred (tracked: crap-rs#443) — see the
+        # header. Only the library-level crap4ts targets run here today.
         target:
-          - { package: crap4rs, test: fuzz_syn_walker }
-          - { package: crap4ts, test: fuzz_oxc_walker }
-          - { package: crap4ts, test: fuzz_istanbul }
+          - { package: crap4ts, test: fuzz_oxc_walker, dir: fuzz_oxc_walker }
+          - { package: crap4ts, test: fuzz_istanbul_raw, dir: fuzz_istanbul }
+          - { package: crap4ts, test: fuzz_istanbul_structured, dir: fuzz_istanbul }
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       # SCOPED nightly — the ONLY nightly toolchain in this repo's CI, and only
-      # on this scheduled job. Pinned to the @nightly branch-HEAD SHA; like the
+      # on this dispatch-only fuzz job. Pinned to the @nightly branch-HEAD SHA; like the
       # @stable pin, Dependabot can't bump version-channel branches, so this
       # needs a manual refresh on the same quarterly cadence (AGENTS.md
       # supply-chain rule 2).
@@ -70,15 +90,16 @@ jobs:
             cargo install cargo-bolero --locked
           fi
       - name: Fuzz ${{ matrix.target.test }}
-        # FIRST-FIRE VALIDATION REQUIRED (tracked in the PR): the exact
-        # `cargo bolero fuzz` target selector for the directory-layout,
-        # multi-`#[test]`-fn targets is confirmed by running `cargo bolero list`
-        # on the first `workflow_dispatch`. If `list` reports a different
-        # identifier (e.g. a `<binary>::<fn>` form), update the selector here.
-        # Flags (`--sanitizer address`, `--engine libfuzzer`, `-T`) follow the
-        # bolero CLI docs and are likewise confirmed on first fire. This lane
-        # is schedule/dispatch-only, so iterating on the invocation blocks no
-        # PR.
+        # `cargo bolero test <target>` is the fuzz command (cargo-bolero 0.13
+        # has no `fuzz` subcommand; `test` drives the engine). `--toolchain
+        # nightly` is REQUIRED: `--sanitizer`/libFuzzer need `-Zsanitizer`
+        # (nightly-only), and the repo's `rust-toolchain.toml` pins
+        # `channel=stable` — which overrides dtolnay's installed-nightly
+        # default, so without this flag cargo-bolero runs stable rustc and
+        # `-Z` is rejected. (The dtolnay step above installs the nightly this
+        # flag selects.) Subcommand + target names + `[profile.fuzz]` +
+        # `--toolchain nightly` validated for the crap4ts targets via `cargo
+        # bolero list` + a workflow_dispatch run.
         env:
           # Matrix values are workflow-defined literals, but routing them
           # through env keeps the run block free of `${{ }}` interpolation
@@ -86,15 +107,19 @@ jobs:
           FUZZ_TEST: ${{ matrix.target.test }}
           FUZZ_PKG: ${{ matrix.target.package }}
         run: |
-          cargo bolero fuzz "$FUZZ_TEST" \
+          cargo bolero test "$FUZZ_TEST" \
             --package "$FUZZ_PKG" \
-            --sanitizer address \
+            --toolchain nightly \
             --engine libfuzzer \
+            --sanitizer address \
             -T 5min
       - name: Upload crash corpus on failure
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fuzz-crashes-${{ matrix.target.test }}
-          path: crates/${{ matrix.target.package }}/tests/${{ matrix.target.test }}/crashes/
+          # Upload the whole target dir (corpus + crashes + bolero's internal
+          # __fuzz__ scratch) so a finding is recoverable for manual promotion
+          # into the committed crashes/ (crash + fix in one PR, per the ADR).
+          path: crates/${{ matrix.target.package }}/tests/${{ matrix.target.dir }}/
           if-no-files-found: ignore

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,3 +136,17 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 # binary; `env!("CARGO_BIN_EXE_crap4rs")` is only set inside the
 # crap4rs crate's tests, so cross-crate invocation needs assert_cmd.
 assert_cmd = "2"
+
+# ── Q4 fuzz profile ───────────────────────────────────────────────────
+# `cargo bolero test` builds with `--profile fuzz` (the coverage-guided
+# nightly lane in `.github/workflows/fuzz-nightly.yml`). Without this
+# profile the CLI errors `profile 'fuzz' is not defined`. bolero's
+# recommended shape (inherits dev + opt for throughput; codegen-units = 1
+# avoids cargo-bolero's known multi-CGU compilation bugs). The stable
+# per-PR lane runs the `check!` targets as ordinary nextest tests and
+# never uses this profile.
+[profile.fuzz]
+inherits = "dev"
+opt-level = 3
+incremental = false
+codegen-units = 1


### PR DESCRIPTION
## Summary

Defers the scheduled nightly coverage-guided fuzz lane (`fuzz-nightly.yml`, #440). First-firing it surfaced a hard cargo-bolero limitation that breaks the crap4rs targets; rather than force a heavyweight workaround now, the lane is shelved to `workflow_dispatch`-only with the crap4rs targets dropped. Restoration is tracked in **#443**.

## Why

`cargo bolero test` has **no test-target scoping flag** — its `<test>` argument is a libtest *filter*, not a `--test` selector. So `cargo bolero test --package crap4rs <target>` builds and runs the **entire crap4rs test suite** (every `harness=false` cucumber harness) under nightly + ASan + `--cfg fuzzing`, just to reach one fuzz target. crap4rs's cucumber harnesses shell the now-ASan-instrumented `crap4rs` binary and fail (`cli_ergonomics_cucumber`: "11 steps failed"). crap4ts's targets are unaffected — its harnesses are library-level and never shell a bin.

The clean fix (a dedicated fuzz member crate holding only the fuzz `[[test]]` targets — the idiomatic cargo-fuzz pattern) is its own piece of work, tracked in #443. Q4 coverage is unaffected in the meantime: the always-on stable per-PR `check!` lane (bounded-random + committed-corpus replay, every PR via nextest) is the net; the nightly lane was deeper coverage-guided *depth*.

## Changes

- **Disable the weekly `schedule:` trigger** — `workflow_dispatch`-only until #443 lands and a full 5-target run is green. Header documents the deferral with `tracked: crap-rs#443`.
- **Drop the 2 crap4rs walker targets** from the matrix; keep the 3 crap4ts targets.
- **Bring the validated invocation** (`cargo bolero test … --toolchain nightly`, real `check!` target names, matrix `dir` for artifact paths) + **`[profile.fuzz]`** so the dispatch path actually works for the crap4ts targets — rather than leaving #440's broken `cargo bolero fuzz` invocation on main.

## Value already returned

The lane is shelved, not worthless: on first fire it found a **real upstream-oxc panic** in the crap4ts walker on malformed input — fixed in **#442** (with a committed regression seed). That's the textbook argument for coverage-guided depth over bounded-random, and it validates keeping #443 on the radar.

## Notes

- Supersedes **#441** (closed) — that PR's `.with_default_cli()` approach only changed the crap4rs failure mode (argv-abort → run-and-fail under ASan), it didn't fix the scoping.
- YAML gates: `actionlint` clean locally; `zizmor` runs in CI (authoritative — Gemini can't review YAML). No new `uses:`, permissions, or untrusted-input usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)