### PR TITLE
fix(crap-core): stamp each adapter's real language in the wire envelope

### DIFF
--- a/crates/crap-core/src/adapters/reporters/json.rs
+++ b/crates/crap-core/src/adapters/reporters/json.rs
@@ -26,6 +26,11 @@ use crate::ports::ParseDiagnostic;
 #[derive(Debug)]
 pub struct JsonConfig<'a, P: ParseDiagnostic> {
     pub tool_version: String,
+    /// Lowercase wire language token for the envelope's `language` field
+    /// (`"rust"` / `"typescript"`). Sourced from the active adapter's
+    /// `AdapterMeta::config_lang_key`, so each adapter stamps its own
+    /// language rather than a shared literal.
+    pub language: String,
     pub metric: ComplexityMetric,
     /// Resolved missing-coverage policy for this run. Recorded in the
     /// envelope (unless `Pessimistic`) so a baseline captures the policy
@@ -115,7 +120,7 @@ pub fn format_json<P: ParseDiagnostic>(
     let envelope = Envelope {
         schema_version: wire::CURRENT_SCHEMA_VERSION,
         tool_version: config.tool_version.clone(),
-        language: "rust".to_string(),
+        language: config.language.clone(),
         timestamp: config.timestamp.clone(),
         metric: Some(config.metric),
         threshold: Some(config.threshold),
@@ -147,6 +152,7 @@ mod tests {
     fn default_config() -> TestJsonConfig {
         JsonConfig {
             tool_version: "0.1.0".to_string(),
+            language: "rust".to_string(),
             metric: ComplexityMetric::Cognitive,
             missing_coverage_policy: MissingCoveragePolicy::Pessimistic,
             threshold: 8.0,
@@ -588,6 +594,7 @@ mod proptests {
         (1.0..100.0f64, prop_oneof![Just(0.0f64), 0.001..2.0f64]).prop_map(
             |(threshold, epsilon)| JsonConfig {
                 tool_version: "0.1.0".to_string(),
+                language: "rust".to_string(),
                 metric: ComplexityMetric::Cognitive,
                 missing_coverage_policy: MissingCoveragePolicy::Pessimistic,
                 threshold,

--- a/crates/crap-core/src/adapters/wire.rs
+++ b/crates/crap-core/src/adapters/wire.rs
@@ -106,10 +106,12 @@ pub struct Envelope<P: ParseDiagnostic> {
     pub schema_version: u32,
     #[serde(default)]
     pub tool_version: String,
-    /// Language tag of the emitting adapter. Note the JSON reporter
-    /// currently stamps `"rust"` for every adapter, so readers must not
-    /// treat this field as a usable identity signal yet; `crap-render`
-    /// pairs each envelope with a language key on the CLI instead.
+    /// Lowercase language tag of the emitting adapter (`"rust"` /
+    /// `"typescript"`), sourced from the adapter's
+    /// `AdapterMeta::config_lang_key`, so each adapter stamps its own
+    /// language. `crap-render` still pairs each envelope with an explicit
+    /// `--input <lang>=<file>` key for routing rather than trusting this
+    /// field, but the field is now a faithful per-adapter identity signal.
     #[serde(default)]
     pub language: String,
     #[serde(default)]

--- a/crates/crap-core/src/bin/crap-render.rs
+++ b/crates/crap-core/src/bin/crap-render.rs
@@ -15,11 +15,12 @@
 //!
 //! `--input <LANG>=<FILE>` pairs each envelope path with the language
 //! key it represents (`rust`, `typescript`, etc.). The language
-//! identity is supplied via CLI rather than read from the envelope
-//! because the JSON wire shape's `language` field is currently
-//! hard-coded "rust" by every emitting binary (a pre-existing bug
-//! tracked elsewhere) — pairing the language at the CLI sidesteps
-//! the field and stays N-adapter agnostic for future adapters.
+//! identity is supplied via CLI rather than read from the envelope's
+//! own `language` field so routing stays explicit and N-adapter
+//! agnostic — the renderer never has to trust per-envelope identity to
+//! place a block. (The envelope's `language` field is now a faithful
+//! per-adapter tag, each adapter stamping its `config_lang_key`, but
+//! the CLI key remains the routing source of truth.)
 //!
 //! `--baseline <LANG>=<FILE>` is the optional baseline counterpart.
 //! Each baseline envelope is composed against the matching `--input`

--- a/crates/crap-core/src/cli/mod.rs
+++ b/crates/crap-core/src/cli/mod.rs
@@ -1622,6 +1622,10 @@ fn format_as_json<P: ParseDiagnostic>(
     });
     let config = reporters::json::JsonConfig {
         tool_version: meta.tool_version.to_string(),
+        // Each adapter stamps its own wire language token (the lowercase
+        // `config_lang_key`: "rust" / "typescript") so the envelope's
+        // `language` field is a usable identity signal per adapter.
+        language: meta.config_lang_key.to_string(),
         metric: inputs.metric,
         missing_coverage_policy: inputs.missing_coverage_policy,
         threshold: inputs.threshold,

--- a/crates/crap-core/tests/snapshots/wire_envelope_crap4ts__envelope.snap
+++ b/crates/crap-core/tests/snapshots/wire_envelope_crap4ts__envelope.snap
@@ -4,7 +4,7 @@ expression: pretty
 ---
 {
   "diff_ref": null,
-  "language": "rust",
+  "language": "typescript",
   "metric": "cyclomatic",
   "result": {
     "functions": [

--- a/crates/crap-core/tests/snapshots/wire_envelope_crap4ts_branches__envelope.snap
+++ b/crates/crap-core/tests/snapshots/wire_envelope_crap4ts_branches__envelope.snap
@@ -4,7 +4,7 @@ expression: pretty
 ---
 {
   "diff_ref": null,
-  "language": "rust",
+  "language": "typescript",
   "metric": "cyclomatic",
   "result": {
     "functions": [

--- a/crates/crap-core/tests/wire_envelope_crap4rs.rs
+++ b/crates/crap-core/tests/wire_envelope_crap4rs.rs
@@ -114,6 +114,16 @@ fn envelope() {
         "envelope.tool_version missing or empty (pre-strip)",
     );
 
+    // Per-adapter language guard (mirrors the crap4ts canary). crap4rs
+    // stamps its own `config_lang_key` ("rust"); this fails loudly if the
+    // wiring regresses to a shared literal.
+    assert_eq!(
+        envelope["language"].as_str(),
+        Some("rust"),
+        "crap4rs envelope.language must be \"rust\", got {:?}",
+        envelope["language"],
+    );
+
     strip_volatile(&mut envelope);
 
     let pretty = serde_json::to_string_pretty(&envelope).expect("envelope re-serializes");

--- a/crates/crap-core/tests/wire_envelope_crap4ts.rs
+++ b/crates/crap-core/tests/wire_envelope_crap4ts.rs
@@ -21,10 +21,11 @@
 //! crap4ts (no cognitive support; default should be cyclomatic).
 //! W2.5 (crap-rs#188) flips this via `AdapterMeta::default_metric`
 //! per locked decision #2. The snapshot was regenerated at W2.5 PR
-//! time; `metric: "cyclomatic"` is now baked. `language: "rust"`
-//! remains wrong-by-design — that flips later when the `Language`
-//! enum lands as part of the deferred HTML-reporter Wave 5
-//! re-launch.
+//! time; `metric: "cyclomatic"` is now baked. `language` was also once
+//! wrong-by-design (`"rust"` for every adapter); it now stamps the
+//! adapter's own `AdapterMeta::config_lang_key`, so `language:
+//! "typescript"` is baked here. An explicit assertion below guards the
+//! value so the per-adapter wiring can't silently regress to a literal.
 //!
 //! ## Volatile fields stripped
 //!
@@ -207,6 +208,17 @@ fn envelope() {
             .as_str()
             .is_some_and(|s| !s.is_empty()),
         "envelope.tool_version missing or empty (pre-strip)",
+    );
+
+    // Explicit per-adapter language guard (crap4ts must stamp its own
+    // `config_lang_key`, not the shared default). Stronger than the
+    // snapshot alone, which could be blindly re-accepted back to a wrong
+    // literal — this assertion fails loudly if the wiring regresses.
+    assert_eq!(
+        envelope["language"].as_str(),
+        Some("typescript"),
+        "crap4ts envelope.language must be \"typescript\", got {:?}",
+        envelope["language"],
     );
 
     strip_volatile(&mut envelope);

--- a/crates/crap-core/tests/wire_envelope_crap4ts_branches.rs
+++ b/crates/crap-core/tests/wire_envelope_crap4ts_branches.rs
@@ -157,6 +157,16 @@ fn envelope() {
         "envelope.tool_version missing or empty (pre-strip)",
     );
 
+    // Per-adapter language guard (mirrors the sibling crap4ts canary).
+    // crap4ts stamps its own `config_lang_key` ("typescript"); this fails
+    // loudly if the wiring regresses to a shared literal.
+    assert_eq!(
+        envelope["language"].as_str(),
+        Some("typescript"),
+        "crap4ts envelope.language must be \"typescript\", got {:?}",
+        envelope["language"],
+    );
+
     strip_volatile(&mut envelope);
     strip_tempdir_paths(&mut envelope, &tempdir_str);
 

--- a/crates/crap4rs/tests/diff_integration.rs
+++ b/crates/crap4rs/tests/diff_integration.rs
@@ -601,6 +601,7 @@ fn json_envelope_contains_diff_ref() {
 
     let config = reporters::json::JsonConfig {
         tool_version: "0.1.0".to_string(),
+        language: "rust".to_string(),
         metric: ComplexityMetric::Cognitive,
         missing_coverage_policy: MissingCoveragePolicy::Pessimistic,
         threshold: 30.0,
@@ -640,6 +641,7 @@ fn json_envelope_diff_ref_null_without_flag() {
 
     let config = reporters::json::JsonConfig {
         tool_version: "0.1.0".to_string(),
+        language: "rust".to_string(),
         metric: ComplexityMetric::Cognitive,
         missing_coverage_policy: MissingCoveragePolicy::Pessimistic,
         threshold: 30.0,

--- a/crates/crap4rs/tests/json_reporter_cucumber.rs
+++ b/crates/crap4rs/tests/json_reporter_cucumber.rs
@@ -55,6 +55,7 @@ impl JsonWorld {
         let view = view::apply(result, ViewSpec::default());
         let config = JsonConfig {
             tool_version: "0.1.0".to_string(),
+            language: "rust".to_string(),
             metric,
             missing_coverage_policy: MissingCoveragePolicy::Pessimistic,
             threshold,

--- a/crates/crap4rs/tests/json_reporter_lcov_diagnostics.rs
+++ b/crates/crap4rs/tests/json_reporter_lcov_diagnostics.rs
@@ -66,6 +66,7 @@ fn diagnostics_included_when_present() {
     let result = make_empty_result();
     let config = JsonConfig {
         tool_version: "0.1.0".to_string(),
+        language: "rust".to_string(),
         metric: ComplexityMetric::Cognitive,
         missing_coverage_policy: MissingCoveragePolicy::Pessimistic,
         threshold: 8.0,


### PR DESCRIPTION
## Summary

The JSON reporter hardcoded `language: "rust"` in the wire envelope for **every** adapter, so crap4ts emitted `"language": "rust"` for TypeScript analysis. This **failed the rc.4 release-plz envelope-publication job** (which asserts the crap4ts envelope's `.language == "typescript"`) and mislabels the wire artifact that envelope-diff consumers read. Same issue #379 first flagged.

## Fix

Thread the adapter's own language through to the envelope:
- Add a `language` field to `JsonConfig` (crap-core json reporter).
- `format_as_json` populates it from `meta.config_lang_key` — the lowercase wire token (`"rust"` / `"typescript"`), already the canonical per-adapter key; `meta` was already in scope.
- `format_json` emits `config.language` instead of the literal.

crap4rs stays `"rust"` (byte-identical); crap4ts now stamps `"typescript"`.

## Why it's safe (adversarially reviewed)

- **Value change, not shape change** — the `language` field already existed and is `#[serde(default)]`, so **no `schema_version` bump**.
- **No consumer compares the field**: the `--baseline` loader drops it (`BaselineSnapshot` has no language field), crap-render routes off the `--input <lang>=<file>` CLI key (never the envelope value), and the delta/baseline mismatch warnings key on metric + missing-coverage-policy only. Old envelopes (language `"rust"` or absent) still deserialize cleanly.
- Confirmed there are no other hardcoded `language` emit sites (markdown/sarif/csv/scorecard-row emit none; the only non-test `Envelope{}` construction is `format_json`).

## Tests / durability

- Two crap4ts wire snapshots flip `rust`→`typescript` (**body-diff verified to be the language line only**); crap4rs snapshot unchanged.
- Explicit `assert_eq!` language guards added to **all three** wire-envelope canaries (crap4rs `"rust"`, both crap4ts `"typescript"`) so the wiring can't silently regress to a literal — snapshots alone can be blindly re-accepted.
- crap-render module doc + `wire.rs` field doc updated (the old "hardcoded rust" notes no longer hold).

## Gates (all green locally)

`cargo nextest run --workspace --all-targets` (1353) · `cargo fmt --check` · `cargo +1.96.0 clippy --workspace --all-targets -D warnings` · `cargo +1.93 check --workspace --all-targets` · `cargo doc -D warnings` · **strict-8 production gate PASS** · and the **exact release-plz crap4ts envelope assertion now returns `true`**.

## Notes

- Found by the rc.4 envelope-publication job; this **unblocks envelope publication on the next release**.
- `crates/crap4ts/tests/fixtures/class-validator-reference.json` still carries the frozen pre-fix `"rust"` — confirmed loaded by no test/CI (only a README reference), so harmless; it'll pick up `"typescript"` when regenerated under #190.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * JSON output now accurately identifies the programming language being analyzed through the language field, reflecting the specific adapter used (e.g., Rust, TypeScript).

* **Improvements**
  * Enhanced language field handling in JSON envelope to correctly represent per-adapter language identity instead of generic labeling.

* **Tests**
  * Added validation tests to ensure the language field is correctly set for each supported adapter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->