### PR TITLE
ci: shift-left npm packaging verification onto the release-plz PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1925,6 +1925,52 @@ jobs:
       - name: Reject unanchored deliberately-wrong markers
         run: python3 scripts/encoded-defect-lint.py
 
+  verify-npm-packaging:
+    # Shift-left of the npm packaging + install-gating gate. The same
+    # check runs post-merge in release-plz.yml's `build-crap4ts-cdylib`
+    # (per-platform matrix); here it runs on the release-plz PR (native
+    # linux-x64-gnu) BEFORE the irreversible publish merge, so a packaging
+    # defect — e.g. a stray os/cpu/libc field that makes `npm install`
+    # reject the platform with EBADPLATFORM, as crap4ts 2.0.0-rc.1 shipped
+    # — fails on the release PR instead of reaching the registry. Single
+    # source of truth: `scripts/verify-npm-packaging.sh`.
+    #
+    # Gated to the release-plz PR (the deliberate dev->prod gate). The
+    # post-merge matrix still covers every platform; this catches the
+    # common case on the runner's native platform, pre-publish. The build
+    # values (target / artifact / node_name) mirror the matrix's
+    # `linux-x64-gnu` row.
+    #
+    # `actions/checkout` SHA-pinned; `persist-credentials: false` + scoped
+    # `permissions: contents: read` per the supply-chain policy. The job
+    # is verification-only and publishes nothing, so it caches like the
+    # other ci.yml build jobs (ci.yml is not a release-relevant workflow).
+    name: verify-npm-packaging
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    if: github.event_name == 'pull_request' && startsWith(github.head_ref, 'release-plz-')
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Set up Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          shared-key: verify-npm-packaging
+          targets: x86_64-unknown-linux-gnu
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '24'
+      - name: Build crap4ts cdylib (linux-x64-gnu)
+        run: cargo build --package crap4ts --release --lib --features napi-binding --target x86_64-unknown-linux-gnu
+      - name: Rename cdylib to the napi .node filename
+        run: cp target/x86_64-unknown-linux-gnu/release/libcrap4ts.so packages/crap4ts/crap4ts.linux-x64-gnu.node
+      - name: Verify npm packaging + install-gating
+        run: bash scripts/verify-npm-packaging.sh
+
   bdd-tracked-lint:
     # Mechanical enforcement of AGENTS.md "BDD hygiene" Rules 1 and 2
     # across `crates/*/tests/features/` (single script, two rules):

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -276,36 +276,18 @@ jobs:
       # to it. crap4ts 2.0.0-rc.1 shipped a stray `libc` entry that made
       # `npm install` reject every macOS install with EBADPLATFORM; the
       # path-require smoke test stayed green and the defect reached npm,
-      # caught only by a sandbox install during the soak. Packing the
-      # package and installing the tarball into a clean project reproduces
-      # that gating on this runner's native platform, pre-publish, so a
-      # packaging defect fails the workflow instead of reaching the registry.
-      # zizmor's adhoc-packages audit flags the tarball `npm install` below;
-      # it is intentional and bounded — this step installs the just-built
-      # local tarball into a throwaway consumer to smoke-test platform
-      # gating, which is inherently lockfile-less. The ignore sits on the
-      # `run:` line because a `#` inside a block scalar is bash, not a YAML
-      # comment, so zizmor only reads a directive on the step's YAML line.
+      # caught only by a sandbox install during the soak. The shared script
+      # packs the package + installs the tarball into a clean project,
+      # reproducing that gating on this runner's native platform.
+      #
+      # SINGLE SOURCE OF TRUTH: `scripts/verify-npm-packaging.sh` is run
+      # here (post-merge, per-platform) AND by ci.yml's `verify-npm-packaging`
+      # job on the release-plz PR (pre-merge, native), so a packaging defect
+      # fails LEFT of the irreversible publish. The `npm install` of a local
+      # tarball now lives in the script, out of zizmor's view, so the former
+      # inline `# zizmor: ignore[adhoc-packages]` is no longer needed.
       - name: Verify npm packaging + install-gating
-        run: | # zizmor: ignore[adhoc-packages]
-          set -euo pipefail
-          work="$(mktemp -d)"
-          ( cd packages/crap4ts && npm pack --pack-destination "$work" )
-          tarball="$(ls "$work"/crap4ts-*.tgz)"
-          echo "packed: $(basename "$tarball")"
-          consumer="$work/consumer"
-          mkdir -p "$consumer"
-          cd "$consumer"
-          npm init -y >/dev/null
-          # `npm install` exits non-zero on EBADPLATFORM; the explicit
-          # node_modules check is a backstop so the failure stays loud even
-          # if a future npm softens platform mismatch to a warning.
-          npm install --no-audit --no-fund "$tarball"
-          if [ ! -d node_modules/crap4ts ]; then
-            echo "::error::npm did not install crap4ts — os/cpu/libc gating rejected this platform (see EBADPLATFORM above). Packaging defect."
-            exit 1
-          fi
-          node -e 'const m = require("crap4ts"); if (typeof m.analyze !== "function") { throw new Error("crap4ts installed from the packed tarball but the analyze export is missing"); } console.log("OK: npm install-gating passed and analyze export present");'
+        run: bash scripts/verify-npm-packaging.sh
 
       - name: Upload cdylib artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/scripts/verify-npm-packaging.sh
+++ b/scripts/verify-npm-packaging.sh
@@ -30,21 +30,37 @@ pkg_dir="${1:-packages/crap4ts}"
 
 echo "::group::npm pack + install-gating ($pkg_dir)"
 work="$(mktemp -d)"
+# Clean the scratch dir on any exit. The trap runs in THIS shell, so the
+# script must not cd into $work itself (the install runs in a subshell
+# below) or the rmdir could fail on a busy cwd.
+trap 'rm -rf "$work"' EXIT
+
 ( cd "$pkg_dir" && npm pack --pack-destination "$work" )
-tarball="$(ls "$work"/crap4ts-*.tgz)"
+# Resolve the packed tarball by glob, not by parsing `ls`. No-match leaves
+# the literal pattern, which the -f guard rejects.
+tarballs=("$work"/crap4ts-*.tgz)
+tarball="${tarballs[0]}"
+if [ ! -f "$tarball" ]; then
+  echo "::error::npm pack produced no crap4ts-*.tgz in $work"
+  exit 1
+fi
 echo "packed: $(basename "$tarball")"
 
 consumer="$work/consumer"
 mkdir -p "$consumer"
-cd "$consumer"
-npm init -y >/dev/null
-# `npm install` exits non-zero on EBADPLATFORM; the explicit node_modules
-# check is a backstop so the failure stays loud even if a future npm
-# softens platform mismatch to a warning.
-npm install --no-audit --no-fund "$tarball"
-if [ ! -d node_modules/crap4ts ]; then
-  echo "::error::npm did not install crap4ts — os/cpu/libc gating rejected this platform (see EBADPLATFORM above). Packaging defect."
-  exit 1
-fi
-node -e 'const m = require("crap4ts"); if (typeof m.analyze !== "function") { throw new Error("crap4ts installed from the packed tarball but the analyze export is missing"); } console.log("OK: npm install-gating passed and analyze export present");'
+# Subshell so the main script's cwd is unchanged (keeps the EXIT trap able
+# to remove $work). A non-zero exit inside propagates via set -e.
+(
+  cd "$consumer"
+  npm init -y >/dev/null
+  # `npm install` exits non-zero on EBADPLATFORM; the explicit node_modules
+  # check is a backstop so the failure stays loud even if a future npm
+  # softens platform mismatch to a warning.
+  npm install --no-audit --no-fund "$tarball"
+  if [ ! -d node_modules/crap4ts ]; then
+    echo "::error::npm did not install crap4ts — os/cpu/libc gating rejected this platform (see EBADPLATFORM above). Packaging defect."
+    exit 1
+  fi
+  node -e 'const m = require("crap4ts"); if (typeof m.analyze !== "function") { throw new Error("crap4ts installed from the packed tarball but the analyze export is missing"); } console.log("OK: npm install-gating passed and analyze export present");'
+)
 echo "::endgroup::"

--- a/scripts/verify-npm-packaging.sh
+++ b/scripts/verify-npm-packaging.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# Verify the crap4ts npm package installs cleanly on THIS runner's native
+# platform and exposes the `analyze` export — the os/cpu/libc install-gating
+# smoke that a path-`require()` of the .node directly cannot exercise.
+#
+# SINGLE SOURCE OF TRUTH for npm packaging verification. Two callers share it:
+#   - release-plz.yml `build-crap4ts-cdylib` (post-merge, per-platform
+#     matrix) — runs this after building + renaming the platform cdylib,
+#     before uploading the artifact that becomes the published package.
+#   - ci.yml `verify-npm-packaging` (the release-plz PR, native platform) —
+#     runs this BEFORE the irreversible release-PR merge, so a packaging
+#     defect (e.g. a stray `libc` field that makes `npm install` reject the
+#     platform with EBADPLATFORM, as crap4ts 2.0.0-rc.1 shipped) fails LEFT
+#     of publish instead of reaching the registry.
+#
+# Precondition: the platform-native .node addon is already built and copied
+# into packages/crap4ts/ (the caller does `cargo build --features
+# napi-binding` + the rename). This script only packs + installs + smoke-
+# tests; it does not build.
+#
+# Why one script: keeping the pack/install/export assertions in a single
+# file run on BOTH the pre-merge and post-merge paths makes them
+# byte-identical — the same shift-left discipline as
+# scripts/build-and-verify-example-envelopes.sh (a release-critical gate
+# must not live only in the publish job).
+set -euo pipefail
+
+pkg_dir="${1:-packages/crap4ts}"
+
+echo "::group::npm pack + install-gating ($pkg_dir)"
+work="$(mktemp -d)"
+( cd "$pkg_dir" && npm pack --pack-destination "$work" )
+tarball="$(ls "$work"/crap4ts-*.tgz)"
+echo "packed: $(basename "$tarball")"
+
+consumer="$work/consumer"
+mkdir -p "$consumer"
+cd "$consumer"
+npm init -y >/dev/null
+# `npm install` exits non-zero on EBADPLATFORM; the explicit node_modules
+# check is a backstop so the failure stays loud even if a future npm
+# softens platform mismatch to a warning.
+npm install --no-audit --no-fund "$tarball"
+if [ ! -d node_modules/crap4ts ]; then
+  echo "::error::npm did not install crap4ts — os/cpu/libc gating rejected this platform (see EBADPLATFORM above). Packaging defect."
+  exit 1
+fi
+node -e 'const m = require("crap4ts"); if (typeof m.analyze !== "function") { throw new Error("crap4ts installed from the packed tarball but the analyze export is missing"); } console.log("OK: npm install-gating passed and analyze export present");'
+echo "::endgroup::"


### PR DESCRIPTION
Release-hardening series, part 2 (the final PR).

## What

The npm pack + install-gating check — the smoke that catches a packaging defect like the crap4ts 2.0.0-rc.1 stray `libc` field (which made `npm install` reject the platform with EBADPLATFORM) — ran **only post-merge** in release-plz.yml's per-platform `build-crap4ts-cdylib` job. This extracts it into a shared script and adds a **pre-merge** job on the release-plz PR so the defect fails **left of the irreversible publish merge**.

- `scripts/verify-npm-packaging.sh` — single source of truth: pack the package, install the tarball into a throwaway consumer, assert the `analyze` export (the os/cpu/libc install-gating a path-`require()` of the `.node` can't exercise).
- `release-plz.yml` `build-crap4ts-cdylib` (post-merge, per-platform) now calls the script. The `npm install` of a local tarball moved into the script (out of zizmor's view), so the former inline `# zizmor: ignore[adhoc-packages]` is dropped.
- `ci.yml` `verify-npm-packaging` job (pre-merge): builds the native `linux-x64-gnu` cdylib + renames to the napi `.node` filename (mirrors the matrix row) + runs the shared script. Gated to `release-plz-*` PRs — the deliberate dev→prod gate.

## Scope note

`cargo publish --dry-run` is deliberately **not** added pre-merge: it can't resolve for crates depending on the not-yet-published crap-core (crates.io publish ordering; release-plz handles it at real publish), and `semver_check = true` already gates the release PR. So the genuinely-shiftable release-only gate here is the npm packaging check.

## Validation

shellcheck + actionlint + zizmor clean on both workflows; setup-rust inputs confirmed; build/rename values mirror the existing matrix.

Part of the release-hardening series. Decision captured in the release-process ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)