### PR TITLE
docs: mdBook product book + trim-hard READMEs + gh-pages /book/ hosting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1007,6 +1007,83 @@ jobs:
             commit -m "ci(pages): publish production report + baseline envelope (${GITHUB_SHA})"
           git push origin HEAD:gh-pages
 
+  book-build:
+    # Build the mdBook product docs (book/) and fail on a broken build —
+    # a missing chapter, a bad SUMMARY.md link, etc. Gate only; the
+    # publish to GitHub Pages happens in `publish-book` on push to main.
+    #
+    # `actions/checkout` SHA-pinned; `persist-credentials: false` (never
+    # pushes) + `permissions: contents: read` per the supply-chain policy.
+    name: Book build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: taiki-e/install-action@15449e3094499af05d8d964a1c884208e4b8b595 # v2
+        with:
+          tool: mdbook
+      - name: Build the book
+        run: mdbook build book
+
+  publish-book:
+    # Publish the built mdBook to GitHub Pages under /book/ on push to
+    # main. The CRAP scorecard reports occupy the Pages root; this copies
+    # the book into /book/ and touches nothing else. Shares the
+    # `gh-pages-publish` concurrency lock with `publish-production-report`
+    # + the per-PR report publish so the three never race on the branch tip.
+    name: Publish book → gh-pages /book/
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    needs: book-build
+    concurrency:
+      group: gh-pages-publish
+      cancel-in-progress: false
+    permissions:
+      # Elevate ONLY here: contents: write to push the rendered book to
+      # the gh-pages branch. The top-level workflow default stays read.
+      contents: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: taiki-e/install-action@15449e3094499af05d8d964a1c884208e4b8b595 # v2
+        with:
+          tool: mdbook
+      - name: Build the book
+        run: mdbook build book
+      - name: Publish to gh-pages /book/
+        # Plain git push (no third-party action — supply-chain conventions).
+        # A separate shallow tokened clone of gh-pages avoids relying on the
+        # main checkout's (deliberately absent) persisted credentials.
+        # `/book/` is replaced wholesale so deleted chapters don't linger;
+        # everything else on gh-pages (the scorecard reports, .nojekyll) is
+        # preserved because we only touch the book/ subtree.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git clone --branch gh-pages --single-branch --depth 1 \
+            "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            gh-pages-pub
+          rm -rf gh-pages-pub/book
+          mkdir -p gh-pages-pub/book
+          cp -R book/book/. gh-pages-pub/book/
+          cd gh-pages-pub
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "gh-pages /book/ already up to date — nothing to publish"
+            exit 0
+          fi
+          git add book
+          git \
+            -c user.name="github-actions[bot]" \
+            -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+            commit -m "ci(pages): publish mdBook to /book/ (${GITHUB_SHA})"
+          git push origin HEAD:gh-pages
+
   scorecard-smoke-ts:
     # Sibling of `scorecard-smoke-rust` for the TypeScript dispatch
     # path. Build crap4ts from the PR, stage it on PATH (the only

--- a/README.md
+++ b/README.md
@@ -5,563 +5,86 @@
 [![npm](https://img.shields.io/npm/v/crap4ts.svg)](https://www.npmjs.com/package/crap4ts)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](#license)
 
-**CRAP (Change Risk Anti-Patterns) score analysis with a shared Rust core and language-specific adapters.** A CRAP score fuses a function's complexity with its test coverage into a single number — high complexity plus low coverage means high risk when the code changes.
+CRAP (Change Risk Anti-Patterns) score analysis with a shared Rust core and language-specific adapters. A CRAP score fuses a function's complexity with its line coverage into one risk number — high complexity plus low coverage means high risk when the code changes. The published formula is `CRAP = complexity² × (1 − coverage)³ + complexity`, where `coverage` is a fraction in `[0, 1]`.
 
-This workspace ships two analyzers over one shared core:
+## Two adapters, one core
 
-| Crate / package | Analyzes | Coverage format | Published to |
-|-----------------|----------|-----------------|--------------|
-| **`crap4rs`** | Rust | LCOV | [crates.io](https://crates.io/crates/crap4rs) |
-| **`crap4ts`** | TypeScript / JavaScript | Istanbul JSON | [npm](https://www.npmjs.com/package/crap4ts) — see its [package README](packages/crap4ts/README.md) |
-| **`crap-core`** | _shared library_ | — | internal: CRAP formula, thresholds, reporters, analysis types |
+| Crate / package | Analyzes | Default metric | Coverage format | Published to |
+|-----------------|----------|----------------|-----------------|--------------|
+| `crap4rs` | Rust | cognitive | LCOV (`lcov.info`) | [crates.io](https://crates.io/crates/crap4rs) |
+| `crap4ts` | TypeScript / JavaScript | cyclomatic | Istanbul JSON (`coverage-final.json`) | [npm](https://www.npmjs.com/package/crap4ts) — see its [package README](packages/crap4ts/README.md) |
+| `crap-core` | shared library | — | — | CRAP formula, thresholds, reporters, analysis types |
 
-Both adapters link the same `crap-core`, so Rust and TypeScript / JavaScript projects get identical CRAP semantics — the same formula, envelope, and reporters.
+Both adapters link the same `crap-core`, so the formula, wire envelope, and reporters are identical across languages. CRAP scores are not directly comparable across languages — the combined view ranks by CRAP/threshold ratio and risk band, not by raw score.
 
-## What is CRAP?
+## Risk bands
 
-The CRAP metric combines **complexity** and **code coverage** into a single risk score:
+Every score lands in one of four risk bands. These bands (score-based) and the build gate (threshold-based) are distinct axes that share the same numbers today — see [understanding CRAP](https://breezy-bays-labs.github.io/crap-rs/book/understanding-crap.html).
 
+| CRAP score | Risk band |
+|------------|-----------|
+| ≤ 8 | Low |
+| ≤ 15 | Acceptable |
+| ≤ 25 | Moderate |
+| > 25 | High |
+
+## Install
+
+```bash
+# Rust analyzer (binstall preferred, falls back to a source build)
+cargo binstall crap4rs
+cargo install crap4rs
+
+# TypeScript / JavaScript analyzer
+npm install -g crap4ts
 ```
-CRAP(complexity, coverage) = complexity² × (1 − coverage)³ + complexity
-```
 
-where `coverage` is the fraction in `[0, 1]` (50% → `0.5`). High complexity + low coverage = high CRAP score = high risk of bugs when changed.
-
-### Risk classification
-
-Every score lands in one of four risk levels:
-
-| CRAP Score | Risk Level |
-|------------|------------|
-| ≤ 8        | Low        |
-| ≤ 15       | Acceptable |
-| ≤ 25       | Moderate   |
-| > 25       | High       |
-
-These boundaries also anchor the threshold presets: `--strict` fires at the Low → Acceptable boundary, the default fires at Acceptable → Moderate, and `--lenient` fires at Moderate → High — so every preset corresponds to "gate at the next risk tier up." See [Threshold (the gate)](#threshold-the-gate) for how the gate works and how the two views relate.
+crap4rs reads LCOV coverage from [cargo-llvm-cov](https://github.com/taiki-e/cargo-llvm-cov) (`cargo llvm-cov --lcov --output-path lcov.info`); install it alongside the analyzer. See [installation](https://breezy-bays-labs.github.io/crap-rs/book/installation.html) for all install paths and coverage prerequisites.
 
 ## Try it locally
 
-Want a hands-on tour without setting up a real project? The repo ships a polyglot pedagogical sample at `crates/crap-examples/` carrying four Rust + four TypeScript modules picked to span every risk band on a single analysis. Each module isolates one term of the CRAP formula `c² × (1 − coverage)³ + c` — see `crates/crap-examples/README.md` for the worked-example heatmap.
+The repo ships a polyglot sample at `crates/crap-examples/` — four Rust and four TypeScript modules spanning every risk band, each isolating one term of the CRAP formula. See `crates/crap-examples/README.md` for the worked-example heatmap.
 
 ```bash
-# Install (pick one):
-cargo install crap4rs                  # Rust analyzer — published to crates.io
-npm install -g crap4ts                 # TypeScript analyzer — published to npm
-
-# Clone + analyze the sample
 git clone https://github.com/breezy-bays-labs/crap-rs.git
 cd crap-rs
-crap4rs --src ./crates/crap-examples/src --coverage crates/crap-examples/lcov.info
-# Expected: 4 risk bands hit (Low, Acceptable, Moderate, High);
-# worst function is config_merger::merge_configs in the High band.
 
-# Same shape for TypeScript:
+# Rust
+crap4rs --src ./crates/crap-examples/src --coverage crates/crap-examples/lcov.info
+
+# TypeScript
 crap4ts --src ./crates/crap-examples/ts --coverage crates/crap-examples/coverage-final.json --exclude '*.test.ts'
 ```
 
-The committed coverage fixtures use paths relative to each adapter's `--src` root. If you regen them yourself, follow `crates/crap-examples/README.md` § Regenerating the fixtures — the regen recipe normalizes paths so the analyzer's coverage matcher joins them cleanly.
-
-The same envelope shape ships as a release asset on every crap-rs release page (`crap4rs-envelope.json` + `crap4ts-envelope.json`); the composite `crap-scorecard` action's [Pattern 2b](.github/actions/scorecard/README.md#pattern-2b--cross-release-envelope-baseline) recipe fetches them as a `--baseline` so the Delta tab renders enabled against the analyzer's cross-release drift.
-
-## crap4rs — the Rust analyzer
-
-Everything from here down documents the `crap4rs` Rust CLI. For TypeScript / JavaScript projects, see the [crap4ts package README](packages/crap4ts/README.md).
-
-## Usage
-
-```bash
-# Generate coverage data
-cargo llvm-cov --lcov --output-path lcov.info
-
-# Run CRAP analysis
-crap4rs --src src/ --coverage lcov.info
-```
-
-### Commands
-
-| Command | Purpose |
-|---------|---------|
-| `crap4rs` (no subcommand) | Run the analyzer. Requires `--coverage <FILE>`. |
-| `crap4rs init` | Write the exhaustive annotated `crap.toml` (every option, documented — see [`crap.example.toml`](crap.example.toml)) in the current directory; trim it down to your needs. Pair with `--force` to overwrite. |
-| `crap4rs completions <SHELL>` | Print a shell completion script to stdout. See [Shell completions](#shell-completions). |
-| `crap4rs help [SUBCOMMAND]` | Long-form help for the binary or a subcommand. |
-
-### Options
-
-Run `crap4rs --help` for the canonical full reference. Grouped here as in `--help` output:
-
-**Input**
-
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--coverage <FILE>` | required for analysis | Path to the LCOV coverage file. Not required for `completions`/`init`. |
-| `--src <DIR>` | `src` | Root directory of source files to analyze. **Repeatable** — pass `--src` more than once (`--src crates/a/src --src crates/b/src`) to union several roots into one report against a single `--coverage`. A single `--src` is unchanged; multiple roots key function paths relative to the git toplevel (requires a git work tree). |
-| `--metric <METRIC>` | `cognitive` | `cognitive` (default) or `cyclomatic`. |
-| `--config <FILE>` | auto-discovered | Explicit config file path; bypasses `crap.toml` auto-discovery. |
-| `--view <NAME>` | — | Resolve a saved view preset from the config (see [Saved view presets](#saved-view-presets---view-name)). |
-| `--baseline <FILE>` | — | Compare against a previously-emitted JSON envelope (see [Comparing two analyses](#comparing-two-analyses---baseline-file)). |
-
-**Output**
-
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--format <FORMAT[,…]>` | `table` | One or more output formats. Each entry is `FORMAT` (stdout) or `FORMAT:FILE` (write to file); a comma-separated list fans out a single analysis pass to multiple destinations (`json:env.json,markdown:report.md` or `markdown:scorecard.md,github-annotations`). Supported formats: `table`, `json`, `markdown`, `csv`, `sarif`, `advice` (experimental), `scorecard-row`, `github-annotations`, `html`. Multi-format invocations may include at most one stdout entry; additional entries must specify a file. |
-| `--annotation-limit <N>` | `10` | Cap on `::warning` lines emitted by `--format github-annotations`. Range `1..=100`; also configurable via `[output] annotation_limit` in the TOML config. The CLI flag wins when both are set. |
-| `--threshold <N>` | metric-correct `default` preset (cognitive 15, cyclomatic 15 today) | CRAP score above which a function fails the check. The default is resolved against the effective metric, not a hard-coded scalar. |
-| `--strict` | — | Use the `strict` preset (cognitive 8, cyclomatic 8 today). Mutually exclusive with `--lenient`. |
-| `--lenient` | — | Use the `lenient` preset (cognitive 25, cyclomatic 25 today). |
-| `--no-fail` | — | Always exit `0`; `result.passed` in JSON still reflects truth. Composes with `--delta-gate` (overrides BOTH gates). |
-| `--delta-gate` | off | Fail the build (exit `1`) when `--baseline` introduces new threshold violations. |
-| `--minimal-view` | — | Omit `view.shown[]` from JSON output (payload-size escape hatch for large codebases). |
-| `--summary` | — | Emit a single-line analysis verdict instead of the full report; short-circuits `--format`. |
-
-**Filtering**
-
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--exclude <GLOB>` | — | Exclude paths matching glob (repeatable). |
-| `--no-gitignore` | respect | Do NOT skip paths in `.gitignore`. |
-| `--diff <REF>` | — | Only analyze functions in files changed since `REF` (CI PR-gating). |
-| `--only-failing` | — | Display only functions exceeding the threshold (gate still ranges over everything). |
-| `--top <N>` | — | Truncate the displayed report to the top `N` highest-CRAP rows. |
-| `--min-coverage <PCT>` | — | Drop displayed rows whose coverage falls below `PCT`. |
-| `--max-coverage <PCT>` | — | Drop displayed rows whose coverage exceeds `PCT`. |
-| `--sort-by <KEY>` | `crap` | `crap` (default), `coverage`, `complexity`, or `path`. |
-| `--group-by <KEY>` | — | Today: `file` (per-file summaries). Under grouping, `--top` and `--sort-by` key at the file level. |
-| `--delta-top <N>` | — | Truncate the delta block to top `N` changes. |
-| `--delta-sort <KEY>` | `score-delta` | `score-delta`, `current-crap`, `baseline-crap`, or `path`. |
-| `--delta-only <KINDS>` | all | Comma-separated subset of `added`, `removed`, `modified`. |
-
-**Display**
-
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--color <COLOR>` | `auto` | `auto`, `always`, or `never`. |
-| `-v`, `--verbose` | — | Show parse diagnostics and matching statistics. |
-| `-q`, `--quiet` | — | Suppress report output, only set exit code. |
-| `--breakdown` | — | Show the per-contributor complexity breakdown for each above-threshold function. In `table` output it prints inline beneath each row; in `markdown` output the breakdowns collect into one collapsed `<details>` block below the table. |
-| `--explain` | — | With `--breakdown`, explain nested cognitive increments in table output. |
-| `--md-full-table` | — | Append the full per-function table to markdown output (default markdown is a compact top-N summary). |
-| `--md-top <N>` | `10` | Number of rows in the markdown top-N table. |
-
-### Config file
-
-The canonical config file name is **`crap.toml`** — a single language-neutral file shared by both `crap4rs` and `crap4ts`, auto-discovered in the working directory. `crap4rs init` writes it, and `--config <FILE>` overrides discovery with an explicit path.
-
-Every supported option, with prose for each field, lives in **[`crap.example.toml`](crap.example.toml)** — the exhaustive annotated reference. It is what `crap4rs init` writes verbatim (trim it down to your real config), is generated from the config type (a sync test keeps it from rotting), and is **not** loaded by the tool — it exists purely as the canonical option reference. The editor-validation schema for `crap.toml` is **[`crap.schema.json`](crap.schema.json)** (point your editor's `$schema` at it for autocomplete + inline validation).
-
-This repo dogfoods its own config: **[`crap.toml`](crap.toml)** at the root is a real, trimmed-down working example (the kind you'd actually commit, not the exhaustive dump). The production CRAP scorecard CI job runs with no analysis flags in the workflow and lets this file own the knobs via auto-discovery — `preset`, the per-language `metric`, and the multi-root `src` array. It also carries a `[views.ci]` preset as a worked reference; that preset only shapes a report when a run opts in with `--view ci` (the production job does not), so it documents the report-shaping surface without gating today. Read it alongside `crap.example.toml` to see the difference between "every option documented" and "a real project's config."
-
-For back-compat, the legacy per-adapter names **`crap4rs.toml`** (and `crap4ts.toml` for crap4ts) are still discovered when no `crap.toml` is present, but are **deprecated aliases**: the tool prints a one-line warning nudging you to rename. A present `crap.toml` always takes precedence over a co-present legacy file (the legacy file is then reported as safe to remove). The config examples below use `crap4rs.toml`; they apply identically to `crap.toml`.
-
-### Threshold (the gate)
-
-`--threshold` is the line above which a function trips the build gate (exit `1` unless `--no-fail`). Tier presets are aligned with the [risk classification](#risk-classification) — each preset fires at the next risk-tier boundary:
-
-| Preset      | Cognitive | Cyclomatic | Risk boundary it gates at |
-|-------------|-----------|------------|---------------------------|
-| `--strict`  | `8`       | `8`        | Low → Acceptable          |
-| default     | `15`      | `15`       | Acceptable → Moderate     |
-| `--lenient` | `25`      | `25`       | Moderate → High           |
-
-Cognitive and cyclomatic columns currently hold the same values. The dual-column infrastructure inside `crap-core` is preserved because the two metrics can diverge in magnitude for the same code (cognitive is nesting-weighted; cyclomatic counts decision points); a future per-metric recalibration is a one-line change without an API churn.
-
-A function with CRAP `5` is `Low` and never trips any preset. A function with CRAP `40` is `High` and trips every preset. A function with CRAP `12` is `Acceptable` (the risk classification) but trips `--strict` (the gate); the two views agree at boundaries but the gate moves earlier than risk reclassification.
-
-Risk classification feeds SARIF severity (`high → error`, `moderate → warning`, `acceptable/low → note`); threshold feeds the exit code. Scorecard-row status (`Red`/`Yellow`/`Green`) — see [docs/scorecard-row-contract.md](docs/scorecard-row-contract.md) — is minted from the threshold gate, not from risk classification.
-
-`crap4rs` and `crap4ts` share the CRAP formula and analysis concepts through `crap-core`; threshold policy is exposed per analyzer and may diverge in the future.
-
-#### Per-path threshold overrides
-
-`crap4rs.toml` accepts a `[thresholds]` block with per-glob overrides — useful when a directory has stricter or looser requirements than the project default. The most-specific (latest-matching) override wins:
-
-```toml
-# crap4rs.toml — domain/ must stay under the strict cutoff, even when
-# the project default is more permissive.
-preset = "default"   # global cutoff = cognitive 15
-
-[[thresholds.overrides]]
-pattern = "src/domain/**"
-threshold = 8        # gate at the strict tier inside domain/
-```
-
-### Why cognitive by default?
-
-Rust's `match` expressions with many arms inflate cyclomatic complexity without adding real risk. A flat 20-arm match is cyclomatic 20 but cognitive 1. Cognitive complexity better reflects actual Rust code risk.
-
-## Investigation patterns
-
-The shaping flags (`--only-failing`, `--top`, `--min-coverage`, `--max-coverage`, `--sort-by`) reorder, filter, and truncate the **displayed report** without ever touching the **underlying analysis**. The gate is unshapeable: `result.passed` and the exit code always reflect the full unfiltered codebase, so a filter that hides every violation does not change the outcome. `--no-fail` overrides only the gate-to-exit-code translation; `result.passed` in JSON still tells the truth, so consumers can detect "would have failed" even when the process exits `0`.
-
-```bash
-# First-run scan: keep the report short
-crap4rs --coverage lcov.info --top 20
-
-# Worst partially-covered functions, sorted by coverage ascending,
-# never fail the build — useful when investigating an untested codebase
-crap4rs --coverage lcov.info \
-  --min-coverage 1 --max-coverage 90 \
-  --sort-by coverage --top 10 \
-  --no-fail
-
-# Top 10 worst files by average CRAP — find which files to refactor first
-crap4rs --coverage lcov.info --group-by file --top 10
-```
-
-Under `--group-by file`, `--top N` truncates to the top N **files** (not functions) and `--sort-by` keys at the file level: `crap` orders by average CRAP descending, `coverage` by average coverage ascending, `complexity` by max complexity descending, `path` alphabetically. The full per-function row list still appears in JSON `view.shown` for drill-down (`jq '.view.shown[] | select(.scored.identity.file_path == "src/blob.rs")'`); pair with `--minimal-view` to drop it for size-sensitive consumers. CSV's column schema shifts under grouping — pin your flags if you script on column position.
-
-### Saved view presets (`--view <NAME>`)
-
-When the same flag set repeats across runs (CI, investigation, paste-into-issue), bake it into `crap4rs.toml` under a `[views.<name>]` block and invoke it with `crap4rs --view <NAME>`:
-
-```toml
-# crap4rs.toml
-[views.ci]
-top = 20
-min_coverage = 0
-max_coverage = 90
-sort = "coverage"
-only_failing = true
-group_by = "file"
-minimal_view = true
-
-[views.investigate]
-sort = "complexity"
-top = 10
-```
-
-```bash
-# CI invocation — exits 1 on violations, 0 otherwise; minimal JSON for log parsing
-crap4rs --coverage lcov.info --view ci --format json
-
-# Investigation — preset's top=10 + sort by complexity, override with --top 25 inline
-crap4rs --coverage lcov.info --view investigate --top 25
-```
-
-**Override priority:** defaults < preset < CLI flags. CLI explicit `Option<T>` values (`--top`, `--min-coverage`, `--sort-by`, `--group-by`) override the preset; bare bool flags (`--no-fail`, `--only-failing`, `--minimal-view`) OR-merge with the preset — an explicit CLI flag adds to the preset's `true` value but cannot turn off a preset's `true`. The gate keystone holds: a preset cannot change `result.passed`, only the displayed view. Unknown preset names exit `2` listing the available presets; invalid preset fields (out-of-range coverage, bad sort string, typos) fail fast at config load with the offending preset's name in the message.
-
-The JSON envelope reflects the same separation: `result.*` always describes the full analysis (gate); `view.*` describes what the operator chose to see (display). An agent or dashboard can act on `result.passed`, `result.summary`, and `result.functions` while rendering only `view.shown`.
-
-### Comparing two analyses (`--baseline <FILE>`)
-
-To track regressions across runs, capture a baseline JSON envelope (typically from `main`) and compare your working tree to it:
-
-```bash
-# Capture the baseline (CI: cache or upload as an artifact)
-crap4rs --coverage lcov.info --format json > baseline.json
-
-# Compare working tree to baseline (informational by default)
-crap4rs --coverage lcov.info --baseline baseline.json
-```
-
-The output adds a "Delta vs baseline" block under the analysis table — per-change rows with kind (added/removed/modified), baseline/current scores, and signed delta. Functions are paired by `(file_path, qualified_name)`; line shifts don't disrupt matching. Renames across files surface as Add+Remove pairs until rename detection ships.
-
-By default, delta is **informational** — the exit code follows the analysis gate alone. Add `--delta-gate` to fail (exit 1) when the comparison introduces new threshold violations:
-
-```bash
-# CI usage: fail the build on new violations only (pre-existing ones don't trip it)
-crap4rs --coverage lcov.info --baseline baseline.json --delta-gate
-```
-
-`new_violations` counts threshold breaches *introduced* by this change — `Added` rows that exceed threshold, plus `Modified` rows where baseline was passing and current isn't. Pre-existing violations (Modified rows where the baseline already exceeded) never contribute, so re-running on unchanged code never trips the gate.
-
-`--no-fail` overrides BOTH gates (analysis + delta), but truth still lives in JSON: consumers see `result.passed` and `delta.summary.passed` regardless of the exit code, so a CI job can post a "would have failed" comment while still exiting 0.
-
-For PR-comment scorecards, pipe the markdown reporter:
-
-```bash
-# Drop into a PR comment body verbatim (status, counts, regressions table, new-violations table)
-crap4rs --coverage lcov.info --baseline baseline.json --format markdown
-```
-
-The shaping flags `--delta-top`, `--delta-sort` (`score-delta` (default) | `current-crap` | `baseline-crap` | `path`), and `--delta-only` (`added,removed,modified`) drive a sibling `DeltaViewSpec` independent of the View shaping. The JSON envelope's additive `delta` block carries the full summary plus `delta.shown` for renderer drill-down — the gate keystone holds for delta as it does for the analysis.
-
-## Output formats
-
-`--format markdown` produces GitHub-flavored Markdown (pipe-syntax table plus a Summary block) — paste it into a PR comment, an issue body, or a doc page. `--format csv` produces RFC 4180 CSV with a fixed header row, suitable for piping into spreadsheets, BI tools, or `awk`/`jq` pipelines that prefer tabular input. Both honor every shaping flag (`--top`, `--sort-by`, `--only-failing`, `--min-coverage` / `--max-coverage`).
-
-### Agent advice (`--format advice`) — experimental
-
-`--format advice` emits the same JSON envelope as `--format json`, but with a populated `Diagnostic` on every over-threshold `view.shown[]` entry. The diagnostic is AST-derived — coverage gaps, complexity drivers, suggested actions, and a flat `root_cause` scalar — so coding agents can read findings and propose remediations without re-walking the source.
-
-```jsonc
-{
-  "schema_version": 1,
-  "view": {
-    "shown": [{
-      "scored": { "identity": { "qualified_name": "branchy_fail", ... } },
-      "exceeds": true,
-      "diagnostic": {
-        "coverage_gaps": [{ "start": 11, "end": 19 }],
-        "complexity_drivers": [{ "kind": "if-branch", "line": 12, "nesting_depth": 1, ... }],
-        "suggested_actions": [
-          { "kind": "add_tests_for_lines", "lines": [...], "applicability": "unspecified" },
-          { "kind": "extract_function", "candidates": [
-            { "line_range": { "start": 12, "end": 16 }, "complexity_contribution": 3,
-              "branch_path": "if-branch", "kind": "deepest_nesting", "recommended": true },
-            ...
-          ], "applicability": "unspecified" }
-        ],
-        "root_cause": "both"
-      }
-    }]
-  }
-}
-```
-
-A grep-friendly stderr summary streams alongside stdout — one line per over-threshold function in `view.shown[]` order:
-
-```text
-[crap=56.00] src/lib.rs:5-21 branchy_fail [actions: add_tests_for_lines,extract_function]
-```
-
-`--format sarif` carries the same `Diagnostic` shape under `result.properties.diagnostic`, so SARIF consumers (and the [`/cut-the-crap` Claude Code skill](#claude-code-skill-cut-the-crap)) read the same advice as `--format advice`.
-
-> **Stability:** `--format advice` is **experimental in v0.3.x**. The shape may grow additively (new fields, new `SuggestedAction` variants under `#[non_exhaustive]`), but `schema_version` stays at `1` and existing fields will not change meaning. The shape stabilises at v0.4.0 with `schema_version: 2`.
-
-### SARIF for GitHub Code Scanning (`--format sarif`)
-
-`--format sarif` emits SARIF v2.1.0 JSON. Pipe it into a `.sarif` file and upload via `github/codeql-action/upload-sarif@v3` — every function whose CRAP score exceeds the threshold becomes an inline annotation on the exact line range in the PR diff. Reviewers see the findings without running crap4rs themselves.
-
-| Risk level     | SARIF `level` |
-| -------------- | ------------- |
-| `high`         | `error`       |
-| `moderate`     | `warning`     |
-| `acceptable`   | `note`        |
-| `low`          | `note`        |
-
-Severity is the [risk classification](#risk-classification), not the threshold gate — a `Moderate` function is a SARIF `warning` regardless of which preset is in effect.
-
-Unlike the table / JSON / Markdown / CSV reporters, SARIF is a **gate translation**, not a display: it iterates the unshapeable analysis. `--top`, `--sort-by`, `--only-failing`, and `--baseline` do **not** alter SARIF output — PR annotations must reflect truth, not a presentation choice. `--no-fail` overrides the exit code only; the `results[]` array still lists every finding.
-
-```yaml
-# .github/workflows/crap-scan.yml
-name: crap-scan
-on: pull_request
-jobs:
-  scan:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      security-events: write   # required for upload-sarif
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: taiki-e/install-action@cargo-llvm-cov
-      - run: cargo llvm-cov --lcov --output-path lcov.info
-      - uses: cargo-bins/cargo-binstall@main
-      - run: cargo binstall -y crap4rs
-      # Always emit SARIF, even on failure, so annotations land on the PR.
-      - run: crap4rs --coverage lcov.info --format sarif --no-fail > crap.sarif
-      - uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: crap.sarif
-```
-
-### GitHub Actions inline annotations (`--format github-annotations`)
-
-`--format github-annotations` emits one
-[GitHub Actions `::warning` workflow command](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions)
-per function above threshold. The runner intercepts the commands from
-stdout and renders them as inline annotations on the PR "Files
-Changed" tab — same UX as SARIF, but with no GitHub Advanced Security
-or Code Scanning subscription required and no per-line annotation
-cap (other than the per-step UI cap below).
-
-```bash
-crap4rs --coverage lcov.info --format github-annotations
-# ::warning file=src/lib.rs,line=42,title=CRAP 32.5::Function `tangled` has CRAP 32.50 (complexity=14, coverage=20.0%) which exceeds threshold 15.0
-```
-
-Like SARIF, this is a **gate translation**, not a display: the
-reporter iterates the unshapeable analysis. `--top`, `--sort-by`,
-`--only-failing`, and `--baseline` do **not** alter what's emitted —
-PR annotations must reflect truth, not a presentation choice.
-
-GitHub silently drops annotations past a per-step UI cap (10 warning
-/ 10 error / 10 notice per step; 50 per job; 50 per workflow). Use
-`--annotation-limit N` (default `10`, range `1..=100`) to cap
-emission; over-cap eligible findings surface as a trailing
-`::notice::N more functions exceed threshold; see scorecard for the
-full list` line so reviewers know findings were dropped. Configurable
-per project via `[output] annotation_limit` in `crap4rs.toml`; the
-CLI flag wins when both are set.
-
-The composite scorecard action exposes this via `annotations: true`
-(see [`.github/actions/scorecard/README.md`](.github/actions/scorecard/README.md#inline-annotations)).
-For a workflow that ships annotations alongside the markdown
-scorecard in a single analyzer invocation, combine the formats:
-
-```yaml
-- run: crap4rs --coverage lcov.info --format markdown:scorecard.md,github-annotations --no-fail
-  # `markdown:scorecard.md` writes the rendered scorecard to a file;
-  # `github-annotations` flows through to stdout where the runner
-  # intercepts the workflow commands.
-```
-
-### Scorecard row (`--format scorecard-row`)
-
-`--format scorecard-row` emits exactly one JSON object — a
-[`Row::CrapDelta`](crates/crap4rs/tests/fixtures/scorecard/schema.json)
-— for consumption by scorecard aggregators (any CI workflow, PR-comment
-bot, or dashboard that composes per-gate verdicts into a unified
-scorecard). The object conforms to the locked `definitions/Row` schema
-fragment owned by this repo (`schema_version: 1`; see
-[`docs/scorecard-row-contract.md`](docs/scorecard-row-contract.md)).
-
-Status is producer-side (crap4rs mints it from `--baseline` + `--threshold`):
-
-| Status   | Trigger |
-| -------- | ------- |
-| `Red`    | A new threshold violation lands (Added function exceeds, or Modified function crosses the threshold). `failure_detail_md` carries the violator list. |
-| `Yellow` | No new violations, but at least one modified function's CRAP score regressed. |
-| `Green`  | Otherwise. |
-
-```bash
-# Run against a PR base baseline + emit a single Row JSON for the aggregator.
-crap4rs \
-  --src . \
-  --coverage lcov.info \
-  --baseline pr-base-envelope.json \
-  --threshold 15 \
-  --format scorecard-row > crap-delta-row.json
-```
-
-Sample output (Red):
-
-```json
-{
-  "type": "CrapDelta",
-  "id": "crap_delta",
-  "label": "CRAP Δ",
-  "anchor": "crap-delta",
-  "status": "Red",
-  "threshold": 15,
-  "delta_count": 2,
-  "delta_text": "5 → 7 (+2)",
-  "failure_detail_md": "**New CRAP threshold violations (>15):**\n- ..."
-}
-```
-
-When `--baseline` is omitted, the row reports the absolute count of
-over-threshold functions (`"N over threshold (no baseline)"` in
-`delta_text`); status is Green when the count is zero, Red otherwise.
-
-> **Tradeoff:** the threshold lives in `crap4rs.toml` / `--threshold`,
-> not in an aggregator's config. CRAP-metric parameters belong to the
-> producer. If a future repo wants aggregator-side CRAP threshold
-> tuning, that's a non-breaking evolution at the wire level — the row
-> shape stays identical; status-minting moves from producer to
-> aggregator. See [`docs/scorecard-row-contract.md`](docs/scorecard-row-contract.md)
-> for the full operator-tunability boundary.
-
-## Shell completions
-
-Print a completion script for your shell to stdout — the subcommand does no file I/O, so redirect it wherever your shell expects completions:
-
-```bash
-# bash
-crap4rs completions bash > /usr/local/etc/bash_completion.d/crap4rs
-
-# zsh — adjust to a directory in your $fpath
-crap4rs completions zsh > ~/.zsh/completions/_crap4rs
-
-# fish
-crap4rs completions fish > ~/.config/fish/completions/crap4rs.fish
-
-# nushell — append the printed module to your config
-crap4rs completions nushell >> ~/.config/nushell/config.nu
-
-# powershell
-crap4rs completions powershell | Out-String | Invoke-Expression
-
-# elvish
-crap4rs completions elvish > ~/.config/elvish/lib/crap4rs.elv
-```
-
-`crap4rs completions <SHELL>` does not need `--coverage`. Unknown shell names exit `2`.
-
-## Claude Code skill (`/cut-the-crap`)
-
-crap4rs ships a reference [Claude Code](https://claude.com/claude-code) skill that consumes `--format advice` and drives a cover-then-split remediation loop on every over-threshold function. It lives in [`skills/cut-the-crap/`](skills/cut-the-crap/) — copy it into your user skills directory once and it's available from any Claude Code session:
-
-```bash
-# from the repo root
-cp -r skills/cut-the-crap ~/.claude/skills/
-```
-
-Then in any Claude Code session:
-
-```text
-/cut-the-crap                       # cover-then-split, apply changes
-/cut-the-crap --explain-only        # produce plan, do not modify
-/cut-the-crap --threshold 15        # custom CRAP threshold
-```
-
-The skill handles the agent-loop side of remediation (covering uncovered branches first, naming proposed extractions, writing a plan to `tmp/cut-the-crap-plan.md` before applying); the crap4rs binary stays a unix-style mechanical emitter. See [`skills/cut-the-crap/SKILL.md`](skills/cut-the-crap/SKILL.md) for the full process specification.
-
-## Coverage notes
-
-### `cargo llvm-cov --lib` only instruments unit-testable code
-
-`cargo llvm-cov --lib` instruments code that is invoked by `#[test]` functions in the same crate. It does **not** cover:
-
-- **Axum handlers** — only called via HTTP in integration tests, not unit tests
-- **Tauri entry points** — only called by the Tauri runtime
-- **BDD-tested code** — cucumber-rs scenarios run as separate processes, outside `--lib`
-
-These functions will show **0% line coverage**, even if they are thoroughly tested. This is expected, not a bug.
-
-**Mitigation:** use `--exclude` to skip paths where 0% coverage is unavoidable:
-
-```toml
-# crap4rs.toml — monorepo example (SvelteKit + Axum)
-# Only analyze unit-testable crates.
-
-preset = "strict"
-
-exclude = [
-  "services/api/src/**",   # Axum handlers — integration-only, no unit test surface
-  "apps/desktop/**",       # Tauri entry point — no unit test surface
-  "**/tests/**",           # Test helpers have 0% coverage by definition
-]
-```
-
-When more than half of analyzed files show 0% coverage, `crap4rs` will print a warning with this hint automatically.
-
-## Installation
-
-```bash
-# From crates.io (requires Rust toolchain)
-cargo install crap4rs
-
-# Or clone and build
-git clone https://github.com/breezy-bays-labs/crap-rs.git
-cd crap-rs
-cargo build --release
-```
-
-## Prerequisites
-
-- [cargo-llvm-cov](https://github.com/taiki-e/cargo-llvm-cov) for generating LCOV coverage data
+The committed coverage fixtures use paths relative to each adapter's `--src` root. To regenerate them, follow `crates/crap-examples/README.md`.
+
+## Documentation
+
+Full documentation lives in the [book](https://breezy-bays-labs.github.io/crap-rs/book/introduction.html). Each chapter owns its scope:
+
+| Chapter | Covers |
+|---------|--------|
+| [Installation](https://breezy-bays-labs.github.io/crap-rs/book/installation.html) | Install paths, prerequisites, toolchain |
+| [Quick start](https://breezy-bays-labs.github.io/crap-rs/book/quick-start.html) | First analysis end to end |
+| [Understanding CRAP](https://breezy-bays-labs.github.io/crap-rs/book/understanding-crap.html) | The formula, risk bands vs. the gate, why cognitive by default |
+| [CLI reference](https://breezy-bays-labs.github.io/crap-rs/book/cli-reference.html) | Every flag, subcommand, and exit code; shell completions |
+| [Configuration](https://breezy-bays-labs.github.io/crap-rs/book/configuration.html) | `crap.toml` schema, presets, per-path thresholds, saved views |
+| [Output formats](https://breezy-bays-labs.github.io/crap-rs/book/output-formats.html) | table, json, markdown, csv, sarif, html, advice, scorecard-row, github-annotations |
+| [CI integration](https://breezy-bays-labs.github.io/crap-rs/book/ci-integration.html) | The composite scorecard action, SARIF upload, `--baseline` / `--delta-gate` |
+| [Multi-language](https://breezy-bays-labs.github.io/crap-rs/book/multi-language.html) | Unified Rust + TypeScript reports via `crap-render` |
+| [Limitations & FAQ](https://breezy-bays-labs.github.io/crap-rs/book/limitations-and-faq.html) | Line-range matching, integration/BDD coverage, `--lib` caveats, threshold calibration |
 
 ## Workspace layout
 
-crap-rs is a Cargo workspace built on a hexagonal (ports & adapters) core:
+crap-rs is a Cargo workspace built on a hexagonal (ports & adapters) core.
 
 | Crate | Role |
 |-------|------|
-| `crap-core` | Language-agnostic core — the CRAP formula, threshold model, result types, reporters, and analysis orchestration (`domain/` → `ports/` → `core/`). |
-| `crap4rs` | Rust adapter — `syn`-based complexity walker, LCOV coverage parser, and the Rust CLI. |
-| `crap4ts` | TypeScript / JavaScript adapter — `oxc`-based complexity walker, Istanbul JSON coverage parser, published to npm as a napi-rs addon. |
+| `crap-core` | Language-agnostic core — CRAP formula, threshold model, result types, reporters, analysis orchestration (`domain/` → `ports/` → `core/`). |
+| `crap4rs` | Rust adapter — `syn`-based complexity walker, LCOV parser, and the Rust CLI. |
+| `crap4ts` | TypeScript / JavaScript adapter — `oxc`-based complexity walker, Istanbul JSON parser, published to npm as a napi-rs addon. |
 
-Each adapter supplies its own `ComplexityPort` and `CoveragePort` implementations; `crap-core` never imports a language toolchain. An `ast-purity` CI gate enforces this — it bans `syn`, `oxc`, and coverage-format types from `crap-core/src/`. The CRAP math is shared; threshold policy stays language-specific, so `crap4rs` and `crap4ts` need not use identical thresholds.
-
-## Self-check
-
-crap-rs analyzes its own source as a CI gate — `crap4rs` runs at `--strict` against each workspace crate (`crap-core`, `crap4rs`, and `crap4ts`).
+Each adapter supplies its own `ComplexityPort` and `CoveragePort`; `crap-core` never imports a language toolchain. An `ast-purity` CI gate enforces this. The CRAP math is shared; threshold policy stays language-specific.
 
 ## License
 

--- a/book/.gitignore
+++ b/book/.gitignore
@@ -1,0 +1,2 @@
+# mdBook build output (rendered HTML is published to gh-pages, never committed)
+/book

--- a/book/book.toml
+++ b/book/book.toml
@@ -1,0 +1,21 @@
+[book]
+title = "crap-rs"
+description = "A CRAP (Change Risk Anti-Patterns) analyzer for Rust and TypeScript — one per-function score fusing source complexity with test coverage."
+authors = ["Breezy Bays Labs"]
+language = "en"
+src = "src"
+
+[output.html]
+git-repository-url = "https://github.com/breezy-bays-labs/crap-rs"
+edit-url-template = "https://github.com/breezy-bays-labs/crap-rs/edit/main/book/{path}"
+# Served from the project's GitHub Pages under /crap-rs/book/ (the CRAP
+# scorecard reports occupy the Pages root). Relative asset links work
+# under the subpath; site-url anchors the search/print base.
+site-url = "/crap-rs/book/"
+
+[output.html.search]
+enable = true
+
+[output.html.fold]
+enable = true
+level = 1

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -1,0 +1,13 @@
+# Summary
+
+[Introduction](introduction.md)
+
+- [Installation](installation.md)
+- [Quick start](quick-start.md)
+- [Understanding CRAP](understanding-crap.md)
+- [CLI reference](cli-reference.md)
+- [Configuration](configuration.md)
+- [Output formats](output-formats.md)
+- [CI integration](ci-integration.md)
+- [Multi-language analysis](multi-language.md)
+- [Limitations & FAQ](limitations-and-faq.md)

--- a/book/src/ci-integration.md
+++ b/book/src/ci-integration.md
@@ -1,0 +1,186 @@
+# CI integration
+
+The `crap-scorecard` composite action runs a CRAP analysis inside your CI and turns it into a markdown scorecard, an optional gate that fails the build, an optional sticky PR comment, and an optional hosted HTML report. This chapter covers it from a consumer's point of view. For the CRAP math see [understanding-crap.md](understanding-crap.md); for the flag surface it wraps see [cli-reference.md](cli-reference.md); for the report layouts it can render see [output-formats.md](output-formats.md).
+
+The action reference uses `@main` and `@<sha>` interchangeably in snippets below. Pin to a release SHA in real workflows (`@<sha> # vN`); `@main` tracks the unstable tip.
+
+## What the action does and doesn't do
+
+The action wraps the analyzer binary; it does not orchestrate coverage or git. Two things are the caller's job, by design:
+
+- **Coverage.** Produce the coverage file before the action runs. Rust: `cargo llvm-cov --workspace --lcov --output-path lcov.info`. TypeScript: an Istanbul `coverage-final.json`. The path is `--coverage` (runtime-required — the action errors if it's missing or unreadable).
+- **Checkout and base refs.** The action never runs `actions/checkout` and never reaches into git to fetch a base ref. Delta mode (below) needs you to produce the baseline yourself.
+
+Drawing the boundary there keeps the action a pure function of its inputs: the same coverage file plus the same flags produce the same scorecard, with no hidden git state.
+
+## Minimal workflow
+
+```yaml
+name: CRAP scorecard
+on:
+  pull_request:
+jobs:
+  scorecard:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@<sha>
+        with:
+          persist-credentials: false
+      - run: cargo llvm-cov --workspace --lcov --output-path lcov.info
+      - uses: breezy-bays-labs/crap-rs/.github/actions/scorecard@<sha>
+        id: crap
+        with:
+          coverage: lcov.info
+      - run: echo "${{ steps.crap.outputs.markdown }}"
+```
+
+That run is report-only: it renders the scorecard to `outputs.markdown` and never fails the build. The sections below add gating, a PR comment, deltas, and a hosted report.
+
+## Core inputs
+
+| Input | Purpose |
+|---|---|
+| `coverage` | Path to the coverage file. Runtime-required. LCOV (`.info`/`.lcov`) for Rust, Istanbul JSON (`.json`) for TypeScript. |
+| `language` | `auto` (default — infers from the `coverage` extension), `rust`, or `typescript`. |
+| `src` | Source root passed to the analyzer. Newline-separated list for multi-root. **Empty by default** — when omitted, `--src` is not forwarded, so the analyzer's own precedence wins (a `crap.toml` `src = [...]`, else its built-in `["src"]`). Pass `src: .` to scan the repo root. |
+| `config` | Path to a `crap.toml`. Forwarded only when set. |
+
+When `src`, `threshold`, and `threshold-preset` are all omitted, the action forwards no corresponding flag and lets a `crap.toml` own those knobs (see [configuration.md](configuration.md)). A wrapper that injected a tool default as an explicit flag would invert that cascade, so the action does not.
+
+The default complexity metric is the adapter's own: crap4rs uses cognitive, crap4ts uses cyclomatic. The action never passes `--metric`.
+
+## Presets
+
+Four optional preset inputs cover the common-case configuration in one line each. Presets are additive — every raw input still works, and an explicit raw input wins when set alongside a preset (the action emits a `::warning::` only on actual conflict, since a GitHub Actions composite cannot tell "caller passed the default" from "caller omitted it").
+
+| Input | Values | Derives |
+|---|---|---|
+| `threshold-preset` | `strict` \| `default` \| `lenient` | `threshold` = 8 / 15 / 25 (cognitive calibration) |
+| `run-mode` | `full` \| `delta` \| `both` | Baseline expectations (delta/both require `baseline:`) |
+| `gate-mode` | `report-only` \| `gate-on-analysis` \| `gate-on-delta` \| `gate-on-both` | The atomic `analysis-gate` + `delta-gate` pair |
+| `languages` | `rust` \| `typescript` \| `rust,typescript` \| `all` | Single value supersedes `language:`; a multi-value set triggers multi-language mode |
+
+The 8/15/25 thresholds are a calibration convention, not empirically derived values, and they are the cognitive scale; crap4ts applies its own cyclomatic calibration automatically. `threshold-preset` and the score-based risk bands are distinct axes that happen to share 8/15/25 today — see [understanding-crap.md](understanding-crap.md). The full input and output tables live in the [action README](https://github.com/breezy-bays-labs/crap-rs/blob/main/.github/actions/scorecard/README.md); this chapter names the inputs a consumer reaches for first.
+
+`languages: rust,typescript` (or `all`) runs both adapters in one invocation and pairs the Rust inputs (`coverage`, `src`, `baseline`) with their `-ts` counterparts (`coverage-ts`, `src-ts`, `baseline-ts`). It produces one combined sticky comment and split outputs. See [multi-language.md](multi-language.md) for the paired-input contract and how the combined view ranks across languages (by CRAP-to-threshold ratio and risk band — cross-language scores are not directly comparable).
+
+## The gate-mode dial
+
+By default the action is measurement-only: it renders the scorecard and exits 0 even when functions sit above the threshold. `gate-mode` is the one dial that turns measurement into a hard gate. It sets `analysis-gate` and `delta-gate` together so the two cannot drift.
+
+| `gate-mode` | Fails the build when… |
+|---|---|
+| `report-only` (default behavior) | Never — render only. |
+| `gate-on-analysis` | Any analyzed function exceeds the threshold. |
+| `gate-on-delta` | A new violation lands relative to the baseline (requires `baseline:`). |
+| `gate-on-both` | Either of the above. |
+
+When a gate trips, the action exits non-zero after the scorecard is rendered, so `outputs.markdown` and the sticky comment are still produced — the gate fails the job; it does not suppress the report.
+
+```yaml
+- uses: breezy-bays-labs/crap-rs/.github/actions/scorecard@<sha>
+  with:
+    coverage: lcov.info
+    gate-mode: gate-on-analysis
+```
+
+## Sticky PR comments
+
+Set `comment-mode: sticky` to post (and update in place on each push) a single PR comment carrying the scorecard. This needs `pull-requests: write` on the calling job.
+
+```yaml
+permissions:
+  contents: read
+  pull-requests: write
+# ...
+- uses: breezy-bays-labs/crap-rs/.github/actions/scorecard@<sha>
+  with:
+    coverage: lcov.info
+    comment-mode: sticky
+    comment-header: crap-scorecard
+```
+
+`comment-header` is the sticky identity — vary it to run two distinct scorecards on one PR (e.g. a gated production card and a report-only one) without their comments colliding. `comment-preamble` prepends a labeling line so a reader can tell two cards apart at a glance. The composed body is also exposed verbatim on the `sticky-message` output for aggregator bots that compose their own comment.
+
+## Baseline and delta
+
+A baseline is a previously captured JSON envelope (`crap4rs … --format json`). Supply it on `baseline:` to render a delta scorecard — what changed versus the baseline — and to enable `gate-on-delta`. Producing the baseline is the caller's job (the action does not auto-checkout the base ref):
+
+```yaml
+steps:
+  - uses: actions/checkout@<sha>
+    with:
+      fetch-depth: 0
+      persist-credentials: false
+  - name: Capture baseline on the PR base
+    run: |
+      git switch --detach origin/${{ github.base_ref }}
+      cargo llvm-cov --workspace --lcov --output-path /tmp/base.lcov
+      cargo install --locked crap4rs
+      crap4rs --coverage /tmp/base.lcov --src . --format json --no-fail > /tmp/baseline.json
+      git switch -
+  - run: cargo llvm-cov --workspace --lcov --output-path lcov.info
+  - uses: breezy-bays-labs/crap-rs/.github/actions/scorecard@<sha>
+    with:
+      coverage: lcov.info
+      baseline: /tmp/baseline.json
+      gate-mode: gate-on-delta
+      comment-mode: sticky
+```
+
+The delta is recomputed from the two envelopes, so the baseline must carry the parameters the gate uses (threshold, epsilon). The action threads those through; a hand-built baseline that omits them recomputes against defaults. For the JSON envelope shape see [output-formats.md](output-formats.md).
+
+## HTML report and GitHub Pages
+
+`html-report: true` renders the full file-by-file HTML report (KPI tiles, distribution bar, file cards, optional dark mode), uploads it as a workflow artifact, and — under `comment-mode: sticky` — appends a download link to the sticky comment. A supplied `baseline:` activates the report's Delta tab automatically. The artifact name is per language (`crap4rs-report-<suffix>` / `crap4ts-report-<suffix>`), suffixed with `-${{ runner.os }}` by default; override `html-artifact-name-suffix` for matrix legs beyond OS, or `actions/upload-artifact` fails on the second leg uploading to the same name.
+
+A workflow-artifact link makes the reviewer download a zip. `pages-publish: true` instead pushes the rendered HTML to a GitHub Pages branch and links the **live hosted page** in the sticky comment — one click, no download.
+
+```yaml
+permissions:
+  contents: write       # required for the gh-pages push
+  pull-requests: write  # required for the sticky comment
+# ...
+- uses: breezy-bays-labs/crap-rs/.github/actions/scorecard@<sha>
+  with:
+    coverage: lcov.info
+    baseline: baseline.json   # optional — enables the Delta tab
+    html-report: true         # required for pages-publish
+    comment-mode: sticky
+    pages-publish: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
+    pages-deploy-path: pr-${{ github.event.number }}
+    pages-url: https://acme.github.io/my-repo/pr-${{ github.event.number }}/
+```
+
+Mechanics that matter:
+
+- **`pages-publish` requires `html-report: true`** (there must be a rendered report to publish) and both `pages-deploy-path` (the path within the branch, e.g. `pr-123`) and `pages-url` (the full public URL, used verbatim as the sticky link). The action does not derive the URL — you pass it, so custom domains and project-vs-user Pages all work.
+- **Publish before post.** The push runs before the sticky comment is composed under `set -euo pipefail`, so a push failure reds the job rather than posting a dead link.
+- **First-run ordering.** When the Pages branch (default `gh-pages`) does not exist, the action creates it as an orphan branch with a `.nojekyll` marker on the first publish. Creating the branch does not make GitHub serve it — enable Pages on the branch once (Settings → Pages → Deploy from a branch → `gh-pages` → `/ (root)`). Until Pages is enabled and has built once, the link 404s even though the file was pushed.
+- **Content is preserved.** The publish copies into `<pages-deploy-path>/index.html`; it does not wipe the branch. Other PRs' directories, the root report, and `baselines/` survive. Per-PR directories accumulate, so ship a `pull_request: types: [closed]` cleanup workflow that removes `pr-<N>/` on close, and give every job that pushes to the branch a shared `concurrency` group with `cancel-in-progress: false`.
+
+## Key outputs
+
+| Output | Use |
+|---|---|
+| `markdown` | The bare rendered scorecard. Consume directly in aggregator bots. |
+| `sticky-message` | The composed sticky body (preamble + scorecard + report link). |
+| `row-json` | The single-row `Row::CrapDelta` JSON for aggregator workflows that re-render with full layout control. |
+| `json-envelope-path` | Path on the runner to the full JSON envelope. |
+| `analysis-passed` / `delta-passed` | `true`/`false` gate results. `delta-passed` is empty with no baseline. |
+| `new-violations` / `regressions` | Counts feeding `gate-on-delta`. |
+| `threshold-resolved` | The threshold the action resolved from its inputs. When the caller defers to `crap.toml`, this still reports the action's `15` fallback, not the analyzer's effective gate — read the envelope for that. |
+| `html-artifact-url` | Report URL when `html-report: true` (resolves only for GitHub-authenticated requests). |
+
+In multi-language mode `row-json` is empty (the action warns) and you read the split `row-json-rust` / `row-json-typescript` instead — see [multi-language.md](multi-language.md).
+
+## Caveats
+
+- **Fork PRs get a read-only token.** GitHub issues a read-only `GITHUB_TOKEN` for `pull_request` events from forks regardless of the job's `permissions:` block. The `comment-mode: sticky` step silently no-ops, and `pages-publish` would 403 — gate it to same-repo events (as above) so a fork PR degrades cleanly to a summary-only card with no hosted link. Two standard workarounds restore fork coverage: a `pull_request_target` trigger with hardened checkout, or a separate `workflow_run`-triggered comment workflow with its own writable token. The advanced privileged-handoff topology (the `fork-handoff` input plus a base-repo `workflow_run` publisher) is documented in [`docs/pages-fork-reports.md`](https://github.com/breezy-bays-labs/crap-rs/blob/main/docs/pages-fork-reports.md). Same-repo branches are unaffected.
+- **crap4ts is not auto-installed.** The action installs crap4rs via `cargo binstall`, but the TypeScript branch does **not** attempt to install crap4ts — it requires the binary pre-installed on `PATH` and fails with an actionable message when it's missing. Prepend its directory to `PATH` in a step that runs before the action.
+- **Integration / BDD / feature-gated code scores `c² + c`.** Code with little or no line coverage scores its complexity squared. For analysis-only crates that is expected, not a bug — gate them `report-only` or scope `src`/`config` to exclude them rather than chasing a passing gate.
+- **`threshold-resolved` is the resolved input, not always the analyzer's gate** (see the outputs table) — only relevant when you let `crap.toml` own the threshold.
+
+The complete input and output tables, the aggregator pattern, and the deep multi-language and fork topologies stay in the [action README](https://github.com/breezy-bays-labs/crap-rs/blob/main/.github/actions/scorecard/README.md).

--- a/book/src/cli-reference.md
+++ b/book/src/cli-reference.md
@@ -1,0 +1,115 @@
+# CLI reference
+
+`crap4rs` (Rust) and `crap4ts` (TypeScript) share one flag surface. crap-core drives both binaries; each binary supplies only its language metadata, default complexity metric, and help examples. Every flag below works identically on both unless noted.
+
+Run a binary's own `--help` for the live, version-stamped surface. This chapter is the durable reference.
+
+```bash
+crap4rs --coverage lcov.info
+crap4ts --coverage coverage-final.json
+```
+
+`--coverage` is required for analysis (see [Input](#input)). For the file formats themselves, see [output formats](output-formats.md); for the CRAP math, [understanding CRAP](understanding-crap.md); for config-file keys, [configuration](configuration.md).
+
+## Subcommands
+
+When a subcommand is present, the analysis path is skipped and `--coverage` is not required.
+
+| Subcommand | Effect |
+|---|---|
+| `completions <SHELL>` | Print a shell completion script to stdout. `<SHELL>` is one of `bash`, `zsh`, `fish`, `powershell`, `elvish`, `nushell`. |
+| `init` | Write an exhaustive, annotated starter config to the canonical config file name in the current directory. Refuses to overwrite an existing file unless `--force` is passed. |
+
+```bash
+crap4rs completions zsh > _crap4rs
+crap4rs init            # writes crap.toml (annotated; every key documented)
+crap4rs init --force    # overwrite an existing config
+```
+
+`init` writes the same deterministic document regardless of flags. `--non-interactive` is accepted for back-compat but no longer changes the output. The generated config documents every supported key; trim it to what you use. Key reference: [configuration](configuration.md).
+
+## Input
+
+| Flag | Value | Default | Notes |
+|---|---|---|---|
+| `--coverage` | `FILE` | — | Coverage file in the adapter's format (`lcov.info` for Rust, `coverage-final.json` for TS). Required at runtime for analysis; clap does not mark it required so subcommands work without it. |
+| `--src` | `DIR` | `src` | Source root to analyze. **Repeatable** — pass more than once to union several roots into one report against the shared `--coverage`. Falls back to the config `src` list, then `src`. |
+| `--metric` | `cognitive` \| `cyclomatic` | per-adapter | See below. |
+| `--missing-coverage-policy` | `pessimistic` \| `optimistic` \| `skip` | `pessimistic` | How to score a function whose source file is absent from the coverage data. The pessimistic default scores such functions as 0% covered (`CRAP = c² + c`) — a deliberate choice that never hides risk, not a measured truth. |
+| `--config` | `FILE` | auto-discover | Path to the config TOML. Default discovers the adapter's config file in the working directory. See [configuration](configuration.md). |
+| `--view` | `NAME` | — | Apply a saved view preset from the config TOML. CLI flags override the preset's fields. See [configuration](configuration.md). |
+| `--baseline` | `FILE` | — | A previously emitted JSON envelope, used as the baseline for delta analysis. Delta is informational unless `--delta-gate` is set. |
+
+### `--metric` default differs per adapter
+
+`crap4rs` defaults to **cognitive** complexity (it captures match arms and nested control flow better for Rust) and also accepts `--metric cyclomatic`.
+
+`crap4ts` is **cyclomatic-only**. It defaults to cyclomatic; passing `--metric cognitive` exits 2 with an "is not yet supported" error.
+
+The complexity metric and the CRAP threshold both differ in magnitude between metrics; the threshold defaults are calibrated per metric.
+
+## Output
+
+| Flag | Value | Default | Notes |
+|---|---|---|---|
+| `--format` / `-f` | spec list | `table` | Comma-separated list of `FORMAT` (stdout) or `FORMAT:FILE` (write to file). One analysis pass fans out to multiple sinks. At most one stdout entry. Formats and samples: [output formats](output-formats.md). |
+| `--threshold` | `FLOAT` | `15` | CRAP cutoff — functions above it fail the gate. Defaults to the calibrated cutoff for the active metric. Mutually exclusive with `--strict` / `--lenient`. |
+| `--strict` | flag | — | Strict preset cutoff (`8`). Mutually exclusive with `--threshold` / `--lenient`. |
+| `--lenient` | flag | — | Lenient preset cutoff (`25`). Mutually exclusive with `--threshold` / `--strict`. |
+| `--no-fail` | flag | off | Always exit 0, even with violations. See [exit codes](#exit-codes). |
+| `--delta-gate` | flag | off | Fail (exit 1) when the `--baseline` comparison introduces new violations. Requires `--baseline`. |
+| `--threshold-epsilon` | `EPS` | `0.0` | Border-jitter suppression band for the delta gate. Requires `--baseline`. Finite, non-negative. |
+| `--minimal-view` | flag | off | Omit the denormalized `view.shown` row array from JSON. The gate is unaffected. JSON only. |
+| `--summary` | flag | off | Emit a single-line verdict instead of the full report. Short-circuits `--format`. |
+| `--annotation-limit` | `N` (1–100) | `10` | Cap on `::warning` annotations emitted by `--format github-annotations`. Ignored by every other format. |
+
+There is **no `--threshold-preset` flag** on the binary. Choose a preset with `--strict` / `--lenient`, or set `preset` in the config TOML ([configuration](configuration.md)). The composite action exposes a separate `threshold-preset` input ([CI integration](ci-integration.md)).
+
+### Threshold gate vs risk bands
+
+The threshold gate (`--threshold` / `--strict` / `--lenient`) decides exit code and the per-function `exceeds` flag, whereas the score-based risk bands are a separate axis used for display and ranking; [understanding CRAP](understanding-crap.md) covers how the two differ and why the `8 / 15 / 25` cutoffs are a calibration convention.
+
+## Filtering
+
+| Flag | Value | Default | Notes |
+|---|---|---|---|
+| `--exclude` | glob | — | Glob to exclude from analysis. Repeatable. `target/` (Rust) and similar build output are excluded via `.gitignore`; test files are **not** excluded by default. |
+| `--no-gitignore` | flag | off | Analyze all files regardless of `.gitignore`. |
+| `--diff` | `REF` | — | Only analyze functions in files changed since the given git ref. |
+| `--only-failing` | flag | off | Display only functions above threshold. **Display-only** — see below. |
+| `--min-coverage` | `PCT` | — | Lower bound (inclusive) on coverage percent for the displayed view. Display-only. |
+| `--max-coverage` | `PCT` | — | Upper bound (inclusive) on coverage percent for the displayed view. Display-only. |
+| `--sort-by` | `crap` \| `coverage` \| `complexity` \| `path` | `crap` | Sort key for the displayed view. Display-only. |
+| `--top` | `N` | no limit | Truncate the displayed view to the top N rows (`0` = no limit). Display-only. |
+| `--group-by` | `file` | — | Aggregate the displayed view by file. `--top` then truncates files, not functions. Display-only. |
+| `--delta-top` | `N` | no limit | Truncate the delta block (independent of `--top`). |
+| `--delta-sort` | `score-delta` \| `current-crap` \| `baseline-crap` \| `path` | `score-delta` | Sort key for the delta block. |
+| `--delta-only` | kinds | all | Comma-separated `added`, `removed`, `modified` for the delta block. |
+
+### Display-only flags never move the gate
+
+`--top`, `--sort-by`, `--only-failing`, `--min-coverage`, `--max-coverage`, and `--group-by` shape what the report *shows*. They never alter the analysis that drives the exit code. `result.passed` in JSON output, every aggregate (`average_crap`, `median_crap`, `distribution`), and the exit code always reflect the **full, unfiltered** codebase. Truncating violations out of the view with `--top 5` does not make a failing run pass.
+
+When you need the gate to see a narrower set, narrow the *analysis* input instead — scope `--src`, `--exclude`, or `--diff`.
+
+## Display
+
+| Flag | Value | Default | Notes |
+|---|---|---|---|
+| `--color` | `auto` \| `always` \| `never` | `auto` | Terminal color. `auto` colorizes only when writing to a TTY. |
+| `--verbose` / `-v` | flag | off | Show parse diagnostics and matching statistics. |
+| `--quiet` / `-q` | flag | off | Suppress report output; set exit code only. Wins over `--summary`. |
+| `--breakdown` | flag | off | Show complexity contributors for above-threshold functions in table output. JSON always includes contributors. |
+| `--explain` | flag | off | Explain nested breakdown increments. Table only, and only with `--breakdown`. |
+| `--md-full-table` | flag | off | Append the full per-function table to `--format markdown`. Markdown only. |
+| `--md-top` | `N` | `10` | Rows in the markdown top-N table. Markdown only. |
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Analysis passed — no function exceeds the threshold. Also returned by `init` and `completions`, and by any run with `--no-fail`. |
+| `1` | At least one function exceeds the threshold (or, with `--delta-gate`, the baseline comparison introduced new violations). |
+| `2` | The run errored — missing `--coverage`, an unreadable file, an unsupported `--metric`, or any other failure. |
+
+`--no-fail` overrides the exit-code translation only: a failing analysis exits `0`, but `result.passed` (and `delta.summary.passed` under `--delta-gate`) still reports the truthful state, so a consumer can detect a would-have-failed run from the JSON. Compose `--no-fail` with `--quiet` for silent success in CI.

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -1,0 +1,148 @@
+# Configuration
+
+A `crap.toml` file records the options you would otherwise pass on every run. Config values are merged with CLI flags at load time; flags always win. For the flags themselves, see the [CLI reference](cli-reference.md). For the CRAP math the thresholds gate against, see [understanding CRAP](understanding-crap.md).
+
+## Discovery and `--config`
+
+Without `--config`, the analyzer walks upward from its anchor directory looking for a config file. The anchor is the first `--src` root, or the working directory when `--src` is unset. Within each directory it resolves the candidate names in priority order; the **nearest ancestor directory that holds any candidate wins**, and the walk stops there.
+
+```text
+.
+├── crap.toml          # discovered from any subdirectory at or below here
+└── crates/
+    └── core/src/      # a run anchored here climbs to ./crap.toml
+```
+
+The walk has no `.git` or workspace boundary — it climbs to the filesystem root. A stray `crap.toml` in a parent of your project (or in `$HOME`) is discovered when no nearer file exists. Pass `--config <path>` to bypass discovery entirely and load exactly that file; the tool has no opinion on what you name it, so no deprecation or shadow notice fires for an explicit path.
+
+Discovery is by **existence, not parseability**. A present-but-malformed canonical file still wins and surfaces its parse error — it never silently falls through to an older file that happens to parse. Only a `NotFound` advances to the next candidate; any other I/O error (a `PermissionDenied` on a higher-priority file) stops the search and reports the path.
+
+### Legacy names and shadow warnings
+
+The canonical name is `crap.toml`. Each adapter also honors one legacy fallback for back-compat: `crap4rs.toml` (crap4rs) and `crap4ts.toml` (crap4ts). Discovering a legacy name emits a rename nudge:
+
+```text
+warning: using deprecated config name `crap4rs.toml`; rename it to `crap.toml`
+```
+
+When a lower-priority candidate also exists **in the winning directory**, it is reported as safe to remove:
+
+```text
+warning: `crap4rs.toml` is shadowed by `crap.toml` and ignored; it is safe to remove
+```
+
+Shadow detection is same-directory only — a file in a parent directory is never called redundant.
+
+## Merge precedence
+
+Each option resolves on a first-match-wins chain: **CLI flag → per-language section → top-level config key → default**. A bare CLI default (a flag the user did not set) does not count as "set" and defers to config. `--src` is the exception: a non-empty `--src` replaces the config `src` list wholesale, an empty `--src` defers to config, and an unset config defers to the `["src"]` default. `--src` has no per-language override.
+
+Threshold resolution is more specific — a literal cutoff always beats a named preset at the same level:
+
+| Order | Source |
+|-------|--------|
+| 1 | `--threshold N` (CLI literal) |
+| 2 | `--strict` / `--lenient` (CLI preset) |
+| 3 | `[language.<name>]` `threshold` |
+| 4 | `[language.<name>]` `preset` |
+| 5 | top-level `threshold` |
+| 6 | top-level `preset` |
+| 7 | no-flag default (the `default` preset, **15**) |
+
+The presets are flat across both metrics today: `strict = 8`, `default = 15`, `lenient = 25`. This is a calibration convention, not an empirically derived constant.
+
+## Reference
+
+`crap.toml` deserializes with `deny_unknown_fields`: an unrecognized or misspelled key fails the run at load time rather than being silently ignored. Every key is optional — an absent key defers to the merge chain above.
+
+### Top-level keys
+
+| Key | Type | Meaning |
+|-----|------|---------|
+| `threshold` | float | Custom numeric CRAP cutoff. Mutually exclusive with `preset`. |
+| `preset` | `"strict"` \| `"default"` \| `"lenient"` | Named threshold preset. Mutually exclusive with `threshold`. |
+| `metric` | `"cognitive"` \| `"cyclomatic"` | Complexity metric. The Rust adapter defaults to `cognitive`; crap4ts is `cyclomatic`-only. See the note on per-language placement below. |
+| `missing_coverage_policy` | `"pessimistic"` \| `"optimistic"` \| `"skip"` | How to score a function whose source file is entirely absent from coverage. The default, `pessimistic` (0% covered → `c²+c`), is a deliberate choice, not ground truth. `optimistic` treats it as 100% covered; `skip` omits it from the report. |
+| `src` | string \| array of strings | Source root(s) to walk. A single root stays src-relative (byte-identical to the long-standing `src = "string"` form); multiple roots are keyed git-toplevel-relative and require a git work tree. |
+| `exclude` | array of strings | Glob patterns matched against project-relative file paths; matching files are dropped from analysis. Each exclusion should carry a tracking issue or ADR. |
+| `overrides` | array of tables | Per-path threshold overrides. See [`[[overrides]]`](#overrides). |
+| `views` | table of tables | Saved view presets. See [`[views.<name>]`](#viewsname). |
+| `language` | table of tables | Per-language overrides. See [`[language.<name>]`](#languagename). |
+| `output` | table | Reporter knobs. See [`[output]`](#output). |
+| `delta` | table | Delta-gate knobs. See [`[delta]`](#delta). |
+
+`threshold` and `preset` are mutually exclusive — a config that sets both is rejected. This carve-out applies at the top level and recursively inside each `[language.<name>]` section.
+
+### `[[overrides]]`
+
+An array of tables, each applying a CRAP cutoff to files matching a glob:
+
+```toml
+[[overrides]]
+pattern = "src/domain/**"   # glob matched against project-relative paths
+threshold = 8.0             # finite, positive
+```
+
+### `[views.<name>]`
+
+A reusable bundle of report-shaping flags, selected at runtime via `--view <name>`. Folding a preset into the run is OR-merge: a CLI bool of `false` reads as "unset" and a preset's `true` still applies.
+
+| Key | Type | Meaning |
+|-----|------|---------|
+| `top` | int | Limit to the N highest-CRAP functions. |
+| `min_coverage` | float | Keep functions with coverage at or above this percent. |
+| `max_coverage` | float | Keep functions with coverage at or below this percent. |
+| `sort` | `"crap"` \| `"coverage"` \| `"complexity"` \| `"path"` | Sort key. |
+| `only_failing` | bool | Show only functions that exceed their threshold. |
+| `no_fail` | bool | Report without failing the process on breaches. |
+| `group_by` | `"file"` | Group rows by file. |
+| `minimal_view` | bool | Render the compact view. |
+
+Coverage bounds are validated at load time: each must be in `[0, 100]`, and `min_coverage` must not exceed `max_coverage`.
+
+### `[language.<name>]`
+
+Per-language override sections keyed by language name (`[language.rust]`, `[language.typescript]`). Each adapter reads **only its own section** and overlays a set value over the shared top-level default; languages the running adapter does not recognize are never selected. A section may assert any subset of `threshold`, `preset`, `metric`, and `exclude`.
+
+`metric` lives here, not only at the top level — a per-language `metric` is the idiomatic place to set it for a multi-language project, since it sits above the top-level `metric` in the merge chain. The same `threshold`/`preset` mutual exclusion applies within each section.
+
+```toml
+metric = "cognitive"        # shared default
+
+[language.rust]
+threshold = 8.0             # crap4rs gates Rust at 8
+metric = "cognitive"
+
+[language.typescript]
+threshold = 15.0            # crap4ts gates TS at 15
+```
+
+### `[output]`
+
+| Key | Type | Meaning |
+|-----|------|---------|
+| `annotation_limit` | int `1..=100` | Cap on `::warning` annotations emitted by the `github-annotations` reporter per run. Matches the `--annotation-limit` range. |
+| `title` | string | Scorecard header label. Absent renders the unlabeled header. |
+| `subtitle` | string | Line rendered beneath the title. |
+
+### `[delta]`
+
+| Key | Type | Meaning |
+|-----|------|---------|
+| `epsilon` | float `>= 0.0` | Threshold-border jitter half-width (absolute CRAP points) for `--delta-gate`. A new violation crossing the threshold but staying within `epsilon` of it — on both the baseline and current side — is treated as border jitter and not counted. Default `0.0` disables suppression. This is a jitter knob, not a noise-only guarantee: a genuinely new in-band violation is suppressed too. |
+
+The `threshold`-vs-`preset` exclusivity, the `annotation_limit` range, and the `epsilon` finiteness are all enforced at load time so config and CLI agree on the legal values.
+
+## Generated artifacts and editor wiring
+
+`crap4rs init` (and `crap4ts init`) writes an exhaustive annotated `crap.toml` — every supported key, with each key's documentation as an inline comment. The committed `crap.example.toml` at the repo root is the same generator output, byte for byte. `init` refuses to overwrite an existing file; pass `--force` to regenerate.
+
+Because the file documents every option, the live config you keep is a trimmed subset. The example shows `threshold` live with `preset` commented out as the mutually-exclusive alternative — uncomment one and delete the other.
+
+The committed `crap.schema.json` is the JSON Schema for `crap.toml`, generated from the same field documentation that drives the annotated example and the docs.rs hovers. Point your editor at it for completion and validation:
+
+```toml
+#:schema ./crap.schema.json
+```
+
+The schema and the example share one prose source, so there is no second hand-authored description to drift.

--- a/book/src/installation.md
+++ b/book/src/installation.md
@@ -1,0 +1,77 @@
+# Installation
+
+crap4rs analyzes Rust; crap4ts analyzes TypeScript and JavaScript. Both share the `crap-core` foundation, which also ships the `crap-render` binary used for multi-language reports. Pick the analyzer that matches your project, then install the matching coverage prerequisites below.
+
+## Rust analyzer — crap4rs
+
+Install from crates.io with a Rust toolchain present:
+
+```bash
+cargo install crap4rs
+```
+
+Prefer a prebuilt binary over a source build with `cargo binstall`. crap4rs ships `[package.metadata.binstall]`, so binstall resolves the matching release tarball and falls back to `cargo install` only when no prebuilt target exists:
+
+```bash
+cargo binstall crap4rs
+```
+
+The binary name is `crap4rs`.
+
+## TypeScript / JavaScript analyzer — crap4ts
+
+Install from npm:
+
+```bash
+npm install -g crap4ts
+```
+
+The npm package ships a native binding built with napi-rs for `linux` and `darwin` on `x64` and `arm64`; it requires Node 18 or later.
+
+> The `crap4ts` CLI binary is not yet published to crates.io — only the npm package carries a working release. To run the CLI on a platform the npm package does not cover, install from source with a Rust toolchain:
+>
+> ```bash
+> cargo install crap4ts
+> ```
+
+The binary name is `crap4ts`.
+
+## Multi-language renderer — crap-render
+
+`crap-render` composes per-language JSON envelopes into a combined report (HTML today). It ships inside `crap-core`:
+
+```bash
+cargo install crap-core      # installs the crap-render binary
+cargo binstall crap-core     # prebuilt, with cargo install fallback
+```
+
+You only need `crap-render` directly when combining Rust and TypeScript results by hand. See [multi-language analysis](multi-language.md) for its usage; in CI the [composite action](ci-integration.md) invokes it for you.
+
+## Coverage prerequisites
+
+crap4rs and crap4ts compute CRAP from your existing coverage data. Generate it with the tooling for your language before running an analysis.
+
+### Rust — LCOV
+
+crap4rs reads LCOV (`lcov.info`). Generate it with [cargo-llvm-cov](https://github.com/taiki-e/cargo-llvm-cov), which needs the `llvm-tools-preview` rustup component:
+
+```bash
+rustup component add llvm-tools-preview
+cargo install cargo-llvm-cov
+cargo llvm-cov --lcov --output-path lcov.info
+```
+
+### TypeScript / JavaScript — Istanbul JSON
+
+crap4ts reads Istanbul-format coverage (`coverage-final.json`). crap4ts consumes the istanbul provider's JSON only — Vitest defaults to the v8 provider, whose JSON is a different shape the adapter does not read, so set the provider explicitly. Any Istanbul-compatible producer works — for example [c8](https://github.com/bcoe/c8), Vitest with the istanbul provider, or `nyc`. Configure your runner to emit the `json` reporter:
+
+```bash
+c8 --reporter=json npm test            # writes coverage/coverage-final.json
+vitest run --coverage --coverage.provider=istanbul --coverage.reporter=json
+```
+
+## Next steps
+
+- [Quick start](quick-start.md) — run your first analysis.
+- [CLI reference](cli-reference.md) — every flag.
+- [CI integration](ci-integration.md) — the scorecard action and coverage setup on a runner.

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -1,0 +1,45 @@
+# Introduction
+
+CRAP (Change Risk Anti-Patterns) is a single number per function that fuses how complex the code is with how well it is tested. Complex code with thin coverage is the code most likely to break when you change it, and CRAP makes that risk one sortable column: a function the size of a one-liner with full coverage scores low; a deeply branched function with no tests scores high. You point the tool at your source and a coverage report, and it ranks every function by how dangerous it is to touch.
+
+## The formula
+
+```
+CRAP(complexity, coverage) = complexity² × (1 − coverage)³ + complexity
+```
+
+`coverage` is the fraction in `[0, 1]` (50% is `0.5`). At full coverage the score collapses to the bare complexity (`complexity² × 0 + complexity`); at zero coverage it is `complexity² + complexity`, the maximum penalty. The cubed uncovered term means missing coverage on complex code dominates fast. The full derivation, worked examples, and the unit distinction (the published formula takes a fraction; the implementation takes a percent) live in [understanding CRAP](understanding-crap.md).
+
+## Two adapters, one core
+
+The metric is language-agnostic, so the workspace splits the universal math from the language-specific extraction:
+
+| Binary | Analyzes | Complexity source | Coverage format |
+|--------|----------|-------------------|-----------------|
+| `crap4rs` | Rust | `syn` AST walk | LCOV (`lcov.info`) |
+| `crap4ts` | TypeScript / JavaScript | `oxc` AST walk | Istanbul JSON (`coverage-final.json`) |
+| `crap-core` | — (shared library) | — | — |
+
+`crap-core` owns the CRAP formula, the analysis types, the reporters, and the wire envelope. Both adapters link it, so a Rust project and a TypeScript project get identical CRAP semantics — the same arithmetic, the same output shapes. The adapters differ only in how they parse source and read coverage.
+
+`crap-core` also ships a `crap-render` binary that takes one or more pre-computed envelopes and renders a combined report. Cross-language scores are not directly comparable on their own axis; the combined view ranks functions by their CRAP-to-threshold ratio and risk band rather than raw score. See [multi-language analysis](multi-language.md).
+
+## Who each binary is for
+
+- **`crap4rs`** — Rust authors who produce LCOV via `cargo-llvm-cov`.
+- **`crap4ts`** — TypeScript and JavaScript authors who produce Istanbul JSON via their test runner.
+- **`crap-render`** — anyone combining envelopes from more than one language into one report (a polyglot repo, a CI summary).
+
+The two adapters never need each other. Pick the one matching your language.
+
+## How this book is laid out
+
+- [Installation](installation.md) — get the binary onto your machine.
+- [Quick start](quick-start.md) — first analysis in a few commands.
+- [Understanding CRAP](understanding-crap.md) — the formula, risk bands, and the threshold gate.
+- [CLI reference](cli-reference.md) — every flag for the adapter binaries.
+- [Configuration](configuration.md) — the config file schema and precedence.
+- [Output formats](output-formats.md) — the table, JSON, HTML, and other reporters.
+- [CI integration](ci-integration.md) — the scorecard composite action and gating in pipelines.
+- [Multi-language analysis](multi-language.md) — `crap-render` and the combined view.
+- [Limitations & FAQ](limitations-and-faq.md) — what CRAP measures, what it does not, and the honest edges.

--- a/book/src/limitations-and-faq.md
+++ b/book/src/limitations-and-faq.md
@@ -1,0 +1,76 @@
+# Limitations & FAQ
+
+Every analyzer makes choices. This chapter collects the ones that shape what a crap4rs score does and does not mean, in one place. Each limit links back to the chapter that owns the detail.
+
+## Limitations
+
+### Matching is positional, not by name
+
+crap4rs joins complexity data to coverage data by file path plus line range, never by function name. The syn walker emits `(file, start_line, end_line)` per function; LCOV `DA:` records give `(file, line, hits)`. A function's coverage is the fraction of its lines that the coverage data marks executed. This is a positional heuristic: it carries no symbol demangling, no `FN:`/`FNDA:` parsing, and no name resolution. A macro that expands across a function's declared span, or coverage data generated against a different revision of the file, can shift the join. See [Understanding CRAP](understanding-crap.md) for the matching model.
+
+### Rust coverage is LCOV-only
+
+The Rust adapter reads `lcov.info` and parses `SF:` and `DA:` records only. `FN:` and `FNDA:` records are ignored — they carry mangled symbols and duplicate information the line-range join already derives. Generate input with `cargo llvm-cov --lcov`. See [Installation](installation.md) for the coverage-generation command and [Multi-language](multi-language.md) for the TypeScript path (Istanbul `coverage-final.json`).
+
+### Code your coverage run never executes scores `c² + c`
+
+A function whose file is absent from the coverage data is treated as 0% covered, so its CRAP score is `c² + c` (complexity squared plus complexity). This is the pessimistic default: it never hides risk. It also means code that a coverage run structurally cannot reach scores high by design, not by defect:
+
+- Integration-only code, HTTP handlers, and binary entry points that `cargo llvm-cov --lib` does not exercise.
+- Code reached only through BDD/cucumber harnesses run out of process.
+- `#[cfg(feature = "…")]` blocks excluded from the default-feature coverage build.
+
+These are expected high scores, not bugs. When more than half the analyzed files have every analyzed function at 0% line coverage, crap4rs prints a warning to stderr naming the likely cause — uninstrumented integration code — and points at `--exclude`. The gate still runs; the warning is advisory.
+
+To change the policy for files missing from coverage, set the missing-coverage policy:
+
+| Policy | Coverage assumed | Resulting CRAP | Use when |
+|--------|------------------|----------------|----------|
+| `pessimistic` (default) | 0% | `c² + c` | You want missing coverage to count as risk. |
+| `optimistic` | 100% | `c` | You run a scoped test slice that legitimately omits files. |
+| `skip` | — (function omitted) | none | The function should not appear at all. |
+
+The default is a choice — the safe one — not a statement about the code. See [Configuration](configuration.md) for the policy key and [CLI reference](cli-reference.md) for the flag.
+
+### Branch coverage is informational; the gate is line-only
+
+When the coverage data carries branch records, crap4rs surfaces a branch-coverage percentage per function. The CRAP score and the `--threshold` gate are computed against line coverage only. Branch data is reported, never gated. Promoting it to a gate would be a separate decision. See [Output formats](output-formats.md) for where the branch column appears.
+
+### Thresholds are a calibration convention
+
+The default gate is 15; the strict preset is 8 and the lenient preset is 25. These numbers are a calibration convention, not an empirically derived constant. They are also distinct from the score-based risk bands (Low ≤ 8, Acceptable ≤ 15, Moderate ≤ 25, High above), which classify every function regardless of the gate. The two axes share the same numbers today but answer different questions: the band is a fixed score classification, the gate is the pass/fail line you set. See [Understanding CRAP](understanding-crap.md) for the bands and [Configuration](configuration.md) for the presets.
+
+### Walker scope: closures fold in, nested functions stand alone
+
+The complexity walker handles two nesting cases distinctly:
+
+- **Closures** count toward their enclosing function. A closure adds nothing by existing, but branching inside its body is charged one extra nesting level, so deeper logic costs more under the cognitive metric.
+- **Nested `fn` items** are recorded as their own separate functions, named by their module path rather than the enclosing function. A `fn helper` declared inside `outer::do_work` appears as `outer::helper`, scored independently.
+
+The default complexity metric for crap4rs is cognitive; cyclomatic is available via flag. See [CLI reference](cli-reference.md) for the metric flag and [Understanding CRAP](understanding-crap.md) for how each metric counts.
+
+## FAQ
+
+### Why does a fully tested function still show a CRAP score above 1?
+
+A CRAP score equals the complexity when coverage is 100%. A function with cognitive complexity 12 and full coverage scores 12 — the formula collapses to the complexity alone. The score above 1 reflects complexity, not a coverage gap. Decompose the function to lower it. See [Understanding CRAP](understanding-crap.md).
+
+### Why is my handler crate all red?
+
+`cargo llvm-cov --lib` does not instrument integration-only code, so those files are absent from coverage and score `c² + c` under the pessimistic default. Either generate coverage that exercises them, set the missing-coverage policy to `optimistic` for a scoped slice, or `--exclude` the uncoverable paths. See [Configuration](configuration.md).
+
+### Can I compare a Rust score to a TypeScript score directly?
+
+No. Cross-language CRAP scores are not directly comparable. The combined view ranks functions by risk band first, then by the ratio of CRAP to its threshold within the band — not by raw score. See [Multi-language](multi-language.md).
+
+### Coverage is a fraction in the formula but I pass a percent — which is it?
+
+The published formula uses coverage as a fraction in `[0, 1]`. The internal computation takes a percentage in `[0, 100]` and clamps out-of-range input. You generate coverage as LCOV either way; the unit difference lives inside the formula. See [Understanding CRAP](understanding-crap.md).
+
+### The `advice` format output looks rough — is that final?
+
+The `advice` format is experimental. Its remediation phrasing may change. The numeric scores it reports are the same scores every other format reports. See [Output formats](output-formats.md).
+
+### Do I have to pass `--coverage`?
+
+clap does not mark `--coverage` as required, but a run needs it: crap4rs computes coverage-aware scores and has nothing to join against without it. In the composite action, `--src` defaults to nothing so configuration wins. See [CLI reference](cli-reference.md) and [CI integration](ci-integration.md).

--- a/book/src/multi-language.md
+++ b/book/src/multi-language.md
@@ -1,0 +1,88 @@
+# Multi-language analysis
+
+A polyglot repository has one CRAP score per function, in two scales that don't share a number line. crap4rs scores Rust functions (cognitive complexity by default); crap4ts scores TypeScript functions (cyclomatic complexity only). `crap-render` composes their JSON envelopes into one HTML report with a Combined view and an optional Delta view — without pretending the two scales are interchangeable.
+
+For the analyzer flags that produce each envelope, see [CLI reference](cli-reference.md). For the CRAP formula itself, see [understanding CRAP](understanding-crap.md). This chapter owns the cross-language layer only: envelope production, the `crap-render` CLI, and the aggregation rules.
+
+## Per-language coverage formats
+
+Each adapter consumes the coverage format native to its toolchain. The formats are not interchangeable; pass each adapter the file its language emits.
+
+| Language | Coverage file | Producer |
+|----------|---------------|----------|
+| Rust | `lcov.info` | `cargo llvm-cov --lcov` |
+| TypeScript | `coverage-final.json` | Istanbul (`nyc`, `c8`, Jest, Vitest) |
+
+The composite action auto-detects the adapter from the `coverage` input's extension (`.info`/`.lcov` → Rust, `.json` → TypeScript). See [CI integration](ci-integration.md).
+
+## Producing envelopes
+
+The unified report composes per-adapter JSON envelopes — the same `--format json` output each analyzer already emits. Run each analyzer over its own source root and coverage file:
+
+```bash
+crap4rs --coverage lcov.info --src crates/core/src --format json > rust.json
+crap4ts --coverage coverage-final.json --src apps/web/src --format json > typescript.json
+```
+
+Each envelope carries its adapter's `tool_version`, `language` tag, complexity `metric`, and `threshold`, so `crap-render` reconstructs the per-adapter footer without re-running analysis.
+
+## The crap-render CLI
+
+`crap-render` ships with crap-core. It composes envelopes; it never analyzes source.
+
+```bash
+crap-render --input rust=rust.json --input typescript=typescript.json --format html --output report.html
+```
+
+| Flag | Meaning |
+|------|---------|
+| `--input <LANG>=<FILE>` | Pair an envelope with its language key. Repeatable; at least one required. |
+| `--baseline <LANG>=<FILE>` | Optional baseline envelope, matched to the `--input` of the same key. Repeatable. |
+| `--format html` | Output format. `html` is the only value today; the flag exists so future formats extend without a breaking change. |
+| `--output <PATH>` | Write target. Omit to write to stdout. |
+| `--threshold <N>` | Workspace threshold echoed in the scope banner. Defaults to the maximum across all per-envelope thresholds. |
+
+The language key in `--input rust=...` — not the envelope's own `language` field — is the routing source of truth: it drives the segmented Language nav and the URL hash (`#rust:current`, `#typescript:delta`, `#combined:current`). Routing stays explicit so the renderer never has to trust per-envelope identity to place a block.
+
+`<LANG>` is an arbitrary key. `rust` maps to the `crap4rs` / Rust labels and `typescript` to `crap4ts` / TypeScript; any other key falls through to itself as both tool name and display label. Adding a language is purely additive — supply another `--input` pair.
+
+### Guards
+
+`crap-render` fails fast on operator errors:
+
+- Two envelopes for the same language key are refused (the common "passed two `rust.json`" mistake), on both `--input` and `--baseline`.
+- A `--baseline <LANG>=...` whose key has no matching `--input` is an error.
+- An envelope whose `schema_version` is outside the supported range fails with a message naming the path and the offending value. Upgrade the emitting adapter or the renderer.
+- An `--input` envelope that omits `metric` or `threshold` renders with the defaults (cognitive / `0`) and a `note:` on stderr, so a hand-built envelope can't silently misrender.
+
+## The unified report: Combined and Delta views
+
+The report has two axes. The **Language** axis is a segmented nav (one panel per `--input`, plus a Combined panel). The **View** axis toggles **Current** vs **Delta** within a panel.
+
+The **Combined** panel aggregates across every adapter into one scorecard plus one workspace-wide ranked function table. The **Delta** axis appears only when at least one `--baseline` was supplied; it shows what changed since the baseline, per language and combined.
+
+### Cross-language aggregation rules
+
+Aggregation is deliberately conservative. Raw CRAP scores are **not** comparable across adapters — cognitive and cyclomatic complexity scale differently, so a Rust function at CRAP 20 and a TypeScript function at CRAP 20 are not equivalent risk. The composer never sorts on raw cross-language CRAP.
+
+**Additive counts (disjoint trees).** Each adapter scans a disjoint source tree, so `total_functions`, `exceeding_threshold`, `total_files`, and the per-tier risk distribution sum cleanly. "Exceeds" is decided per-adapter against that adapter's own threshold first, then counted — binary per function, so the sum is honest.
+
+**Ranking by risk band, then ratio.** The Combined ranked table sorts by risk level descending, then by CRAP/threshold **ratio** descending within each band, with a stable tie-break on qualified name then file path. The ratio ("how far over this function's own threshold") is dimensionally consistent across adapters in a way raw CRAP is not. The same rule orders the Combined Delta regression table. Risk **bands** (the score-based classification) and the threshold **gate** are distinct axes that happen to share the 8/15/25 numbers today — see [understanding CRAP](understanding-crap.md).
+
+**Consistent by construction.** Both adapters derive every function's risk level from one shared crap-core classifier and serialize it through one shared type. There is no per-language risk-classification step to drift, so the Combined ranking's band axis is consistent across adapters by construction, not by convention.
+
+### Asymmetric baselines
+
+Baselines are independent per language. Supplying `--baseline rust=...` but not `--baseline typescript=...` is allowed and well-defined:
+
+- Languages **with** a baseline get a working Delta tab and contribute to the Combined Delta ranking.
+- Languages **without** a baseline render the Delta tab **disabled** (a tooltip points reviewers to supply one); their Current view is unaffected.
+- The Combined Delta panel lists `contributing_languages` and `missing_baseline_languages` so reviewers see that the Combined Delta represents fewer languages than the Combined Current view.
+
+A baseline scored with a **different complexity metric** than its input is not diffed — cognitive and cyclomatic are incomparable scales, so the recomputed delta would be confident garbage. That language degrades to the disabled-Delta state with a metric-mismatch tooltip, a stderr warning, and an unchanged exit code; other languages are unaffected. An envelope that merely *omits* `metric` carries no evidence of disagreement, so absence never trips the guard.
+
+Combined Delta is regression-focused: it ranks regressions and new functions. Improvements and removed functions are summarized but not ranked.
+
+## CI and consumers
+
+In CI, the composite action drives `crap-render` for you — set `html-report: true` with `languages: rust,typescript` (or `all`) and pass per-language `src`/`coverage` inputs. The action fetches the latest released envelope as a baseline to populate the Delta tab. See [CI integration](ci-integration.md). The manual `crap-render` invocation above is for local debugging and bespoke pipelines.

--- a/book/src/output-formats.md
+++ b/book/src/output-formats.md
@@ -1,0 +1,227 @@
+# Output formats
+
+`--format SPEC` selects what the analysis pass emits. One pass, many shapes: the analyzer walks the source and joins coverage once, then renders the result through every requested reporter. The flag mechanics (parsing, defaults, fan-out grammar) live in the [CLI reference](cli-reference.md); this chapter shows one sample per reporter and states what each is for.
+
+## The `--format SPEC[:FILE]` fan-out
+
+Each `--format` entry is a `FORMAT` (write to stdout) or `FORMAT:FILE` (write to that path). Pass a comma-separated list to fan a single pass out to several sinks:
+
+```bash
+crap4rs --coverage lcov.info --format json:envelope.json,markdown:report.md,github-annotations
+```
+
+That run produces three artifacts from one analysis: a JSON envelope on disk, a Markdown report on disk, and GitHub Actions annotations on stdout.
+
+### The single-stdout rule
+
+At most one entry in a multi-format invocation may target stdout; the rest must name a file. Two stdout sinks would interleave indistinguishably. One stdout sink alongside file sinks is the shape CI workflows need — e.g. `markdown:scorecard.md,github-annotations`, where the runner intercepts the workflow commands from stdout while the Markdown lands on disk.
+
+When `--format` is omitted, the default is `table` to stdout.
+
+## The reporters
+
+| Format | Sink | For |
+|---|---|---|
+| `table` | terminal | Human reading at the terminal; the default |
+| `json` | machine | Full envelope — every function, summary, view, optional delta |
+| `markdown` | PR comment | Paste into a PR comment or issue; sticky-comment marker |
+| `csv` | spreadsheet | One row per function, no summary; pivot/sort externally |
+| `sarif` | Code Scanning | GitHub Code Scanning via `upload-sarif` |
+| `github-annotations` | Actions runner | Inline `::warning` annotations on the Files Changed tab |
+| `scorecard-row` | aggregator | One `Row::CrapDelta` JSON object for scorecard composition |
+| `html` | browser | Self-contained dashboard |
+| `advice` | CI log / agent | Grep-friendly one-line-per-violation remediation hints (experimental) |
+
+### `table`
+
+The default. ANSI-colored, fixed columns, a two-line summary footer. Colorize with `--color` (auto/always/never); see the [CLI reference](cli-reference.md).
+
+```text
+crap4rs vX.Y.Z — CRAP Score Analysis
+
++------------------------------+--------------+----+------+-------+----------+
+| File                         | Function     | CC | Cov% | CRAP  | Risk     |
++============================================================================+
+| src/domain/crap.rs           | complex_fn   | 20 | 30.0 | 45.20 | high     |
+|------------------------------+--------------+----+------+-------+----------|
+| src/adapters/coverage/mod.rs | parse_record | 6  | 72.5 | 15.00 | moderate |
+|------------------------------+--------------+----+------+-------+----------|
+| src/lib.rs                   | simple_fn    | 2  | 95.0 | 3.00  | low      |
++------------------------------+--------------+----+------+-------+----------+
+
+Summary: 3 functions | 2 above threshold (8) | worst: 45.2 | FAIL
+         avg: 21.1 | median: 15.0 | low: 1 | acceptable: 0 | moderate: 1 | high: 1
+```
+
+The `Risk` column is the score-based risk band; the `above threshold` count is the gate. These are [distinct axes](understanding-crap.md) that share the same numbers by default. `CC` is the complexity count under the active metric — cognitive for crap4rs, cyclomatic for crap4ts (see [understanding CRAP](understanding-crap.md)).
+
+### `json`
+
+The full envelope. `result` is the gate (every function, the summary, `passed`); `view` is the shaped display (`shown` rows, `spec`, `eligible_count`, `truncated`). When `--baseline` is set, a `delta` block joins the two. Pipe to `jq` for filtering. The `coverage` field reads as a percent here; the published formula uses a fraction — see [understanding CRAP](understanding-crap.md).
+
+```json
+{
+  "language": "rust",
+  "metric": "cognitive",
+  "schema_version": 2,
+  "threshold": 8.0,
+  "result": {
+    "functions": [
+      {
+        "exceeds": false,
+        "threshold": 8.0,
+        "scored": {
+          "complexity": 5,
+          "complexity_metric": "cognitive",
+          "coverage_percent": 80.0,
+          "crap": { "value": 5.16, "risk_level": "acceptable" },
+          "identity": {
+            "file_path": "src/domain/crap.rs",
+            "qualified_name": "compute_crap",
+            "span": { "start_line": 1, "end_line": 10, "start_column": 0, "end_column": 0 }
+          },
+          "contributors": []
+        }
+      }
+    ],
+    "passed": true,
+    "summary": { "total_functions": 1, "exceeding_threshold": 0, "average_crap": 5.16, "median_crap": 5.16 }
+  },
+  "view": {
+    "eligible_count": 1,
+    "truncated": false,
+    "shown": [ "…same shape as result.functions…" ],
+    "spec": { "sort": "crap", "limit": null, "group_by": null }
+  }
+}
+```
+
+`result` is unaffected by view-shaping flags (`--top`, `--sort-by`, `--only-failing`) — the gate stays over the full unfiltered set. Only `view` reflects shaping. Use this envelope as the `--baseline` for a later delta run.
+
+### `markdown`
+
+GitHub-flavored Markdown for PR comments and issues. A compact summary block plus a top-N table (failures if any, otherwise worst-by-CRAP). The leading HTML comment is a sticky-comment marker a bot keys on to update one comment in place.
+
+```markdown
+<!-- crap4rs:scorecard -->
+
+# crap4rs vX.Y.Z — CRAP Score Analysis
+
+## Summary
+
+**Result:** FAIL · **Functions:** 3 · **Above threshold (8):** 2
+
+| Metric     | Worst | Average | Median |
+|------------|------:|--------:|-------:|
+| CRAP       | 45.20 |   21.07 |  15.00 |
+| Complexity |    20 |     9.3 |    6.0 |
+| Coverage   | 30.0% |   65.8% |  72.5% |
+
+**Risk distribution:** low 1 · acceptable 0 · moderate 1 · high 1
+
+## Failures (2 above threshold 8)
+
+| File | Function | CC | Cov% | CRAP | Risk |
+|------|----------|----|------|------|------|
+| src/domain/crap.rs | complex_fn | 20 | 30.0 | 45.20 | high |
+| src/adapters/coverage/mod.rs | parse_record | 6 | 72.5 | 15.00 | moderate |
+```
+
+`--md-top N` bounds the table; `--md-full-table` appends the full row-per-function table. See the [CLI reference](cli-reference.md).
+
+### `csv`
+
+RFC 4180, one row per function shown by the view, no summary header. Data-only — pivot or sort it in a spreadsheet. The `complexity_metric` column carries the analysis-wide metric on every row.
+
+```csv
+file,function,start_line,end_line,complexity,complexity_metric,coverage_percent,crap_score,risk_level,exceeds_threshold
+src/domain/crap.rs,complex_fn,1,10,20,cognitive,30.0,45.20,high,true
+src/adapters/coverage/mod.rs,parse_record,1,10,6,cognitive,72.5,15.00,moderate,true
+src/lib.rs,simple_fn,1,10,2,cognitive,95.0,3.00,low,false
+```
+
+With `--baseline`, the schema mode-switches to row-per-change (a `change_kind` column plus side-by-side baseline/current scores). Pin your expected columns on whether `--baseline` was passed.
+
+### `sarif`
+
+SARIF v2.1.0 for GitHub Code Scanning. One `result` per over-threshold function, derived from the gate (view-shaping does not alter it). The risk band sets the result `level`: High maps to `error`, Moderate to `warning`, and Low or Acceptable to `note`. Upload with the `upload-sarif` action; see [CI integration](ci-integration.md).
+
+```json
+{
+  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": { "driver": {
+        "name": "crap4rs",
+        "rules": [ { "id": "crap/threshold-exceeded", "name": "ThresholdExceeded" } ]
+      } },
+      "results": [
+        {
+          "ruleId": "crap/threshold-exceeded",
+          "level": "error",
+          "message": { "text": "Function `complex_fn` has CRAP 45.20 (complexity=20, coverage=30.0%) which exceeds threshold 8.0" },
+          "locations": [ { "physicalLocation": {
+            "artifactLocation": { "uri": "src/domain/crap.rs" },
+            "region": { "startLine": 1, "endLine": 10 }
+          } } ],
+          "partialFingerprints": { "functionIdentity": "src/domain/crap.rs:complex_fn" }
+        }
+      ]
+    }
+  ]
+}
+```
+
+### `github-annotations`
+
+`::warning` workflow-command lines, one per over-threshold function, sorted CRAP descending. The Actions runner renders each inline on the PR Files Changed tab — universal, free, no Code Scanning dependency. Derived from the gate, not the view.
+
+```text
+::warning file=src/domain/crap.rs,line=1,title=CRAP 45.2::Function `complex_fn` has CRAP 45.20 (complexity=20, coverage=30.0%) which exceeds threshold 8.0
+::warning file=src/adapters/coverage/mod.rs,line=1,title=CRAP 15.0::Function `parse_record` has CRAP 15.00 (complexity=6, coverage=72.5%) which exceeds threshold 8.0
+```
+
+GitHub silently drops annotations past a per-step cap (10 warning / 10 error / 10 notice per step). When the over-threshold set exceeds `--annotation-limit` (default 10), the reporter emits the top-N by CRAP and appends a trailing `::notice::N more functions exceed threshold; see scorecard for the full list` line. See the [CLI reference](cli-reference.md) for the flag.
+
+### `scorecard-row`
+
+One `Row::CrapDelta` JSON object — no envelope, no markdown — for a downstream scorecard aggregator to compose into a multi-gate PR comment. `status` is minted producer-side (Red / Yellow / Green); `failure_detail_md` is present only on Red. The full wire shape, status policy, and schema versioning are in [`docs/scorecard-row-contract.md`](https://github.com/breezy-bays-labs/crap-rs/blob/main/docs/scorecard-row-contract.md).
+
+```json
+{
+  "type": "CrapDelta",
+  "id": "crap_delta",
+  "label": "CRAP Δ",
+  "anchor": "crap-delta",
+  "status": "Red",
+  "threshold": 15,
+  "delta_count": 2,
+  "delta_text": "5 → 7 (+2)",
+  "failure_detail_md": "**New CRAP threshold violations (>15):**\n- `foo` — `a.rs:1` — CRAP 22.0 (newly added)\n"
+}
+```
+
+`crap4rs` and `crap4ts` route this format through the same shared pipeline, so the row shape is byte-identical across both. Consume it via the composite action's `outputs.row-json`; see [CI integration](ci-integration.md).
+
+### `html`
+
+A self-contained HTML dashboard — inline CSS, inline script, no external assets, mobile-responsive. Renders a verdict-stamped header, KPI tiles, a risk-distribution bar, the worst offenders, and a `<details>` card per file with a function-level table. The bundled script handles a theme toggle, a file-list filter, and a `/` keyboard shortcut.
+
+```bash
+crap4rs --coverage lcov.info --format html:report.html
+```
+
+When `--baseline` is set, a delta tab is added alongside the current view. Unifying multiple languages into one HTML document goes through the `crap-render` binary, covered in [multi-language](multi-language.md).
+
+### `advice` (experimental)
+
+A grep-friendly stream, one line per over-threshold function, in view order:
+
+```text
+[crap=45.20] src/cli/mod.rs:600-720 complex_handler [actions: add_tests_for_lines,extract_function]
+[crap=15.00] src/adapters/coverage/mod.rs:80-145 parse_record [actions: simplify_branching,accept_inherent_complexity]
+[crap=8.50] src/util.rs:30-42 opaque_helper [actions: none]
+```
+
+The shape is `[crap=N.NN] file:start-end qualified::name [actions: <kinds>]`. Lines are intentionally not aligned across rows so `awk` and `grep` parse the stream without padding. This format is experimental — the `actions` vocabulary may change.

--- a/book/src/quick-start.md
+++ b/book/src/quick-start.md
@@ -1,0 +1,85 @@
+# Quick start
+
+Two analyzers, one shared core: `crap4rs` scores Rust against LCOV coverage, `crap4ts` scores TypeScript/JavaScript against Istanbul JSON coverage. Each follows the same four steps — generate coverage, run the analyzer, read the table, gate. Install instructions live in [installation.md](installation.md).
+
+The flow per adapter:
+
+1. Generate a coverage file from your test run.
+2. Point the analyzer at your source root and that coverage file.
+3. Read the ranked table on stdout.
+4. Re-run with `--strict` once you want CI to fail on the worst functions.
+
+## Rust, end to end
+
+```bash
+# 1. Generate LCOV coverage
+cargo llvm-cov --lcov --output-path lcov.info
+
+# 2. Run the analyzer (default complexity metric is cognitive)
+crap4rs --src src/ --coverage lcov.info
+
+# 3. Read the ranked table on stdout (printed above)
+
+# 4. Gate: fail (exit 1) on any function above the strict cutoff
+crap4rs --src src/ --coverage lcov.info --strict
+```
+
+`--coverage` is required on the analysis path; `--src` defaults to `src` when omitted. The default metric for `crap4rs` is cognitive — `match`-heavy Rust inflates cyclomatic counts without adding real risk. Pass `--metric cyclomatic` to switch.
+
+## TypeScript/JavaScript, end to end
+
+```bash
+# 1. Generate Istanbul JSON coverage (must be the istanbul provider,
+#    not v8 — see installation.md)
+npm test -- --coverage
+
+# 2. Run the analyzer (crap4ts is cyclomatic-only)
+crap4ts --src src/ --coverage coverage-final.json --exclude '*.test.ts'
+
+# 3. Read the ranked table on stdout (printed above)
+
+# 4. Gate on the strict cutoff
+crap4ts --src src/ --coverage coverage-final.json --exclude '*.test.ts' --strict
+```
+
+`crap4ts` measures cyclomatic complexity only. Coverage comes from the Istanbul JSON shape (`coverage-final.json`); the v8 provider's JSON is a different shape the adapter does not consume.
+
+## Reading the table
+
+The default `table` output ranks functions by CRAP score, worst first. Each row carries the function's location, complexity, line coverage percent, CRAP score, and its risk band. The score fuses complexity with the fraction of lines covered:
+
+```
+CRAP = complexity² × (1 − coverage)³ + complexity
+```
+
+The math, the units, and the risk bands are covered in [understanding-crap.md](understanding-crap.md); every output format (JSON, Markdown, SARIF, HTML, and the rest) appears in [output-formats.md](output-formats.md).
+
+## Gating with `--strict`
+
+Without a threshold flag, the gate fires at CRAP 15. `--strict` lowers it to 8, `--lenient` raises it to 25:
+
+```bash
+crap4rs --src src/ --coverage lcov.info --strict
+```
+
+When any function exceeds the active cutoff, the process exits `1` — wire that into CI to block the merge. The preset cutoffs, the calibration caveat, and how the threshold gate differs from the score-based risk band are covered in [understanding-crap.md](understanding-crap.md). The full flag surface is in [cli-reference.md](cli-reference.md); CI wiring is in [ci-integration.md](ci-integration.md).
+
+## Clone and try
+
+The repo ships a pedagogical sample at `crates/crap-examples/`: four Rust modules under `src/` and four matching TypeScript modules under `ts/`, picked so a single analysis spans every risk band. Committed coverage fixtures (`lcov.info`, `coverage-final.json`) let you run both adapters without generating coverage first.
+
+```bash
+git clone https://github.com/breezy-bays-labs/crap-rs.git
+cd crap-rs
+
+# Rust — paths in lcov.info are relative to --src
+crap4rs --src ./crates/crap-examples/src \
+  --coverage crates/crap-examples/lcov.info
+
+# TypeScript
+crap4ts --src ./crates/crap-examples/ts \
+  --coverage crates/crap-examples/coverage-final.json \
+  --exclude '*.test.ts'
+```
+
+The four modules together land in the Low, Acceptable, Moderate, and High bands on a fresh run. Per-language complexity counts differ between the adapters (cognitive for Rust, cyclomatic for TS), so the absolute scores differ — what holds constant is the cross-module ranking and the four-band spread. The corpus, the per-module intent, and the recipe for regenerating the fixtures are documented in `crates/crap-examples/README.md`. Analyzing more than one Rust crate at once with multiple `--src` roots is covered in [multi-language.md](multi-language.md).

--- a/book/src/understanding-crap.md
+++ b/book/src/understanding-crap.md
@@ -1,0 +1,85 @@
+# Understanding the CRAP score
+
+CRAP (Change Risk Anti-Patterns) scores a single function by combining its complexity with its test coverage. High complexity is tolerable when coverage is high; the same complexity with no coverage is dangerous to change. CRAP makes that tradeoff a number.
+
+## The formula
+
+```
+CRAP(c, cov) = c² × (1 − cov)³ + c
+```
+
+- `c` is the function's complexity (cognitive or cyclomatic — see below). Always an integer ≥ 1.
+- `cov` is the line-coverage **fraction** in `[0, 1]` in this published form.
+
+Internally `compute_crap` takes coverage as a **percent** in `[0, 100]`, clamps it to that range, then divides by 100 before applying the cube. Keep the units straight: the formula above uses a fraction; the implementation signature uses a percent. Coverage outside the range is clamped (150% scores as 100%, −10% scores as 0%), never rejected. The result is rounded to two decimal places.
+
+## Two identities
+
+The cube term is what makes coverage dominate. Two endpoints fall out directly:
+
+| Coverage | Score | Why |
+|----------|-------|-----|
+| 100% | `c` | `(1 − 1)³ = 0`, so only the trailing `+ c` survives. A fully covered function scores its raw complexity. |
+| 0% | `c² + c` | `(1 − 0)³ = 1`, so the full `c²` term is added. An untested function's score grows quadratically with complexity. |
+
+The score is always ≥ 1, monotonically increases with complexity, and monotonically decreases with coverage.
+
+## Worked values
+
+| Complexity | Coverage | CRAP | Calculation |
+|------------|----------|------|-------------|
+| 1 | 100% | 1.00 | `1 × 0 + 1` |
+| 1 | 0% | 2.00 | `1 × 1 + 1` |
+| 10 | 100% | 10.00 | `100 × 0 + 10` |
+| 10 | 0% | 110.00 | `100 × 1 + 10` |
+| 5 | 50% | 8.13 | `25 × 0.5³ + 5 = 25 × 0.125 + 5` |
+| 15 | 90% | 15.23 | `225 × 0.1³ + 15 = 225 × 0.001 + 15` |
+
+The 5@50% case shows the leverage of coverage: halving the tested lines on a complexity-5 function adds only ~3 to the score, but the same function untested would score 30.
+
+## Cognitive vs cyclomatic complexity
+
+CRAP is agnostic to which complexity metric feeds it — the formula is identical. crap4rs supports both:
+
+| Metric | Counts | Default |
+|--------|--------|---------|
+| Cognitive | Nesting depth + structural complexity. Each construct adds `1 + nesting_depth`. | crap4rs default |
+| Cyclomatic | Decision points (branches). Each construct adds 1, flat. | Classic CRAP metric |
+
+Cognitive is the crap4rs default because it suits match-heavy Rust. A flat `match` with N arms is one decision a reader processes at once, not N independent branches: cognitive scores it as **1**, cyclomatic as **N**. Nesting `match` inside a loop inside an `if` is what cognitive penalizes — and that is what actually makes Rust hard to change. crap4ts (the TypeScript adapter) is cyclomatic-only.
+
+Because the two metrics produce different-magnitude scores for the same code, never compare a cognitive CRAP score against a cyclomatic one as if they were the same scale.
+
+## What coverage means
+
+Coverage is **line coverage**, measured by a positional heuristic — not by function name. The complexity walker emits each function as a `(file, start_line, end_line)` span; the LCOV parser emits `(file, line, hits)` records. A function's coverage is the fraction of instrumented lines that fall **within its span** (inclusive on both ends) and were hit at least once.
+
+This is positional matching, not name matching. There is no symbol demangling and no `FN`/`FNDA` parsing. A function whose span contains no instrumented lines is treated as 100% covered (nothing to miss). Coverage is computed strictly per file — lines in one file never count toward a function in another.
+
+Branch coverage, when present, is collected the same way (branch points within the span) and surfaced informationally. The CRAP gate is **line-only**; branch coverage never feeds the score.
+
+For where the spans and coverage records come from, see [introduction](introduction.md). For coverage-file generation, see [quick start](quick-start.md).
+
+## Risk bands
+
+Every score is classified into one of four bands by `classify_risk`:
+
+| Band | Score range |
+|------|-------------|
+| Low | ≤ 8 |
+| Acceptable | ≤ 15 |
+| Moderate | ≤ 25 |
+| High | > 25 |
+
+The bands are score-based, fixed, and metric-agnostic. They describe a function's intrinsic risk regardless of any threshold you set.
+
+## Bands and the gate are two separate axes
+
+The cutoffs 8 / 15 / 25 appear twice in this tool, and they mean different things:
+
+- **Risk bands** (Low / Acceptable / Moderate / High) are a *classification*, derived purely from the score via `classify_risk`. They never change.
+- **The threshold gate** is a *pass/fail line*. A function "exceeds" when its score is above the active threshold. The default gate is 15; the strict preset is 8 and the lenient preset is 25.
+
+These two axes share the numbers 8 / 15 / 25 today by calibration convention — the presets are set at the band boundaries — but they are conceptually independent. A function can sit in the Moderate band (score 20) and still pass a lenient gate (threshold 25). Never read "risk level: Moderate" as "exceeds threshold," or vice versa. The thresholds themselves are a calibration convention, not empirically derived values.
+
+For how to set the gate, see [CLI reference](cli-reference.md) and [configuration](configuration.md).

--- a/crates/crap-core/README.md
+++ b/crates/crap-core/README.md
@@ -4,36 +4,35 @@
 [![docs.rs](https://img.shields.io/docsrs/crap-core)](https://docs.rs/crap-core)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](https://github.com/breezy-bays-labs/crap-rs#license)
 
-**Language-agnostic foundation for the CRAP (Change Risk Anti-Patterns) analyzer family.** Domain types, port traits, threshold and risk logic, reporters, and the shared scorecard envelope used by every CRAP adapter.
+Language-agnostic foundation for the CRAP (Change Risk Anti-Patterns) analyzer family. Domain types, port traits, threshold and risk logic, reporters, and the shared scorecard envelope used by every CRAP adapter.
 
 ## What this is
 
-`crap-core` is the shared backbone for analyzers that compute CRAP scores —
+`crap-core` is the shared backbone for analyzers that compute CRAP scores across source languages:
 
 ```
 CRAP(complexity, coverage) = complexity² × (1 − coverage)³ + complexity
 ```
 
-— across different source languages. It owns:
+It owns:
 
-- The **CRAP formula** and four-tier **risk classification** (Low / Acceptable / Moderate / High)
-- The **`ComplexityPort` and `CoveragePort`** traits that language adapters implement
-- The locked **wire envelope** (`scorecard`, `delta`, `crap-delta` shapes) consumed by reporters and downstream tooling
-- **All reporters** — `table`, `markdown`, `json`, `csv`, `sarif`, `scorecard`, `scorecard-row`, `github-annotations`. HTML is on the roadmap
-- **Threshold presets** (`strict` / default / `lenient`), configuration parsing, and delta-gate semantics
+- The CRAP formula and score-based risk classification (Low / Acceptable / Moderate / High).
+- The `ComplexityPort` and `CoveragePort` traits that language adapters implement.
+- The locked wire envelope (`scorecard`, `delta`, `crap-delta` shapes) consumed by reporters and downstream tooling.
+- The reporters — `table`, `markdown`, `json`, `csv`, `sarif`, `scorecard-row`, `github-annotations`, and `html` (single-language `format_html` and multi-language `format_html_multi`, the latter driven by the `crap-render` binary).
+- Threshold presets, configuration parsing, and delta-gate semantics.
 
-If you're using `crap-core` directly, you're probably building a new language adapter. End users want one of the adapter crates instead:
+If you depend on `crap-core` directly, you are probably building a new language adapter. End users want one of the adapter crates instead:
 
-- **[`crap4rs`](https://crates.io/crates/crap4rs)** — Rust analyzer (`syn` complexity + LCOV coverage; cognitive complexity default)
-- **[`crap4ts`](https://crates.io/crates/crap4ts)** — TypeScript / JavaScript analyzer (`oxc` complexity + Istanbul JSON coverage; cyclomatic complexity)
+- [`crap4rs`](https://crates.io/crates/crap4rs) — Rust analyzer (`syn` complexity + LCOV coverage; cognitive complexity default).
+- [`crap4ts`](https://crates.io/crates/crap4ts) — TypeScript / JavaScript analyzer (`oxc` complexity + Istanbul JSON coverage; cyclomatic complexity only).
 
-Both link `crap-core` and produce byte-identical scorecard envelopes for the same `(complexity, coverage)` inputs — Rust and TypeScript CI gates stay consistent.
+Both link `crap-core` and produce byte-identical scorecard envelopes for the same `(complexity, coverage)` inputs.
 
 ## Install
 
-```toml
-[dependencies]
-crap-core = "0.4"
+```sh
+cargo add crap-core
 ```
 
 ## Quick example
@@ -41,124 +40,25 @@ crap-core = "0.4"
 ```rust
 use crap_core::domain::crap::compute_crap;
 
-let score = compute_crap(15, 0.90);
-assert_eq!(format!("{:.2}", score), "15.23");
+// compute_crap takes coverage as a percent in [0, 100] and returns a
+// Result<CrapScore, CrapError>; CrapScore exposes value and risk_level.
+let score = compute_crap(15, 90.0).unwrap();
+assert_eq!(format!("{:.2}", score.value), "15.23");
 ```
 
 For the port traits and how adapters wire complexity + coverage data into a `Scorecard`, see the [API docs on docs.rs](https://docs.rs/crap-core).
 
-## Threshold presets and risk tiers
-
-`crap-core` defines four risk tiers and three preset gates calibrated against them. Every adapter inherits this taxonomy automatically.
-
-| CRAP score | Risk tier |
-|---|---|
-| ≤ 8 | Low |
-| ≤ 15 | Acceptable |
-| ≤ 25 | Moderate |
-| > 25 | High |
-
-| Preset | Threshold | Gates at | Use for |
-|---|---|---|---|
-| `--strict` | CRAP ≤ 8 | Low → Acceptable | safety-critical, high-quality libraries |
-| *(default)* | CRAP ≤ 15 | Acceptable → Moderate | typical app / library code |
-| `--lenient` | CRAP ≤ 25 | Moderate → High | legacy / transitional codebases |
-
-The same preset values apply for both cognitive and cyclomatic complexity inputs (adapters choose which metric they pass into the formula).
-
-## What the output looks like
-
-Every reporter consumes the same `AnalysisView` projection over the scored functions. Adapters never re-render shapes themselves — they hand `crap-core` the data and pick a `--format`.
-
-### Table — TTY default
-
-```
-crap4rs v0.5.0 — CRAP Score Analysis
-
-+------------------------------------+----------------------------------+----+-------+-------+----------+
-| File                               | Function                         | CC | Cov%  | CRAP  | Risk     |
-+========================================================================================================+
-| adapters/reporters/table.rs        | inject_breakdown_subrows         | 13 | 100.0 | 13.00 | moderate |
-| domain/summary.rs                  | compute_summary                  | 13 | 100.0 | 13.00 | moderate |
-| adapters/reporters/markdown.rs     | format_markdown_delta            | 12 |  97.1 | 12.00 | moderate |
-+------------------------------------+----------------------------------+----+-------+-------+----------+
-```
-
-### JSON — programmatic / cross-tool
-
-```json
-{
-  "schema_version": 2,
-  "run_meta": { "tool": "crap4rs", "version": "0.5.0", "metric": "cognitive" },
-  "result": {
-    "summary": {
-      "total_functions": 988,
-      "exceeding_threshold": 0,
-      "distribution": { "low": 951, "acceptable": 22, "moderate": 15, "high": 0 },
-      "max_crap": { "value": 13.0, "risk_level": "moderate" }
-    },
-    "functions": [
-      {
-        "scored": {
-          "identity": { "file_path": "src/lib.rs", "qualified_name": "process_request", "span": { "start_line": 42, "end_line": 87 } },
-          "complexity": 11,
-          "complexity_metric": "cognitive",
-          "coverage_percent": 42.3,
-          "crap": { "value": 28.42, "risk_level": "high" }
-        },
-        "threshold": 15.0,
-        "exceeds": true
-      }
-    ]
-  }
-}
-```
-
-The envelope shape is locked across patch releases of the adapter that emits it — downstream consumers can pin against a `schema_version`.
-
-### GitHub Actions inline annotations
-
-```
-::warning file=src/lib.rs,line=42,title=CRAP 28.4::Function `process_request` has CRAP 28.42 (complexity=11, coverage=42.3%) which exceeds threshold 15.0
-```
-
-Renders as an inline annotation on the PR Files Changed tab — no GitHub Advanced Security / Code Scanning license required.
-
-### Markdown — PR-comment ready
-
-```markdown
-# crap4rs v0.5.0 — CRAP Score Analysis
-
-**Result:** PASS · **Functions:** 988 · **Above threshold (15):** 0
-
-| Metric     | Worst | Average | Median |
-|------------|------:|--------:|-------:|
-| CRAP       | 13.00 |    1.62 |   1.00 |
-| Complexity |    13 |     1.6 |    1.0 |
-| Coverage   |  0.0% |   98.3% | 100.0% |
-
-**Risk distribution:** low 951 · acceptable 22 · moderate 15 · high 0
-```
-
-### HTML report
-
-Interactive, sortable HTML report with per-function contributor drill-down. **Coming in a future release** — open an issue if you want early-access interest tracked.
-
-### Other formats
-
-`csv`, `sarif` (Code Scanning surface), `scorecard` (single-row CI gate), `scorecard-row` (cross-adapter parity-locked CI row).
-
-Multiple formats compose in one pass: `--format json:envelope.json,markdown:report.md` writes both from a single analysis.
+The risk bands (score-based `classify_risk`) and the threshold gate (default 15) are distinct axes that share the same `8/15/25` numbers — the book covers both in [understanding-crap.md](https://breezy-bays-labs.github.io/crap-rs/book/understanding-crap.html). The reporter output gallery lives in [output-formats.md](https://breezy-bays-labs.github.io/crap-rs/book/output-formats.html), and the `crap-render` multi-language render path in [multi-language.md](https://breezy-bays-labs.github.io/crap-rs/book/multi-language.html).
 
 ## Stability
 
-`crap-core` is at `0.x` and follows pre-1.0 semver — breaking changes can land on minor bumps; adapter crates pin against a specific minor. The wire envelope schema is locked once published — patch releases never change envelope shape; minor releases may add fields under `#[serde(default)]`.
+`crap-core` is at `0.x` and follows pre-1.0 semver — breaking changes can land on minor bumps; adapter crates pin against a specific minor. The wire envelope schema is locked once published: patch releases never change envelope shape; minor releases may add fields under `#[serde(default)]`.
 
 ## See also
 
-- **Repository**: [github.com/breezy-bays-labs/crap-rs](https://github.com/breezy-bays-labs/crap-rs)
-- **Project README**: [workspace overview](https://github.com/breezy-bays-labs/crap-rs#readme)
-- **Issues**: [github.com/breezy-bays-labs/crap-rs/issues](https://github.com/breezy-bays-labs/crap-rs/issues)
+- Repository: [github.com/breezy-bays-labs/crap-rs](https://github.com/breezy-bays-labs/crap-rs)
+- Project README: [workspace overview](https://github.com/breezy-bays-labs/crap-rs#readme)
+- Issues: [github.com/breezy-bays-labs/crap-rs/issues](https://github.com/breezy-bays-labs/crap-rs/issues)
 
 ## License
 

--- a/crates/crap4rs/README.md
+++ b/crates/crap4rs/README.md
@@ -53,12 +53,11 @@ Fail a PR only on newly introduced or newly elevated violations with `--baseline
 
 ## Library use
 
-```toml
-[dependencies]
-crap4rs = "*"
+```bash
+cargo add crap4rs
 ```
 
-`crap4rs` re-exports `crap-core`'s public API and adds the Rust-specific adapters (syn walker, LCOV parser). If you only need scoring, envelope, and reporter logic without Rust-specific I/O, depend on [`crap-core`](https://crates.io/crates/crap-core) directly.
+`crap4rs` re-exports `crap-core`'s public API and adds the Rust-specific adapters (syn walker, LCOV parser). If you only need scoring, envelope, and reporter logic without Rust-specific I/O, depend on [`crap-core`](https://crates.io/crates/crap-core) directly (`cargo add crap-core`).
 
 ## Stability
 

--- a/crates/crap4rs/README.md
+++ b/crates/crap4rs/README.md
@@ -4,209 +4,61 @@
 [![docs.rs](https://img.shields.io/docsrs/crap4rs)](https://docs.rs/crap4rs)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](https://github.com/breezy-bays-labs/crap-rs#license)
 
-**CRAP (Change Risk Anti-Patterns) score analyzer for Rust.** Find the functions in your codebase that are both complex *and* under-tested — the ones most likely to break when changed.
+CRAP (Change Risk Anti-Patterns) score analyzer for Rust. It finds the functions that are both complex and under-tested — the ones most likely to break when changed.
 
-`crap4rs` combines [`syn`](https://crates.io/crates/syn)-driven AST complexity with [`cargo-llvm-cov`](https://github.com/taiki-e/cargo-llvm-cov) LCOV output. One pass, one CI gate, one number per function.
+`crap4rs` joins [`syn`](https://crates.io/crates/syn)-driven AST complexity with [`cargo-llvm-cov`](https://github.com/taiki-e/cargo-llvm-cov) LCOV output, matching functions to coverage by line range. One pass, one CI gate, one number per function.
 
 ```
 CRAP(complexity, coverage) = complexity² × (1 − coverage)³ + complexity
 ```
 
-High complexity + low coverage = high CRAP = high change risk.
+High complexity plus low coverage yields high CRAP, which means high change risk. See [understanding-crap.md](https://breezy-bays-labs.github.io/crap-rs/book/understanding-crap.html) for the math, units, and why the default metric is cognitive complexity.
 
 ## Install
 
 ```bash
-# Pre-built binaries (recommended)
-cargo binstall crap4rs
-
-# From source
-cargo install crap4rs
+cargo binstall crap4rs   # pre-built binary
+cargo install crap4rs    # from source
 ```
 
-## 30-second tour
+See [installation.md](https://breezy-bays-labs.github.io/crap-rs/book/installation.html) for prerequisites and `cargo-llvm-cov` setup.
+
+## Quick run
 
 ```bash
-cargo llvm-cov --lcov --output-path lcov.info     # generate coverage
-crap4rs --coverage lcov.info                       # analyze
-crap4rs --coverage lcov.info --strict              # gate CI strictly
-crap4rs --coverage lcov.info --format markdown     # PR-comment friendly
+cargo llvm-cov --lcov --output-path lcov.info   # generate coverage
+crap4rs --coverage lcov.info                     # analyze (default gate: CRAP > 15)
+crap4rs --coverage lcov.info --strict            # gate strictly (CRAP > 8)
+crap4rs --coverage lcov.info --format markdown   # PR-comment friendly
 ```
 
-## Why cognitive complexity (default)
+`--coverage` is required at runtime. The full flag surface lives in [cli-reference.md](https://breezy-bays-labs.github.io/crap-rs/book/cli-reference.html); the report gallery (table, markdown, JSON, GitHub annotations, CSV, SARIF, HTML) lives in [output-formats.md](https://breezy-bays-labs.github.io/crap-rs/book/output-formats.html).
 
-`crap4rs` defaults to **cognitive complexity**, not cyclomatic. Rust code leans heavily on `match`, nested control flow, and combinator chains — and cyclomatic complexity counts every `match` arm as +1, which inflates the score on perfectly readable Rust idioms.
+## Thresholds and risk tiers
 
-Cognitive complexity scores how *hard a function is to follow*, weighting by nesting depth and structural break-up rather than raw branch count. A 12-arm `match` over an enum scores 1 (one decision); a deeply nested `if let Some(_) = ... { if let Ok(_) = ... { ... } }` scores higher because the nesting hurts readers.
+The no-flag gate fails on CRAP above 15. `--strict` lowers it to 8, `--lenient` raises it to 25. Override with `--threshold <N>`. Risk bands (score-based classification) and the threshold gate are distinct axes that happen to share the same numbers today.
 
-Cyclomatic is still available — `--metric cyclomatic` — for parity with classic CRAP tooling or comparing against other complexity reporters.
+| Risk band | CRAP score | Preset that gates here |
+|---|---|---|
+| Low | ≤ 8 | `--strict` |
+| Acceptable | ≤ 15 | *(default)* |
+| Moderate | ≤ 25 | `--lenient` |
+| High | > 25 | — |
 
-## Threshold presets
+These numbers are a calibration convention, not an empirically derived constant. Set per-codebase defaults in `crap.toml` — see [configuration.md](https://breezy-bays-labs.github.io/crap-rs/book/configuration.html). How missing-from-coverage files are scored is a configurable choice; see [limitations-and-faq.md](https://breezy-bays-labs.github.io/crap-rs/book/limitations-and-faq.html).
 
-`crap4rs` ships three preset gates calibrated against four risk tiers:
+## CI gates
 
-| Preset | Threshold | Gates at | Use for |
-|---|---|---|---|
-| `--strict` | CRAP ≤ 8 | Low → Acceptable | safety-critical, high-quality libraries |
-| *(default)* | CRAP ≤ 15 | Acceptable → Moderate | typical app / library code |
-| `--lenient` | CRAP ≤ 25 | Moderate → High | legacy / transitional codebases |
-
-The risk tiers themselves:
-
-| CRAP score | Risk |
-|---|---|
-| ≤ 8 | Low |
-| ≤ 15 | Acceptable |
-| ≤ 25 | Moderate |
-| > 25 | High |
-
-The presets correspond to "gate at the next risk tier up." Override with `--threshold <N>` for a custom value, or define presets per-codebase in `crap.toml` (the canonical config name, written by `crap4rs init`). The legacy name `crap4rs.toml` is still discovered as a deprecated alias when no `crap.toml` is present.
-
-### Files missing from coverage
-
-When a source file is absent from the coverage report — a `#[cfg(feature = "…")]` module left out of the coverage build, an untested file, or a scoped per-package run — its functions are scored at 0% coverage by default, which inflates their CRAP (a complexity-`c` function jumps to `c² + c`). Choose how that case is handled with `--missing-coverage-policy` (or a `missing_coverage_policy` key in `crap.toml`):
-
-| Value | Behavior |
-|---|---|
-| `pessimistic` (default) | Score at 0% coverage — never hides risk. |
-| `optimistic` | Score at 100% coverage (CRAP = complexity) — for a scoped local test slice that legitimately omits some files. |
-| `skip` | Omit those functions from the report entirely. |
-
-The chosen policy is recorded in the JSON envelope (unless `pessimistic`), so a `--baseline` delta run warns when its policy differs from the baseline's.
-
-## What it looks like
-
-### Table (TTY default)
-
-```
-crap4rs v0.5.0 — CRAP Score Analysis
-
-+------------------------------------+----------------------------------+----+-------+-------+----------+
-| File                               | Function                         | CC | Cov%  | CRAP  | Risk     |
-+========================================================================================================+
-| adapters/reporters/table.rs        | inject_breakdown_subrows         | 13 | 100.0 | 13.00 | moderate |
-| domain/summary.rs                  | compute_summary                  | 13 | 100.0 | 13.00 | moderate |
-| adapters/reporters/markdown.rs     | format_markdown_delta            | 12 |  97.1 | 12.00 | moderate |
-| core/mod.rs                        | ensure_source_files_found        |  7 |  60.9 |  9.94 | moderate |
-| domain/matching.rs                 | compute_branch_coverage          | 10 | 100.0 | 10.00 | moderate |
-+------------------------------------+----------------------------------+----+-------+-------+----------+
-
-Functions: 988 · Above threshold: 0 · Worst CRAP: 13.00 · Distribution: 951 low · 22 acceptable · 15 moderate · 0 high
-```
-
-### Markdown (`--format markdown`) — PR-comment ready
-
-The first output line is always a hidden HTML comment, `<!-- crap4rs:scorecard -->` — invisible when rendered, but a stable anchor that sticky-PR-comment tooling can match on to find and update its own comment instead of posting a new one on every push. The marker carries the adapter name, so a Rust and a TypeScript scorecard can sticky to separate comments on the same PR. (A multi-language combined comment contains both adapters' markers, so match accordingly if you post combined output.) With `--breakdown`, the complexity-contributor bullets of the above-threshold functions collect into one collapsed `<details>` block below the scorecard table — below the table rather than between rows, since a `<details>` placed inside a markdown table terminates it.
-
-```markdown
-<!-- crap4rs:scorecard -->
-
-# crap4rs v0.5.0 — CRAP Score Analysis
-
-**Result:** PASS · **Functions:** 988 · **Above threshold (15):** 0
-
-| Metric     | Worst | Average | Median |
-|------------|------:|--------:|-------:|
-| CRAP       | 13.00 |    1.62 |   1.00 |
-| Complexity |    13 |     1.6 |    1.0 |
-| Coverage   |  0.0% |   98.3% | 100.0% |
-
-**Risk distribution:** low 951 · acceptable 22 · moderate 15 · high 0
-```
-
-### GitHub annotations (`--format github-annotations`) — inline PR review
-
-Drops findings as inline warnings on the PR Files Changed tab, no GHAS / Code Scanning license needed:
-
-```
-::warning file=src/lib.rs,line=42,title=CRAP 28.4::Function `process_request` has CRAP 28.42 (complexity=11, coverage=42.3%) which exceeds threshold 15.0
-```
-
-### JSON (`--format json`) — programmatic consumption
-
-```json
-{
-  "schema_version": 2,
-  "run_meta": { "tool": "crap4rs", "version": "0.5.0", "metric": "cognitive" },
-  "result": {
-    "summary": {
-      "total_functions": 988,
-      "exceeding_threshold": 0,
-      "distribution": { "low": 951, "acceptable": 22, "moderate": 15, "high": 0 },
-      "max_crap": { "value": 13.0, "risk_level": "moderate" }
-    },
-    "functions": [
-      {
-        "scored": {
-          "identity": { "file_path": "src/lib.rs", "qualified_name": "process_request", "span": { "start_line": 42, "end_line": 87 } },
-          "complexity": 11,
-          "complexity_metric": "cognitive",
-          "coverage_percent": 42.3,
-          "crap": { "value": 28.42, "risk_level": "high" },
-          "contributors": [ /* per-decision-point breakdown */ ]
-        },
-        "threshold": 15.0,
-        "exceeds": true
-      }
-    ]
-  }
-}
-```
-
-### Other formats
-
-- `--format csv` — spreadsheet ingestion
-- `--format sarif` — Code Scanning upload (requires GHAS) for surface-as-security-finding flows
-- `--format scorecard` — single-row CI gate output for cross-PR delta tracking
-- **HTML report** — interactive, sortable, with per-function contributor drill-down. *Coming in a future release; file an issue for early-access interest.*
-
-Multiple formats compose in one pass: `--format json:envelope.json,markdown:report.md` writes both files from a single analysis.
-
-## Delta gates — fail PRs that introduce new high-CRAP functions
-
-```bash
-# Generate baseline on main
-crap4rs --coverage main-lcov.info --format json > baseline.json
-
-# On PR — fail only on NEW threshold violations
-crap4rs --coverage pr-lcov.info --baseline baseline.json --delta-gate
-```
-
-A function above-threshold on main doesn't fail the PR; only functions newly introduced or newly elevated do. Lets teams ratchet quality forward without blocking every PR on pre-existing debt.
-
-### Relocations don't count as new violations
-
-A function that is **moved to another file, renamed, or moved between modules** — with its body otherwise unchanged — is recognized as a single `renamed` change rather than an unrelated `removed` + `added` pair. Because the relocated function carries its baseline score forward, a pure relocation contributes **zero new violations**, so large migrations and refactors sail through the delta gate even when the moved function was already over threshold. A relocation that *also* worsens the score (e.g. coverage drops as it moves) still counts — the relocation wasn't the only change.
-
-The match is conservative: a function is paired across the move only when the match is unambiguous — the same name *and* the same structure, or (for a rename) a distinctive structure with exactly one candidate on each side. Ambiguous or trivial functions stay `added` + `removed`. Enabling rename detection can only ever *lower* the new-violation count, never raise it, so it can never newly fail a PR the old behavior would have passed — that is the migration-friendly guarantee. The honest limitation: because matching works from the analysis output rather than source text, a genuinely-unrelated function whose structure happens to exactly match a removed one (and is its only structural twin) is indistinguishable from a real rename and will pair — which can lower the count below the true figure. The guards make that rare, but it is not impossible. The `renamed` count appears in every delta report (table, markdown, JSON, CSV, HTML), and the JSON envelope's `delta` block carries both the baseline and current sides of each `renamed` row for the full from → to audit trail.
-
-### Threshold-border jitter suppression (opt-in)
-
-A function whose CRAP score sits right on the threshold line can flip across it on pure measurement noise — coverage rounding, or surrounding-code edits shifting per-line attribution. Set a **threshold-border epsilon** to stop that jitter from tripping the delta gate:
-
-```bash
-crap4rs --coverage pr-lcov.info --baseline baseline.json --delta-gate --threshold-epsilon 0.5
-```
-
-or in `crap.toml`:
-
-```toml
-[delta]
-epsilon = 0.5
-```
-
-`epsilon` is an **absolute, unitless CRAP-point** band half-width (not a percentage of the threshold — so the same value is a tighter *relative* band at threshold 25 than at 8). A would-be new violation whose transition stays within `epsilon` of the threshold — on **both** the baseline and current side — is treated as border jitter and not counted; the count of what was suppressed surfaces as `border_jitter_suppressed` in the delta summary (JSON always; the table/markdown/HTML reports show the line whenever `epsilon` is set, so an opt-in run confirms the band is active even when nothing was suppressed). The default `0.0` disables suppression entirely, so output is byte-identical to a run without the flag.
-
-This is deliberately **narrow** — it tolerates oscillation *across the threshold line*, not delta magnitude or coverage flakiness in general. And it is a *jitter* knob, **not** a "noise-only" guarantee: like rename detection it can only ever lower the new-violation count, so a genuinely-new function that happens to land inside the band is suppressed too. For an `Added` row there is only the current reading — no prior state to jitter from — so an in-band new function is a one-sided *soft threshold bypass*. Keep `epsilon` small.
+Fail a PR only on newly introduced or newly elevated violations with `--baseline` plus `--delta-gate`; relocations and threshold-border jitter are handled so migrations and refactors don't trip the gate. The delta walkthrough lives in [cli-reference.md](https://breezy-bays-labs.github.io/crap-rs/book/cli-reference.html) and [limitations-and-faq.md](https://breezy-bays-labs.github.io/crap-rs/book/limitations-and-faq.html); the composite GitHub Action is documented in [ci-integration.md](https://breezy-bays-labs.github.io/crap-rs/book/ci-integration.html).
 
 ## Library use
 
 ```toml
 [dependencies]
-crap4rs = "0.5"
+crap4rs = "*"
 ```
 
-`crap4rs` re-exports `crap-core`'s public API and adds the Rust-specific adapters (syn walker, LCOV parser). If you only need the scoring/envelope/reporter logic without Rust-specific I/O, depend on [`crap-core`](https://crates.io/crates/crap-core) directly.
+`crap4rs` re-exports `crap-core`'s public API and adds the Rust-specific adapters (syn walker, LCOV parser). If you only need scoring, envelope, and reporter logic without Rust-specific I/O, depend on [`crap-core`](https://crates.io/crates/crap-core) directly.
 
 ## Stability
 
@@ -214,10 +66,11 @@ crap4rs = "0.5"
 
 ## See also
 
-- **Repository**: [github.com/breezy-bays-labs/crap-rs](https://github.com/breezy-bays-labs/crap-rs)
-- **TypeScript / JavaScript analyzer**: [`crap4ts`](https://crates.io/crates/crap4ts) (crates.io) · [npm package](https://www.npmjs.com/package/crap4ts)
-- **Shared core library**: [`crap-core`](https://crates.io/crates/crap-core)
-- **Issues**: [github.com/breezy-bays-labs/crap-rs/issues](https://github.com/breezy-bays-labs/crap-rs/issues)
+- Documentation: the [crap-rs book](https://breezy-bays-labs.github.io/crap-rs/book/)
+- Repository: [github.com/breezy-bays-labs/crap-rs](https://github.com/breezy-bays-labs/crap-rs)
+- TypeScript / JavaScript analyzer: [`crap4ts`](https://crates.io/crates/crap4ts) (crates.io) · [npm](https://www.npmjs.com/package/crap4ts) — cyclomatic metric; see [multi-language.md](https://breezy-bays-labs.github.io/crap-rs/book/multi-language.html)
+- Shared core library: [`crap-core`](https://crates.io/crates/crap-core)
+- Issues: [github.com/breezy-bays-labs/crap-rs/issues](https://github.com/breezy-bays-labs/crap-rs/issues)
 
 ## License
 

--- a/crates/crap4ts/README.md
+++ b/crates/crap4ts/README.md
@@ -5,7 +5,7 @@
 [![docs.rs](https://img.shields.io/docsrs/crap4ts)](https://docs.rs/crap4ts)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](https://github.com/breezy-bays-labs/crap-rs#license)
 
-**Rust-powered CRAP (Change Risk Anti-Patterns) score analyzer for TypeScript and JavaScript.** Find the functions in your codebase that are both complex *and* under-tested.
+CRAP (Change Risk Anti-Patterns) score analyzer for TypeScript and JavaScript, powered by Rust. It finds the functions that are both complex and under-tested.
 
 `crap4ts` combines [oxc](https://oxc.rs/)-driven AST complexity with [Istanbul](https://istanbul.js.org/) JSON coverage. One pass, one CI gate, one number per function.
 
@@ -13,7 +13,7 @@
 CRAP(complexity, coverage) = complexity² × (1 − coverage)³ + complexity
 ```
 
-High complexity + low coverage = high CRAP = high change risk.
+High complexity plus low coverage yields a high CRAP score. See [understanding CRAP](https://breezy-bays-labs.github.io/crap-rs/book/understanding-crap.html) for the math and the unit conventions.
 
 > **JavaScript / Node consumers**: install [`crap4ts` from npm](https://www.npmjs.com/package/crap4ts) — that package ships pre-built Node addons for every supported platform. Its [npm README](https://github.com/breezy-bays-labs/crap-rs/blob/main/packages/crap4ts/README.md) covers Node-side usage.
 >
@@ -25,9 +25,9 @@ High complexity + low coverage = high CRAP = high change risk.
 cargo install crap4ts
 ```
 
-Pre-built CLI binaries for `crap4ts` are tracked for a future release (the napi `cdylib` for the npm package ships pre-built today; the standalone CLI artifact does not yet). Use `cargo install` for now, or install the [npm package](https://www.npmjs.com/package/crap4ts) if you're consuming from Node.
+Pre-built standalone CLI binaries are tracked for a future release; the napi `cdylib` for the npm package ships pre-built today, the CLI artifact does not yet. Use `cargo install` for now, or install the [npm package](https://www.npmjs.com/package/crap4ts) if you consume from Node. See [installation](https://breezy-bays-labs.github.io/crap-rs/book/installation.html) for all install paths.
 
-## 30-second tour
+## Quick run
 
 ```bash
 # Generate Istanbul JSON coverage (e.g. via Vitest + istanbul provider)
@@ -40,161 +40,54 @@ crap4ts --coverage coverage/coverage-final.json --src src
 crap4ts --coverage coverage/coverage-final.json --src src --strict
 ```
 
+`--coverage` is required at runtime. The full flag surface lives in the [CLI reference](https://breezy-bays-labs.github.io/crap-rs/book/cli-reference.html); see [quick start](https://breezy-bays-labs.github.io/crap-rs/book/quick-start.html) for a guided first run.
+
 ## Why cyclomatic complexity (only)
 
-`crap4ts` 2.x ships **cyclomatic complexity** as the only supported metric. Two reasons:
+`crap4ts` ships cyclomatic complexity as the only supported metric. Two reasons:
 
-1. **Classic CRAP semantics.** Cyclomatic decision-point count is the original CRAP metric and aligns with how virtually every TypeScript / JavaScript quality tool (ESLint's `complexity` rule, SonarJS, Code Climate, etc.) reports complexity. CI gates and reviewer expectations transfer cleanly.
-2. **AST signal density differs from Rust.** TypeScript code doesn't lean as heavily on `match`-style branching as idiomatic Rust does, so the cognitive-vs-cyclomatic divergence is much smaller. Cyclomatic ships first; cognitive may follow in a later release if the ecosystem demand justifies the additional walker logic.
+1. **Classic CRAP semantics.** Cyclomatic decision-point count is the original CRAP metric and aligns with how TypeScript and JavaScript quality tools report complexity (for example ESLint's `complexity` rule). CI gates and reviewer expectations transfer cleanly.
+2. **AST signal density differs from Rust.** TypeScript code leans less on `match`-style branching than idiomatic Rust, so the cognitive-vs-cyclomatic divergence is smaller. Cognitive may follow in a later release if ecosystem demand justifies the additional walker logic.
 
 Passing `--metric cognitive` errors out cleanly with `MetricNotSupported`.
 
-The companion Rust analyzer [`crap4rs`](https://crates.io/crates/crap4rs) defaults to cognitive complexity for the inverse reason — Rust idioms benefit from it. The shared CRAP formula, risk tiers, and envelope shape are identical across both adapters; only the complexity number entering the formula differs.
+The companion Rust analyzer [`crap4rs`](https://crates.io/crates/crap4rs) defaults to cognitive complexity for the inverse reason — Rust idioms benefit from it. The shared CRAP formula, risk bands, and envelope shape are identical across both adapters; only the complexity number entering the formula differs.
 
-## Threshold presets
+## Threshold gate and risk bands
 
-`crap4ts` ships three preset gates calibrated against four risk tiers:
+The default gate (no flag) is CRAP ≤ 15. The two preset flags shift it:
 
-| Preset | Threshold | Gates at | Use for |
-|---|---|---|---|
-| `--strict` | CRAP ≤ 8 | Low → Acceptable | safety-critical, high-quality libraries |
-| *(default)* | CRAP ≤ 15 | Acceptable → Moderate | typical app / library code |
-| `--lenient` | CRAP ≤ 25 | Moderate → High | legacy / transitional codebases |
+| Flag | Gate | Use for |
+|---|---|---|
+| `--strict` | CRAP ≤ 8 | safety-critical, high-quality libraries |
+| *(default)* | CRAP ≤ 15 | typical app / library code |
+| `--lenient` | CRAP ≤ 25 | legacy / transitional codebases |
 
-The risk tiers themselves:
+The threshold gate and the score-based risk bands are distinct axes that share the same numbers today:
 
-| CRAP score | Risk |
+| CRAP score | Risk band |
 |---|---|
 | ≤ 8 | Low |
 | ≤ 15 | Acceptable |
 | ≤ 25 | Moderate |
 | > 25 | High |
 
-The presets correspond to "gate at the next risk tier up." Override with `--threshold <N>` for a custom value, or define presets per-codebase in `crap.toml` (the canonical config name, written by `crap4ts init`). The legacy name `crap4ts.toml` is still discovered as a deprecated alias when no `crap.toml` is present.
+The `8`/`15`/`25` values are a calibration convention, not empirically derived. Override or define per-codebase presets in [configuration](https://breezy-bays-labs.github.io/crap-rs/book/configuration.html).
 
-## What it looks like
+## Output formats
 
-### Table (TTY default)
+Table (TTY default), markdown, GitHub annotations, JSON, CSV, SARIF, scorecard-row, and an interactive HTML report all ship today. The output gallery and per-format details live in [output formats](https://breezy-bays-labs.github.io/crap-rs/book/output-formats.html). Multiple formats compose in one pass.
 
-```
-crap4ts v2.0.0-rc.2 — CRAP Score Analysis
+The JSON wire envelope is byte-identical to `crap4rs`'s output — same fields, same risk-band strings, same delta-gate semantics — so a multi-language monorepo can drive a single CI gate across both ecosystems. Delta gates, rename detection, and threshold-epsilon jitter suppression are covered in the [CLI reference](https://breezy-bays-labs.github.io/crap-rs/book/cli-reference.html) and [limitations and FAQ](https://breezy-bays-labs.github.io/crap-rs/book/limitations-and-faq.html).
 
-+-----------------------------+-------------------------+----+-------+-------+----------+
-| File                        | Function                | CC | Cov%  | CRAP  | Risk     |
-+=========================================================================================+
-| src/walker.ts               | walkExpression          | 14 |  72.0 | 17.06 | moderate |
-| src/cli.ts                  | resolveConfig           | 11 |  88.5 | 11.16 | acceptable |
-| src/reporters/markdown.ts   | renderTopOffenders      |  9 | 100.0 |  9.00 | acceptable |
-| src/coverage/istanbul.ts    | parseStatementMap       |  8 |  91.2 |  8.05 | acceptable |
-+-----------------------------+-------------------------+----+-------+-------+----------+
+## Two artifacts from one crate
 
-Functions: 142 · Above threshold: 1 · Worst CRAP: 17.06 · Distribution: 98 low · 32 acceptable · 11 moderate · 1 high
-```
+`crap4ts` is the TypeScript / JavaScript adapter in the [`crap-rs`](https://github.com/breezy-bays-labs/crap-rs) workspace. It compiles to two artifacts:
 
-### Markdown (`--format markdown`) — PR-comment ready
+- A standalone Rust CLI binary, built from source with `cargo install crap4ts` (this page). Prebuilt binaries and `cargo binstall` support are tracked for a future release.
+- A [napi-rs](https://napi.rs/) `cdylib` Node addon, distributed via [npm](https://www.npmjs.com/package/crap4ts).
 
-The first output line is always a hidden HTML comment, `<!-- crap4ts:scorecard -->` — invisible when rendered, but a stable anchor that sticky-PR-comment tooling can match on to find and update its own comment instead of posting a new one on every push. The marker carries the adapter name, so a Rust and a TypeScript scorecard can sticky to separate comments on the same PR. (A multi-language combined comment contains both adapters' markers, so match accordingly if you post combined output.) With `--breakdown`, the complexity-contributor bullets of the above-threshold functions collect into one collapsed `<details>` block below the scorecard table — below the table rather than between rows, since a `<details>` placed inside a markdown table terminates it.
-
-```markdown
-<!-- crap4ts:scorecard -->
-
-# crap4ts v2.0.0-rc.2 — CRAP Score Analysis
-
-**Result:** FAIL · **Functions:** 142 · **Above threshold (15):** 1
-
-| Metric     | Worst | Average | Median |
-|------------|------:|--------:|-------:|
-| CRAP       | 17.06 |    2.41 |   1.00 |
-| Complexity |    14 |     2.3 |    1.0 |
-| Coverage   |  0.0% |   89.4% |  98.5% |
-
-**Risk distribution:** low 98 · acceptable 32 · moderate 11 · high 1
-```
-
-### GitHub annotations (`--format github-annotations`) — inline PR review
-
-Drops findings as inline warnings on the PR Files Changed tab, no GHAS / Code Scanning license needed:
-
-```
-::warning file=src/walker.ts,line=128,title=CRAP 17.1::Function `walkExpression` has CRAP 17.06 (complexity=14, coverage=72.0%) which exceeds threshold 15.0
-```
-
-### JSON (`--format json`) — programmatic consumption
-
-```json
-{
-  "schema_version": 2,
-  "run_meta": { "tool": "crap4ts", "version": "2.0.0-rc.2", "metric": "cyclomatic" },
-  "result": {
-    "summary": {
-      "total_functions": 142,
-      "exceeding_threshold": 1,
-      "distribution": { "low": 98, "acceptable": 32, "moderate": 11, "high": 1 },
-      "max_crap": { "value": 17.06, "risk_level": "moderate" }
-    },
-    "functions": [
-      {
-        "scored": {
-          "identity": { "file_path": "src/walker.ts", "qualified_name": "walkExpression", "span": { "start_line": 128, "end_line": 184 } },
-          "complexity": 14,
-          "complexity_metric": "cyclomatic",
-          "coverage_percent": 72.0,
-          "crap": { "value": 17.06, "risk_level": "moderate" }
-        },
-        "threshold": 15.0,
-        "exceeds": true
-      }
-    ]
-  }
-}
-```
-
-The wire envelope is byte-identical to `crap4rs`'s output — same fields, same risk-tier strings, same delta-gate semantics. A multi-language monorepo can drive a single CI gate across both ecosystems.
-
-### Other formats
-
-- `--format csv` — spreadsheet ingestion
-- `--format sarif` — Code Scanning upload (requires GHAS) for surface-as-security-finding flows
-- `--format scorecard` — single-row CI gate output for cross-PR delta tracking
-- **HTML report** — interactive, sortable, with per-function contributor drill-down. *Coming in a future release; file an issue for early-access interest.*
-
-Multiple formats compose in one pass: `--format json:envelope.json,markdown:report.md` writes both files from a single analysis.
-
-## Delta gates — fail PRs that introduce new high-CRAP functions
-
-```bash
-# Generate baseline on main
-crap4ts --coverage main-coverage/coverage-final.json --src src --format json > baseline.json
-
-# On PR — fail only on NEW threshold violations
-crap4ts --coverage pr-coverage/coverage-final.json --src src --baseline baseline.json --delta-gate
-```
-
-A function above-threshold on main doesn't fail the PR; only functions newly introduced or newly elevated do. Lets teams ratchet quality forward without blocking every PR on pre-existing debt.
-
-### Relocations don't count as new violations
-
-A function that is **moved to another file, renamed, or moved between modules** — body otherwise unchanged — is recognized as a single `renamed` change rather than an unrelated `removed` + `added` pair, so a pure relocation contributes **zero new violations** and large migrations sail through the delta gate. A relocation that *also* worsens the score still counts. The matching is conservative (the same name *and* structure, or a distinctive structure with exactly one candidate per side). Enabling rename detection can only *lower* the new-violation count, never raise it (it never newly fails a PR) — but, since matching works from analysis output rather than source text, a genuinely-unrelated function whose structure coincidentally matches a removed one can pair and thereby lower the count below the true figure; the guards make that rare, not impossible. This is the same `crap-core` delta engine `crap4rs` uses, so the behavior — and the `renamed` count in every report format — is identical across both adapters.
-
-### Threshold-border jitter suppression (opt-in)
-
-A function whose CRAP score sits on the threshold line can flip across it on measurement noise. Set a **threshold-border epsilon** to stop that jitter from tripping the delta gate, via `--threshold-epsilon 0.5` or a `crap.toml` (or legacy `crap4ts.toml`) `[delta]` table:
-
-```toml
-[delta]
-epsilon = 0.5
-```
-
-`epsilon` is an **absolute, unitless CRAP-point** band half-width. A would-be new violation whose transition stays within `epsilon` of the threshold — on **both** sides — is treated as border jitter and not counted; what was suppressed surfaces as `border_jitter_suppressed` in the delta summary. The default `0.0` disables it (byte-identical output). It is deliberately narrow (oscillation across the line, not delta magnitude) and is a *jitter* knob, **not** a noise-only guarantee: like rename detection it only lowers the count, so a genuinely-new in-band violation is suppressed too (an in-band `Added` row is a one-sided soft threshold bypass). Same `crap-core` engine as `crap4rs` — identical behavior across both adapters. Keep `epsilon` small.
-
-## What this is (architecture)
-
-`crap4ts` is the TypeScript / JavaScript adapter in the [`crap-rs`](https://github.com/breezy-bays-labs/crap-rs) workspace. It compiles to two artifacts from one crate:
-
-- A standalone Rust CLI binary, distributed via crates.io (this page) and `cargo binstall`
-- A [napi-rs](https://napi.rs/) `cdylib` Node addon, distributed via [npm](https://www.npmjs.com/package/crap4ts)
-
-Both share the same walker (`oxc` for complexity), the same Istanbul JSON coverage parser, and the same [`crap-core`](https://crates.io/crates/crap-core) scoring/reporter pipeline as the Rust adapter [`crap4rs`](https://crates.io/crates/crap4rs).
+Both share the same `oxc` walker, the same Istanbul JSON coverage parser, and the same [`crap-core`](https://crates.io/crates/crap-core) scoring and reporter pipeline as the Rust adapter [`crap4rs`](https://crates.io/crates/crap4rs).
 
 ## Library use (Rust)
 
@@ -203,11 +96,11 @@ Both share the same walker (`oxc` for complexity), the same Istanbul JSON covera
 crap4ts = "2"
 ```
 
-Most users want the CLI or the npm package; the library crate is intended for downstream tooling that needs programmatic access to TypeScript walking + scoring without spawning a subprocess.
+Most users want the CLI or the npm package; the library crate is for downstream tooling that needs programmatic TypeScript walking and scoring without spawning a subprocess.
 
 ## Stability
 
-`crap4ts` is in the `2.0.0-rc.x` release-candidate series ahead of the GA `2.0.0` cut. The CLI surface, configuration shape, and scorecard envelope are locked across the rc series; rc bumps fix bugs and tighten the walker. See the [changelog](https://github.com/breezy-bays-labs/crap-rs/blob/main/packages/crap4ts/CHANGELOG.md) for the per-version history.
+`crap4ts` is in the `2.0.0-rc.x` release-candidate series ahead of the GA `2.0.0` cut. The CLI surface, configuration shape, and scorecard envelope are locked across the rc series; rc bumps fix bugs and tighten the walker. See the [changelog](https://github.com/breezy-bays-labs/crap-rs/blob/main/packages/crap4ts/CHANGELOG.md) for per-version history.
 
 ## See also
 

--- a/crates/crap4ts/README.md
+++ b/crates/crap4ts/README.md
@@ -91,12 +91,11 @@ Both share the same `oxc` walker, the same Istanbul JSON coverage parser, and th
 
 ## Library use (Rust)
 
-```toml
-[dependencies]
-crap4ts = "2"
+```bash
+cargo add crap4ts
 ```
 
-Most users want the CLI or the npm package; the library crate is for downstream tooling that needs programmatic TypeScript walking and scoring without spawning a subprocess.
+Most users want the CLI or the npm package; the library crate is for downstream tooling that needs programmatic TypeScript walking and scoring without spawning a subprocess. (The crate is on a `2.0.0-rc` prerelease line — `cargo add` resolves the current release; a manual `[dependencies]` entry needs an explicit prerelease requirement.)
 
 ## Stability
 

--- a/packages/crap4ts/README.md
+++ b/packages/crap4ts/README.md
@@ -1,26 +1,16 @@
 # crap4ts
 
-Rust-powered [CRAP](https://www.artima.com/weblogs/viewpost.jsp?thread=210575) (Change Risk Anti-Patterns) score analyzer for TypeScript and JavaScript. Combines [oxc](https://oxc.rs/)-driven AST complexity with [Istanbul](https://istanbul.js.org/) JSON coverage to identify functions that are both complex and under-tested.
+Rust-powered [CRAP (Change Risk Anti-Patterns)](https://breezy-bays-labs.github.io/crap-rs/book/understanding-crap.html) score analyzer for TypeScript and JavaScript. Combines [oxc](https://oxc.rs/)-driven AST complexity with [Istanbul](https://istanbul.js.org/) JSON coverage to find functions that are both complex and under-tested.
 
-`crap4ts@2.x` is the TypeScript adapter for [`crap-rs`](https://github.com/breezy-bays-labs/crap-rs), distributed as a [napi-rs](https://napi.rs/) Node addon. The CRAP formula, scorecard envelope, and reporter shapes are shared with [`crap4rs`](https://github.com/breezy-bays-labs/crap-rs) (the Rust adapter) so TypeScript projects get identical semantics to Rust projects.
-
-## Status
-
-This is `2.0.0-rc.1` — a release candidate in a 48–72 h soak window before the GA `2.0.0` cut. Try it on a sandbox project; file issues against [`breezy-bays-labs/crap-rs`](https://github.com/breezy-bays-labs/crap-rs/issues) if you hit anything.
+crap4ts is the TypeScript adapter for the `crap-rs` analyzer, distributed as a [napi-rs](https://napi.rs/) Node addon. It shares its CRAP formula, scorecard envelope, and reporter shapes with the Rust adapter (`crap4rs`), so a CRAP score means the same thing whether you analyze a TypeScript project or a Rust one. crap4ts measures complexity with the cyclomatic metric; crap4rs defaults to cognitive.
 
 ## Install
 
 ```sh
-npm install crap4ts@2.0.0-rc.1
-# or
-pnpm add crap4ts@2.0.0-rc.1
+npm install crap4ts
+# pre-release channel:
+npm install crap4ts@rc
 ```
-
-Published platforms in `2.0.0-rc.1`:
-- macOS (arm64 + x64)
-- Linux (x64 / glibc)
-
-Windows and Linux arm64 / musl are tracked for a later release (see [`crap-rs`#154](https://github.com/breezy-bays-labs/crap-rs/issues/154)).
 
 ## Usage
 
@@ -31,19 +21,24 @@ const json = analyze({
   sourceRoot: 'src',
   coveragePath: 'coverage/coverage-final.json',
   // Optional:
-  // threshold: 16,            // metric-correct default (cyclomatic: 16, cognitive: 25)
-  // metric: 'cyclomatic',     // 'cyclomatic' (default) or 'cognitive' (not yet supported)
+  // threshold: 15,        // default gate
+  // metric: 'cyclomatic', // crap4ts is cyclomatic-only
 });
 
 const { result, diagnostics } = JSON.parse(json);
 console.log(result.summary);
 ```
 
-Generate `coverage-final.json` via your test runner with Istanbul coverage enabled (`jest --coverage`, `vitest --coverage`, `c8 --reporter=json`, etc.).
+Generate `coverage-final.json` with Istanbul coverage enabled in your test runner (`jest --coverage`, `vitest --coverage`, `c8 --reporter=json`, etc.).
 
-## Migrating from `crap4ts@1.x`
+Use the istanbul coverage provider, not v8 — crap4ts consumes the Istanbul JSON shape only. For Vitest, set `coverage.provider: 'istanbul'`.
 
-See [`MIGRATION.md`](https://github.com/breezy-bays-labs/crap-rs/blob/main/MIGRATION.md) for the full upgrade guide. Short version: scores may differ for three compounding reasons (calibrated threshold default, TS-specific calibration not yet validated, arrow-function coverage handling), and the subpath exports (`crap4ts/formula`, `crap4ts/complexity`, `crap4ts/coverage`) are not re-exposed in 2.x — call `analyze()` and read fields from the returned JSON.
+## Documentation
+
+The CRAP score, the threshold gate, and the full reporter gallery (terminal, JSON, HTML — HTML ships today) are documented in the book:
+
+- [Quick start (TypeScript)](https://breezy-bays-labs.github.io/crap-rs/book/quick-start.html)
+- [Understanding CRAP](https://breezy-bays-labs.github.io/crap-rs/book/understanding-crap.html)
 
 ## License
 


### PR DESCRIPTION
Public-facing documentation overhaul.

## What

- **`book/`** — a 10-chapter [mdBook](https://rust-lang.github.io/mdBook/): Introduction, Installation, Quick start, Understanding the CRAP score, CLI reference, Configuration, Output formats, CI integration, Multi-language analysis, Limitations & FAQ. Authored against a no-fluff style guide (declarative voice, every token earns its keep, honest about limits inline) and **fact-checked against the source** — every flag, `--format` value, config key, the CRAP formula + units, the risk-bands-vs-threshold-gate distinction, exit codes, and the honest limits match the code.
- **READMEs trimmed hard** and pointed at the hosted book. Root README **582 → ~115 lines**; crate/npm READMEs link the book by absolute Pages URL so they resolve on crates.io and npm. Long-standing inaccuracies fixed along the way: HTML ships (was "coming soon" in 3 READMEs); cognitive is the crap4rs default / cyclomatic-only for crap4ts; default gate is 15; there is no `scorecard` format (only `scorecard-row`); no pinned version strings; the crap-core library example now compiles (`compute_crap(...).unwrap().value`).
- **CI** — a `book-build` gate (every PR; fails on a broken book) + a `publish-book` job (push to main) that renders the book and publishes it to GitHub Pages under **`/book/`**, sharing the `gh-pages-publish` concurrency lock so it never races the scorecard report publish. The reports at the Pages root are untouched.

## Process

Built via three workflows: a parallel fact-gather + TOC/style-guide design; parallel chapter + README authoring against the locked style guide; and an adversarial review (fact-check vs source + product-clarity + structural-consistency). All review findings (1 blocker + 3 majors + nits) were applied and re-verified. `mdbook build` is green; all cross-links resolve; no fluff / version-pins / internal-name leaks.

## Note

Merging this triggers the **first `/book/` publish** to GitHub Pages (`https://breezy-bays-labs.github.io/crap-rs/book/`). Nothing publishes from the PR itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added published mdBook documentation, including a structured book with introduction, installation, quick start, CLI reference, configuration, output formats, CI integration, multi-language workflow, and FAQ pages.
  * Added GitHub Pages publishing for the documentation at `/book/`.

* **Documentation**
  * Rewrote the main README and crate/package READMEs to be shorter, clearer, and more focused on installation, usage, and where to find the full docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->