### PR TITLE
ci: suppress zizmor adhoc-packages on intentional release npm installs

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -280,8 +280,14 @@ jobs:
       # package and installing the tarball into a clean project reproduces
       # that gating on this runner's native platform, pre-publish, so a
       # packaging defect fails the workflow instead of reaching the registry.
+      # zizmor's adhoc-packages audit flags the tarball `npm install` below;
+      # it is intentional and bounded — this step installs the just-built
+      # local tarball into a throwaway consumer to smoke-test platform
+      # gating, which is inherently lockfile-less. The ignore sits on the
+      # `run:` line because a `#` inside a block scalar is bash, not a YAML
+      # comment, so zizmor only reads a directive on the step's YAML line.
       - name: Verify npm packaging + install-gating
-        run: |
+        run: | # zizmor: ignore[adhoc-packages]
           set -euo pipefail
           work="$(mktemp -d)"
           ( cd packages/crap4ts && npm pack --pack-destination "$work" )
@@ -338,7 +344,11 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Upgrade npm to an OIDC-capable version
-        run: npm install -g npm@^11.5.1
+        # zizmor's adhoc-packages audit flags this global install; it is
+        # intentional and bounded — upgrading npm itself to an OIDC-capable
+        # version is a prerequisite for trusted publishing and is inherently
+        # a global, lockfile-less install.
+        run: npm install -g npm@^11.5.1 # zizmor: ignore[adhoc-packages]
 
       - name: Verify package.json + Cargo.toml versions match
         # Belt-and-braces check. package.json is normally bumped on


### PR DESCRIPTION
## Summary

The zizmor gate is **red on main right now** — not from any code change. A zizmor 1.x minor release added the `adhoc-packages` audit (between 2026-06-20 and 06-22), which flags two legitimate ad-hoc npm installs in `release-plz.yml` → 2 low findings → exit 12. The `pipx run 'zizmor>=1.5,<2'` pin caps the major version but not new audits within a minor, so the gate drifted red.

## The two findings (both legitimate)

- **`npm install "$tarball"`** (build-tarball smoke-install) — installs the just-built local crap4ts tarball into a throwaway consumer to verify platform/EBADPLATFORM gating *before* publish. Installing a local tarball is inherently lockfile-less.
- **`npm install -g npm@^11.5.1`** — upgrades npm itself to an OIDC-capable version, a prerequisite for trusted publishing. A global package-manager upgrade is inherently ad-hoc.

## Fix

Per AGENTS.md supply-chain rule 6, intentional + bounded suppressions get inline `# zizmor: ignore[adhoc-packages]` directives (no tracking issue needed for permanent suppressions).

One subtlety worth noting: the tarball directive sits on the step's **`run:` line**, not the offending bash line — a `#` inside a `run: |` block scalar is part of the bash string, not a YAML comment, so zizmor only reads a directive on the step's YAML line. (The single-line `npm install -g` directive works inline because there the `#` *is* a YAML comment.)

## Verification

`pipx run 'zizmor>=1.5,<2' .github/` locally → **"No findings to report"** (exit 0). This is the exact CI invocation.

Unblocks the zizmor gate for #445 (Dependabot) and #373 (release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and release automation configuration with additional validation steps and safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->