### PR TITLE
ci: encoded-defect lint — anchor deliberately-wrong values to a tracking issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1888,6 +1888,43 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: python3 scripts/version-edit-lint.py
 
+  encoded-defect-lint:
+    # Mechanical enforcement of AGENTS.md "Encoded-defect discipline": a
+    # deliberately-wrong / deferred VALUE frozen into a test, snapshot, or
+    # fixture must carry a tracking anchor — `tracked: crap-rs#<n>` (active)
+    # or `resolved: crap-rs#<n>` (historical/post-mortem). The rc.4 release
+    # shipped a wire envelope whose `language` was frozen to the wrong value
+    # under a "wrong-by-design pending a later fix" comment, and because the
+    # snapshot WAS the oracle the deferred defect sailed green to publish.
+    # This gate makes that deferral class accountable — same discipline as
+    # `~/.claude/rules/exclusions.md` (documentation rots; CI doesn't).
+    #
+    # Matches only unambiguous "deliberately wrong" markers (wrong-by-design
+    # / known-wrong / wrong-on-purpose / deliberately|intentionally wrong),
+    # NOT bare "by design" (a legitimate design statement). Scoped to
+    # source/test/snapshot/fixture files under `crates/` (excludes
+    # `scripts/` + `*.md`, which name the markers in their own definition).
+    #
+    # `actions/checkout` SHA-pinned per the repo-wide convention;
+    # `persist-credentials: false` (never pushes) + `permissions:
+    # contents: read` enforce least privilege. Mirrors the `lefthook.yml`
+    # pre-push step — single source of truth in
+    # `scripts/encoded-defect-lint.py`. See AGENTS.md "Encoded-defect
+    # discipline".
+    name: encoded-defect lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Self-test the encoded-defect lint logic
+        run: python3 scripts/encoded-defect-lint.py --self-test
+      - name: Reject unanchored deliberately-wrong markers
+        run: python3 scripts/encoded-defect-lint.py
+
   bdd-tracked-lint:
     # Mechanical enforcement of AGENTS.md "BDD hygiene" Rules 1 and 2
     # across `crates/*/tests/features/` (single script, two rules):

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -786,3 +786,55 @@ There is **no inline override**: the only legitimate feature-PR version
 touch is a new crate (exempt). A genuine one-off bump belongs on the
 release-plz path. The decision is captured in
 `adr-release-process-and-public-api-boundary`.
+
+## Encoded-defect discipline
+
+A **deliberately-wrong / deferred value** frozen into a test, snapshot, or
+fixture must carry a **tracking anchor**. This is the exclusions discipline
+(`~/.claude/rules/exclusions.md`) applied to *values*: if you knowingly
+encode a wrong value, you must name the issue that owns it.
+
+### Why
+
+The rc.4 release shipped a wire envelope whose `language` field was frozen
+to the wrong value (`"rust"` for the TypeScript adapter) under a comment
+labeling it deliberately wrong "pending a later fix" — and because a
+shape-lock **snapshot was the oracle**, the deferred defect sailed green
+through every PR until publish. (Corollary: a snapshot is a *tautological*
+oracle — it bakes whatever the output is. For a field with a
+knowable-correct value, assert it with an explicit `assert_eq!` oracle, not
+a snapshot. The wire-envelope canaries were converted to explicit oracles.)
+
+### The rule
+
+A line carrying an unambiguous "deliberately wrong" marker must have an
+anchor comment within a few lines:
+
+- `tracked: crap-rs#<n>` — **active** deferral; an open issue owns the fix.
+- `resolved: crap-rs#<n>` — **historical** reference; a post-mortem doc
+  narrating a defect that has SINCE been fixed (so the narrative can name
+  the marker without the lint mistaking it for a live defect).
+
+Markers (case-insensitive): `wrong-by-design`, `known-wrong`,
+`wrong-on-purpose`, `deliberately wrong`, `intentionally wrong`. Bare
+"by design" is a legitimate design statement and is **not** a marker — the
+discriminator is *wrong*.
+
+### Mechanical enforcement
+
+`scripts/encoded-defect-lint.py` (the `encoded-defect-lint` CI job +
+`lefthook.yml` pre-push command — single source of truth in the script)
+fails on any unanchored marker. It is scoped to source/test/snapshot/
+fixture files under `crates/` (`.rs .snap .json .ts .toml .feature`) and
+deliberately excludes `scripts/` and `*.md` — the lint and these docs name
+the markers in their own definitions. A `--self-test` guards the rule logic
+(documentation rots; CI doesn't — same pattern as
+`scripts/bdd-tracked-lint.py`).
+
+**Honest limitation:** this is a heuristic text matcher. It enforces that a
+*labeled* deferral is also *anchored*; it cannot detect a deferred wrong
+value that carries no marker at all. The labeling convention is what makes
+the deferral visible; the lint makes the anchor mandatory once it is. The
+narrow marker set keeps the false-match floor near zero (verified by an
+adversarial whole-tree FP-hunt at authoring time). The decision is captured
+in `adr-release-process-and-public-api-boundary`.

--- a/crates/crap-core/tests/wire_envelope_crap4ts.rs
+++ b/crates/crap-core/tests/wire_envelope_crap4ts.rs
@@ -15,7 +15,7 @@
 //! refactors. Separate per-adapter snapshots give cleaner failure
 //! attribution than a single dual-fixture snapshot would.
 //!
-//! ## Wrong-by-design values that flipped at W2.5
+//! ## Wrong-by-design values that flipped at W2.5 — resolved: crap-rs#188 (metric), crap-rs#450 (language)
 //!
 //! Through W1.3 the snapshot baked `metric: "cognitive"` — wrong for
 //! crap4ts (no cognitive support; default should be cyclomatic).
@@ -23,7 +23,8 @@
 //! per locked decision #2. The snapshot was regenerated at W2.5 PR
 //! time; `metric: "cyclomatic"` is now baked. `language` was also once
 //! wrong-by-design (`"rust"` for every adapter); it now stamps the
-//! adapter's own `AdapterMeta::config_lang_key`, so `language:
+//! adapter's own `AdapterMeta::config_lang_key` (resolved: crap-rs#450),
+//! so `language:
 //! "typescript"` is baked here. An explicit assertion below guards the
 //! value so the per-adapter wiring can't silently regress to a literal.
 //!

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -152,6 +152,16 @@ pre-push:
         case "$branch" in release-plz-*) echo "skip: release-plz branch"; exit 0 ;; esac
         python3 scripts/version-edit-lint.py
       timeout: 30s
+    encoded-defect-lint:
+      # Mechanical enforcement of AGENTS.md "Encoded-defect discipline": a
+      # deliberately-wrong / deferred value frozen into a test, snapshot, or
+      # fixture must carry a `tracked: crap-rs#<n>` (active) or
+      # `resolved: crap-rs#<n>` (historical) anchor. Local-velocity layer of
+      # the same check that `.github/workflows/ci.yml`'s `encoded-defect-lint`
+      # job runs on every push. Single source of truth:
+      # `scripts/encoded-defect-lint.py`.
+      run: python3 scripts/encoded-defect-lint.py
+      timeout: 30s
     clippy:
       run: cargo clippy --workspace --all-targets -- -D warnings
       timeout: 300s

--- a/scripts/encoded-defect-lint.py
+++ b/scripts/encoded-defect-lint.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Encoded-defect lint — a deferred/known-wrong VALUE frozen into a test,
+snapshot, or fixture must carry a tracking anchor.
+
+The *why* lives in AGENTS.md ("Encoded-defect discipline") and the ADR
+(`adr-release-process-and-public-api-boundary`). This script is the
+*what*. The rc.4 release shipped a wire envelope whose `language` field
+was frozen to the wrong value (`"rust"` for the TypeScript adapter) with
+a source comment labeling it deliberately wrong "pending a later fix" —
+and because the snapshot WAS the oracle, the deferred defect sailed green
+through every PR until it was published. (See memory
+`snapshot-not-value-oracle`: a shape-lock snapshot is a tautological
+oracle.)
+
+This lint makes that class of deferral ACCOUNTABLE — the same discipline
+as `~/.claude/rules/exclusions.md` and `scripts/bdd-tracked-lint.py`: if
+you knowingly encode a wrong value, you must anchor it to an issue.
+
+What it flags: a line containing an unambiguous "deliberately wrong"
+marker that lacks a nearby anchor comment.
+
+  Markers (case-insensitive):
+    wrong-by-design | wrong by design | known-wrong | known wrong |
+    wrong-on-purpose | wrong on purpose | deliberately wrong |
+    intentionally wrong
+
+  Anchor (within ANCHOR_WINDOW lines of the marker, same file):
+    tracked: crap-rs#<n>     (active deferral — an open issue owns the fix)
+    resolved: crap-rs#<n>    (historical/post-mortem reference to a CLOSED
+                              issue — e.g. a doc comment narrating a defect
+                              that has SINCE been fixed)
+
+Why these markers and NOT bare "by design": "by design" appears benignly
+across the repo (a metric is "adapter-agnostic by design", the staleness
+check "warns, never fails — by design", etc.). The discriminator is the
+word **wrong** (or "known-wrong" / "on-purpose"): a value described as
+*wrong* on purpose is, by definition, an encoded defect. Bare "by design"
+is a legitimate design statement and is deliberately NOT matched.
+
+Honest limitation (mirrors memory `never-raises-is-not-never-hides`): this
+is a HEURISTIC text matcher. It cannot detect a deferred wrong value that
+carries NO marker comment at all (the writer simply stays silent) — only
+the discipline of *labeling* deferrals is enforceable here; the labeling
+itself is a convention. The lint's job is to ensure that WHEN a deferral
+is labeled, it is also anchored. Its precise-marker design keeps the
+false-match floor near zero (verified by an adversarial FP-hunt over the
+whole tree at authoring time); the `--self-test` guards the rule logic.
+
+Scope: tracked source/test/snapshot/fixture files under `crates/`
+(`.rs .snap .json .ts .toml .feature`). EXCLUDES `scripts/` (this lint
+and its siblings name the markers in their own source) and `*.md`
+(AGENTS.md / READMEs document the rule using the marker words). A
+deferred *value* lives in code/tests/snapshots/fixtures, not in prose
+docs or lint source — scoping there is what keeps the lint from matching
+its own definition.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+
+# Unambiguous "deliberately wrong" markers. The shared discriminator is
+# "wrong" / "known-wrong" / "on-purpose" — NOT bare "by design".
+MARKER_RE = re.compile(
+    r"wrong[-\s]by[-\s]design"
+    r"|known[-\s]wrong"
+    r"|wrong[-\s]on[-\s]purpose"
+    r"|deliberately[-\s]wrong"
+    r"|intentionally[-\s]wrong",
+    re.IGNORECASE,
+)
+
+ANCHOR_RE = re.compile(r"(?:tracked|resolved):\s*crap-rs#\d+", re.IGNORECASE)
+
+# A deferral comment usually sits on the marker line or immediately
+# around it. Window is generous enough to span a short doc block but
+# small enough that one anchor can't excuse an unrelated marker.
+ANCHOR_WINDOW = 6
+
+SCAN_EXTS = (".rs", ".snap", ".json", ".ts", ".toml", ".feature")
+
+
+def find_violations(text: str, path: str) -> list[str]:
+    """Return violation messages for marker lines in `text` lacking a
+    nearby anchor. Pure function — the unit under self-test."""
+    lines = text.splitlines()
+    violations: list[str] = []
+    for i, line in enumerate(lines):
+        m = MARKER_RE.search(line)
+        if not m:
+            continue
+        lo = max(0, i - ANCHOR_WINDOW)
+        hi = min(len(lines), i + ANCHOR_WINDOW + 1)
+        window = "\n".join(lines[lo:hi])
+        if ANCHOR_RE.search(window):
+            continue
+        violations.append(
+            f"{path}:{i + 1}: encoded-defect marker {m.group(0)!r} without a "
+            f"`tracked: crap-rs#<n>` (active) or `resolved: crap-rs#<n>` "
+            f"(historical) anchor within {ANCHOR_WINDOW} lines"
+        )
+    return violations
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+def _tracked_files() -> list[str]:
+    out = subprocess.run(
+        ["git", "ls-files", "crates/"],
+        capture_output=True,
+        text=True,
+        # Pin UTF-8 (not the locale default — CP1252 on some Windows
+        # runners) so non-ASCII tracked paths decode consistently.
+        encoding="utf-8",
+        errors="replace",
+        check=True,
+    ).stdout
+    files = []
+    for line in out.splitlines():
+        p = line.strip()
+        if not p or not p.endswith(SCAN_EXTS):
+            continue
+        if p.startswith("scripts/"):
+            continue
+        files.append(p)
+    return files
+
+
+def run_cli() -> int:
+    violations: list[str] = []
+    for path in _tracked_files():
+        try:
+            with open(path, encoding="utf-8") as fh:
+                text = fh.read()
+        except (OSError, UnicodeDecodeError):
+            continue  # binary / unreadable — skip
+        violations.extend(find_violations(text, path))
+
+    if violations:
+        print("✗ encoded-defect lint failed — a deliberately-wrong value must be anchored.")
+        print("  Add `tracked: crap-rs#<n>` (open issue owns the fix) or, for a")
+        print("  post-mortem reference to an already-fixed issue, `resolved: crap-rs#<n>`.")
+        print("  See AGENTS.md 'Encoded-defect discipline' and memory snapshot-not-value-oracle.\n")
+        for v in violations:
+            print(f"  - {v}")
+        return 1
+
+    print("✓ encoded-defect lint passed (no unanchored deliberately-wrong markers).")
+    return 0
+
+
+# --------------------------------------------------------------------------
+# self-test
+# --------------------------------------------------------------------------
+
+def self_test() -> int:
+    cases = [
+        # (name, text, expect_violation_count)
+        ("unanchored wrong-by-design fails", "let x = 1; // wrong-by-design\n", 1),
+        (
+            "anchored (tracked) passes",
+            "// wrong-by-design pending the fix\n// tracked: crap-rs#450 — language flip\nlet x = 1;\n",
+            0,
+        ),
+        (
+            "anchored (resolved) passes — post-mortem",
+            "//! ## Wrong-by-design values that flipped at W2.5\n"
+            "//! resolved: crap-rs#449 — now stamps the adapter's real language\n",
+            0,
+        ),
+        ("bare 'by design' NOT matched", "// adapter-agnostic by design — source format is irrelevant\n", 0),
+        ("bare 'by design' (warns never fails) NOT matched", "// warns, never fails — by design\n", 0),
+        ("known-wrong unanchored fails", "expected = 2.0  # known-wrong placeholder\n", 1),
+        (
+            "known-wrong anchored passes",
+            "expected = 2.0  # known-wrong; tracked: crap-rs#999 — recalibrate\n",
+            0,
+        ),
+        ("wrong-on-purpose unanchored fails", "value: 'rust'  // wrong on purpose\n", 1),
+        ("intentionally wrong unanchored fails", "x = 1 // intentionally wrong for now\n", 1),
+        ("benign 'wrong' word NOT matched", "// returns an error if the path is wrong\n", 0),
+        ("benign 'design' word NOT matched", "// the design of this module follows hexagonal ports\n", 0),
+        (
+            "anchor outside window does NOT excuse",
+            "// wrong-by-design\n" + ("// filler\n" * 8) + "// tracked: crap-rs#1\n",
+            1,
+        ),
+        (
+            "two markers, one shared anchor in window, both pass",
+            "// wrong-by-design here\n// and known-wrong there\n// tracked: crap-rs#7\n",
+            0,
+        ),
+    ]
+    failures = 0
+    for name, text, expect in cases:
+        got = len(find_violations(text, "x"))
+        ok = got == expect
+        print(f"  [{'PASS' if ok else 'FAIL'}] {name} (expected {expect}, got {got})")
+        if not ok:
+            failures += 1
+    if failures:
+        print(f"\n✗ self-test: {failures} case(s) failed")
+        return 1
+    print(f"\n✓ self-test: all {len(cases)} cases passed")
+    return 0
+
+
+if __name__ == "__main__":
+    if "--self-test" in sys.argv[1:]:
+        sys.exit(self_test())
+    sys.exit(run_cli())

--- a/scripts/encoded-defect-lint.py
+++ b/scripts/encoded-defect-lint.py
@@ -63,12 +63,17 @@ import sys
 
 # Unambiguous "deliberately wrong" markers. The shared discriminator is
 # "wrong" / "known-wrong" / "on-purpose" — NOT bare "by design".
+# `[-_\s]+` between words tolerates any separator a writer might use —
+# hyphen, underscore, or one-or-more spaces/tabs (`wrong-by-design`,
+# `wrong_by_design`, `wrong by design`) — without widening the matched
+# vocabulary. (`\s` is intra-line only: the lint scans line by line.)
+_SEP = r"[-_\s]+"
 MARKER_RE = re.compile(
-    r"wrong[-\s]by[-\s]design"
-    r"|known[-\s]wrong"
-    r"|wrong[-\s]on[-\s]purpose"
-    r"|deliberately[-\s]wrong"
-    r"|intentionally[-\s]wrong",
+    rf"wrong{_SEP}by{_SEP}design"
+    rf"|known{_SEP}wrong"
+    rf"|wrong{_SEP}on{_SEP}purpose"
+    rf"|deliberately{_SEP}wrong"
+    rf"|intentionally{_SEP}wrong",
     re.IGNORECASE,
 )
 
@@ -119,12 +124,13 @@ def _tracked_files() -> list[str]:
         errors="replace",
         check=True,
     ).stdout
+    # NB: the scan is scoped to `crates/` (the git ls-files arg), so
+    # `scripts/` and root-level `*.md` — which name the markers in their
+    # own definitions — are excluded by SCOPE, no path filter needed.
     files = []
     for line in out.splitlines():
         p = line.strip()
         if not p or not p.endswith(SCAN_EXTS):
-            continue
-        if p.startswith("scripts/"):
             continue
         files.append(p)
     return files
@@ -134,10 +140,14 @@ def run_cli() -> int:
     violations: list[str] = []
     for path in _tracked_files():
         try:
-            with open(path, encoding="utf-8") as fh:
+            # errors="replace": scan a file with stray invalid-UTF-8 bytes
+            # (replacing them with U+FFFD) rather than silently skipping it
+            # — a marker is overwhelmingly likely to be in the valid-ASCII
+            # portion, so dropping the whole file would create a blind spot.
+            with open(path, encoding="utf-8", errors="replace") as fh:
                 text = fh.read()
-        except (OSError, UnicodeDecodeError):
-            continue  # binary / unreadable — skip
+        except OSError:
+            continue  # unreadable — skip
         violations.extend(find_violations(text, path))
 
     if violations:
@@ -174,6 +184,9 @@ def self_test() -> int:
         ),
         ("bare 'by design' NOT matched", "// adapter-agnostic by design — source format is irrelevant\n", 0),
         ("bare 'by design' (warns never fails) NOT matched", "// warns, never fails — by design\n", 0),
+        ("underscore separator matches", "let x = 1; // wrong_by_design\n", 1),
+        ("multiple-space separator matches", "// this is wrong  by  design here\n", 1),
+        ("mixed separators (known_wrong) matches", "v = 2  # known_wrong\n", 1),
         ("known-wrong unanchored fails", "expected = 2.0  # known-wrong placeholder\n", 1),
         (
             "known-wrong anchored passes",


### PR DESCRIPTION
Release-hardening series, part 3.

## What

A CI lint + lefthook hook that **fails on a deliberately-wrong / deferred value** frozen into a test, snapshot, or fixture **unless it carries a tracking anchor** — `tracked: crap-rs#<n>` (active) or `resolved: crap-rs#<n>` (historical/post-mortem).

## Why

The rc.4 release shipped a wire envelope with `language` frozen to the wrong value (`"rust"` for the TS adapter) under a "wrong-by-design pending a later fix" comment — and because a shape-lock **snapshot was the oracle**, the deferred defect sailed green through every PR until publish. This makes that deferral class accountable (the exclusions discipline, applied to values). Corollary documented in AGENTS.md: a snapshot is a *tautological* oracle; use an explicit `assert_eq!` for knowable-correct values.

## False-positive safety (this is a build-failing heuristic lint)

- Matches only **unambiguous** markers — `wrong-by-design`, `known-wrong`, `wrong-on-purpose`, `deliberately wrong`, `intentionally wrong`. The discriminator is *wrong*; bare **"by design"** (8 benign uses in the tree) is **not** matched.
- Dual `tracked:`/`resolved:` anchor within a 6-line window.
- Scoped to source/test/snapshot/fixture files under `crates/` (`.rs .snap .json .ts .toml .feature`); **excludes `scripts/` and `*.md`** — the lint and these docs name the markers in their own definitions (self-match avoidance).
- **Adversarial whole-tree FP-hunt** at authoring flagged *only* the known post-mortem doc block in `wire_envelope_crap4ts.rs` — now anchored `resolved: crap-rs#188` (metric flip) / `crap-rs#450` (language flip), both shipped. Zero other matches.
- `--self-test` (13 cases incl. bare-"by design", benign "wrong"/"design", anchor-outside-window) guards the rule logic; runs in CI before the live check.

**Honest limitation** (in the AGENTS.md section): it's a heuristic text matcher — it enforces that a *labeled* deferral is *anchored*; it can't detect a deferred value that carries no marker at all.

## Validation

fmt + actionlint + zizmor clean; lefthook validates; `wire_envelope_crap4ts` test passes (doc-only edit, no snapshot change); lint self-test 13/13; lint clean on the tree.

Part of the release-hardening series (crap-rs#448-adjacent). Decision captured in the release-process ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)