### PR TITLE
refactor(core)!: make JsonConfig + DeltaContext #[non_exhaustive] (public-API boundary)

### DIFF
--- a/crates/crap-core/src/adapters/reporters/json.rs
+++ b/crates/crap-core/src/adapters/reporters/json.rs
@@ -23,7 +23,17 @@ use crate::ports::ParseDiagnostic;
 /// is generic across adapters. crap4rs concretizes via the
 /// `JsonConfig<'a>` type alias in `crap4rs::adapters::reporters::json`
 /// so v0.4 callers' type paths stay byte-identical.
+///
+/// `#[non_exhaustive]`: a public, additive-only options struct. Marking
+/// it non-exhaustive forbids cross-crate struct-literal construction and
+/// exhaustive matching, so adding a field later is a minor (non-breaking)
+/// change rather than a major one — the same shape `HtmlMultiOptions`
+/// already uses. (Adding `epsilon` is what made a prior release register
+/// as breaking; that class is now closed.) Cross-crate tests construct it
+/// via the gated [`JsonConfig::for_test`] constructor below; in-crate
+/// code still uses struct literals freely.
 #[derive(Debug)]
+#[non_exhaustive]
 pub struct JsonConfig<'a, P: ParseDiagnostic> {
     pub tool_version: String,
     /// Lowercase wire language token for the envelope's `language` field
@@ -58,6 +68,47 @@ pub struct JsonConfig<'a, P: ParseDiagnostic> {
     pub delta: Option<DeltaContext<'a, P>>,
 }
 
+/// Cross-crate test constructor for [`JsonConfig`].
+///
+/// `#[non_exhaustive]` blocks struct-literal construction from other
+/// crates, so adapter integration tests (which legitimately build a
+/// `JsonConfig` to exercise the JSON reporter) need a constructor. This
+/// takes the fields those tests actually vary and defaults the rest
+/// (`epsilon = 0.0`, `minimal_view = false`, the three `Option` fields to
+/// `None`); a test that needs `diff_ref` or `diagnostics` sets the field
+/// afterward — `#[non_exhaustive]` still permits cross-crate writes to an
+/// already-built value, only struct-literal creation is removed.
+///
+/// Gated on `test` (in-crate) OR the `test-helpers` feature (the arm
+/// adapter integration tests reach through their `crap-core` dev-dep), so
+/// it never reaches a production build.
+#[cfg(any(test, feature = "test-helpers"))]
+impl<'a, P: ParseDiagnostic> JsonConfig<'a, P> {
+    #[allow(clippy::too_many_arguments)]
+    pub fn for_test(
+        tool_version: String,
+        language: String,
+        metric: ComplexityMetric,
+        missing_coverage_policy: MissingCoveragePolicy,
+        threshold: f64,
+        timestamp: String,
+    ) -> Self {
+        Self {
+            tool_version,
+            language,
+            metric,
+            missing_coverage_policy,
+            threshold,
+            epsilon: 0.0,
+            timestamp,
+            diagnostics: None,
+            diff_ref: None,
+            minimal_view: false,
+            delta: None,
+        }
+    }
+}
+
 /// Bundles everything the JSON reporter needs to render the `delta`
 /// block: the shaped view (post-filter / sort / truncate) plus the
 /// underlying delta and baseline metadata captured when the baseline
@@ -65,7 +116,13 @@ pub struct JsonConfig<'a, P: ParseDiagnostic> {
 ///
 /// Generic over `P: ParseDiagnostic` — see `JsonConfig` for the
 /// rationale.
+///
+/// `#[non_exhaustive]` for the same additive-only reason as `JsonConfig`.
+/// Unlike `JsonConfig` this needs no `for_test` constructor: its sole
+/// construction site is in-crate (`cli::format_as_json`), where
+/// `#[non_exhaustive]` imposes no restriction.
 #[derive(Debug)]
+#[non_exhaustive]
 pub struct DeltaContext<'a, P: ParseDiagnostic> {
     /// Shaped view — drives `shown`, `spec`, `eligible_count`, `truncated`.
     pub view: &'a DeltaView<'a>,

--- a/crates/crap-core/src/adapters/reporters/json.rs
+++ b/crates/crap-core/src/adapters/reporters/json.rs
@@ -87,21 +87,21 @@ pub struct JsonConfig<'a, P: ParseDiagnostic> {
 impl<'a, P: ParseDiagnostic> JsonConfig<'a, P> {
     #[allow(clippy::too_many_arguments)]
     pub fn for_test(
-        tool_version: String,
-        language: String,
+        tool_version: impl Into<String>,
+        language: impl Into<String>,
         metric: ComplexityMetric,
         missing_coverage_policy: MissingCoveragePolicy,
         threshold: f64,
-        timestamp: String,
+        timestamp: impl Into<String>,
     ) -> Self {
         Self {
-            tool_version,
-            language,
+            tool_version: tool_version.into(),
+            language: language.into(),
             metric,
             missing_coverage_policy,
             threshold,
             epsilon: 0.0,
-            timestamp,
+            timestamp: timestamp.into(),
             diagnostics: None,
             diff_ref: None,
             minimal_view: false,

--- a/crates/crap-core/src/adapters/reporters/json.rs
+++ b/crates/crap-core/src/adapters/reporters/json.rs
@@ -30,8 +30,9 @@ use crate::ports::ParseDiagnostic;
 /// change rather than a major one — the same shape `HtmlMultiOptions`
 /// already uses. (Adding `epsilon` is what made a prior release register
 /// as breaking; that class is now closed.) Cross-crate tests construct it
-/// via the gated [`JsonConfig::for_test`] constructor below; in-crate
-/// code still uses struct literals freely.
+/// via the gated `for_test` constructor below (a plain code span, not an
+/// intra-doc link — `for_test` is `#[cfg]`-gated and absent from the
+/// default doc build); in-crate code still uses struct literals freely.
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct JsonConfig<'a, P: ParseDiagnostic> {

--- a/crates/crap4rs/tests/diff_integration.rs
+++ b/crates/crap4rs/tests/diff_integration.rs
@@ -599,19 +599,15 @@ fn json_envelope_contains_diff_ref() {
         .unwrap()
         .result;
 
-    let config = reporters::json::JsonConfig {
-        tool_version: "0.1.0".to_string(),
-        language: "rust".to_string(),
-        metric: ComplexityMetric::Cognitive,
-        missing_coverage_policy: MissingCoveragePolicy::Pessimistic,
-        threshold: 30.0,
-        epsilon: 0.0,
-        timestamp: "2026-03-29T00:00:00Z".to_string(),
-        diagnostics: None,
-        diff_ref: Some("HEAD"),
-        minimal_view: false,
-        delta: None,
-    };
+    let mut config = reporters::json::JsonConfig::for_test(
+        "0.1.0".to_string(),
+        "rust".to_string(),
+        ComplexityMetric::Cognitive,
+        MissingCoveragePolicy::Pessimistic,
+        30.0,
+        "2026-03-29T00:00:00Z".to_string(),
+    );
+    config.diff_ref = Some("HEAD");
     let view = crap4rs::domain::view::apply(&result, crap4rs::domain::view::ViewSpec::default());
     let json_str = reporters::format_json(&view, &config).unwrap();
     let v: serde_json::Value = serde_json::from_str(&json_str).unwrap();
@@ -639,19 +635,14 @@ fn json_envelope_diff_ref_null_without_flag() {
         .unwrap()
         .result;
 
-    let config = reporters::json::JsonConfig {
-        tool_version: "0.1.0".to_string(),
-        language: "rust".to_string(),
-        metric: ComplexityMetric::Cognitive,
-        missing_coverage_policy: MissingCoveragePolicy::Pessimistic,
-        threshold: 30.0,
-        epsilon: 0.0,
-        timestamp: "2026-03-29T00:00:00Z".to_string(),
-        diagnostics: None,
-        diff_ref: None,
-        minimal_view: false,
-        delta: None,
-    };
+    let config = reporters::json::JsonConfig::for_test(
+        "0.1.0".to_string(),
+        "rust".to_string(),
+        ComplexityMetric::Cognitive,
+        MissingCoveragePolicy::Pessimistic,
+        30.0,
+        "2026-03-29T00:00:00Z".to_string(),
+    );
     let view = crap4rs::domain::view::apply(&result, crap4rs::domain::view::ViewSpec::default());
     let json_str = reporters::format_json(&view, &config).unwrap();
     let v: serde_json::Value = serde_json::from_str(&json_str).unwrap();

--- a/crates/crap4rs/tests/diff_integration.rs
+++ b/crates/crap4rs/tests/diff_integration.rs
@@ -600,12 +600,12 @@ fn json_envelope_contains_diff_ref() {
         .result;
 
     let mut config = reporters::json::JsonConfig::for_test(
-        "0.1.0".to_string(),
-        "rust".to_string(),
+        "0.1.0",
+        "rust",
         ComplexityMetric::Cognitive,
         MissingCoveragePolicy::Pessimistic,
         30.0,
-        "2026-03-29T00:00:00Z".to_string(),
+        "2026-03-29T00:00:00Z",
     );
     config.diff_ref = Some("HEAD");
     let view = crap4rs::domain::view::apply(&result, crap4rs::domain::view::ViewSpec::default());
@@ -636,12 +636,12 @@ fn json_envelope_diff_ref_null_without_flag() {
         .result;
 
     let config = reporters::json::JsonConfig::for_test(
-        "0.1.0".to_string(),
-        "rust".to_string(),
+        "0.1.0",
+        "rust",
         ComplexityMetric::Cognitive,
         MissingCoveragePolicy::Pessimistic,
         30.0,
-        "2026-03-29T00:00:00Z".to_string(),
+        "2026-03-29T00:00:00Z",
     );
     let view = crap4rs::domain::view::apply(&result, crap4rs::domain::view::ViewSpec::default());
     let json_str = reporters::format_json(&view, &config).unwrap();

--- a/crates/crap4rs/tests/json_reporter_cucumber.rs
+++ b/crates/crap4rs/tests/json_reporter_cucumber.rs
@@ -53,19 +53,14 @@ impl JsonWorld {
         let metric = self.metric.unwrap_or(ComplexityMetric::Cognitive);
         let threshold = self.threshold.unwrap_or(8.0);
         let view = view::apply(result, ViewSpec::default());
-        let config = JsonConfig {
-            tool_version: "0.1.0".to_string(),
-            language: "rust".to_string(),
+        let config = JsonConfig::for_test(
+            "0.1.0".to_string(),
+            "rust".to_string(),
             metric,
-            missing_coverage_policy: MissingCoveragePolicy::Pessimistic,
+            MissingCoveragePolicy::Pessimistic,
             threshold,
-            epsilon: 0.0,
-            timestamp: "2026-05-04T00:00:00Z".to_string(),
-            diagnostics: None,
-            diff_ref: None,
-            minimal_view: false,
-            delta: None,
-        };
+            "2026-05-04T00:00:00Z".to_string(),
+        );
         let json_str = format_json(&view, &config).expect("format_json should succeed");
         self.output = Some(serde_json::from_str(&json_str).expect("output should be valid JSON"));
     }

--- a/crates/crap4rs/tests/json_reporter_cucumber.rs
+++ b/crates/crap4rs/tests/json_reporter_cucumber.rs
@@ -54,12 +54,12 @@ impl JsonWorld {
         let threshold = self.threshold.unwrap_or(8.0);
         let view = view::apply(result, ViewSpec::default());
         let config = JsonConfig::for_test(
-            "0.1.0".to_string(),
-            "rust".to_string(),
+            "0.1.0",
+            "rust",
             metric,
             MissingCoveragePolicy::Pessimistic,
             threshold,
-            "2026-05-04T00:00:00Z".to_string(),
+            "2026-05-04T00:00:00Z",
         );
         let json_str = format_json(&view, &config).expect("format_json should succeed");
         self.output = Some(serde_json::from_str(&json_str).expect("output should be valid JSON"));

--- a/crates/crap4rs/tests/json_reporter_lcov_diagnostics.rs
+++ b/crates/crap4rs/tests/json_reporter_lcov_diagnostics.rs
@@ -65,12 +65,12 @@ fn diagnostics_included_when_present() {
 
     let result = make_empty_result();
     let mut config = JsonConfig::for_test(
-        "0.1.0".to_string(),
-        "rust".to_string(),
+        "0.1.0",
+        "rust",
         ComplexityMetric::Cognitive,
         MissingCoveragePolicy::Pessimistic,
         8.0,
-        "2026-03-28T12:00:00Z".to_string(),
+        "2026-03-28T12:00:00Z",
     );
     config.diagnostics = Some(&diag);
 

--- a/crates/crap4rs/tests/json_reporter_lcov_diagnostics.rs
+++ b/crates/crap4rs/tests/json_reporter_lcov_diagnostics.rs
@@ -64,19 +64,15 @@ fn diagnostics_included_when_present() {
         serde_json::from_str(diag_json).expect("diagnostics JSON should deserialize");
 
     let result = make_empty_result();
-    let config = JsonConfig {
-        tool_version: "0.1.0".to_string(),
-        language: "rust".to_string(),
-        metric: ComplexityMetric::Cognitive,
-        missing_coverage_policy: MissingCoveragePolicy::Pessimistic,
-        threshold: 8.0,
-        epsilon: 0.0,
-        timestamp: "2026-03-28T12:00:00Z".to_string(),
-        diagnostics: Some(&diag),
-        diff_ref: None,
-        minimal_view: false,
-        delta: None,
-    };
+    let mut config = JsonConfig::for_test(
+        "0.1.0".to_string(),
+        "rust".to_string(),
+        ComplexityMetric::Cognitive,
+        MissingCoveragePolicy::Pessimistic,
+        8.0,
+        "2026-03-28T12:00:00Z".to_string(),
+    );
+    config.diagnostics = Some(&diag);
 
     let analysis_view = view::apply(&result, ViewSpec::default());
     let json_str = format_json(&analysis_view, &config).expect("format_json should succeed");


### PR DESCRIPTION
Release-hardening series, part 5 (the public-API-boundary half of crap-rs#448).

> ⏸️ **HOLD — awaiting operator approval before merge.** This is the one consequential, breaking change in the series; per the standing agreement it does not auto-merge. Built, reviewed, and green for your go/no-go.

## The reframe (council finding)

The original premise was "JsonConfig leaked `pub`; shrink it to `pub(crate)`." A council design pass (CAO + CEng, both verdict **SOUND**) **flipped that premise** against the live code:

- `JsonConfig` / `DeltaContext` are **genuinely public** — re-exported via the crap4rs v0.4 shim aliases (`crap4rs::adapters::reporters::json::{JsonConfig,DeltaContext}`) and constructed by 4 crap4rs integration tests. Demoting to `pub(crate)` would **break** that public surface.
- The real cause of the spurious 0.9.0 "breaking" bump (adding `epsilon`, crap-rs#379) is that a downstream-struct-literal-constructible `pub` struct makes **any field addition** a major break.

So the correct fix is **`#[non_exhaustive]`** — the exact shape `HtmlMultiOptions` already uses — not visibility narrowing.

## What

- `JsonConfig`, `DeltaContext`: add `#[non_exhaustive]` (stay `pub`; fields stay `pub`).
- New `#[cfg(any(test, feature = "test-helpers"))] JsonConfig::for_test(...)` constructor — `#[non_exhaustive]` blocks the cross-crate struct literals the adapter tests use; this restores exactly that path. **Reuses the existing `test-helpers` feature + crap4rs's existing dev-dep opt-in — zero Cargo.toml changes.** `DeltaContext` needs none (sole construction site is in-crate).
- 4 crap4rs test sites migrated to `for_test(...)` + post-construction field sets for the `diff_ref` / `diagnostics` cases.

## Semver impact

**Reduces** future false-breaking — the whole point. Adding `#[non_exhaustive]` is itself a **one-time breaking change** (marked `BREAKING CHANGE:` in the commit so release-plz computes a breaking bump), after which additive fields are non-breaking forever. Pay-once / save-forever.

## Validation

- `cargo nextest run --workspace --all-targets`: **1353/1353 pass** (incl. the wire_envelope snapshots — no drift; no `crap4rs/src` touched).
- `cargo +1.93 check --workspace --all-targets` (MSRV, `--all-targets` exercises the feature-gated path): clean.
- `cargo clippy --workspace --all-targets -- -D warnings` + `cargo fmt --check`: clean.
- crap4ts / crap-render construct neither type (verified) — zero blast radius beyond the 4 enumerated crap4rs tests.

## Deferred (tracked separately)

- A non-gated `JsonConfig::new`/builder if a *production* external consumer ever needs to construct it (today construction is in-crate). Out of scope.
- A cargo-semver-checks baseline / a CI assertion that reporter-config structs stay `#[non_exhaustive]` — PR 2 (semver-gate hardening) territory.

Part of crap-rs#448. Decision captured in the release-process ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the JSON reporting format’s compatibility so future updates can add fields without breaking existing integrations.
  * Made test coverage around JSON output more reliable, helping ensure consistent report generation.
  
* **Documentation**
  * Clarified how JSON report data is intended to be used and extended over time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->